### PR TITLE
fix: fix wheelZoom behaviour by removing the deprecated mousewheel event

### DIFF
--- a/plugins/behaviour.analysis/index.js
+++ b/plugins/behaviour.analysis/index.js
@@ -131,11 +131,11 @@ G6.registerBehaviour('panNode', graph => {
 // wheel zoom
 G6.registerBehaviour('wheelZoom', graph => {
   let timeout;
-  graph.behaviourOn('mousewheel', ev => {
+  graph.behaviourOn('wheel', ev => {
     const { domEvent } = ev;
     domEvent.preventDefault();
   });
-  graph.behaviourOn('mousewheel', Util.throttle(update, 16));
+  graph.behaviourOn('wheel', Util.throttle(update, 16));
 
   function update(ev) {
     const {

--- a/src/controller/event.js
+++ b/src/controller/event.js
@@ -20,7 +20,6 @@ const EVENT = {
   DRAGEND: 'dragend',
   DROP: 'drop',
   CONTEXTMENU: 'contextmenu',
-  MOUSEWHEEL: 'mousewheel',
   WHEEL: 'wheel',
   KEYDOWN: 'keydown',
   KEYUP: 'keyup',
@@ -30,7 +29,7 @@ const SHAKE_TOLERANCE = 9; // use to tolerate click shake prevent drag shake. Th
 
 // native dom events list:
 const MouseEventTypes = [ EVENT.DBLCLICK, EVENT.MOUSEDOWN, EVENT.MOUSEUP, EVENT.MOUSEENTER, EVENT.MOUSELEAVE, EVENT.MOUSEMOVE,
-  EVENT.CONTEXTMENU, EVENT.MOUSEWHEEL, EVENT.WHEEL ];
+  EVENT.CONTEXTMENU, EVENT.WHEEL ];
 const KeyboardEventTypes = [ EVENT.KEYDOWN, EVENT.KEYUP, EVENT.KEYPRESS ];
 const CANVAS = 'canvas:';
 function parentNodeHasTag(n, t) {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->
在这个更改后 https://github.com/antvis/g6/commit/9219f47ac7d86f0825f7410637cf9e354dc30924 , `behaviour.analysis` 里的 `wheelZoom` 在 Chrome 下就不起作用了。 `mousewheel` 和 `wheel` 都提供，Chrome 选择了监听标准的 `wheel` 事件。

所以可以去掉 `mousewheel`.

##### References
https://developer.mozilla.org/en-US/docs/Web/Events/mousewheel
https://developer.mozilla.org/en-US/docs/Web/Events/wheel