### PR TITLE
Fix behavior types & click-select Behavior support ctrl key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # ChangeLog
+#### 3.4.3
+- fix: support extends BehaviorOption；
+- fix: click-select Behavior support multiple selection using ctrl key.
+
 #### 3.4.2
 - feat: zoom-canvas behavior supports hiding non-keyshape elements when scaling canvas;
 - refactor: when the second parameter is null, clearItemStates will clear all states of the item;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antv/g6",
-  "version": "3.4.2",
+  "version": "3.4.3",
   "description": "A Graph Visualization Framework in JavaScript",
   "keywords": [
     "antv",
@@ -50,7 +50,7 @@
     "site:deploy": "npm run site:build && gh-pages -d public",
     "start": "npm run site:develop",
     "test": "jest",
-    "test-live": "DEBUG_MODE=1 jest --watch  ./tests/unit/state/update-element-states-spec.ts",
+    "test-live": "DEBUG_MODE=1 jest --watch  ./tests/unit/issues-spec.ts",
     "lint-staged:js": "eslint --ext .js,.jsx,.ts,.tsx",
     "watch": "father build -w",
     "cdn": "antv-bin upload -n @antv/g6"

--- a/src/behavior/behavior.ts
+++ b/src/behavior/behavior.ts
@@ -1,30 +1,6 @@
 import { clone, each, wrapBehavior } from '@antv/util/lib';
-import { ModelConfig, DefaultBehaviorType } from '../types';
+import { BehaviorOption } from '../types';
 import behaviorOption from './behaviorOption';
-import { IGraph } from '../interface/graph';
-import { G6Event } from '../types';
-
-type GetEvents = 'getEvents';
-type ShouldBegin = 'shouldBegin';
-type ShouldUpdate = 'shouldUpdate';
-type ShouldEnd = 'shouldEnd';
-type Bind = 'bind';
-type Unbind = 'unbind';
-type BehaviorOption<U> = {
-  [T in keyof U]: T extends GetEvents
-    ? () => { [key in G6Event]?: string }
-    : T extends ShouldBegin
-    ? (cfg?: ModelConfig) => boolean
-    : T extends ShouldEnd
-    ? (cfg?: ModelConfig) => boolean
-    : T extends ShouldUpdate
-    ? (cfg?: ModelConfig) => boolean
-    : T extends Bind
-    ? (graph: IGraph) => void
-    : T extends Unbind
-    ? (graph: IGraph) => void
-    : (...args: DefaultBehaviorType[]) => unknown;
-};
 
 export default class Behavior {
   // 所有自定义的 Behavior 的实例
@@ -35,7 +11,7 @@ export default class Behavior {
    * @param type Behavior 名称
    * @param behavior Behavior 定义的方法集合
    */
-  public static registerBehavior<T, U>(type: string, behavior: BehaviorOption<U>) {
+  public static registerBehavior(type: string, behavior: BehaviorOption) {
     if (!behavior) {
       throw new Error(`please specify handler for this behavior: ${type}`);
     }

--- a/src/behavior/click-select.ts
+++ b/src/behavior/click-select.ts
@@ -2,7 +2,7 @@ import each from '@antv/util/lib/each';
 import { G6Event, IG6GraphEvent } from '../types';
 
 const DEFAULT_TRIGGER = 'shift';
-const ALLOW_EVENTS = ['shift', 16, 'ctrl', 17, 'alt', 18];
+const ALLOW_EVENTS = ['shift', 'ctrl', 'alt', 'control'];
 
 export default {
   getDefaultCfg(): object {
@@ -78,16 +78,14 @@ export default {
     graph.emit('nodeselectchange', { selectedItems: { nodes: [], edges: [] }, select: false });
   },
   onKeyDown(e: IG6GraphEvent) {
-    const self = this as any;
     let code = e.key;
     if (!code) {
       return;
     }
-    code = code.toLowerCase();
-    if (code === self.trigger) {
-      self.keydown = true;
+    if (code.toLowerCase() === this.trigger.toLowerCase() || code.toLowerCase() === 'control') {
+      this.keydown = true;
     } else {
-      self.keydown = false;
+      this.keydown = false;
     }
   },
   onKeyUp() {

--- a/src/global.ts
+++ b/src/global.ts
@@ -1,5 +1,5 @@
 export default {
-  version: '3.4.2',
+  version: '3.4.3',
   rootContainerClassName: 'root-container',
   nodeContainerClassName: 'node-container',
   edgeContainerClassName: 'edge-container',

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -352,6 +352,7 @@ export interface BehaviorOption {
   shouldEnd?(e?: IG6GraphEvent): boolean;
   bind?(e: IGraph): void;
   unbind?(e: IGraph): void;
+  [key: string]: unknown;
 }
 
 export type IEvent = Record<G6Event, string>;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->
1. BehaviorOption 类型支持用户继承，添加了 [key:string]: unknow；
2. click-select Behavior 支持通过按住 ctrl 多选。
 