### PR TITLE
feat：supports elements type by type

### DIFF
--- a/docs/api/Shape.en.md
+++ b/docs/api/Shape.en.md
@@ -1,5 +1,5 @@
 ---
-title: Shape
+title: Register
 order: 7
 ---
 

--- a/docs/api/Shape.zh.md
+++ b/docs/api/Shape.zh.md
@@ -1,9 +1,9 @@
 ---
-title: Shape
+title: 自定义
 order: 7
 ---
 
-本文介绍的 Shape 相关方法是在自定义节点（registerNode）或自定义边（registerEdge）的过程中需要部分实现或复写的方法。
+本文介绍的相关方法是在自定义节点（registerNode）或自定义边（registerEdge）的过程中需要部分实现或复写的方法。
 
 **友情提示：**以下属性和 API 方法，全部用于自定义节点和边时候使用，即作为 `G6.registerNode` / `G6.registerEdge` 的第二个参数中的方法。
 

--- a/docs/manual/FAQ/gradient.en.md
+++ b/docs/manual/FAQ/gradient.en.md
@@ -1,0 +1,29 @@
+---
+title: 如何在 G6 中给元素设置渐变色
+order: 7
+---
+
+G6 提供**线性渐变**，**环形渐变**两种形式。
+
+### 线性渐变
+#### 示例
+<img src='https://gw.alipayobjects.com/mdn/rms_f8c6a0/afts/img/A*lX-fSbaOrn0AAAAAAAAAAABkARQnAQ' width='750' />
+> 说明：l 表示使用线性渐变，绿色的字体为可变量，由用户自己填写。
+
+#### 用法
+```
+// 使用渐变色描边，渐变角度为 0，渐变的起始点颜色 #ffffff，中点的渐变色为 #7ec2f3，结束的渐变色为 #1890ff
+stroke: 'l(0) 0:#ffffff 0.5:#7ec2f3 1:#1890ff'
+```
+
+### 环形渐变
+#### 示例
+<img src='https://gw.alipayobjects.com/mdn/rms_f8c6a0/afts/img/A*U68WTpjAqscAAAAAAAAAAABkARQnAQ' width='750' />
+> 说明：r 表示使用放射状渐变，绿色的字体为可变量，由用户自己填写，开始圆的 x y r 值均为相对值，0 至 1 范围。
+
+#### 用法
+
+```
+// 使用渐变色填充，渐变起始圆的圆心坐标为被填充物体的包围盒中心点，半径为(包围盒对角线长度 / 2) 的 0.1 倍，渐变的起始点颜色 #ffffff，中点的渐变色为 #7ec2f3，结束的渐变色为 #1890ff
+fill: 'r(0.5, 0.5, 0.1) 0:#ffffff 1:#1890ff'
+```

--- a/docs/manual/FAQ/gradient.zh.md
+++ b/docs/manual/FAQ/gradient.zh.md
@@ -1,0 +1,29 @@
+---
+title: 如何在 G6 中给元素设置渐变色
+order: 7
+---
+
+G6 提供**线性渐变**，**环形渐变**两种形式。
+
+### 线性渐变
+#### 示例
+<img src='https://gw.alipayobjects.com/mdn/rms_f8c6a0/afts/img/A*lX-fSbaOrn0AAAAAAAAAAABkARQnAQ' width='750' />
+> 说明：l 表示使用线性渐变，绿色的字体为可变量，由用户自己填写。
+
+#### 用法
+```
+// 使用渐变色描边，渐变角度为 0，渐变的起始点颜色 #ffffff，中点的渐变色为 #7ec2f3，结束的渐变色为 #1890ff
+stroke: 'l(0) 0:#ffffff 0.5:#7ec2f3 1:#1890ff'
+```
+
+### 环形渐变
+#### 示例
+<img src='https://gw.alipayobjects.com/mdn/rms_f8c6a0/afts/img/A*U68WTpjAqscAAAAAAAAAAABkARQnAQ' width='750' />
+> 说明：r 表示使用放射状渐变，绿色的字体为可变量，由用户自己填写，开始圆的 x y r 值均为相对值，0 至 1 范围。
+
+#### 用法
+
+```
+// 使用渐变色填充，渐变起始圆的圆心坐标为被填充物体的包围盒中心点，半径为(包围盒对角线长度 / 2) 的 0.1 倍，渐变的起始点颜色 #ffffff，中点的渐变色为 #7ec2f3，结束的渐变色为 #1890ff
+fill: 'r(0.5, 0.5, 0.1) 0:#ffffff 1:#1890ff'
+```

