### PR TITLE
fix: compatibility for G6 3.3

### DIFF
--- a/docs/manual/FAQ/upgradeGuide.en.md
+++ b/docs/manual/FAQ/upgradeGuide.en.md
@@ -20,7 +20,30 @@ The built outcomes of esm and commonjs do not support layouts with Web-Worker.
 
 ## The Usage of Plugins
 You don't need to import other packages when you are using the built-in plugins of G6. Only use them by `G6.PluginName` after import G6. e.g.
+
 ```javascript
+// <= G6 3.2
+// Import by CDN. you need import G6 and the plugins you need.
+<script src="https://gw.alipayobjects.com/os/antv/assets/lib/jquery-3.2.1.min.js"></script>
+<script src="https://gw.alipayobjects.com/os/antv/pkg/_antv.g6-3.1.0/build/minimap.js"></script>
+<script src="https://gw.alipayobjects.com/os/antv/pkg/_antv.g6-3.1.0/build/grid.js"></script>
+// Or import by NPM.  you need import G6 and the plugins you need.
+import G6, { Minimap, Grid } from '@antv/G6'
+
+const minimap = new Minimap({
+	//... configurations
+})
+const grid = new Grid({
+	//... configurations
+})
+
+
+// G6 3.3
+// Import by CDN. Yuo only need to import G6.
+<script src="https://gw.alipayobjects.com/os/antv/pkg/_antv.g6-3.3.0/dist/g6.min.js"></script>
+// Or import by NPM. Yuo only need to import G6.
+import G6 from '@antv/G6'
+
 const minimap = new G6.Minimap({
 	//... configurations
 })

--- a/docs/manual/FAQ/upgradeGuide.en.md
+++ b/docs/manual/FAQ/upgradeGuide.en.md
@@ -241,6 +241,49 @@ G6.registerEdge('customNode', {
 ```
 
 
+
+
+
+#### marker
+In G6 3.2 and previous versions, the radius of the marker was assigned by `r` or `radius`.
+
+In G6 3.3, the radius of marker can be assigned by `r` only.
+
+e.g.
+```javascript
+// <= G6 3.2.x
+G6.registerEdge('customNode', {
+  draw(cfg, group) {
+    const marker = group.addShape('marker', {
+    	attrs: {
+        // ... Other attributes
+        radius: cfg.size[0]
+      },
+      draggable: true,
+      name: 'marker-shape'
+    });
+    return keyShape;
+  }
+});
+
+
+// <= G6 3.3
+G6.registerEdge('customNode', {
+  draw(cfg, group) {
+    const marker = group.addShape('marker', {
+    	attrs: {
+        // ... Other attributes
+        r: cfg.size[0]
+      },
+      draggable: true,
+      name: 'marker-shape'
+    });
+    return keyShape;
+  }
+});
+```
+
+
 ## pixelRatio
 In G6 3.2 and previous versions, you need to assign the `pixelRatio` when instantiating the Graph.
 
@@ -270,3 +313,9 @@ There three properties in the callback function of `nodeselectchange` for `click
 - `target`: The manipulated node currently. It might be selected or deselected
 - `selectedItems`: The selected nodes and edges currently as `{nodes: [...], edges: [...]}`
 - `select`: Whether the option is select or deselect currently. `true` | `false`
+
+## SVG Renderer
+In G6 3.2 and previous versions, you can assign the renderer with options options `'canvas'` and `'svg'` for graph when instantiating the Graph.
+
+In G6 3.3, to make a better version with canvas, we do not support SVG
+ renderer temporary. But we will support it in the future.

--- a/docs/manual/FAQ/upgradeGuide.zh.md
+++ b/docs/manual/FAQ/upgradeGuide.zh.md
@@ -233,6 +233,45 @@ G6.registerEdge('customNode', {
 });
 ```
 
+#### marker 图形
+G6 3.2 及之前版本中，marker 图形的半径是通过 `r` 或 `radius` 指定。
+
+G6 3.3 中，marker 的图形半径只能通过 `r` 指定。
+
+例如：
+```javascript
+// <= G6 3.2.x
+G6.registerEdge('customNode', {
+  draw(cfg, group) {
+    const marker = group.addShape('marker', {
+    	attrs: {
+        // ... 其他图形属性
+        radius: cfg.size[0]
+      },
+      draggable: true,
+      name: 'marker-shape'
+    });
+    return keyShape;
+  }
+});
+
+
+// <= G6 3.3
+G6.registerEdge('customNode', {
+  draw(cfg, group) {
+    const marker = group.addShape('marker', {
+    	attrs: {
+        // ... 其他图形属性
+        r: cfg.size[0]
+      },
+      draggable: true,
+      name: 'marker-shape'
+    });
+    return keyShape;
+  }
+});
+```
+
 
 ## pixelRatio
 在 G6 3.2 及之前的版本中，需要用户根据当前分辨率在实例化图时指定 `pixelRatio`。
