### PR TITLE
修复 mode更改是如果有官方panNode则panNode中方法会保留

### DIFF
--- a/plugins/behaviour.analysis/index.js
+++ b/plugins/behaviour.analysis/index.js
@@ -90,17 +90,17 @@ G6.registerBehaviour('panNode', graph => {
   let node;
   let dx;
   let dy;
-  graph.on('node:mouseenter', () => {
+  graph.behaviourOn('node:mouseenter', () => {
     graph.css({
       cursor: 'move'
     });
   });
-  graph.on('node:mouseleave', () => {
+  graph.behaviourOn('node:mouseleave', () => {
     graph.css({
       cursor: 'default'
     });
   });
-  graph.on('node:dragstart', ({ item, x, y }) => {
+  graph.behaviourOn('node:dragstart', ({ item, x, y }) => {
     graph.css({
       cursor: 'move'
     });
@@ -109,7 +109,7 @@ G6.registerBehaviour('panNode', graph => {
     dx = model.x - x;
     dy = model.y - y;
   });
-  graph.on('node:drag', ev => {
+  graph.behaviourOn('node:drag', ev => {
     graph.preventAnimate(() => {
       graph.update(node, {
         x: ev.x + dx,
@@ -117,10 +117,10 @@ G6.registerBehaviour('panNode', graph => {
       });
     });
   });
-  graph.on('node:dragend', () => {
+  graph.behaviourOn('node:dragend', () => {
     node = undefined;
   });
-  graph.on('canvas:mouseleave', () => {
+  graph.behaviourOn('canvas:mouseleave', () => {
     node = undefined;
   });
 });


### PR DESCRIPTION
Checklist

[√ ] npm test passes

[ √] commit message follows commit guidelines

Description of change
对于官方指定行为‘panNode’中方法 会保留不会随着mode更改而改变
https://github.com/antvis/g6/issues/544
CodePen Link: https://codepen.io/anon/pen/KrGwKz

所以可以可以把panNode中的graph.on替换为graph.behaviourOn.