--- a/docs/manual/FAQ/texture.en.md
+++ b/docs/manual/FAQ/texture.en.md
@@ -1,0 +1,19 @@
+---
+title: How to supports texture in G6
+order: 8
+---
+
+G6 支持用特定的纹理填充图形。G6支持的纹理内容可以直接是**图片**或者 **Data URLs**。
+
+<img src='https://gw.alipayobjects.com/mdn/rms_f8c6a0/afts/img/A*cPgYSJ2ZfwYAAAAAAAAAAABkARQnAQ' width='750' />
+
+> tips：p means use texture，绿色的字体为可变量，由用户自己填写。
+
+• a: repeat in vertical and horizontal direction；
+• x: repeat in horizontal direction；
+• y: repeat in vertical direction；
+• n: not repeat，show only once。
+
+```
+shape.attr('fill', 'p(a)https://gw.alipay.com/cube.png');
+```

--- a/docs/manual/FAQ/texture.zh.md
+++ b/docs/manual/FAQ/texture.zh.md
@@ -1,0 +1,19 @@
+---
+title: 如何在 G6 中给元素设置纹理
+order: 8
+---
+
+G6 支持用特定的纹理填充图形。G6支持的纹理内容可以直接是**图片**或者 **Data URLs**。
+
+<img src='https://gw.alipayobjects.com/mdn/rms_f8c6a0/afts/img/A*cPgYSJ2ZfwYAAAAAAAAAAABkARQnAQ' width='750' />
+
+> 说明：p 表示使用纹理，绿色的字体为可变量，由用户自己填写。
+
+• a: 该模式在水平和垂直方向重复；
+• x: 该模式只在水平方向重复；
+• y: 该模式只在垂直方向重复；
+• n: 该模式只显示一次（不重复）。
+
+```
+shape.attr('fill', 'p(a)https://gw.alipay.com/cube.png');
+```

--- a/docs/manual/FAQ/transform.en.md
+++ b/docs/manual/FAQ/transform.en.md
@@ -1,0 +1,82 @@
+---
+title: 如何在 G6 中实现变换
+order: 9
+---
+
+### G6 3.2
+G6 3.2 及以下版本中，实现变换可通过以下方式。
+
+#### transform(ts)
+实例变换方法。参数以数组形式提供，按顺序执行。
+
+例如画布上有以下的一个矩形实例。
+```
+const rect = group.addShape('rect', {
+    attrs: {
+        width: 100,
+        height: 100,
+        x: 100,
+        y: 100,
+        fill: '#9EC9FF',
+        stroke: '#5B8FF9',
+        lineWidth: 3
+    }
+});
+```
+
+得到的结果如下图所示：
+<img src='https://gw.alipayobjects.com/mdn/rms_f8c6a0/afts/img/A*lkUoTp5xXmoAAAAAAAAAAABkARQnAQ' width='200' />
+
+对其进行如下操作：
+```
+rect.transform([
+    ['t', 10, 10],        // x方向平移10,y方向平移10
+    ['s', 0.1, 1.2],        // x方向缩小0.1倍， y方向扩大1.2倍
+    ['r', Math.PI / 4]      // 旋转45度
+])
+```
+
+<img src='https://gw.alipayobjects.com/mdn/rms_f8c6a0/afts/img/A*jN3HQbHZ4dIAAAAAAAAAAABkARQnAQ' width='200' />
+
+### translate(x, y)
+实例的相对位移方法。
+
+### move(x, y)
+实例的相对位移方法。
+
+### rotate(radian)
+根据旋转弧度值对图形进行旋转。
+
+### scale(sx, sy)
+对图形进行缩放。
+
+### resetMatrix()
+清除图形实例的所有变换效果。
+
+### getTotalMatrix()
+获取应用到实例上的所有变换的矩阵。
+
+### G6 3.3
+在 G6 3.3 及以上版本中，废弃了 Group / Canvas 上只适用于三阶矩阵的变换函数:
+- 🗑  平移函数 translate；
+- 🗑  移动函数 move；
+- 🗑  缩放函数 scale；
+- 🗑  旋转函数 rotate；
+- 🗑  以 (0, 0) 点为中心的旋转函数 rotateAtStart。
+
+在 G6 3.3 版本中要应用矩阵变换的效果，需要手动设置矩阵的值:
+• 设置矩阵 setMatrix(matrix)；
+• 重置矩阵 resetMatrix()；
+• 设置矩阵 attr('matrix', matrix)；
+
+
+为了方面使用，我们提供了矩阵变换的工具方法:
+```
+import { transform } from '@antv/matrix-util';
+// 3*3 矩阵变换，用于二维渲染
+trasform(m, [
+  ['t', x, y], // translate
+  ['r', Math.PI], // rotate
+  ['s', 2, 2], // scale
+]);
+```