@@ -262,3 +301,7 @@ G6 3.3 统一了这两个 behavior 的 `nodeselectchange` 事件。使用 `sele
 - `selectedItems`：当前被选中的所有节点与边。`{nodes: [...], edges: [...]}`
 - `select`：当前操作是选中还是取消。`true` | `false`
 
+## SVG 渲染
+在 G6 3.2 及之前的版本中，可以在实例化图时为图指定渲染器，`renderer` 可选为 `'canvas'` 或 `'svg'`。
+
+在 G6 3.3 中，我们致力于更好的 Canvas 版本，暂时不支持 SVG 方式渲染。`renderer` 参数不再起效。SVG 渲染在以后的版本中提供支持。

--- a/docs/manual/FAQ/upgradeGuide.zh.md
+++ b/docs/manual/FAQ/upgradeGuide.zh.md
@@ -21,6 +21,28 @@ esm 及 commonjs 构建产物不支持 webworker 布局。
 ## 插件 Plugins
 使用 G6 内置插件时不再需要引入其他包，引入 G6 后直接通过 `G6.PluginName` 的方式获得。例如：
 ```javascript
+// <= G6 3.2
+// CDN 引入 G6 以及需要使用的插件
+<script src="https://gw.alipayobjects.com/os/antv/assets/lib/jquery-3.2.1.min.js"></script>
+<script src="https://gw.alipayobjects.com/os/antv/pkg/_antv.g6-3.1.0/build/minimap.js"></script>
+<script src="https://gw.alipayobjects.com/os/antv/pkg/_antv.g6-3.1.0/build/grid.js"></script>
+// 或 NPM 引入，需要引入 G6 及需要使用的插件
+import G6, { Minimap, Grid } from '@antv/G6'
+
+const minimap = new Minimap({
+	//... configurations
+})
+const grid = new Grid({
+	//... configurations
+})
+
+
+// G6 3.3
+// CDN 引入，只需要引入 G6
+<script src="https://gw.alipayobjects.com/os/antv/pkg/_antv.g6-3.3.0/dist/g6.min.js"></script>
+// 或 NPM 引入，只需要引入 G6
+import G6 from '@antv/G6'
+
 const minimap = new G6.Minimap({
 	//... configurations
 })

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "site:deploy": "npm run site:build && gh-pages -d public",
     "start": "npm run site:develop",
     "test": "jest",
-    "test-live": "DEBUG_MODE=1 jest --watch  ./tests/unit/plugins/minimap-spec.ts",
+    "test-live": "DEBUG_MODE=1 jest --watch  ./tests/unit/shape/findByClassName-spec.ts",
     "lint-staged:js": "eslint --ext .js,.jsx,.ts,.tsx",
     "watch": "father build -w",
     "cdn": "antv-bin upload -n @antv/g6"

