### PR TITLE
修复 strict: true 下 TS 错误：src/item

### DIFF
--- a/src/interface/item.ts
+++ b/src/interface/item.ts
@@ -1,7 +1,7 @@
 import { IGroup } from '@antv/g-base/lib/interfaces';
 import { Point } from '@antv/g-base/lib/types';
 import Group from "@antv/g-canvas/lib/group";
-import { IBBox, IPoint, IShapeBase, Item, ModelConfig, ModelStyle, ShapeStyle } from '../types';
+import { IBBox, IPoint, IShapeBase, Item, ModelConfig, ModelStyle, ShapeStyle, Indexable } from '../types';
 
 
 // item 的配置项
@@ -63,10 +63,10 @@ export type IItemBaseConfig = Partial<{
   target: string | Item;
 
   linkCenter: boolean;
-}>
+}> & Indexable
 
 export interface IItemBase {
-  _cfg: IItemBaseConfig;
+  _cfg: IItemBaseConfig | null;
 
   destroyed: boolean;
 

--- a/src/interface/item.ts
+++ b/src/interface/item.ts
@@ -63,7 +63,7 @@ export type IItemBaseConfig = Partial<{
   target: string | Item;
 
   linkCenter: boolean;
-}> & Indexable
+}> & Indexable<any>
 
 export interface IItemBase {
   _cfg: IItemBaseConfig | null;

--- a/src/item/edge.ts
+++ b/src/item/edge.ts
@@ -5,7 +5,7 @@ import { EdgeConfig, IPoint, NodeConfig, SourceTarget } from '../types';
 import Item from './item';
 import Node from './node'
 
-const END_MAP = { source: 'start', target: 'end' };
+const END_MAP: { [key:string]: string } = { source: 'start', target: 'end' };
 const ITEM_NAME_SUFFIX = 'Node'; // 端点的后缀，如 sourceNode, targetNode
 const POINT_NAME_SUFFIX = 'Point'; // 起点或者结束点的后缀，如 startPoint, endPoint
 const ANCHOR_NAME_SUFFIX = 'Anchor';
@@ -101,7 +101,7 @@ export default class Edge extends Item implements IEdge {
    * 通过端点的中心获取控制点
    * @param model 
    */
-  private getControlPointsByCenter(model) {
+  private getControlPointsByCenter(model: EdgeConfig) {
     const sourcePoint = this.getEndPoint('source');
     const targetPoint = this.getEndPoint('target');
     const shapeFactory = this.get('shapeFactory');

--- a/src/item/edge.ts
+++ b/src/item/edge.ts
@@ -1,11 +1,11 @@
 import isNil from '@antv/util/lib/is-nil';
 import isPlainObject from '@antv/util/lib/is-plain-object'
 import { IEdge, INode } from "../interface/item";
-import { EdgeConfig, IPoint, NodeConfig, SourceTarget } from '../types';
+import { EdgeConfig, IPoint, NodeConfig, SourceTarget, Indexable } from '../types';
 import Item from './item';
 import Node from './node'
 
-const END_MAP: { [key:string]: string } = { source: 'start', target: 'end' };
+const END_MAP: Indexable<string> = { source: 'start', target: 'end' };
 const ITEM_NAME_SUFFIX = 'Node'; // 端点的后缀，如 sourceNode, targetNode
 const POINT_NAME_SUFFIX = 'Point'; // 起点或者结束点的后缀，如 startPoint, endPoint
 const ANCHOR_NAME_SUFFIX = 'Anchor';

--- a/src/item/item.ts
+++ b/src/item/item.ts
@@ -16,7 +16,7 @@ const RESERVED_STYLES = [ 'fillStyle', 'strokeStyle',
   'path', 'points', 'img', 'symbol' ];
   
 export default class ItemBase implements IItemBase {
-  public _cfg: IItemBaseConfig | null = {}
+  public _cfg: IItemBaseConfig
   private defaultCfg: IItemBaseConfig = {
     /**
      * id
@@ -81,7 +81,7 @@ export default class ItemBase implements IItemBase {
   constructor(cfg: IItemBaseConfig) {
     this._cfg = Object.assign(this.defaultCfg, this.getDefaultCfg(), cfg)
     const group = cfg.group
-    group!.set('item', this)
+    if (group) group.set('item', this)
 
     let id = this.get('model').id
 
@@ -90,7 +90,7 @@ export default class ItemBase implements IItemBase {
     }
 
     this.set('id', id)
-    group!.set('id', id)
+    if (group) group.set('id', id)
 
     const stateStyles = this.get('model').stateStyles;
     this.set('stateStyles', stateStyles);
@@ -169,7 +169,7 @@ export default class ItemBase implements IItemBase {
    * @return {object | string | number} 属性值
    */
   public get(key: string) {
-    return this._cfg![key]
+    return this._cfg[key]
   }
 
   /**
@@ -182,7 +182,7 @@ export default class ItemBase implements IItemBase {
     if(isPlainObject(key)) {
       this._cfg = Object.assign({}, this._cfg, key)
     } else {
-      this._cfg![key] = val
+      this._cfg[key] = val
     }
   }
 
@@ -567,7 +567,7 @@ export default class ItemBase implements IItemBase {
         group.stopAnimate();
       }
       group.remove();
-      this._cfg = null;
+      (this._cfg as IItemBaseConfig | null) = null;
       this.destroyed = true;
     }
   }

--- a/src/item/item.ts
+++ b/src/item/item.ts
@@ -231,7 +231,7 @@ export default class ItemBase implements IItemBase {
   public getKeyShapeStyle(): ShapeStyle {
     const keyShape = this.getKeyShape();
     if (keyShape) {
-      const styles: ShapeStyle & Indexable = {};
+      const styles: ShapeStyle & Indexable<any> = {};
       each(keyShape.attr(), (val, key) => {
         if (RESERVED_STYLES.indexOf(key) < 0) {
           styles[key] = val;

--- a/src/item/node.ts
+++ b/src/item/node.ts
@@ -65,7 +65,7 @@ export default class Node extends Item implements INode {
    * 根据锚点的索引获取连接点
    * @param  {Number} index 索引
    */
-  public getLinkPointByAnchor(index): IPoint {
+  public getLinkPointByAnchor(index: number): IPoint {
     const anchorPoints = this.getAnchorPoints();
     return anchorPoints[index];
   }
@@ -80,19 +80,19 @@ export default class Node extends Item implements INode {
     const bbox = this.getBBox();
     const { centerX, centerY } = bbox;
     const anchorPoints = this.getAnchorPoints();
-    let intersectPoint: IPoint;
+    let intersectPoint: IPoint | null;
     switch (type) {
       case 'circle':
         intersectPoint = getCircleIntersectByPoint({
-          x: centerX,
-          y: centerY,
+          x: centerX!,
+          y: centerY!,
           r: bbox.width / 2
         }, point);
         break;
       case 'ellipse':
         intersectPoint = getEllispeIntersectByPoint({
-          x: centerX,
-          y: centerY,
+          x: centerX!,
+          y: centerY!,
           rx: bbox.width / 2,
           ry: bbox.height / 2
         }, point);
@@ -109,7 +109,7 @@ export default class Node extends Item implements INode {
       linkPoint = this.getNearestPoint(anchorPoints, linkPoint);
     }
     if (!linkPoint) { // 如果最终依然没法找到锚点和连接点，直接返回中心点
-      linkPoint = { x: centerX, y: centerY };
+      linkPoint = { x: centerX, y: centerY } as IPoint;
     }
     return linkPoint;
   }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -367,4 +367,4 @@ export interface ViewPortEventParam {
   matrix: Matrix;
 }
 
-export interface Indexable { [key:string]: any}
+export interface Indexable<T> { [key:string]: T}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -366,3 +366,5 @@ export interface ViewPortEventParam {
   action: string;
   matrix: Matrix;
 }
+
+export interface Indexable { [key:string]: any}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->

针对 src/item 下 TS strict 模式下的错误进行了修复。

在修改这个 PR 的问题时，需要在 tsconfig 中加上 `"strict": true`。在修改时才能看到报错。

strict 模式下主要的几类问题：

+ implict any，就是函数入参或者变量声明没有指明类型，这个时候默认是 any，严格模式下要求必须声明类型
+ strictNullCheck，有可能为 null 或者 undefined 的值，调这个值的方法，就会报错。简单的说就是 null 和 undefined 会是单独的类型，和其他值区分开来。所以这要求我们在代码里需要做一些判断，或者给默认值，这样可以很大程度避免 JS 动态特性带来的空值报错问题。

如果不能理解改动的原因，可以在 master 分支上打开 `"strict": true` 看一下具体的报错。