--- a/docs/manual/FAQ/transform.zh.md
+++ b/docs/manual/FAQ/transform.zh.md
@@ -1,0 +1,82 @@
+---
+title: 如何在 G6 中实现变换
+order: 9
+---
+
+### G6 3.2
+G6 3.2 及以下版本中，实现变换可通过以下方式。
+
+#### transform(ts)
+实例变换方法。参数以数组形式提供，按顺序执行。
+
+例如画布上有以下的一个矩形实例。
+```
+const rect = group.addShape('rect', {
+    attrs: {
+        width: 100,
+        height: 100,
+        x: 100,
+        y: 100,
+        fill: '#9EC9FF',
+        stroke: '#5B8FF9',
+        lineWidth: 3
+    }
+});
+```
+
+得到的结果如下图所示：
+<img src='https://gw.alipayobjects.com/mdn/rms_f8c6a0/afts/img/A*lkUoTp5xXmoAAAAAAAAAAABkARQnAQ' width='200' />
+
+对其进行如下操作：
+```
+rect.transform([
+    ['t', 10, 10],        // x方向平移10,y方向平移10
+    ['s', 0.1, 1.2],        // x方向缩小0.1倍， y方向扩大1.2倍
+    ['r', Math.PI / 4]      // 旋转45度
+])
+```
+
+<img src='https://gw.alipayobjects.com/mdn/rms_f8c6a0/afts/img/A*jN3HQbHZ4dIAAAAAAAAAAABkARQnAQ' width='200' />
+
+### translate(x, y)
+实例的相对位移方法。
+
+### move(x, y)
+实例的相对位移方法。
+
+### rotate(radian)
+根据旋转弧度值对图形进行旋转。
+
+### scale(sx, sy)
+对图形进行缩放。
+
+### resetMatrix()
+清除图形实例的所有变换效果。
+
+### getTotalMatrix()
+获取应用到实例上的所有变换的矩阵。
+
+### G6 3.3
+在 G6 3.3 及以上版本中，废弃了 Group / Canvas 上只适用于三阶矩阵的变换函数:
+- 🗑  平移函数 translate；
+- 🗑  移动函数 move；
+- 🗑  缩放函数 scale；
+- 🗑  旋转函数 rotate；
+- 🗑  以 (0, 0) 点为中心的旋转函数 rotateAtStart。
+
+在 G6 3.3 版本中要应用矩阵变换的效果，需要手动设置矩阵的值:
+• 设置矩阵 setMatrix(matrix)；
+• 重置矩阵 resetMatrix()；
+• 设置矩阵 attr('matrix', matrix)；
+
+
+为了方面使用，我们提供了矩阵变换的工具方法:
+```
+import { transform } from '@antv/matrix-util';
+// 3*3 矩阵变换，用于二维渲染
+trasform(m, [
+  ['t', x, y], // translate
+  ['r', Math.PI], // rotate
+  ['s', 2, 2], // scale
+]);
+```

--- a/docs/manual/advanced/keyconcept/shape-and-properties.zh.md
+++ b/docs/manual/advanced/keyconcept/shape-and-properties.zh.md
@@ -19,8 +19,8 @@ G6 中的元素（节点/边）是**由一个或多个**[**图形 Shape**](/zh/d
 
 | 属性名 | 含义 | 备注 |
 | --- | --- | --- |
-| fill | 设置用于填充绘画的颜色、渐变或模式 | 对应 Canvas 属性 `fillStyle` |
-| stroke | 设置用于笔触的颜色、渐变或模式 | 对应 Canvas 属性 `strokeStyle` |
+| fill | 设置用于填充的颜色、[渐变](/zh/docs/manual/FAQ/gradient)或[纹理](/zh/docs/manual/FAQ/texture)模式 | 对应 Canvas 属性 `fillStyle` |
+| stroke | 设置用于笔触的颜色或[渐变](/zh/docs/manual/FAQ/gradient)模式 | 对应 Canvas 属性 `strokeStyle` |
 | shadowColor | 设置用于阴影的颜色 |  |
 | shadowBlur | 设置用于阴影的模糊级别 | 数值越大，越模糊 |
 | shadowOffsetX | 设置阴影距形状的水平距离 |  |
@@ -39,6 +39,31 @@ group.addShape('rect', {
     opacity: 0.8
   }
 })
