### PR TITLE
Fix/dagre

### DIFF
--- a/src/layout/dagre.js
+++ b/src/layout/dagre.js
@@ -79,13 +79,15 @@ Layout.registerLayout('dagre', {
     });
     dagre.layout(g);
     let coord;
-    g.nodes().forEach((node, i) => {
+    g.nodes().forEach(node => {
       coord = g.node(node);
+      const i = nodes.findIndex(it => it.id === node);
       nodes[i].x = coord.x;
       nodes[i].y = coord.y;
     });
-    g.edges().forEach((edge, i) => {
+    g.edges().forEach(edge => {
       coord = g.edge(edge);
+      const i = edges.findIndex(it => it.source === edge.v && it.target === edge.w);
       edges[i].startPoint = coord.points[0];
       edges[i].endPoint = coord.points[coord.points.length - 1];
       if (self.controlPoints) {

--- a/test/unit/layout/dagre-spec.js
+++ b/test/unit/layout/dagre-spec.js
@@ -10,26 +10,6 @@ document.body.appendChild(div);
 const data = {
   nodes: [
     {
-      id: '1',
-      type: 'alps',
-      name: 'alps_file1',
-      label: '1',
-      conf: [
-        {
-          label: 'conf',
-          value: 'pai_graph.conf'
-        },
-        {
-          label: 'dot',
-          value: 'pai_graph.dot'
-        },
-        {
-          label: 'init',
-          value: 'init.rc'
-        }
-      ]
-    },
-    {
       id: '2',
       type: 'alps',
       name: 'alps_file2',
@@ -50,10 +30,10 @@ const data = {
       ]
     },
     {
-      id: '3',
+      id: '1',
       type: 'alps',
-      name: 'alps_file3',
-      label: '3',
+      name: 'alps_file1',
+      label: '1',
       conf: [
         {
           label: 'conf',
@@ -114,6 +94,26 @@ const data = {
       type: 'feature_etl',
       name: 'feature_etl_1',
       label: '6',
+      conf: [
+        {
+          label: 'conf',
+          value: 'pai_graph.conf'
+        },
+        {
+          label: 'dot',
+          value: 'pai_graph.dot'
+        },
+        {
+          label: 'init',
+          value: 'init.rc'
+        }
+      ]
+    },
+    {
+      id: '3',
+      type: 'alps',
+      name: 'alps_file3',
+      label: '3',
       conf: [
         {
           label: 'conf',


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->
fix(dagre): 修复 dagre 布局中节点位置设置错误的问题.

G6 在调用 dagre.js(后面特指 dagre.js 库) 后，会将 dagre.js 生成的坐标信息(x, y等)，还原到 {nodes, edges}中，
但是在还原的过程中，依赖的是 dagre.js 给我们的 节点 和 边 的索引(index)，然而在 dagre.js 返回的 nodes 和 edges 数组中元素的顺序与我们setNode和setEdge时的顺序是不一致的，从而导致了节点位置错误。

G6 的 test case 中，给的测试数据太“标准”了，即测试数据的节点顺序是按照 1, 2, 3, 4, 5……的顺序，正好与 dagre.js 计算并布局后的 nodes 和 edges 顺序一致，导致没有测试出来。

#1032 提到的也是这个问题，可以看他的代码里面，31和32节点在数组中的位置不是“升序”的，导致和 dagre.js 计算出来的不一致，导致错误。

这里有两个链接：

使用 G6 的 dagre layout 布局，点击变化 nodes 中元素顺序，可以使得界面布局混乱：

https://codesandbox.io/s/g6-default-dagre-vdwm7

使用本 pull-request 修复后的示例：

https://codesandbox.io/s/g6-default-dagre-fixed-06tuh
    
Fixed #1032