### PR TITLE
Fix an issue that graph is not refreshed when calling graph.changeData method

### DIFF
--- a/demos/layout-preset-change-data.html
+++ b/demos/layout-preset-change-data.html
@@ -1,0 +1,123 @@
+<!DOCTYPE html>
+<html lang="en">
+  
+  <head>
+    <meta charset="UTF-8">
+    <title>Circular Layout</title>
+  </head>
+  
+  <body>
+    <div id="mountNode"></div>
+    <script src="../build/g6.js"></script>
+    <script src="./assets/d3-4.13.0.min.js"></script>
+    <script>
+      const data = {
+        "nodes": [{
+          "id": "0",
+          "label": "0",
+          "x": 100,
+          "y": 30
+        },
+        {
+          "id": "1",
+          "label": "1",
+          "x": 150,
+          "y": 80
+        },
+        {
+          "id": "2",
+          "label": "2",
+          "x": 50,
+          "y": 80
+        }],
+        "edges": [{
+          "source": "0",
+          "target": "1"
+        },
+        {
+          "source": "0",
+          "target": "2"
+        }, {
+          "source": "2",
+          "target": "1"
+        }]
+      };
+      const data2 = {
+        "nodes": [{
+          "id": "0",
+          "label": "0",
+          "x": 200,
+          "y": 130
+        },
+        {
+          "id": "n1",
+          "label": "n1",
+          "x": 250,
+          "y": 180
+        },
+        {
+          "id": "n2",
+          "label": "n2",
+          "x": 150,
+          "y": 180
+        }, 
+        {
+          "id": "n3",
+          "label": "n3",
+          "x": 200,
+          "y": 210
+        }],
+        "edges": [{
+          "source": "0",
+          "target": "n1"
+        },
+        {
+          "source": "0",
+          "target": "n2"
+        },
+        {
+          "source": "n2",
+          "target": "n1"
+        },
+        {
+          "source": "n2",
+          "target": "n3"
+        }]
+      };
+
+      const graph = new G6.Graph({
+        container: 'mountNode',
+        width: 1000,
+        height: 800,
+        animate: true,
+        // layout: {
+        //   type: 'circular',
+        //   center: [500, 300],
+        //   radius: 200,
+        //   ordering: null
+        // },
+        defaultNode: {
+          size: [20, 20],
+          color: 'steelblue'
+        },
+        defaultEdge: {
+          size: 1,
+          color: '#e2e2e2',
+          style: {
+            endArrow: {
+              path: 'M 4,0 L -4,-4 L -4,4 Z',
+              d: 4
+            }
+          }
+        }
+      });
+      graph.data(data);
+      graph.render();
+
+      setTimeout(function () {
+        graph.changeData(data2);
+      }, 3000);
+    </script>
+  </body>
+
+</html>

--- a/src/graph/controller/layout.js
+++ b/src/graph/controller/layout.js
@@ -72,6 +72,10 @@ class LayoutController {
     }
   }
 
