### PR TITLE
feat: set offset as a option in tooltip

### DIFF
--- a/src/behavior/edge-tooltip.ts
+++ b/src/behavior/edge-tooltip.ts
@@ -6,6 +6,7 @@ export default Object.assign(
     getDefaultCfg(): object {
       return {
         item: 'edge',
+        offset: 12,
         formatText(model: EdgeConfig) {
           return `source: ${model.source} target: ${model.target}`;
         },

--- a/src/behavior/tooltip-base.ts
+++ b/src/behavior/tooltip-base.ts
@@ -2,8 +2,6 @@ import modifyCSS from '@antv/dom-util/lib/modify-css';
 import createDom from '@antv/dom-util/lib/create-dom';
 import { IG6GraphEvent } from '../types';
 
-const OFFSET = 12;
-
 export default {
   onMouseEnter(e: IG6GraphEvent) {
     const { item } = e;
@@ -60,12 +58,12 @@ export default {
     if (x > width / 2) {
       x -= bbox.width;
     } else {
-      x += OFFSET;
+      x += this.offset;
     }
     if (y > height / 2) {
       y -= bbox.height;
     } else {
-      y += OFFSET;
+      y += this.offset;
     }
     const left = `${x}px`;
     const top = `${y}px`;

--- a/src/behavior/tooltip.ts
+++ b/src/behavior/tooltip.ts
@@ -6,6 +6,7 @@ export default Object.assign(
     getDefaultCfg(): object {
       return {
         item: 'node',
+        offset: 12,
         formatText(model) {
           return model.label;
         },


### PR DESCRIPTION
#1347 #1409 
允许用户自己设置tooltip的offset的值。
考虑过当处于右下角区域时，x和y都再减去offset，但是实际测试时发现展示效果变化比较大，所以没有更新上去。建议团队考虑下要不要这样做。