### PR TITLE
Fix: graph.focusItem(item) not working if item is a string

### DIFF
--- a/src/graph/controller/view.js
+++ b/src/graph/controller/view.js
@@ -65,7 +65,7 @@ class View {
   }
   focus(item) {
     if (Util.isString(item)) {
-      item = this.graph.findById[item];
+      item = this.graph.findById(item);
     }
     if (item) {
       const matrix = item.get('group').getMatrix();


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->
If the type of item for graph.focusItem(item) is string, the function cannot work properly. The reason is that `this.graph.findById(item)` was written as `this.graph.findById[item]` by mistake in `\g6\src\graph\controller\view.js` at line 68.
