### PR TITLE
fix behavior/drag-node: drag distance depends on zoom ratio

### DIFF
--- a/src/behavior/drag-node.js
+++ b/src/behavior/drag-node.js
@@ -54,14 +54,16 @@ module.exports = {
   _update(item, e, force) {
     const origin = this.origin;
     const model = item.get('model');
+    const graph = this.graph;
+    const zoom = graph.getZoom();
     if (!this.point) {
       this.point = {
         x: model.x,
         y: model.y
       };
     }
-    const x = e.clientX - origin.x + this.point.x;
-    const y = e.clientY - origin.y + this.point.y;
+    const x = (e.clientX - origin.x) / zoom + this.point.x;
+    const y = (e.clientY - origin.y) / zoom + this.point.y;
     this.origin = { x: e.clientX, y: e.clientY };
     this.point = { x, y };
     if (this.delegate && !force) {


### PR DESCRIPTION
##### Checklist
- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x ] commit message follows commit guidelines

##### Description of change
修复`src/behavior/drag-node`下拖拽节点行为的位置应该同当前画布缩放比例成正比。
问题发生：当画布缩放后，即当前`graph.getZoom()`的值不等于1时，拖拽节点的距离同在画布上渲染的距离不一致
修复方案：计算节点拖拽距离时，取同当前画布缩放比例的比值作为当前画布的可视距离
