### PR TITLE
fix: polyline not support options styles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,5 @@ lib
 
 *.sw*
 *.un~
+.cache
+public

--- a/demos/fix-behavior.html
+++ b/demos/fix-behavior.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Rect节点分组</title>
+</head>
+<body>
+<div id="mountNode"></div>
+<script src="../build/g6.js"></script>
+<script>
+  const data = {
+    nodes: [
+      {id: '1', x: 50, y: 50, size: 20},
+      {id: '2', x: 150, y: 50, size: 20},
+      {id: '3', x: 200, y: 50, size: 20},
+      {id: '4', x: 300, y: 130, size: 20},
+      {id: '5', x: 350, y: 50, size: 20},
+      {id: '6', x: 450, y: 50, size: 20},
+      {id: '7', x: 500, y: 50, size: 20},
+      {id: '8', x: 600, y: 50, size: 20},
+      {id: '9', x: 650, y: 50, size: 20},
+      {id: '10', x: 750, y: 50, size: 20},
+      {id: '11', x: 800, y: 50, size: 20},
+      {id: '12', x: 900, y: 150, size: 20},
+      {id: '13', x: 950, y: 50, size: 20},
+      {id: '14', x: 1050, y: 150, size: 20},
+      {id: '15', x: 1100, y: 50, size: 20},
+    ],
+    edges: [
+      {source: '1', target: '2', shape: 'line', label: 'line'},
+      {source: '3', target: '4', shape: 'polyline', label: 'polyline'},
+      {source: '5', target: '6', shape: 'arc', label: 'arc'},
+      {source: '7', target: '8', shape: 'quadratic', label: 'quadratic'},
+      {source: '9', target: '10', shape: 'cubic', label: 'cubic'},
+      {source: '11', target: '12', shape: 'cubic-vertical', label: 'cubic-vertical'},
+      {source: '13', target: '14', shape: 'cubic-horizontal', label: 'cubic-horizontal'},
+      {source: '15', target: '15', shape: 'loop', label: 'loop'}
+    ]
+  }
+
+  const graph = new G6.Graph({
+    container: 'mountNode',
+    nodeStateStyles: {
+      selected: {
+        fill: 'red',
+        stroke: 'red',
+      }
+    },
+    modes: {
+      default: [
+        'drag-node',
+        'click-select',
+        'brush-select',
+        {
+          type: 'zoom-canvas',
+          sensitivity: 0.3,
+        },
+      ],
+    },
+    width: 1500,
+    height: 300,
+    linkCenter: true      // 使边连入节点的中心
+  });
+  graph.data(data);
+  graph.render();
+</script>
+</body>
+</html>

--- a/demos/internal-edges.html
+++ b/demos/internal-edges.html
@@ -8,6 +8,50 @@
 <div id="mountNode"></div>
 <script src="../build/g6.js"></script>
 <script>
