### PR TITLE
refactor: fix TypeScript type error

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,37 @@
-import { version } from '../package.json'
+import { version } from '../package.json';
 import Behaviors from './behavior';
-import Graph from './graph/graph'
-import TreeGraph from './graph/tree-graph'
+import Graph from './graph/graph';
+import TreeGraph from './graph/tree-graph';
 import Shape from './shape';
 import Layout from './layout';
 import Global from './global';
 import Util from './util';
 import Plugins from './plugins';
+
+const registerNode = Shape.registerNode;
+const registerEdge = Shape.registerEdge;
+const registerBehavior = Behaviors.registerBehavior;
+const registerLayout = Layout.registerLayout;
+const Minimap = Plugins.Minimap;
+const Grid = Plugins.Grid;
+const Bundling = Plugins.Bundling;
+const Menu = Plugins.Menu;
+
+export {
+  registerNode,
+  Graph,
+  TreeGraph,
+  Util,
+  registerEdge,
+  Layout,
+  Global,
+  registerLayout,
+  Minimap,
+  Grid,
+  Bundling,
+  Menu,
+  registerBehavior,
+};
 
 export default {
   version,
@@ -22,5 +47,5 @@ export default {
   Minimap: Plugins.Minimap,
   Grid: Plugins.Grid,
   Bundling: Plugins.Bundling,
-  Menu: Plugins.Menu
-}
+  Menu: Plugins.Menu,
+};


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/8186664/74494689-9ff62080-4f10-11ea-97be-05f2269fb3ca.png)

原来的导出方式 G6 本身是一个对象，无法当做命名空间来使用，导致类型用起来比较复杂。新的方式可以只解决导出类型，对 tree shaking 也比较友好。只是新增不会造成任何 break change