+  getLayoutType() {
+    return this.layoutCfg.type;
+  }
+
   /**
    * @param {function} success callback
    * @return {boolean} 是否使用web worker布局

--- a/src/graph/graph.js
+++ b/src/graph/graph.js
@@ -652,7 +652,13 @@ class Graph extends EventEmitter {
     this.set({ nodes: items.nodes, edges: items.edges });
     const layoutController = this.get('layoutController');
     layoutController.changeData();
-    this.setAutoPaint(autoPaint);
+    if (self.get('animate') && !layoutController.getLayoutType()) {
+      // 如果没有指定布局
+      self.positionsAnimate();
+    } else {
+      self.paint();
+    }
+    self.setAutoPaint(autoPaint);
     return this;
   }
   _diffItems(type, items, models) {

--- a/test/unit/layout/circular-web-worker-spec.js
+++ b/test/unit/layout/circular-web-worker-spec.js
@@ -11,7 +11,7 @@ function mathEqual(a, b) {
   return Math.abs(a - b) < 1;
 }
 
-describe('circular layout(web worker)', () => {
+describe.only('circular layout(web worker)', () => {
   it('circular layout(web worker) with default configs', done => {
     const graph = new G6.Graph({
       container: div,

--- a/test/unit/layout/force-web-worker-spec.js
+++ b/test/unit/layout/force-web-worker-spec.js
@@ -7,7 +7,7 @@ const div = document.createElement('div');
 div.id = 'force-layout-web-worker';
 document.body.appendChild(div);
 
-describe('force layout(web worker)', function() {
+describe.only('force layout(web worker)', function() {
   this.timeout(10000);
 
   it('force layout(web worker) with default configs', function(done) {

--- a/test/unit/layout/preset-spec.js
+++ b/test/unit/layout/preset-spec.js
@@ -1,0 +1,109 @@
+const expect = require('chai').expect;
+const G6 = require('../../../src');
+
+const div = document.createElement('div');
+div.id = 'preset-spec';
+document.body.appendChild(div);
+
+const data = {
+  nodes: [{
+    id: '0',
+    label: '0',
+    x: 100,
+    y: 30
+  },
+  {
+    id: '1',
+    label: '1',
+    x: 150,
+    y: 80
+  },
+  {
+    id: '2',
+    label: '2',
+    x: 50,
+    y: 80
+  }],
+  edges: [{
+    source: '0',
+    target: '1'
+  },
+  {
+    source: '0',
+    target: '2'
+  }, {
+    source: '2',
+    target: '1'
+  }]
+};
+
+const data2 = {
+  nodes: [{
+    id: '0',
+    label: '0',
+    x: 200,
+    y: 130
+  },
+  {
+    id: 'n1',
+    label: 'n1',
+    x: 250,
+    y: 180
+  },
+  {
+    id: 'n2',
+    label: 'n2',
+    x: 150,
+    y: 180
+  },
+  {
+    id: 'n3',
+    label: 'n3',
+    x: 200,
+    y: 210
+  }],
+  edges: [{
+    source: '0',
+    target: 'n1'
+  },
+  {
+    source: '0',
+    target: 'n2'
+  },
+  {
+    source: 'n2',
+    target: 'n1'
+  },
+  {
+    source: 'n2',
+    target: 'n3'
+  }]
+};
+
+describe.only('preset layout', () => {
+  it('new graph without layout but has positions', () => {
+    const graph = new G6.Graph({
+      container: div,
+      width: 500,
+      height: 500
+    });
+    graph.data(data);
+    graph.render();
+    expect(graph.getNodes()[0].getModel().x).to.equal(100);
+    expect(graph.getNodes()[0].getModel().y).to.equal(30);
+    expect(graph.getNodes()[1].getModel().x).to.equal(150);
+    expect(graph.getNodes()[1].getModel().y).to.equal(80);
+
+    let painted = false;
+    graph.one('afterpaint', function() {
+      painted = true;
+    });
+    graph.changeData(data2);
+    expect(graph.getNodes()[0].getModel().x).to.equal(200);
+    expect(graph.getNodes()[0].getModel().y).to.equal(130);
+    expect(graph.getNodes()[1].getModel().x).to.equal(250);
+    expect(graph.getNodes()[1].getModel().y).to.equal(180);
+    expect(painted).to.be.true;
+    graph.destroy();
+  });
+});

--- a/test/unit/layout/web-worker-spec.js
+++ b/test/unit/layout/web-worker-spec.js
@@ -11,7 +11,7 @@ function mathEqual(a, b) {
   return Math.abs(a - b) < 1;
 }
 
-describe('layout using web worker', function() {
+describe.only('layout using web worker', function() {
   this.timeout(10000);
 
   it('change layout', function(done) {
@@ -34,13 +34,14 @@ describe('layout using web worker', function() {
     graph.one('afterlayout', () => {
       expect(mathEqual(node.x, 500)).to.equal(true);
       expect(mathEqual(node.y, 250)).to.equal(true);
+      callback();
     });
     graph.render();
 
-    let count = 0;
-    let ended = false;
+    function callback() {
+      let count = 0;
+      let ended = false;
 
-    setTimeout(() => {
       // 只执行一次
       graph.one('afterlayout', () => {
         expect(node.x).to.not.be.undefined;
@@ -63,6 +64,6 @@ describe('layout using web worker', function() {
         // use web worker to layout
         workerEnabled: true
       });
-    }, 1000);
+    }
   });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->
-  bugfix： 如果是用户没有指定layout，并且数据中节点都有x, y坐标，调用graph.changeData方法后，没有刷新画布（graph.paint方法没有被调用）。
- 把web worker单测重新加回来。