--- a/src/behavior/collapse-expand.ts
+++ b/src/behavior/collapse-expand.ts
@@ -16,7 +16,7 @@ export default {
     let trigger: string;
     // 检测输入是否合法
     if (ALLOW_EVENTS.includes(this.trigger)) {
-      ({ trigger } = this.trigger);
+      ({ trigger } = this);
     } else {
       trigger = DEFAULT_TRIGGER;
       console.warn('Behavior collapse-expand 的 trigger 参数不合法，请输入 \'click\' 或 \'dblclick\'');

--- a/src/graph/tree-graph.ts
+++ b/src/graph/tree-graph.ts
@@ -226,6 +226,17 @@ export default class TreeGraph  extends Graph implements ITreeGraph {
   }
 
   /**
+   * 已更名为 updateLayout，为保持兼容暂且保留。
+   * 更改并应用树布局算法
+   * @param {object} layout 布局算法
+   */
+  public changeLayout(layout: any) {
+    console.warn('Please call updateLayout instead of changeLayout. changeLayout will be discarded soon');
+    const self = this;
+    self.updateLayout(layout);
+  }
+
+  /**
    * 更改并应用树布局算法
    * @param {object} layout 布局算法
    */
@@ -238,6 +249,17 @@ export default class TreeGraph  extends Graph implements ITreeGraph {
     self.set('layout', layout);
     self.set('layoutMethod', self.getLayout());
     self.layout();
+  }
+
+  /**
+   * 已更名为 layout，为保持兼容暂且保留。
+   * 根据目前的 data 刷新布局，更新到画布上。用于变更数据之后刷新视图。
+   * @param {boolean} fitView 更新布局时是否需要适应窗口
+   */
+  public refreshLayout(fitView?: boolean) {
+    console.warn('Please call layout instead of refreshLayout. refreshLayout will be discarded soon');
+    const self = this;
+    self.layout(fitView);
   }
 
   /**

--- a/src/shape/shape.ts
+++ b/src/shape/shape.ts
@@ -13,6 +13,7 @@ import augment from '@antv/util/lib/augment'
 
 augment(GGroup, {
   findByClassName(className) {
+    console.warn('findByClassName will be discarded soon. Please use group.find(element => element.get(\'className\')===\'some-classname\') instead.');
     return this.find((shape: IShape) => shape.get('className') === className)
   }
 })

--- a/src/shape/shape.ts
+++ b/src/shape/shape.ts
@@ -9,6 +9,14 @@ import { upperFirst } from '@antv/util'
 import { ShapeOptions } from '../interface/shape'
 import { IPoint, Item, ModelConfig, NodeConfig, EdgeConfig } from '../types';
 
+import augment from '@antv/util/lib/augment'
+
+augment(GGroup, {
+  findByClassName(className) {
+    return this.find((shape: IShape) => shape.get('className') === className)
+  }
+})
+
 const cache: {
   [key: string]: string;
 } = {} // ucfirst 开销过大，进行缓存
@@ -124,7 +132,13 @@ const ShapeFramework = {
   /**
    * 绘制
    */
-  draw(/* cfg, group */) {
+  draw(cfg, group) {
+    return this.drawShape(cfg, group);
+  },
+  /**
+   * 绘制
+   */
+  drawShape(/* cfg, group */) {
 
   },
   /**
@@ -192,7 +206,9 @@ export default class Shape {
 
   public static registerNode(shapeType: string, nodeDefinition: ShapeOptions, extendShapeType?: string) {
     const shapeFactory = Shape.Node;
+    // extendShapeType = extendShapeType ? extendShapeType : 'single-node';
     const extendShape = extendShapeType ? shapeFactory.getShape(extendShapeType) : ShapeFramework;
+    // const extendShape = shapeFactory.getShape(extendShapeType);
 
     const shapeObj = Object.assign({}, extendShape, nodeDefinition)
     shapeObj.type = shapeType

--- a/tests/unit/graph/tree-graph-spec.ts
+++ b/tests/unit/graph/tree-graph-spec.ts
@@ -1,5 +1,6 @@
 import G6 from '../../../src';
 import { timerOut } from '../util/timeOut'
+import TreeGraph from '../../../src/graph/tree-graph';
 
 const div = document.createElement('div');
 div.id = 'tree-spec';

--- a/tests/unit/shape/findByClassName-spec.ts
+++ b/tests/unit/shape/findByClassName-spec.ts
@@ -1,0 +1,74 @@
+/**
+ * @fileOverview Shape 工厂方法的测试
+ * @author dxq613@gmai.com
+ */
+
+import G6 from '../../../src';
+
+const div = document.createElement('div');
+div.id = 'graph-spec';
+document.body.appendChild(div);
+
+describe('register node', () => {
+  const data = {
+    nodes: [
+      {
+        id: 'node1',
+        x: 50,
+        y: 50
+      },
+      {
+        id: 'node2' ,
+        x: 250,
+        y: 50
+      },
+    ],
+    edges: [{
+      source: 'node1',
+      target: 'node2'
+    }]
+  }
+  it('shape test wihout extended shape and draw function', () => {
+    G6.registerNode('custom-node', {
+      drawShape(cfg, group) {
+        const keyShape = group.addShape('circle', {
+        attrs: {
+            x: 0,
+            y: 0,
+            r: 30,
+            fill: '#87e8de'
+        }
+        });
+        const circle = group.addShape('circle', {
+        attrs: {
+            x: 0,
+            y: 0,
+            r: 10,
+            fill: '#ff0000'
+        },
+        className: 'test-circle'
+        });
+
+        return keyShape;
+      },
+      afterDraw(cfg, group) {
+        const foundShape = group.findByClassName('test-circle');
+        expect(foundShape.attr('r')).toBe(10);
+        expect(foundShape.attr('fill')).toBe('#ff0000');
+      }
+    }, 'single-node');
+    const graph = new G6.Graph({
+      container: div,
+      width: 500,
+      height: 500,
+      defaultNode: {
+        type: 'custom-node'
+      }
+    });
+    graph.data(data);
+    graph.render();
+    expect(graph.getNodes()[0].getModel().x).not.toBe(undefined);
+    expect(graph.getNodes()[0].getModel().y).not.toBe(undefined);
+    graph.destroy();
+  });
+});

--- a/tests/unit/shape/register-spec.ts
+++ b/tests/unit/shape/register-spec.ts
@@ -1,0 +1,122 @@
+/**
+ * @fileOverview Shape 工厂方法的测试
+ * @author dxq613@gmai.com
+ */
+
+import G6 from '../../../src';
+
+const div = document.createElement('div');
+div.id = 'graph-spec';
+document.body.appendChild(div);
+
+describe('register node', () => {
+  const data = {
+    nodes: [
+      {
+        id: 'node1',
+        x: 50,
+        y: 50
+      },
+      {
+        id: 'node2' ,
+        x: 250,
+        y: 50
+      },
+    ],
+    edges: [{
+      source: 'node1',
+      target: 'node2'
+    }]
+  }
+  it('shape test wihout extended shape and draw function', () => {
+    G6.registerNode('custom-node', {
+      drawShape(cfg, group) {
+        const keyShape = group.addShape('circle', {
+        attrs: {
+            x: 0,
+            y: 0,
+            r: 30,
+            fill: '#87e8de'
+        }
+        });
+
+        return keyShape;
+      }
+    }, 'single-node');
+    const graph = new G6.Graph({
+      container: div,
+      width: 500,
+      height: 500,
+      defaultNode: {
+        type: 'custom-node'
+      }
+    });
+    graph.data(data);
+    graph.render();
+    expect(graph.getNodes()[0].getModel().x).not.toBe(undefined);
+    expect(graph.getNodes()[0].getModel().y).not.toBe(undefined);
+    graph.destroy();
+  });
+  it('register node wihout draw and drawShape, extend circle', () => {
+    G6.registerNode('custom-node', {
+        setState(name, value, item) {
+            const group = item.getContainer();
+            const shape = group.get('children')[0]; // 顺序根据 draw 时确定
+            if(name === 'active') {
+              if(value) {
+                shape.attr('stroke', 'red');
+              } else {
+                shape.attr('stroke', '#333');
+              }
+            }
+          }
+    }, 'circle');
+    const graph = new G6.Graph({
+      container: div,
+      width: 500,
+      height: 500,
+      defaultNode: {
+        type: 'custom-node'
+      }
+    });
+    graph.data(data);
+    graph.render();
+    graph.on('node:click', evt => {
+      const { item } = evt;
+      graph.setItemState(item, 'active', true);
+    });
+    graph.on('canvas:click', evt => {
+      graph.getNodes().forEach(node => {
+        graph.setItemState(node, 'active', false);
+      })
+    });
+    expect(graph.getNodes()[0].getModel().x).not.toBe(undefined);
+    expect(graph.getNodes()[0].getModel().y).not.toBe(undefined);
+    graph.destroy();
+  });
+  it('register edge wihout draw and drawShape function, extend quadratic', () => {
+    G6.registerEdge('custom-edge', {
+        getControlPoints(cfg) {
+          const controlPoints = []; // 指定controlPoints
+          const level = -5; // 从 -10， 10
+          const offset = level * -25; // 根据不同的level 计算不同的偏移
+          const { startPoint, endPoint } = cfg;
+          const innerPoint = G6.Util.getControlPoint(startPoint, endPoint, 0.5, offset);
+          controlPoints.push(innerPoint);
+          return controlPoints;
+        },
+    }, 'quadratic');
+    const graph = new G6.Graph({
+      container: div,
+      width: 500,
+      height: 500,
+      defaultEdge: {
+        type: 'custom-edge'
+      }
+    });
+    graph.data(data);
+    graph.render();
+    expect(graph.getNodes()[0].getModel().x).not.toBe(undefined);
+    expect(graph.getNodes()[0].getModel().y).not.toBe(undefined);
+  });
+});


### PR DESCRIPTION
- feat: compatibility of group.findByClassName which is removed by G 4.0. 
- fix: collapse-expand behavior bug. 
- test: findByClassName-spec. 
- docs: update upgrade guide. 
- fix: compatibility for changeLayout and refreshLayout of TreeGraph. 
- fix: must rewrite draw function when register node or edge without extended shape problem