+  G6.registerEdge('new-polyline', {
+    options: {
+      style: {
+        lineWidth: 5,
+        stroke: 'green'
+      }
+    },
+    drawLabel(cfg, group) {
+      const labelstyle = this.getLabelStyle(cfg, {}, group)
+      const { x, y } = labelstyle
+      cfg.label = 'xxx'
+      const label = group.addShape('text', {
+        attrs: {
+          x, y,
+          stroke: 'blue',
+        }
+      })
+      console.log('labelStyle', labelstyle, label)
+      return label
+    }
+  }, 'polyline')
+
+  G6.registerNode('new-circle', {
+    options: {
+      style: {
+        lineWidth: 5,
+        fill: 'green'
+      }
+    },
+    drawLabel(cfg, group) {
+      const labelstyle = this.getLabelStyle(cfg, {}, group)
+      const { x, y } = labelstyle
+      const label = group.addShape('text', {
+        attrs: {
+          x, y,
+          text: '默认',
+          stroke: 'red',
+        }
+      })
+      console.log('labelStyle', labelstyle, label)
+      return label
+    }
+  }, 'circle')
+
   const graph = new G6.Graph({
     container: 'mountNode',
     width: 800,
@@ -30,7 +74,7 @@
         label: 'node1',
         x: 100,
         y: 100,
-        // shape: 'circle'
+        shape: 'new-circle'
       },
       {
         id: 'node4',
@@ -83,34 +127,34 @@
       },
     ],
     edges: [
-      // {
-      //   source: 'node1',
-      //   target: 'node4',
-      //   shape: 'polyline',
-      //   label: 'edge1-4',
-      //   controlPoints: [
-      //     { x: 100, y: 200 },
-      //   ],
-      //   style: {
-      //     radius: 10,
-      //     offset: 20
-      //   }
-      // },
-      // {
-      //   source: 'node4',
-      //   target: 'node5',
-      //   shape: 'polyline',
-      //   label: 'edge5-7',
-      //   style: {
-      //     lineWidth: 1.5,
-      //     stroke: '#888',
-      //   }
-      // },
-      // {
-      //   source: 'node4',
-      //   target: 'node7',
-      //   shape: 'line'
-      // },
+      {
+        source: 'node1',
+        target: 'node4',
+        shape: 'new-polyline',
+        label: 'edge1-4',
+        controlPoints: [
+          { x: 100, y: 200 },
+        ],
+        style: {
+          radius: 10,
+          offset: 20
+        }
+      },
+      {
+        source: 'node4',
+        target: 'node5',
+        shape: 'new-polyline',
+        label: 'edge5-7',
+        // style: {
+        //   lineWidth: 1.5,
+        //   stroke: '#888',
+        // }
+      },
+      {
+        source: 'node4',
+        target: 'node7',
+        shape: 'line'
+      },
       {
         source: 'node4',
         target: 'node6',

--- a/src/behavior/brush-select.js
+++ b/src/behavior/brush-select.js
@@ -85,7 +85,7 @@ module.exports = {
     this.graph.paint();
   },
   onMouseUp(e) {
-    if (!this.brush) {
+    if (!this.brush && !this.dragging) {
       return;
     }
 
@@ -96,7 +96,8 @@ module.exports = {
     const graph = this.graph;
     const autoPaint = graph.get('autoPaint');
     graph.setAutoPaint(false);
-    this.brush.hide();
+    this.brush.destroy();
+    this.brush = null;
     this._getSelectedNodes(e);
     this.dragging = false;
     this.graph.paint();
@@ -201,7 +202,9 @@ module.exports = {
   },
   onKeyUp() {
     if (this.brush) {
-      this.brush.hide();
+      // 清除所有选中状态后，设置拖得动状态为false，并清除框选的brush
+      this.brush.destroy();
+      this.brush = null;
       this.dragging = false;
     }
     this.keydown = false;

--- a/src/shape/edges/polyline.js
+++ b/src/shape/edges/polyline.js
@@ -47,12 +47,15 @@ Shape.registerEdge('polyline', {
     return keyShape;
   },
   getShapeStyle(cfg) {
-    const color = cfg.color || Global.defaultEdge.color;
-    const size = cfg.size || Global.defaultEdge.size;
     const customOptions = this.getCustomConfig(cfg) || {};
     const { style: defaultStyle } = this.options;
     const { style: customStyle } = customOptions;
-    const style = Util.deepMix({}, defaultStyle, customStyle, cfg.style);
+
+    const strokeStyle = {
+      stroke: cfg.color
+    };
+
+    const style = Util.deepMix({}, defaultStyle, customStyle, strokeStyle, cfg.style);
     cfg = this.getPathPoints(cfg);
     this.radius = style.radius;
     this.offset = style.offset;
@@ -74,9 +77,8 @@ Shape.registerEdge('polyline', {
     }
     const path = this.getPath(points, routeCfg);
     const attrs = Util.deepMix({}, Global.defaultEdge.style, style, {
-      stroke: color,
-      lineWidth: size
-    }, cfg.style, { path });
+      lineWidth: cfg.size
+    }, { path });
     return attrs;
   },
   getPath(points, routeCfg) {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->
- 布局支持回调函数；
- 类型文件 export item；
- 修复 polyline 不支持 options 中配置的样式问题。