### PR TITLE
fix: 修复 panNode、panBlank 同时使用冲突的问题

### DIFF
--- a/plugins/behaviour.analysis/index.js
+++ b/plugins/behaviour.analysis/index.js
@@ -21,6 +21,8 @@ function panCanvas(graph, button = 'left', panBlank = false) {
             x: ev.domX,
             y: ev.domY
           };
+        } else {
+          resetStatus();
         }
       } else {
         lastPoint = {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->

panNode、panBlank 同时使用，单击空白区时，会触发 `mousedown`，但是不会触发 `dragend`、`canvas:mouseleave` ，导致 lastPoint 存在未清除的值，影响下一次节点拖动，使画布出现不期望的同时拖动。
