### PR TITLE
feat: support set the background of the label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # ChangeLog
+
+#### 3.4.5
+
+- feat: support set the background of the label on node or edge;
+- fix: changeData clear states；
+- fix：state not work when don't set default labelCfg;
+
 #### 3.4.4
+
 - feat: background color for downloadImage and toDataURL;
 - feat: support configure image for grid plugin;
 - fix: initial position for fruchterman layout;
@@ -8,10 +16,12 @@
 - fix: polyline without L attributes.
 
 #### 3.4.3
+
 - fix: support extends BehaviorOption;
 - fix: click-select Behavior support multiple selection using ctrl key.
 
 #### 3.4.2
+
 - feat: zoom-canvas behavior supports hiding non-keyshape elements when scaling canvas;
 - refactor: when the second parameter is null, clearItemStates will clear all states of the item;
 - fix: (changeData bug)[https://github.com/antvis/G6/issues/1323];
@@ -20,6 +30,7 @@
 - fix: problem of dagre with controlPoints and loop edges.
 
 #### 3.4.1
+
 - feat: force layout clone original data model to allow the customized properties;
 - fix: BehaviorOptions type error;
 - fix: fitView the graph with data whose nodes and edges are empty arrays;
@@ -28,10 +39,12 @@
 - refactor: update G and the fill of custom arrow should be assigned by user.
 
 #### 3.4.0
+
 - feat: SVG renderer;
 - refactor: new state mechanism with multiple values, sub graphics shape style settings.
 
 #### 3.3.7
+
 - feat: beforeaddchild and afteraddchild emit for TreeGraph;
 - feat: built-in nodes' labels can be captured;
 - fix: drag shadow caused by localRefresh, update the g-canvas version;
@@ -40,8 +53,8 @@
 - fix: update nodes with empty string label;
 - fix: abnormal rendering when a graph has image nodes and other type nodes.
 
-
 #### 3.3.6
+
 - feat: support edge weight for dagre layout;
 - feat: automatically add draggable to keyShape, users do not need to assign it when custom a node or an edge;
 - fix: cannot read 0 or null problem in getPointByCanvas;
@@ -56,16 +69,18 @@
 - doc: fix shouldUpdate problem in treeWithLargeData demo on the site.
 
 #### 3.3.5
+
 - fix: 3.3.4 is not published successfully;
 
 #### 3.3.4
+
 - fix: 3.3.3 is not published successfully;
 - fix: delegate or keyShape type minimap does not display bug;
 - fix: dragging bug on minimap with a graph whose bbox is nagtive;
 - fix: null matrix bug, create a unit matrix for null.
 
-
 #### 3.3.3
+
 - fix: delegate or keyShape type minimap does not display bug;
 - fix: null matrix in focus() and getLoopCfgs() bug.
 
@@ -99,23 +114,28 @@
 - refactor: plugins usage is changed into new G6.PluginName()
 
 #### 3.2.7
+
 - feat: supports create the group without nodes in node-group;
 - fix: supports destoryed properties and fix issue 1094;
 
 #### 3.2.6
+
 - feat: supports sort the nodes on one circle according to the data ordering or some attribute in radial layout
 - fix: grid layout with cols and rows
 - feat: fix the nodes with position information in their original data and random the positions of others when the layout is not defined for graph
 
 #### 3.2.5
+
 - fix: click-select trigger error
 - fix: solved position problem for minimap
 
 #### 3.2.4
+
 - fix: typescript compile error
 - fix: delete sankey lib
 
 #### 3.2.3
+
 - fix: group position error
 - fix: supports not set layout type
 

--- a/docs/manual/FAQ/set-label-bg.en.md
+++ b/docs/manual/FAQ/set-label-bg.en.md
@@ -1,0 +1,43 @@
+---
+title: Set the background of the label on node or edge
+order: 0
+---
+
+### Problem
+
+在 G6 3.4.4 以下的版本中，当我们想要给节点或边的 label 添加背景时，需要用户自己使用 `group.addShape('rect', {})` 来实现，对 G6 不太熟悉的用户来说，处理起来可能比较麻烦，且实现方式不够友好。
+
+### Solution
+
+在 G6 3.4.5 版本中，我们增加了配置项，用户可以直接通过以下配置为节点或边设置背景。
+
+**特别说明：** 该功能是由 GitHub 用户 @zhanba 贡献 [feat: add label background](https://github.com/antvis/G6/pull/1354) 。
+
+```
+const graph = new G6.Graph({
+  // ...
+  defaultNode: {
+    position: 'left',
+    style: {
+      background: {
+        fill: '#ffffff',
+        stroke: 'green',
+        padding: [3, 2, 3, 2],
+        radius: 2,
+        lineWidth: 3,
+      },
+    },
+  },
+  defaultEdge: {
+    autoRotate: true,
+    style: {
+      background: {
+        fill: '#ffffff',
+        stroke: '#000000',
+        padding: [2, 2, 2, 2],
+        radius: 2,
+      },
+    },
+  }
+})
+```

--- a/docs/manual/FAQ/set-label-bg.en.md
+++ b/docs/manual/FAQ/set-label-bg.en.md
@@ -5,13 +5,13 @@ order: 0
 
 ### Problem
 
-在 G6 3.4.4 以下的版本中，当我们想要给节点或边的 label 添加背景时，需要用户自己使用 `group.addShape('rect', {})` 来实现，对 G6 不太熟悉的用户来说，处理起来可能比较麻烦，且实现方式不够友好。
+In versions below G6 3.4.4, when we want to add the background to label of a node or edge, wo need use `group.addShape('rect', {})` to implement it, the implementation method is not friendly enough.
 
 ### Solution
 
-在 G6 3.4.5 版本中，我们增加了配置项，用户可以直接通过以下配置为节点或边设置背景。
+In G6 3.4.5 version, uses can set the background for nodes or edges through `background` configuration.
 
-**特别说明：** 该功能是由 GitHub 用户 @zhanba 贡献 [feat: add label background](https://github.com/antvis/G6/pull/1354) 。
+**Important Hint：** The [PR](https://github.com/antvis/G6/pull/1354) comes from GitHub use @zhanba.
 
 ```
 const graph = new G6.Graph({

--- a/docs/manual/FAQ/set-label-bg.zh.md
+++ b/docs/manual/FAQ/set-label-bg.zh.md
@@ -1,0 +1,43 @@
+---
+title: 设置节点或边的背景
+order: 0
+---
+
+### 问题
+
+在 G6 3.4.4 以下的版本中，当我们想要给节点或边的 label 添加背景时，需要用户自己使用 `group.addShape('rect', {})` 来实现，对 G6 不太熟悉的用户来说，处理起来可能比较麻烦，且实现方式不够友好。
+
+### 解决方法
+
+在 G6 3.4.5 版本中，我们增加了配置项，用户可以直接通过以下配置为节点或边设置背景。
+
+**特别说明：** 该功能是由 GitHub 用户 @zhanba 贡献 [feat: add label background](https://github.com/antvis/G6/pull/1354) 。
+
+```
+const graph = new G6.Graph({
+  // ...
+  defaultNode: {
+    position: 'left',
+    style: {
+      background: {
+        fill: '#ffffff',
+        stroke: 'green',
+        padding: [3, 2, 3, 2],
+        radius: 2,
+        lineWidth: 3,
+      },
+    },
+  },
+  defaultEdge: {
+    autoRotate: true,
+    style: {
+      background: {
+        fill: '#ffffff',
+        stroke: '#000000',
+        padding: [2, 2, 2, 2],
+        radius: 2,
+      },
+    },
+  }
+})
+```

--- a/examples/shape/labelBg/demo/edgeBg.js
+++ b/examples/shape/labelBg/demo/edgeBg.js
@@ -1,0 +1,94 @@
+import G6 from '@antv/g6';
+
+const data = {
+  nodes: [
+    {
+      id: 'node1',
+      x: 150,
+      y: 50,
+      label: 'node1',
+    },
+    {
+      id: 'node2',
+      x: 250,
+      y: 200,
+      label: 'node2',
+    },
+    {
+      id: 'node3',
+      x: 100,
+      y: 350,
+      label: 'node3',
+    },
+  ],
+  edges: [
+    {
+      source: 'node1',
+      target: 'node2',
+      label: 'edge 1',
+    },
+    {
+      source: 'node2',
+      target: 'node3',
+      label: 'edge 2',
+    },
+    {
+      source: 'node3',
+      target: 'node1',
+      label: 'edge 3',
+    },
+  ],
+};
+
+const width = document.getElementById('container').scrollWidth;
+const height = document.getElementById('container').scrollHeight || 500;
+const graph = new G6.Graph({
+  container: 'container',
+  width,
+  height,
+  defaultNode: {
+    type: 'circle',
+    size: [40],
+    color: '#5B8FF9',
+    style: {
+      fill: '#9EC9FF',
+      lineWidth: 3,
+    },
+    labelCfg: {
+      style: {
+        fill: '#1890ff',
+        fontSize: 14,
+      },
+      position: 'bottom',
+    },
+  },
+  defaultEdge: {
+    labelCfg: {
+      autoRotate: true,
+      style: {
+        background: {
+          fill: '#ffffff',
+          stroke: '#9EC9FF',
+          padding: [2, 2, 2, 2],
+          radius: 2,
+        },
+      },
+    },
+  },
+  modes: {
+    default: ['drag-canvas', 'drag-node'],
+  },
+  nodeStateStyles: {
+    // 鼠标hover状态下的配置
+    hover: {
+      fillOpacity: 0.8,
+    },
+    // 选中节点状态下的配置
+    selected: {
+      lineWidth: 5,
+    },
+  },
+});
+
+graph.data(data);
+graph.render();

--- a/examples/shape/labelBg/demo/meta.json
+++ b/examples/shape/labelBg/demo/meta.json
@@ -1,0 +1,24 @@
+{
+  "title": {
+    "zh": "中文分类",
+    "en": "Category"
+  },
+  "demos": [
+    {
+      "filename": "nodeBg.js",
+      "title": {
+        "zh": "设置节点文本背景",
+        "en": "Set Node Label Background"
+      },
+      "screenshot": "https://gw.alipayobjects.com/mdn/rms_f8c6a0/afts/img/A*m5ABT5ra4w4AAAAAAAAAAABkARQnAQ"
+    },
+    {
+      "filename": "edgeBg.js",
+      "title": {
+        "zh": "设置边上文本背景",
+        "en": "Set Edge label Background"
+      },
+      "screenshot": "https://gw.alipayobjects.com/mdn/rms_f8c6a0/afts/img/A*w_bNSZTlPXUAAAAAAAAAAABkARQnAQ"
+    }
+  ]
+}

--- a/examples/shape/labelBg/demo/nodeBg.js
+++ b/examples/shape/labelBg/demo/nodeBg.js
@@ -1,0 +1,87 @@
+import G6 from '@antv/g6';
+
+const data = {
+  nodes: [
+    {
+      id: 'node1',
+      x: 150,
+      y: 50,
+      label: 'node1',
+    },
+    {
+      id: 'node2',
+      x: 250,
+      y: 200,
+      label: 'node2',
+    },
+    {
+      id: 'node3',
+      x: 100,
+      y: 350,
+      label: 'node3',
+    },
+  ],
+  edges: [
+    {
+      source: 'node1',
+      target: 'node2',
+      label: 'edge 1',
+    },
+    {
+      source: 'node2',
+      target: 'node3',
+      label: 'edge 2',
+    },
+    {
+      source: 'node3',
+      target: 'node1',
+      label: 'edge 3',
+    },
+  ],
+};
+
+const width = document.getElementById('container').scrollWidth;
+const height = document.getElementById('container').scrollHeight || 500;
+const graph = new G6.Graph({
+  container: 'container',
+  width,
+  height,
+  defaultNode: {
+    type: 'circle',
+    size: [40],
+    color: '#5B8FF9',
+    style: {
+      fill: '#9EC9FF',
+      lineWidth: 3,
+    },
+    labelCfg: {
+      style: {
+        fill: '#1890ff',
+        fontSize: 14,
+        background: {
+          fill: '#ffffff',
+          stroke: '#9EC9FF',
+          padding: [2, 2, 2, 2],
+          radius: 2,
+        },
+      },
+      position: 'bottom',
+    },
+  },
+  modes: {
+    default: ['drag-canvas', 'drag-node'],
+  },
+  nodeStateStyles: {
+    // 鼠标hover状态下的配置
+    hover: {
+      fillOpacity: 0.8,
+    },
+    // 选中节点状态下的配置
+    selected: {
+      lineWidth: 5,
+    },
+  },
+});
+
+graph.data(data);
+graph.render();

--- a/examples/shape/labelBg/index.en.md
+++ b/examples/shape/labelBg/index.en.md
@@ -1,0 +1,47 @@
+---
+title: Label Background
+order: 5
+---
+
+Set the background of the label on Node or Edge.
+
+## Usage
+
+Set the background of the label on edge：
+
+```
+const graph = new G6.Graph({
+  // ...
+  defaultNode: {
+    position: 'left',
+    style: {
+      background: {
+        fill: '#ffffff',
+        stroke: 'green',
+        padding: [3, 2, 3, 2],
+        radius: 2,
+        lineWidth: 3,
+      },
+    },
+  }
+})
+```
+
+Set the background of the label on node:
+
+```
+const graph = new G6.Graph({
+  // ...
+  defaultEdge: {
+    autoRotate: true,
+    style: {
+      background: {
+        fill: '#ffffff',
+        stroke: '#000000',
+        padding: [2, 2, 2, 2],
+        radius: 2,
+      },
+    },
+  }
+})
+```

--- a/examples/shape/labelBg/index.zh.md
+++ b/examples/shape/labelBg/index.zh.md
@@ -1,0 +1,49 @@
+---
+title: 设置文本背景
+order: 5
+---
+
+设置 Node 或 Edge label 的背景。
+
+## 使用指南
+
+当节点或边上的 label 需要设置背景时，通过在 style 中增加 background 来实现。
+
+设置边的背景：
+
+```
+const graph = new G6.Graph({
+  // ...
+  defaultNode: {
+    position: 'left',
+    style: {
+      background: {
+        fill: '#ffffff',
+        stroke: 'green',
+        padding: [3, 2, 3, 2],
+        radius: 2,
+        lineWidth: 3,
+      },
+    },
+  }
+})
+```
+
+设置节点 label 的背景：
+
+```
+const graph = new G6.Graph({
+  // ...
+  defaultEdge: {
+    autoRotate: true,
+    style: {
+      background: {
+        fill: '#ffffff',
+        stroke: '#000000',
+        padding: [2, 2, 2, 2],
+        radius: 2,
+      },
+    },
+  }
+})
+```

--- a/src/shape/edge.ts
+++ b/src/shape/edge.ts
@@ -200,14 +200,14 @@ const singleEdge: ShapeOptions = {
       return {};
     }
     const bbox = label.getBBox();
-    const backgroundStyle = labelCfg?.style?.background;
+    const backgroundStyle = labelCfg.style && labelCfg.style.background;
     if (!backgroundStyle) {
       return {};
     }
     const { padding } = backgroundStyle;
     const backgroundWidth = bbox.width + padding[1] + padding[3];
     const backgroundHeight = bbox.height + padding[0] + padding[2];
-    const labelPosition = labelCfg.position ?? this.labelPosition;
+    const labelPosition = labelCfg.position || this.labelPosition;
     const style = {
       ...backgroundStyle,
       width: backgroundWidth,

--- a/src/shape/node.ts
+++ b/src/shape/node.ts
@@ -7,6 +7,7 @@ import { IShape, IElement } from '@antv/g-canvas/lib/interfaces';
 import { isArray, isNil, mix } from '@antv/util';
 import { ILabelConfig, ShapeOptions } from '../interface/shape';
 import { Item, LabelStyle, NodeConfig, ModelConfig } from '../types';
+import { formatPadding } from '../util/base';
 import Global from '../global';
 import Shape from './shape';
 import { shapeBase } from './shapeBase';
@@ -110,14 +111,15 @@ const singleNode: ShapeOptions = {
       return {};
     }
     const bbox = label.getBBox();
-    const backgroundStyle = labelCfg?.style?.background;
+    const backgroundStyle = labelCfg.style && labelCfg.style.background;
     if (!backgroundStyle) {
       return {};
     }
-    const { padding } = backgroundStyle;
+
+    const padding = formatPadding(backgroundStyle.padding);
     const backgroundWidth = bbox.width + padding[1] + padding[3];
     const backgroundHeight = bbox.height + padding[0] + padding[2];
-    const labelPosition = labelCfg.position ?? this.labelPosition;
+    const labelPosition = labelCfg.position || this.labelPosition;
 
     let { offset } = labelCfg;
     if (isNil(offset)) {
@@ -134,26 +136,26 @@ const singleNode: ShapeOptions = {
     switch (labelPosition) {
       case 'top':
         style = {
-          x: 0 - bbox.width / 2,
-          y: 0 - height / 2 - (offset as number) - bbox.height,
+          x: 0 - bbox.width / 2 - padding[3],
+          y: 0 - height / 2 - (offset as number) - bbox.height - padding[0],
         };
         break;
       case 'bottom':
         style = {
-          x: 0 - bbox.width / 2,
-          y: height / 2 + (offset as number),
+          x: 0 - bbox.width / 2 - padding[3],
+          y: height / 2 + (offset as number) - padding[2],
         };
         break;
       case 'left':
         style = {
-          x: 0 - width / 2 - (offset as number) - bbox.width,
-          y: 0 - bbox.height / 2,
+          x: 0 - width / 2 - (offset as number) - bbox.width - padding[3],
+          y: padding[0] + padding[2] === 0 ? 0 : -bbox.height / 2 + (padding[0] + padding[2]) / 2,
         };
         break;
       default:
         style = {
-          x: width / 2 + (offset as number),
-          y: 0 - bbox.height / 2,
+          x: width / 2 + (offset as number) - padding[3],
+          y: padding[0] + padding[2] === 0 ? 0 : -bbox.height / 2 + (padding[0] + padding[2]) / 2,
         };
         break;
     }

--- a/src/shape/shapeBase.ts
+++ b/src/shape/shapeBase.ts
@@ -216,7 +216,7 @@ export const shapeBase: ShapeOptions = {
 
         // 取 nodeLabel，edgeLabel 的配置项
         const cfgStyle = cfg.labelCfg ? cfg.labelCfg.style : undefined;
-        const cfgBgStyle = labelCfg.style?.background;
+        const cfgBgStyle = labelCfg.style && labelCfg.style.background;
 
         // 需要融合当前 label 的样式 label.attr()。不再需要全局/默认样式，因为已经应用在当前的 label 上
         const labelStyle = Object.assign({}, label.attr(), calculateStyle, cfgStyle);
@@ -255,6 +255,9 @@ export const shapeBase: ShapeOptions = {
           // const labelBgStyle = Object.assign({}, labelBg.attr(), calculateBgStyle, cfgBgStyle);
           const labelBgStyle = Object.assign({}, calculateBgStyle, cfgBgStyle);
           labelBg.resetMatrix();
+          if (rotate) {
+            labelBg.rotateAtStart(rotate);
+          }
           labelBg.attr(labelBgStyle);
         } else {
           group.removeChild(labelBg);
@@ -399,7 +402,9 @@ export const shapeBase: ShapeOptions = {
     const model = item.getModel();
 
     if (value) {
-      const modelStateStyle = model.stateStyles ? model.stateStyles[name] : this.options.stateStyles && this.options.stateStyles[name];
+      const modelStateStyle = model.stateStyles
+        ? model.stateStyles[name]
+        : this.options.stateStyles && this.options.stateStyles[name];
       return mix({}, model.style, modelStateStyle);
     }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -127,6 +127,7 @@ export type LabelStyle = Partial<{
   background?: {
     fill?: string;
     stroke?: string;
+    lineWidth?: number;
     radius?: number[] | number;
     padding?: number[] | number;
   };

--- a/stories/label/component/edge-label-background.tsx
+++ b/stories/label/component/edge-label-background.tsx
@@ -29,9 +29,10 @@ const nodeLabelCfg2 = {
   style: {
     background: {
       fill: '#ffffff',
-      stroke: '#000000',
-      padding: [2, 2, 2, 2],
+      stroke: 'green',
+      padding: [3, 2, 3, 2],
       radius: 2,
+      lineWidth: 3,
     },
   },
 };
@@ -141,28 +142,15 @@ const CustomNode = () => {
       });
       graph.data(data1);
       graph.render();
-      console.log('---0');
+
+      graph.on('node:mouseenter', () => {
+        graph.changeData(data2);
+      });
+
+      graph.on('node:mouseleave', () => {
+        graph.changeData(data1);
+      });
     }
-  });
-
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      graph.changeData(data2);
-      console.log('1000');
-    }, 1000);
-    return () => {
-      clearTimeout(timer);
-    };
-  });
-
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      graph.changeData(data1);
-      console.log('3000');
-    }, 3000);
-    return () => {
-      clearTimeout(timer);
-    };
   });
 
   return <div ref={container} />;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->
1. 支持设置节点或边上label的背景；
2. 修复 changeData 后原有的 state 没有清除的问题；
3. 修复当不设置默认文本样式时，setItemState 后恢复不了文本原始样式问题。