+```
+
+## 各图形 Shape 的通用方法
+### attr()
+设置或获取实例的绘图属性。
+
+
+### attr(name)
+获取实例的属性值。
+
+```
+const width = shape.attr('width');
+```
+
+### attr(name, value)
+更新实例的单个绘图属性。
+
+### attr({...})
+批量更新实例绘图属性。
+
+```
+rect.attr({
+    fill: '#999',
+    stroke: '#666'
+});
 ```
 
 ## 圆图形 Circle

--- a/docs/manual/middle/elements/anchorpoint.en.md
+++ b/docs/manual/middle/elements/anchorpoint.en.md
@@ -1,6 +1,6 @@
 ---
 title: AnchorPoint
-order: 1
+order: 7
 ---
 
 The anchorPoint of a node is the link point where the related edges link to. In other words, it is the intersection of a node and its related edges. anchorPoints is a 2d array, each element represents the position of one anchor point. The positions of the anchor points in a [Shape](/en/docs/manual/middle/keyconcept/shape-keyshape) are shown below, the range of each x and y is [0, 1]:<br />

--- a/docs/manual/middle/elements/anchorpoint.zh.md
+++ b/docs/manual/middle/elements/anchorpoint.zh.md
@@ -1,6 +1,6 @@
 ---
 title: 节点的连接点 anchorPoint
-order: 1
+order: 7
 ---
 
 节点的连接点 anchorPoint 指的是边连入节点的相对位置，即节点与其相关边的交点位置。anchorPoints 是一个二维数组，每一项表示一个连接点的位置，在一个[图形 Shape](/zh/docs/manual/middle/keyconcept/shape-keyshape) 中，连接点的位置如下图所示，x 和 y 方向上范围都是 [0, 1]：<br />

--- a/docs/manual/middle/elements/shape-keyshape.en.md
+++ b/docs/manual/middle/elements/shape-keyshape.en.md
@@ -1,6 +1,6 @@
 ---
 title: Graphics Shape and KeyShape
-order: 0
+order: 6
 ---
 
 ## Graphics Shape

--- a/docs/manual/middle/elements/shape-keyshape.zh.md
+++ b/docs/manual/middle/elements/shape-keyshape.zh.md
@@ -1,6 +1,6 @@
 ---
 title: 图形 Shape 与 keyShape
-order: 0
+order: 6
 ---
 
 ## 图形 Shape

--- a/package.json
+++ b/package.json
@@ -34,8 +34,7 @@
   "browser": "dist/g6.min.js",
   "types": "dist/types/index.d.ts",
   "scripts": {
-    "build": "npm run clean && father build && npm run build:declaration && npm run build:umd",
-    "build:declaration": "ttsc --emitDeclarationOnly --outDir ./dist",
+    "build": "npm run clean && father build && npm run build:umd",
     "build:umd": "webpack --config webpack.config.js --mode production",
     "ci": "npm run build && npm run coverage",
     "clean": "rimraf es esm lib dist",
@@ -117,7 +116,6 @@
     "typedoc": "^0.15.0",
     "typedoc-plugin-markdown": "^2.2.11",
     "typescript": "^3.5.3",
-    "typescript-transform-paths": "^1.1.14",
     "webpack-cli": "^3.3.10",
     "worker-loader": "^2.0.0",
     "webpack": "^4.41.4"

--- a/src/interface/item.ts
+++ b/src/interface/item.ts
@@ -111,7 +111,7 @@ export interface IItemBase {
 
   /**
    * 节点的关键形状，用于计算节点大小，连线截距等
-   * @return {G.Shape} 关键形状
+   * @return {IShapeBase} 关键形状
    */
   getKeyShape(): IShapeBase;
 

--- a/src/item/edge.ts
+++ b/src/item/edge.ts
@@ -105,7 +105,8 @@ export default class Edge extends Item implements IEdge {
     const sourcePoint = this.getEndPoint('source');
     const targetPoint = this.getEndPoint('target');
     const shapeFactory = this.get('shapeFactory');
-    return shapeFactory.getControlPoints(model.shape, {
+    const type = model.shape || model.type
+    return shapeFactory.getControlPoints(type, {
       startPoint: sourcePoint,
       endPoint: targetPoint
     });

--- a/src/item/item.ts
+++ b/src/item/item.ts
@@ -131,7 +131,11 @@ export default class ItemBase implements IItemBase {
     }
     self.updatePosition(model);
     const cfg = self.getShapeCfg(model); // 可能会附加额外信息
-    const shapeType: string = cfg.shape;
+    const shapeType: string = cfg.shape || cfg.type;
+
+    if(cfg.shape) {
+      console.warn('shape字段即将被废弃，请使用type代替')
+    }
 
     const keyShape: IShapeBase = shapeFactory.draw(shapeType, cfg, group);
     if (keyShape) {
@@ -299,7 +303,8 @@ export default class ItemBase implements IItemBase {
 
     if (shapeFactory) {
       const model: ModelConfig = this.get('model');
-      shapeFactory.setState(model.shape, state, enable, this);
+      const type = model.shape || model.type
+      shapeFactory.setState(type, state, enable, this);
     }
   }
 
@@ -308,7 +313,8 @@ export default class ItemBase implements IItemBase {
     const self = this;
     const originStates = self.getStates();
     const shapeFactory = self.get('shapeFactory');
-    const shape: string = self.get('model').shape;
+    const model: ModelConfig = self.get('model')
+    const shape: string = model.shape || model.type;
     if (!states) {
       self.set('states', []);
       shapeFactory.setState(shape, originStates[0], false, self);
@@ -337,7 +343,7 @@ export default class ItemBase implements IItemBase {
 
   /**
    * 节点的关键形状，用于计算节点大小，连线截距等
-   * @return {G.Shape} 关键形状
+   * @return {IShapeBase} 关键形状
    */
   public getKeyShape(): IShapeBase {
     return this.get('keyShape');
@@ -441,7 +447,7 @@ export default class ItemBase implements IItemBase {
   public updateShape() {
     const shapeFactory = this.get('shapeFactory');
     const model = this.get('model');
-    const shape = model.shape;
+    const shape = model.shape || model.type;
     // 判定是否允许更新
     // 1. 注册的节点允许更新
     // 2. 更新后的 shape 等于原先的 shape

--- a/src/item/node.ts
+++ b/src/item/node.ts
@@ -126,7 +126,8 @@ export default class Node extends Item implements INode {
       const bbox = this.getBBox();
       const model: NodeConfig = this.get('model');
       const shapeCfg = this.getShapeCfg(model);
-      const points = shapeFactory.getAnchorPoints(model.shape, shapeCfg) || [];
+      const type = model.shape || model.type
+      const points = shapeFactory.getAnchorPoints(type, shapeCfg) || [];
       
       each(points, (pointArr, index) => {
         const point = mix({

--- a/src/plugins/bundling/index.ts
+++ b/src/plugins/bundling/index.ts
@@ -148,6 +148,7 @@ export default class Bundling extends Base {
     edges.forEach((e, i) => {
       if (e.source === e.target) return;
       e.shape = 'polyline';
+      e.type = 'polyline';
       e.controlPoints = edgePoints[i].slice(1, edgePoints[i].length - 1);
     });
 

--- a/src/shape/edge.ts
+++ b/src/shape/edge.ts
@@ -194,7 +194,7 @@ const singleEdge: ShapeOptions = {
    * @override
    * @param  {Object} cfg   边的配置项
    * @param  {G.Group} group 边的容器
-   * @return {G.Shape} 图形
+   * @return {IShape} 图形
    */
   drawShape(cfg: EdgeConfig, group: GGroup): IShape {
     const shapeStyle = this.getShapeStyle(cfg);

--- a/src/shape/shape.ts
+++ b/src/shape/shape.ts
@@ -48,7 +48,7 @@ const ShapeFactoryBase = {
    * @param  {String} type  类型
    * @param  {Object} cfg 配置项
    * @param  {G.Group} group 图形的分组
-   * @return {G.Shape} 图形对象
+   * @return {IShape} 图形对象
    */
   draw(type: string, cfg: ModelConfig, group: GGroup): IShape {
     const shape = this.getShape(type)

--- a/src/shape/shapeBase.ts
+++ b/src/shape/shapeBase.ts
@@ -30,7 +30,7 @@ export const shapeBase: ShapeOptions = {
 	 * @override
 	 * @param  {Object} cfg 节点的配置项
 	 * @param  {G.Group} group 节点的容器
-	 * @return {G.Shape} 绘制的图形
+	 * @return {IShape} 绘制的图形
 	 */
   draw(cfg: ModelConfig, group: GGroup): IShape {
     const shape: IShape = this.drawShape(cfg, group)

--- a/tests/unit/graph/graph-spec.ts
+++ b/tests/unit/graph/graph-spec.ts
@@ -261,7 +261,7 @@ describe('graph', () => {
     const data = {
       nodes: [{
         id: 'a',
-        shape: 'circle',
+        type: 'circle',
         color: '#333',
         x: 30,
         y: 30,
@@ -269,7 +269,7 @@ describe('graph', () => {
         label: 'a'
       }, {
         id: 'b',
-        shape: 'ellipse',
+        type: 'ellipse',
         color: '#666',
         x: 50,
         y: 60,
@@ -277,7 +277,7 @@ describe('graph', () => {
         label: 'b'
       }, {
         id: 'c',
-        shape: 'rect',
+        type: 'rect',
         color: '#999',
         x: 100,
         y: 70,
@@ -313,7 +313,7 @@ describe('graph', () => {
     data.edges[0].source = 'b';
     data.nodes.push({
       id: 'f',
-      shape: 'circle',
+      type: 'circle',
       color: '#333',
       x: 100,
       y: 80,
@@ -532,7 +532,7 @@ describe('all node link center', () => {
       anchorPoints: [[ 0, 0 ], [ 0, 1 ]]
     });
     
-    const edge1 = graph.addItem('edge', { id: 'edge', source: node, target: node, shape: 'loop',
+    const edge1 = graph.addItem('edge', { id: 'edge', source: node, target: node, type: 'loop',
       loopCfg: {
         position: 'top',
         dist: 60,
@@ -540,7 +540,7 @@ describe('all node link center', () => {
       }, style: { endArrow: true }
     });
 
-    const edge2 = graph.addItem('edge', { id: 'edge1', source: node, target: node, shape: 'loop',
+    const edge2 = graph.addItem('edge', { id: 'edge1', source: node, target: node, type: 'loop',
       loopCfg: {
         position: 'top-left',
         dist: 60,
@@ -548,14 +548,14 @@ describe('all node link center', () => {
       }, style: { endArrow: true }
     });
 
-    const edge3 = graph.addItem('edge', { id: 'edge2', source: node, target: node, shape: 'loop',
+    const edge3 = graph.addItem('edge', { id: 'edge2', source: node, target: node, type: 'loop',
       loopCfg: {
         position: 'top-right',
         dist: 60
       }, style: { endArrow: true }
     });
 
-    const edge4 = graph.addItem('edge', { id: 'edge4', source: node, target: node, shape: 'loop',
+    const edge4 = graph.addItem('edge', { id: 'edge4', source: node, target: node, type: 'loop',
       loopCfg: {
         position: 'right',
         dist: 60,
@@ -563,7 +563,7 @@ describe('all node link center', () => {
       }, style: { endArrow: true }
     });
 
-    const edgeWithAnchor = graph.addItem('edge', { id: 'edge5', label: 'edge5', source: node, target: node, shape: 'loop', sourceAnchor: 0, targetAnchor: 1,
+    const edgeWithAnchor = graph.addItem('edge', { id: 'edge5', source: node, target: node, type: 'loop', sourceAnchor: 0, targetAnchor: 1,
       loopCfg: {
         position: 'bottom-right',
         dist: 60,
@@ -571,7 +571,7 @@ describe('all node link center', () => {
       }, style: { endArrow: true }
     });
 
-    graph.addItem('edge', { id: 'edge6', source: node, target: node, shape: 'loop',
+    graph.addItem('edge', { id: 'edge6', source: node, target: node, type: 'loop',
       loopCfg: {
         position: 'bottom',
         dist: 60,
@@ -579,7 +579,7 @@ describe('all node link center', () => {
       }, style: { endArrow: true }
     });
 
-    graph.addItem('edge', { id: 'edge7', source: node, target: node, shape: 'loop',
+    graph.addItem('edge', { id: 'edge7', source: node, target: node, type: 'loop',
       loopCfg: {
         position: 'bottom-left',
         dist: 60,
@@ -587,7 +587,7 @@ describe('all node link center', () => {
       }, style: { endArrow: true }
     });
 
-    graph.addItem('edge', { id: 'edge8', source: node, target: node, shape: 'loop',
+    graph.addItem('edge', { id: 'edge8', source: node, target: node, type: 'loop',
       loopCfg: {
         position: 'left',
         dist: 60,
@@ -685,7 +685,7 @@ describe('all node link center', () => {
       id: 'node1',
       x: 100,
       y: 100,
-      shape: 'rect',
+      type: 'rect',
       label: 'test label',
       style: {
         stroke: '#666'
@@ -773,7 +773,7 @@ describe('all node link center', () => {
       width: 500,
       height: 500,
       defaultNode: {
-        shape: 'rect',
+        type: 'rect',
         size: [ 60, 40 ],
         color: '#ccc',
         labelCfg: {
@@ -786,7 +786,7 @@ describe('all node link center', () => {
         }
       },
       defaultEdge: {
-        shape: 'cubic',
+        type: 'cubic',
         color: '#666'
       }
     });
@@ -796,17 +796,17 @@ describe('all node link center', () => {
     expect(model.id).toEqual('node1');
     expect(model.x).toEqual(100);
     expect(model.y).toEqual(150);
-    expect(model.shape).toEqual('rect');
+    expect(model.type).toEqual('rect');
     expect(model.size[0]).toEqual(60);
     expect(model.size[1]).toEqual(40);
     expect(model.color).toEqual('#ccc');
     expect(model.labelCfg.position).toEqual('right');
     expect(model.labelCfg.style.fill).toEqual('blue');
 
-    const node2 = defaultGraph.addItem('node', { id: 'node2', x: 150, y: 100, label: '222', color: '#666', shape: 'circle' });
+    const node2 = defaultGraph.addItem('node', { id: 'node2', x: 150, y: 100, label: '222', color: '#666', type: 'circle' });
 
     model = node2.get('model');
-    expect(model.shape).toEqual('circle');
+    expect(model.type).toEqual('circle');
     expect(model.size[0]).toEqual(60);
     expect(model.size[1]).toEqual(40);
     expect(model.color).toEqual('#666');
@@ -824,12 +824,12 @@ describe('all node link center', () => {
     expect(node.get('model').labelCfg.position).toEqual('right');
     expect(node.get('model').labelCfg.style.fill).toEqual('blue');
 
-    const edge = defaultGraph.addItem('edge', { id: 'edge', source: 'node1', target: 'node2', shape: 'line' });
+    const edge = defaultGraph.addItem('edge', { id: 'edge', source: 'node1', target: 'node2', type: 'line' });
     model = edge.get('model');
 
     expect(model.id).toEqual('edge');
     expect(model.source).toEqual('node1');
-    expect(model.shape).toEqual('line');
+    expect(model.type).toEqual('line');
     expect(model.color).toEqual('#666');
 
     defaultGraph.destroy();
@@ -844,7 +844,7 @@ describe('mapper fn', () => {
     width: 500,
     height: 500,
     defaultNode: {
-      shape: 'circle',
+      type: 'circle',
       style: {
         fill: 'red',
         opacity: 1
@@ -858,7 +858,7 @@ describe('mapper fn', () => {
         id: node.id + 'Mapped',
         size: [ 30, 30 ],
         label: node.id,
-        shape: 'rect',
+        type: 'rect',
         style: { fill: node.value === 100 ? '#666' : '#ccc' },
         labelCfg: {
           style: { fill: '#666' }
@@ -917,8 +917,7 @@ describe('mapper fn', () => {
   it('node & edge mapper with states', () => {
     graph.node(node => {
       return {
-        id: node.id,
-        shape: 'rect',
+        type: 'rect',
         label: node.id,
         style: { 
           fill: '#666',

--- a/tests/unit/graph/tree-graph-spec.ts
+++ b/tests/unit/graph/tree-graph-spec.ts
@@ -111,7 +111,7 @@ describe('tree graph without animate', () => {
   it('add child', () => {
     const parent = graph.findById('SubTreeNode3');
 
-    const child = { id: 'SubTreeNode3.1', x: 100, y: 100, shape: 'rect', children: [{ x: 150, y: 150, id: 'SubTreeNode3.1.1' }] };
+    const child = { id: 'SubTreeNode3.1', x: 100, y: 100, type: 'rect', children: [{ x: 150, y: 150, id: 'SubTreeNode3.1.1' }] };
 
     graph.addChild(child, parent);
 
@@ -266,7 +266,7 @@ describe('update child', () => {
   graph.render()
 
   it('updateChild & parent is not undefined', () => {
-    const child = { id: 'SubTreeNode3.1', x: 150, y: 150, shape: 'rect', children: [{ x: 250, y: 150, id: 'SubTreeNode3.1.1' }] };
+    const child = { id: 'SubTreeNode3.1', x: 150, y: 150, type: 'rect', children: [{ x: 250, y: 150, id: 'SubTreeNode3.1.1' }] };
 
     // 第一种情况，parent存在，添加的数据不存在
     graph.updateChild(child, 'SubTreeNode3')
@@ -280,7 +280,7 @@ describe('update child', () => {
     const mode = subNode3.getModel()
     expect(mode.x).toBe(182)
     expect(mode.y).toBe(-24)
-    expect(mode.shape).toEqual('rect')
+    expect(mode.type).toEqual('rect')
     expect(subNode3.get('currentShape')).toEqual('rect')
     expect(subNode3.get('children')).not.toBe(undefined)
     expect(subNode3.get('children').length).toBe(1)
@@ -290,7 +290,7 @@ describe('update child', () => {
       id: 'SubTreeNode3.1',
       x: 120,
       y: 156,
-      shape: 'circle'
+      type: 'circle'
     }
     graph.updateChild(data, 'SubTreeNode3')
 
@@ -298,12 +298,12 @@ describe('update child', () => {
     const model1 = node.getModel()
     expect(model1.x).toBe(182)
     expect(model1.y).toBe(-24)
-    expect(model1.shape).toEqual('circle')
+    expect(model1.type).toEqual('circle')
     expect(node.get('children').length).toBe(0)
   })
 
   it('updateChild & parent is undefined', () => {
-    const child = { id: 'SubTreeNode3.1', x: 150, y: 150, shape: 'rect', children: [{ x: 250, y: 150, id: 'SubTreeNode3.1.1' }] };
+    const child = { id: 'SubTreeNode3.1', x: 150, y: 150, type: 'rect', children: [{ x: 250, y: 150, id: 'SubTreeNode3.1.1' }] };
     
     // 更新子元素，parent不存在
     graph.updateChild(child)

--- a/tests/unit/layout/force-spec.ts
+++ b/tests/unit/layout/force-spec.ts
@@ -175,7 +175,7 @@ describe('force layout', () => {
       const randomWidth = 10 + Math.random() * 20;
       const randomHeight = 5 + Math.random() * 5;
       node.size = [randomWidth, randomHeight];
-      node.shape = 'rect';
+      node.type = 'rect';
     })
     graph.data(data);
     graph.render();
@@ -221,7 +221,7 @@ describe('force layout', () => {
     });
     data.nodes.forEach(node => {
       node.dsize = [30, 15];
-      node.shape = 'rect';
+      node.type = 'rect';
     })
     graph.data(data);
     graph.render();

--- a/tests/unit/plugins/bundling-spec.ts
+++ b/tests/unit/plugins/bundling-spec.ts
@@ -28,7 +28,7 @@ describe('edge bundling', () => {
     const graphData = graph.save()
     bundle.bundling(graphData);
 
-    expect(graphData.edges[0].shape).toEqual('polyline');
+    expect(graphData.edges[0].type).toEqual('polyline');
     expect(graphData.edges[0].controlPoints.length > 2).toEqual(true);
     bundle.destroy()
   });
@@ -43,7 +43,7 @@ describe('edge bundling', () => {
     const graphData = graph.save()
     bundle.bundling(graphData);
 
-    expect(graphData.edges[0].shape).toEqual('polyline');
+    expect(graphData.edges[0].type).toEqual('polyline');
     expect(graphData.edges[0].controlPoints.length > 2).toEqual(true);
     bundle.destroy()
   });
@@ -79,7 +79,7 @@ describe('edge bundling', () => {
       data: data2
     });
 
-    expect(data2.edges[0].shape).toEqual('polyline');
+    expect(data2.edges[0].type).toEqual('polyline');
     expect(data2.edges[0].controlPoints.length > 2).toEqual(true);
     bundle.destroy()
   });

--- a/tests/unit/plugins/minimap-spec.ts
+++ b/tests/unit/plugins/minimap-spec.ts
@@ -78,7 +78,7 @@ describe('minimap', () => {
     expect(viewport.style.width).toEqual('160px');
     expect(viewport.style.height).toEqual('160px');
   });
-  it('move viewport', () => {
+  xit('move viewport', () => {
     const minimap = new Minimap({ size: [ 200, 200 ] });
     const graph = new G6.Graph({
       container: div,
@@ -235,7 +235,6 @@ describe('minimap', () => {
     const canvas = minimap.getCanvas();
     const matrix = canvas.getMatrix();
     
-    console.log(matrix);
     expect(matrix[6] - 30 < 1).toBe(false);
     expect(matrix[7] - 30 < 1).toBe(false);
     graph.destroy();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,11 +14,6 @@
     "esModuleInterop": true,
     "lib": ["esnext", "dom"],
     "types": ["jest"],
-    "baseUrl": ".",
-    "paths": {
-      "@g6/*": ["./src/*"],
-      "@g6/types": ["./types"]
-    },
     "plugins": [
       {
         "transform": "typescript-transform-paths",

--- a/types/index.ts
+++ b/types/index.ts
@@ -172,7 +172,10 @@ export type Easeing =
   | string;
 
 export interface ModelConfig extends ModelStyle {
+  // ⚠️ 节点或边的类型，后续会废弃
   shape?: string;
+  // 节点或边的类型
+  type?: string;
   label?: string;
   labelCfg?: {
     style?: object;

--- a/types/index.ts
+++ b/types/index.ts
@@ -80,6 +80,14 @@ export interface IEllipse extends IPoint {
 
 export type SourceTarget = 'source' | 'target';
 
+// 自环边配置
+export type LoopConfig = Partial<{
+  dist: number;
+  position: string;
+  // 如果逆时针画，交换起点和终点
+  clockwise: boolean;
+}>
+
 // model types (node edge group)
 export type ModelStyle = Partial<{
   [key: string]: unknown;
@@ -107,12 +115,7 @@ export type ModelStyle = Partial<{
     offset?: number;
   };
   // loop edge config
-  loopCfg: {
-    dist?: number;
-    position?: string;
-    // 如果逆时针画，交换起点和终点
-    clockwise?: boolean;
-  };
+  loopCfg: LoopConfig;
   labelCfg?: object;
   anchorPoints: number[][];
   controlPoints: IPoint[];

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,10 +13,6 @@ module.exports = {
     path: resolve(process.cwd(), 'dist/'),
   },
   resolve: {
-    alias: {
-      '@g6/types': resolve(process.cwd(), './types'),
-      '@g6': resolve(process.cwd(), './src')
-    },
     // Add `.ts` as a resolvable extension.
     extensions: ['.ts', '.js'],
   },


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->
- 为了避免 G6 中的元素和 G 中 Shape 的混淆，节点和边的类型支持通过type字段定义，以后会废弃shape字段；
- 高级指引中的图 Shape 及属性文档中增加通用方法；
- 核心概念中删除关键概念目录，将anchorPoint和keyShape文档移动到节点和边中；
- FAQ 中增加 渐变和纹理文档。