### PR TITLE
修复当自定义的节点中心位置不在中心点时delegate错位的问题

### DIFF
--- a/demos/custom-node-card.html
+++ b/demos/custom-node-card.html
@@ -481,6 +481,9 @@
       container: 'mountNode',
       width: 800,
       height: 600,
+      modes: {
+        default: ['drag-node']
+      },
       defaultNode: {
         shape: 'card-node'
       }

--- a/src/behavior/drag-node.js
+++ b/src/behavior/drag-node.js
@@ -194,29 +194,30 @@ module.exports = {
           attrs: {
             width: bbox.width,
             height: bbox.height,
-            x: x - bbox.width / 2,
-            y: y - bbox.height / 2,
+            x: x + bbox.x,
+            y: y + bbox.y,
             ...attrs
           }
         });
         this.target.set('delegateShape', this.shape);
       }
       this.shape.set('capture', false);
+    } else {
+      if (this.targets.length > 0) {
+        const clientX = e.x - this.origin.x + this.originPoint.minX;
+        const clientY = e.y - this.origin.y + this.originPoint.minY;
+        this.shape.attr({
+          x: clientX,
+          y: clientY
+        });
+      } else if (this.target) {
+        this.shape.attr({
+          x: x + bbox.x,
+          y: y + bbox.y
+        });
+      }
     }
 
-    if (this.targets.length > 0) {
-      const clientX = e.x - this.origin.x + this.originPoint.minX;
-      const clientY = e.y - this.origin.y + this.originPoint.minY;
-      this.shape.attr({
-        x: clientX,
-        y: clientY
-      });
-    } else if (this.target) {
-      this.shape.attr({
-        x: x - bbox.width / 2,
-        y: y - bbox.height / 2
-      });
-    }
     this.graph.paint();
   },
   /**


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->
修复当自定义节点时，x和y坐标不为中心点时，拖动过程中delegate错位的问题。