### PR TITLE
Test combo 20200424

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,7 +68,7 @@ dist
 temp
 .DS_Store
 .idea
-demos/assets/screenshots
+demos
 lib
 
 *.sw*

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "site:deploy": "npm run site:build && gh-pages -d public",
     "start": "npm run site:develop",
     "test": "jest",
-    "test-live": "DEBUG_MODE=1 jest --watch  ./tests/unit/util/graphic-spec.ts",
+    "test-live": "DEBUG_MODE=1 jest --watch  ./tests/unit/behavior/drag-combo-spec.ts",
     "lint-staged:js": "eslint --ext .js,.jsx,.ts,.tsx",
     "watch": "father build -w",
     "cdn": "antv-bin upload -n @antv/g6"
@@ -93,7 +93,6 @@
     "@storybook/addon-info": "^5.2.8",
     "@storybook/addon-knobs": "^5.2.8",
     "@storybook/react": "^5.2.8",
-    "@types/jest": "^24.0.18",
     "@types/node": "^12.12.22",
     "@umijs/fabric": "^2.0.0",
     "awesome-typescript-loader": "^5.2.1",

--- a/src/graph/controller/item.ts
+++ b/src/graph/controller/item.ts
@@ -237,7 +237,7 @@ export default class ItemController {
 
     item.update(cfg);
 
-    if (type === NODE) {
+    if (type === NODE || type === COMBO) {
       const edges: IEdge[] = (item as INode).getEdges();
       each(edges, (edge: IEdge) => {
         graph.refreshItem(edge);

--- a/src/graph/graph.ts
+++ b/src/graph/graph.ts
@@ -202,11 +202,6 @@ export default class Graph extends EventEmitter implements IGraph {
         className: Global.comboContainerClassName
       })
 
-      const delegateGroup: IGroup = group.addGroup({
-        id: `${id}-delegate`,
-        className: Global.delegateContainerClassName,
-      });
-
       // 用于存储自定义的群组
       const customGroup: IGroup = group.addGroup({
         id: `${id}-group`,
@@ -216,8 +211,13 @@ export default class Graph extends EventEmitter implements IGraph {
       customGroup.toBack();
       comboGroup.toBack();
 
-      this.set({ nodeGroup, edgeGroup, customGroup, delegateGroup, comboGroup });
+      this.set({ nodeGroup, edgeGroup, customGroup, comboGroup });
     }
+    const delegateGroup: IGroup = group.addGroup({
+      id: `${id}-delegate`,
+      className: Global.delegateContainerClassName,
+    });
+    this.set({ delegateGroup });
     this.set('group', group);
   }
 

--- a/src/graph/graph.ts
+++ b/src/graph/graph.ts
@@ -1199,17 +1199,69 @@ export default class Graph extends EventEmitter implements IGraph {
   }
 
   /**
+   * 根据已经存在的节点或 combo 创建新的 combo
+   * @param combo combo ID 或 Combo 配置
+   * @param elements 添加到 Combo 中的元素，包括节点和 combo
+   */
+  public createCombo(combo: string | ComboConfig, elements: string[]): void  {
+    // step 1: 创建新的 Combo
+    let comboId = ''
+    if (isString(combo)) {
+      comboId = combo
+      this.addItem('combo', {
+        id: combo
+      })
+    } else {
+      comboId = combo.id
+      this.addItem('combo', combo)
+    }
+
+    const currentCombo = this.findById(comboId) as ICombo
+    
+    const trees = elements.map(elementId => {
+      const item = this.findById(elementId)
+
+      // step 2: 将元素添加到 Combo 中
+      currentCombo.addChild(item as INode | ICombo)
+
+      const model = item.getModel()
+      const type = item.getType()
+      if (type === 'combo') {
+        (model as ComboConfig).parentId = comboId
+      } else if (type === 'node') {
+        (model as NodeConfig).comboId = comboId
+      }
+
+      return {
+        depth: 1,
+        itemType: type,
+        ...model
+      }
+    })
+
+    // step3: 更新 comboTrees 结构
+    const comboTrees = this.get('comboTrees')
+    comboTrees.forEach(ctree => {
+      if (ctree.id === comboId) {
+        ctree.itemType = 'combo'
+        ctree.children = trees
+      }
+    })
+
+    this.updateCombos()
+  }
+
+  /**
    * 解散 combo
    * @param {String | INode | ICombo} item 需要被解散的 Combo item 或 id
    */
   public uncombo(combo: string | ICombo) {
     const self = this;
-    let comboItem: ICombo;
+    let comboItem: ICombo = combo as ICombo;
     if (isString(combo)) {
       comboItem = this.findById(combo) as ICombo;
-    } else {
-      comboItem = combo;
     }
+    
     if (!comboItem || comboItem.getType() !== 'combo') {
       console.warn('The item is not a combo!');
       return;
@@ -1315,7 +1367,9 @@ export default class Graph extends EventEmitter implements IGraph {
     // 当 combo 存在parentId 或 comboId 时，才将其移除
     if (model.parentId || model.comboId) {
       const combo = this.findById((model.parentId || model.comboId) as string) as ICombo
-      combo.removeChild(uItem)
+      if (combo) {
+        combo.removeChild(uItem)
+      }
     }
 
     const type = uItem.getType()
@@ -1329,12 +1383,16 @@ export default class Graph extends EventEmitter implements IGraph {
     // 只有当移入到指定 combo 时才添加
     if (parentId) {
       const parentCombo = this.findById(parentId) as ICombo
-      parentCombo.addChild(uItem as ICombo | INode)
+      if (parentCombo) {
+        parentCombo.addChild(uItem as ICombo | INode)
+      }
     }
     // 如果原先有父亲 combo，则从原父 combo 的子元素数组中删除
     if (oldParentId) {
       const parentCombo = this.findById(oldParentId) as ICombo
-      parentCombo.removeChild(uItem as ICombo | INode)
+      if (parentCombo) {
+        parentCombo.removeChild(uItem as ICombo | INode)
+      }
     }
 
     const newComboTrees = reconstructTree(this.get('comboTrees'), model.id, parentId);

--- a/src/interface/graph.ts
+++ b/src/interface/graph.ts
@@ -158,6 +158,13 @@ export interface IGraph extends EventEmitter {
   uncombo(item: String | ICombo): void;
 
   /**
+   * 根据已经存在的节点或 combo 创建新的 combo
+   * @param combo combo ID 或 Combo 配置
+   * @param elements 添加到 Combo 中的元素，包括节点和 combo
+   */
+  createCombo(combo: string | ComboConfig, elements: string[]): void;
+
+  /**
    * 设置元素状态
    * @param {Item} item 元素id或元素实例
    * @param {string} state 状态名称

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -31,6 +31,8 @@ export type Padding = number | string | number[];
 export interface ArrowConfig {
   d?: number;
   path?: string;
+  stroke?: string;
+  fill?: string;
 }
 
 // Shape types

--- a/src/util/graphic.ts
+++ b/src/util/graphic.ts
@@ -536,6 +536,8 @@ export const reconstructTree = (trees: ComboTree[], subtreeId?: string, newParen
         } else {
           subtree.comboId = newParentId
         }
+        const index = brothers.indexOf(child);
+        brothers.splice(index, 1);
         foundSubTree = true
       }
       return true;
@@ -573,7 +575,11 @@ export const reconstructTree = (trees: ComboTree[], subtreeId?: string, newParen
           if (comboChildsMap[child.parentId]) depth = comboChildsMap[child.parentId].depth + 2;
           else if (comboChildsMap[child.comboId]) depth = comboChildsMap[child.comboId].depth + 1;
           child.depth = depth;
-          comboChildsMap[child.id]['depth'] = child.depth
+          if (comboChildsMap[child.id]) {
+            if (comboChildsMap[child.id]) {
+              comboChildsMap[child.id]['depth'] = child.depth
+            }
+          }
           return true;
         });
       });

--- a/stories/Case/component/tutorial.tsx
+++ b/stories/Case/component/tutorial.tsx
@@ -600,8 +600,8 @@ const Tutorial = () => {
         const response = await fetch(
           'https://gw.alipayobjects.com/os/basement_prod/6cae02ab-4c29-44b2-b1fd-4005688febcb.json',
         );
-        const data = await response.json();
-        console.log(data);
+        // const data = await response.json();
+        const data = response as GraphData;
         const nodes = data.nodes;
         const edges = data.edges;
         nodes.forEach(node => {

--- a/stories/Combo/combo.stories.tsx
+++ b/stories/Combo/combo.stories.tsx
@@ -7,6 +7,7 @@ import CollapseExpand from './component/collapse-expand-combo';
 import ComboLayoutCollapseExpand from './component/combo-layout-collapse-expand';
 import CollapseExpandVEdge from './component/collapse-expand-vedge';
 import ComboCollapseExpandTree from './component/combo-collapse-expand-tree';
+import ComboExample from './component/combo-example'
 
 export default { title: 'Combo' };
 
@@ -28,4 +29,5 @@ storiesOf('Combo', module)
   ))
   .add('collapse expand tree', () => (
     <ComboCollapseExpandTree />
-  ));
+  ))
+  .add('combo example', () => <ComboExample />)

--- a/stories/Combo/component/combo-example.tsx
+++ b/stories/Combo/component/combo-example.tsx
@@ -1,0 +1,228 @@
+import React, { useEffect } from 'react';
+import G6 from '../../../src';
+import { IGraph } from '../../../src/interface/graph';
+import { ComboConfig } from '../../../src/types';
+import { IGroup } from '@antv/g-base/lib/interfaces';
+
+let graph: IGraph = null;
+
+G6.registerCombo('custom-combo', {
+  draw: (cfg, group) => {
+    const style = cfg.style || {};
+    const keyShape = group.addShape('circle', {
+      attrs: style,
+      className: 'circle-combo',
+      name: 'circle-combo',
+      draggable: true,
+    });
+    group.addShape('marker', {
+      attrs: {
+        x: 0,//keyShape.attr('r') + 5,
+        y: 0,
+        r: 5,
+        stroke: 'blue',
+        symbol: 'triangle-down'
+      },
+      name: 'marker-shape'
+    })
+    return keyShape;
+  },
+  update: (cfg, item) => {
+    const group = item.get('group');
+    if (cfg.markerStyle) {
+      const marker = group.find(ele => ele.get('name') === 'marker-shape');
+      marker.attr(cfg.markerStyle);
+    }
+    const keyShape = group.get('children')[0];
+    keyShape.attr(cfg.style);
+  }
+}, 'circle-combo');
+
+const data = {
+  nodes: [
+    {
+      id: 'node1',
+      x: 150,
+      y: 150,
+      label: 'node1',
+      comboId: 'A'
+    },
+    {
+      id: 'node2',
+      x: 200,
+      y: 250,
+      label: 'node2',
+      comboId: 'B'
+    },
+    {
+      id: 'node3',
+      x: 100,
+      y: 250,
+      label: 'node3',
+    },
+    {
+      id: 'node4',
+      x: 50,
+      y: 50,
+      label: 'node4',
+      comboId: 'D'
+    },
+    {
+      id: 'node5',
+      x: 100,
+      y: 100,
+      label: 'node5',
+      comboId: 'E'
+    },
+    {
+      id: 'node6',
+      x: 500,
+      y: 200,
+      label: 'node6'
+    },
+    {
+      id: 'node7',
+      x: 600,
+      y: 200,
+      label: 'node7'
+    }
+  ],
+  edges: [
+    {
+      source: 'node1',
+      target: 'node2',
+    },
+    {
+      source: 'node2',
+      target: 'node3',
+    },
+    {
+      source: 'node3',
+      target: 'node1',
+    },
+    {
+      source: 'A',
+      target: 'D'
+    }
+  ],
+  combos: [
+  {
+    id: 'A',
+    parentId: 'B',
+    label: 'gorup A',
+    padding: [50, 30, 10, 10],
+    type: 'rect',
+    style: {
+      stroke: 'red',
+      fill: 'green'
+    }
+  }, {
+    id: 'B',
+    label: 'gorup B',
+    padding: [50, 10, 10, 50],
+    // type: 'custom-combo'
+  },
+  {
+    id: 'D',
+    label: 'gorup D',
+    parentId: 'E',
+  }, 
+  {
+    id: 'E',
+  },
+  {
+    id: 'FF',
+    label: '空分组',
+    type: 'custom-combo',
+    style: {
+      stroke: 'green',
+      lineWidth: 3
+    }
+  }
+  ]
+};
+
+const DefaultCombo = () => {
+  const container = React.useRef();
+  useEffect(() => {
+    if (!graph) {
+      graph = new G6.Graph({
+        container: container.current as string | HTMLElement,
+        width: 1000,
+        height: 800,
+        groupByTypes: false,
+        modes: {
+          default: [ 'drag-canvas', 'drag-combo', 'drag-node', 'collapse-expand-combo' ]
+        },
+        defaultCombo: {
+          // size: [100, 100],
+          type: 'circle',
+          style: {
+            fill: '#ccc',
+            opacity: 0.9
+          }
+        },
+        comboStateStyles: {
+          selected: {
+            'text-shape': {
+              fill: '#f00',
+              fontSize: 20
+            },
+            fill: '#f00'
+          },
+          state2: {
+            stroke: '#0f0'
+          }
+        },
+        defaultEdge: {
+          style: {
+            stroke: '#f00',
+            lineWidth: 3
+          }
+        }
+      });
+     
+    }
+    graph.data(data);
+    graph.render();
+    let selected = false;
+    graph.on('node:click', e => {
+      graph.hideItem(e.item);
+    })
+    graph.on('combo:click', e => {
+      
+    });
+    // graph.on('canvas:click', e => {
+    //   // graph.setItemState(graph.findById('A'), 'selected', true);
+    //   // console.log( graph.findAllByState('combo', 'selected'))
+    //   const hidedCombos = graph.findAll('combo', combo => {
+    //     if (!combo.isVisible()) return true;
+    //     return false;
+    //   });
+    //   hidedCombos.forEach(combo => {
+    //     graph.showItem(combo);
+    //   })
+
+    //   graph.updateComboTree('A', 'M');
+    // });
+  });
+
+  const handleCreateCombo = () => {
+
+    graph.createCombo({
+      id: 'newCombo',
+      label: 'newCombo',
+      type: 'rect'
+    }, ['node6', 'node7'])
+  }
+
+  const handleUnCombo = () => {
+    graph.uncombo('newCombo')
+  }
+  return <div ref={container}>
+    <button onClick={handleCreateCombo}>成组</button>
+    <button onClick={handleUnCombo}>拆组</button>
+  </div>;
+};
+
+export default DefaultCombo;

--- a/stories/Combo/component/combo-layout-collapse-expand.tsx
+++ b/stories/Combo/component/combo-layout-collapse-expand.tsx
@@ -950,7 +950,7 @@ const ComboLayoutCollapseExpand = () => {
         height: 500,
         // fitView: true,
         modes: {
-          default: ['drag-canvas', 'drag-node', 'zoom-canvas'],  // , 'collapse-expand-combo'
+          default: ['drag-canvas', 'drag-node', 'zoom-canvas', 'collapse-expand-combo', 'drag-combo'],  // , 'collapse-expand-combo'
         },
         layout: {
           type: 'comboForce'

--- a/stories/Issues/attrs/index.tsx
+++ b/stories/Issues/attrs/index.tsx
@@ -133,20 +133,19 @@ export default () => {
       nodes: [
         {
           id: "2",
-          dataType: "alps",
-          name: "alps_file2",
+          name: "name1",
           conf: [
             {
               label: "conf",
-              value: "pai_graph.conf"
+              value: "value1"
             },
             {
               label: "dot",
-              value: "pai_graph.dot"
+              value: "value2"
             },
             {
               label: "init",
-              value: "init.rc"
+              value: "init1"
             }
           ]
         }

--- a/stories/Issues/component/dagre-arrow.tsx
+++ b/stories/Issues/component/dagre-arrow.tsx
@@ -8,57 +8,57 @@ const data = {
     {
       id: '1',
       dataType: 'alps',
-      name: 'alps_file1',
+      name: 'name1',
       conf: [
         {
           label: 'conf',
-          value: 'pai_graph.conf',
+          value: 'value1',
         },
         {
           label: 'dot',
-          value: 'pai_graph.dot',
+          value: 'value2',
         },
         {
           label: 'init',
-          value: 'init.rc',
+          value: 'value3',
         },
       ],
     },
     {
       id: '2',
       dataType: 'alps',
-      name: 'alps_file2',
+      name: 'name2',
       conf: [
         {
           label: 'conf',
-          value: 'pai_graph.conf',
+          value: 'value1',
         },
         {
           label: 'dot',
-          value: 'pai_graph.dot',
+          value: 'value2',
         },
         {
           label: 'init',
-          value: 'init.rc',
+          value: 'value3',
         },
       ],
     },
     {
       id: '3',
       dataType: 'alps',
-      name: 'alps_file3',
+      name: 'name3',
       conf: [
         {
           label: 'conf',
-          value: 'pai_graph.conf',
+          value: 'value1',
         },
         {
           label: 'dot',
-          value: 'pai_graph.dot',
+          value: 'value2',
         },
         {
           label: 'init',
-          value: 'init.rc',
+          value: 'value3',
         },
       ],
     },
@@ -69,15 +69,15 @@ const data = {
       conf: [
         {
           label: 'conf',
-          value: 'pai_graph.conf',
+          value: 'value1',
         },
         {
           label: 'dot',
-          value: 'pai_graph.dot',
+          value: 'value2',
         },
         {
           label: 'init',
-          value: 'init.rc',
+          value: 'value3',
         },
       ],
     },
@@ -88,15 +88,15 @@ const data = {
       conf: [
         {
           label: 'conf',
-          value: 'pai_graph.conf',
+          value: 'value1',
         },
         {
           label: 'dot',
-          value: 'pai_graph.dot',
+          value: 'value2',
         },
         {
           label: 'init',
-          value: 'init.rc',
+          value: 'value3',
         },
       ],
     },
@@ -107,15 +107,15 @@ const data = {
       conf: [
         {
           label: 'conf',
-          value: 'pai_graph.conf',
+          value: 'value1',
         },
         {
           label: 'dot',
-          value: 'pai_graph.dot',
+          value: 'value2',
         },
         {
           label: 'init',
-          value: 'init.rc',
+          value: 'value3',
         },
       ],
     },
@@ -126,15 +126,15 @@ const data = {
       conf: [
         {
           label: 'conf',
-          value: 'pai_graph.conf',
+          value: 'value1',
         },
         {
           label: 'dot',
-          value: 'pai_graph.dot',
+          value: 'value2',
         },
         {
           label: 'init',
-          value: 'init.rc',
+          value: 'value3',
         },
       ],
     },
@@ -145,15 +145,15 @@ const data = {
       conf: [
         {
           label: 'conf',
-          value: 'pai_graph.conf',
+          value: 'value1',
         },
         {
           label: 'dot',
-          value: 'pai_graph.dot',
+          value: 'value2',
         },
         {
           label: 'init',
-          value: 'init.rc',
+          value: 'value3',
         },
       ],
     },

--- a/stories/Issues/ggeditorNode/baseNode.ts
+++ b/stories/Issues/ggeditorNode/baseNode.ts
@@ -1,0 +1,258 @@
+import G6 from '../../../src';
+import { isArray } from 'lodash'
+
+const WRAPPER_BORDER_WIDTH = 2;
+const WRAPPER_HORIZONTAL_PADDING = 10;
+
+const WRAPPER_CLASS_NAME = 'node-wrapper';
+const CONTENT_CLASS_NAME = 'node-content';
+const LABEL_CLASS_NAME = 'node-label';
+
+const canvas = document.createElement('canvas');
+const canvasContext = canvas.getContext('2d');
+function optimizeMultilineText(text: string, font: string, maxRows: number, maxWidth: number) {
+  canvasContext.font = font;
+
+  if (canvasContext.measureText(text).width <= maxWidth) {
+    return text;
+  }
+
+  let multilineText = [];
+
+  let tempText = '';
+  let tempTextWidth = 0;
+
+  for (const char of text) {
+    const { width } = canvasContext.measureText(char);
+
+    if (tempTextWidth + width >= maxWidth) {
+      multilineText.push(tempText);
+
+      tempText = '';
+      tempTextWidth = 0;
+    }
+
+    tempText += char;
+    tempTextWidth += width;
+  }
+
+  if (tempText) {
+    multilineText.push(tempText);
+  }
+
+  if (multilineText.length > maxRows) {
+    const ellipsis = '...';
+    const ellipsisWidth = canvasContext.measureText(ellipsis).width;
+
+    let tempText = '';
+    let tempTextWidth = 0;
+
+    for (const char of multilineText[maxRows - 1]) {
+      const { width } = canvasContext.measureText(char);
+
+      if (tempTextWidth + width > maxWidth - ellipsisWidth) {
+        break;
+      }
+
+      tempText += char;
+      tempTextWidth += width;
+    }
+
+    multilineText = multilineText.slice(0, maxRows - 1).concat(`${tempText}${ellipsis}`);
+  }
+
+  return multilineText.join('\n');
+}
+
+const bizNode = {
+  options: {
+    size: [120, 60],
+    wrapperStyle: {
+      fill: '#5487ea',
+      radius: 8,
+    },
+    contentStyle: {
+      fill: '#ffffff',
+      radius: 6,
+    },
+    labelStyle: {
+      fill: '#000000',
+      textAlign: 'center',
+      textBaseline: 'middle',
+    },
+    stateStyles: {
+      'active': {
+        wrapperStyle: {},
+        contentStyle: {},
+        labelStyle: {},
+      } as any,
+      'selected': {
+        wrapperStyle: {},
+        contentStyle: {},
+        labelStyle: {},
+      } as any,
+    },
+  },
+
+  getOptions(model) {
+    return Object.assign({}, this.options, this.getCustomConfig(model) || {}, model);
+  },
+
+  draw(model, group) {
+    const keyShape = this.drawWrapper(model, group);
+
+    this.drawContent(model, group);
+    this.drawLabel(model, group);
+
+    return keyShape;
+  },
+
+  drawWrapper(model, group) {
+    const [width, height] = this.getSize(model);
+    const { wrapperStyle } = this.getOptions(model);
+
+    const shape = group.addShape('rect', {
+      className: WRAPPER_CLASS_NAME,
+      draggable: true,
+      attrs: {
+        x: 0,
+        y: -WRAPPER_BORDER_WIDTH * 2,
+        width,
+        height: height + WRAPPER_BORDER_WIDTH * 2,
+        ...wrapperStyle,
+      },
+    });
+
+    return shape;
+  },
+
+  drawContent(model, group) {
+    const [width, height] = this.getSize(model);
+    const { contentStyle } = this.getOptions(model);
+
+    const shape = group.addShape('rect', {
+      className: CONTENT_CLASS_NAME,
+      draggable: true,
+      attrs: {
+        x: 0,
+        y: 0,
+        width,
+        height,
+        ...contentStyle,
+      },
+    });
+
+    return shape;
+  },
+
+  drawLabel(model, group) {
+    const [width, height] = this.getSize(model);
+    const { labelStyle } = this.getOptions(model);
+
+    const shape = group.addShape('text', {
+      className: LABEL_CLASS_NAME,
+      draggable: true,
+      attrs: {
+        x: width / 2,
+        y: height / 2,
+        text: model.label,
+        ...labelStyle,
+      },
+    });
+
+    return shape;
+  },
+
+  setLabelText(model, group) {
+    const shape = group.findByClassName(LABEL_CLASS_NAME);
+
+    if (!shape) {
+      return;
+    }
+
+    const [width] = this.getSize(model);
+    const { fontStyle, fontWeight, fontSize, fontFamily } = shape.attr();
+
+    const text = model.label;
+    const font = `${fontStyle} ${fontWeight} ${fontSize}px ${fontFamily}`;
+
+    shape.attr('text', optimizeMultilineText(text, font, 2, width - WRAPPER_HORIZONTAL_PADDING * 2));
+  },
+
+  update(model, item) {
+    const group = item.getContainer();
+
+    this.setLabelText(model, group);
+  },
+
+  setState(name, value, item) {
+    const group = item.getContainer();
+    const model = item.getModel();
+    const states = item.getStates();
+
+    [WRAPPER_CLASS_NAME, CONTENT_CLASS_NAME, LABEL_CLASS_NAME].forEach(className => {
+      const shape = group.findByClassName(className);
+      const options = this.getOptions(model);
+
+      const shapeName = className.split('-')[1];
+
+      shape.attr({
+        ...options[`${shapeName}Style`],
+      });
+
+      states.forEach(state => {
+        if (options.stateStyles[state] && options.stateStyles[state][`${shapeName}Style`]) {
+          shape.attr({
+            ...options.stateStyles[state][`${shapeName}Style`],
+          });
+        }
+      });
+    });
+
+    if (name === 'selected') {
+      const wrapperShape = group.findByClassName(WRAPPER_CLASS_NAME);
+
+      const [width, height] = this.getSize(model);
+
+      if (value) {
+        wrapperShape.attr({
+          x: -WRAPPER_BORDER_WIDTH,
+          y: -WRAPPER_BORDER_WIDTH * 2,
+          width: width + WRAPPER_BORDER_WIDTH * 2,
+          height: height + WRAPPER_BORDER_WIDTH * 3,
+        });
+      } else {
+        wrapperShape.attr({
+          x: 0,
+          y: -WRAPPER_BORDER_WIDTH * 2,
+          width,
+          height: height + WRAPPER_BORDER_WIDTH * 2,
+        });
+      }
+    }
+
+    if (this.afterSetState) {
+      this.afterSetState(name, value, item);
+    }
+  },
+
+  getSize(model) {
+    const { size } = this.getOptions(model);
+
+    if (!isArray(size)) {
+      return [size, size];
+    }
+
+    return size;
+  },
+
+  getCustomConfig() {
+    return {};
+  },
+
+  getAnchorPoints() {
+    return [];
+  },
+};
+
+G6.registerNode('bizNode', bizNode);

--- a/stories/Issues/ggeditorNode/index.tsx
+++ b/stories/Issues/ggeditorNode/index.tsx
@@ -1,0 +1,257 @@
+
+import React, { useRef, useEffect } from "react";
+import G6 from '../../../src';
+import './baseNode'
+// import "./styles.css";
+
+function getNodeSide(item): 'left' | 'right' {
+  const model = item.getModel();
+
+  if (model.side) {
+    return model.side as 'left' | 'right';
+  }
+
+  const parent = item.get('parent');
+
+  if (parent) {
+    return getNodeSide(parent);
+  }
+
+  return 'right';
+}
+
+function getRectPath(x: number, y: number, w: number, h: number, r: number) {
+  if (r) {
+    return [
+      ['M', +x + +r, y],
+      ['l', w - r * 2, 0],
+      ['a', r, r, 0, 0, 1, r, r],
+      ['l', 0, h - r * 2],
+      ['a', r, r, 0, 0, 1, -r, r],
+      ['l', r * 2 - w, 0],
+      ['a', r, r, 0, 0, 1, -r, -r],
+      ['l', 0, r * 2 - h],
+      ['a', r, r, 0, 0, 1, r, -r],
+      ['z'],
+    ];
+  }
+
+  const res = [['M', x, y], ['l', w, 0], ['l', 0, h], ['l', -w, 0], ['z']];
+
+  res.toString = toString;
+
+  return res;
+}
+
+
+function getUnfoldButtonPath() {
+  const w = 14;
+  const h = 14;
+  const rect = getRectPath(0, 0, w, h, 2);
+  const hp = `M${(w * 3) / 14},${h / 2}L${(w * 11) / 14},${h / 2}`;
+  const vp = `M${w / 2},${(h * 3) / 14}L${w / 2},${(h * 11) / 14}`;
+
+  return rect + hp + vp;
+}
+
+function getFoldButtonPath() {
+  const w = 14;
+  const h = 14;
+  const rect = getRectPath(0, 0, w, h, 2);
+  const hp = `M${(w * 3) / 14},${h / 2}L${(w * 11) / 14},${h / 2}`;
+  const vp = '';
+
+  return rect + hp + vp;
+}
+
+
+
+export const FOLD_BUTTON_CLASS_NAME = 'node-fold-button';
+export const UNFOLD_BUTTON_CLASS_NAME = 'node-unfold-button';
+
+const bizMindNode = {
+  afterDraw(model, group) {
+    this.drawButton(model, group);
+  },
+
+  afterUpdate(model, item) {
+    const group = item.getContainer();
+
+    this.drawButton(model, group);
+    this.adjustButton(model, item);
+  },
+
+  drawButton(model, group) {
+    const { children, collapsed } = model;
+
+    [FOLD_BUTTON_CLASS_NAME, UNFOLD_BUTTON_CLASS_NAME].forEach(className => {
+      const shape = group.findByClassName(className);
+
+      if (shape) {
+        shape.destroy();
+      }
+    });
+
+    if (!children || !children.length) {
+      return;
+    }
+
+    if (!collapsed) {
+      group.addShape('path', {
+        className: FOLD_BUTTON_CLASS_NAME,
+        attrs: {
+          path: getFoldButtonPath(),
+          fill: 'red',
+          stroke: '#ccc1d8',
+        },
+      });
+    } else {
+      group.addShape('path', {
+        className: UNFOLD_BUTTON_CLASS_NAME,
+        attrs: {
+          path: getUnfoldButtonPath(),
+          fill: 'blue',
+          stroke: '#ccc1d8',
+        },
+      });
+    }
+  },
+
+  adjustButton(model, item) {
+    const { children, collapsed } = model;
+
+    if (!children || !children.length) {
+      return;
+    }
+
+    const group = item.getContainer();
+    const shape = group.findByClassName(!collapsed ? FOLD_BUTTON_CLASS_NAME : UNFOLD_BUTTON_CLASS_NAME);
+
+    const [width, height] = this.getSize(model);
+
+    const x = getNodeSide(item) === 'left' ? -24 : width + 10;
+    const y = height / 2 - 9;
+
+    shape.translate(x, y);
+  },
+
+  getAnchorPoints() {
+    return [
+      [0, 0.5],
+      [1, 0.5],
+    ];
+  },
+};
+
+G6.registerNode('bizMindNode', bizMindNode, 'bizNode');
+
+G6.registerNode('pathNode', {
+  draw(cfg, group) {
+    return group.addShape('path', {
+      className: FOLD_BUTTON_CLASS_NAME,
+      attrs: {
+        path: getFoldButtonPath(),
+        fill: 'red',
+        stroke: '#ccc1d8',
+      },
+    });
+  }
+})
+
+export default () => {
+  const graphContainer = useRef(null);
+  let graph = null
+
+  // 图初始化
+  useEffect(() => {
+    if (!graph) {
+      graph = new G6.Graph({
+        container: graphContainer.current,
+        width: 500,
+        height: 500,
+        // layout: {
+        //   type: 'mindmap',
+        //   direction: 'H',
+        //   getHeight: () => {
+        //     return 16;
+        //   },
+        //   getWidth: () => {
+        //     return 16;
+        //   },
+        //   getVGap: () => {
+        //     return 180;
+        //   },
+        //   getHGap: () => {
+        //     return 150;
+        //   },
+        // },
+        defaultNode: {
+          type: "pathNode",
+        },
+      
+        defaultEdge: {
+          type: "cubic-vertical",
+          style: {
+            radius: 20,
+            offset: 45,
+            endArrow: true,
+            lineWidth: 2,
+            stroke: "#C2C8D5"
+          }
+        },
+        modes: {
+          default: ["drag-canvas", "zoom-canvas", "click-select"]
+        },
+        fitView: true
+      });
+    }
+    
+
+    // const data = {
+    //   id: '0',
+    //   label: 'Central Topic',
+    //   children: [
+    //     {
+    //       id: '1',
+    //       side: 'left',
+    //       label: 'Main Topic 1',
+    //     },
+    //     {
+    //       id: '2',
+    //       side: 'right',
+    //       label: 'Main Topic 2',
+    //     },
+    //     {
+    //       id: '3',
+    //       side: 'right',
+    //       label: 'Main Topic 3',
+    //     },
+    //   ],
+    // };
+
+    const data = {
+      nodes: [
+        {
+          id: 'node1',
+          x: 100,
+          y: 100
+        }
+      ]
+    }
+    
+    graph.data(data);
+    graph.render();
+
+    graph.on('click', evt  => {
+      console.log(evt)
+    })
+    
+  }, []);
+
+
+  return (
+    <div>
+      <div ref={graphContainer} />
+    </div>
+  );
+};

--- a/stories/Issues/issues.stories.tsx
+++ b/stories/Issues/issues.stories.tsx
@@ -5,6 +5,7 @@ import DagreArrow from './component/dagre-arrow';
 import ChageData from './changeData'
 import ChangeAttr from './attrs'
 import ForceLayout from './forceLayout'
+import GGEditorNode from './ggeditorNode'
 
 export default { title: 'Issues' };
 
@@ -22,3 +23,4 @@ storiesOf('Issues', module)
   <ChangeAttr />
 ))
 .add('forcelayout', () => <ForceLayout />)
+.add('ggeditor node issue', () => <GGEditorNode />)

--- a/stories/Tree/component/self-tree.tsx
+++ b/stories/Tree/component/self-tree.tsx
@@ -1,0 +1,430 @@
+import React, { useEffect } from 'react';
+import G6 from '../../../src';
+import { IGraph } from '../../../src/interface/graph';
+import { EdgeConfig } from '../../../src/types';
+
+let graph: IGraph = null;
+const data = {
+  nodes: [
+    {
+        id: '0',
+        label: '流程1',
+        row: 1,  // 第一层
+        content: '22222222,222',
+        x: 20,
+        y: 50,
+        anchorPoints:[
+          [1, 0.5],  
+        ],
+        labelCfg: {
+          position: 'center',
+        },
+    }, {
+        id: '1',
+        label: '流程2',
+        content: '11111111,111',
+        row: 1,
+        x: 170,
+        y: 50,
+        anchorPoints:[
+          [0, 0.5],  
+          [1, 0.5],  
+        ],
+        labelCfg: {
+          position: 'center',
+        },
+    }, {
+        id: '1__',
+        label: '80%',
+        row: 1,
+        x: 170,
+        y: 50,
+        labelCfg: {
+          position: 'center',
+        },
+        shape: 'nodeLabel',
+    }, {
+        id: '1_1',
+        label: '分支1',
+        row: 2,  // 第二层
+        x: 170,
+        y: 100,
+        anchorPoints:[
+          [0, 0.5],  
+        ],
+        labelCfg: {
+          position: 'center',
+        },
+    }, {
+        id: '1_1__',
+        label: '70%',
+        row: 2,
+        x: 170,
+        y: 100,
+        labelCfg: {
+          position: 'center',
+        },
+        shape: 'nodeLabel',
+    }, {
+        id: '2',
+        label: '流程3',
+        row: 1,
+        x: 320,
+        y: 50,
+        anchorPoints:[
+          [0, 0.5],  
+          [1, 0.5],  
+        ]
+    }, {
+        id: '2__',
+        label: '60%',
+        row: 1,
+        x: 320,
+        y: 50,
+        labelCfg: {
+          position: 'center',
+        },
+        shape: 'nodeLabel',
+    }, {
+        id: '2_1',
+        label: '分支2',
+        row: 2,
+        x: 320,
+        y: 100,
+        anchorPoints:[
+          [0, 0.5],  
+        ]
+    }, {
+        id: '2_1__',
+        label: '50%',
+        row: 2,
+        x: 320,
+        y: 100,
+        labelCfg: {
+          position: 'center',
+        },
+        shape: 'nodeLabel',
+    }, {
+        id: '3',
+        label: '流程4',
+        row: 1,
+        x: 470,
+        y: 50,
+        anchorPoints:[
+          [0, 0.5],  
+          [1, 0.5],  
+        ]
+    }, {
+        id: '3__',
+        label: '40%',
+        row: 1,
+        x: 470,
+        y: 50,
+        labelCfg: {
+          position: 'center',
+        },
+        shape: 'nodeLabel',
+    }, {
+        id: '3_1',
+        label: '分支3',
+        row: 2,
+        x: 470,
+        y: 100,
+        anchorPoints:[
+          [0, 0.5],  
+        ]
+    }, {
+        id: '3_1__',
+        label: '30%',
+        row: 2,
+        x: 470,
+        y: 100,
+        labelCfg: {
+          position: 'center',
+        },
+        shape: 'nodeLabel',
+    }
+  ],
+  edges: [
+    {
+        id: '0-1',
+        source: '0',
+        target: '1',
+        sourceAnchor: 0, // 指定起始的连接点锚点
+        targetAnchor: 0, // 指定终止的连接点锚点
+    }, {
+        id: '0-1_1',
+        source: '0',
+        target: '1_1',
+        shape: 'hvh',
+        sourceAnchor: 1,
+        targetAnchor: 0,
+    }, {
+        id: '1-2',
+        source: '1',
+        target: '2',
+        sourceAnchor: 1,
+        targetAnchor: 0,
+    }, {
+        id: '1-2_1',
+        source: '1',
+        target: '2_1',
+        shape: 'hvh',
+        sourceAnchor: 1,
+        targetAnchor: 0,
+    }, {
+        id: '2-3',
+        source: '2',
+        target: '3',
+        sourceAnchor: 1,
+        targetAnchor: 0,
+    }, {
+        id: '2-3_1',
+        source: '2',
+        target: '3_1',
+        shape: 'hvh',
+        sourceAnchor: 1,
+        targetAnchor: 0,
+    }
+  ]
+};
+
+G6.registerNode('operation', {
+  drawShape: function (cfg, group) {
+    var rect = group.addShape('rect', {
+      attrs: cfg.row === 1 
+      ? {
+        x: cfg.x,
+        y: cfg.content ? cfg.y - 10 : cfg.y,
+        width: 150,
+        height: cfg.content ? 48 : 28,
+        radius: cfg.content ? 4 : 12,
+        stroke: '#1890FF',
+        fill: '#E6F7FF',
+        fillOpacity: 0.4,
+        lineWidth: 2         
+      } : {
+        x: cfg.x,
+        y: cfg.content ? cfg.y - 10 : cfg.y,
+        width: 150,
+        height: cfg.content ? 48 : 28,
+        radius: cfg.content ? 24 : 12,
+        stroke: '#13C2C2',
+        fill: '#E6FFFB',
+        fillOpacity: 0.4,
+        lineWidth: 2
+      }
+    });
+    
+    return rect;
+  },
+  drawLabel: function (cfg: any, group) {
+    var label = group.addShape('text', {
+      position: 'center',
+      attrs: {
+        x: cfg.x + 75,
+        y: cfg.y + 14,
+        position: 'center',
+        text: cfg.content ? cfg.label + cfg.content : cfg.label,
+        textAlign: 'center',
+        textBaseline: 'middle',
+        fill: '#666',
+        stroke: '#FFF',
+        fontSize: 12,
+      }
+    });
+    return label;
+  },
+}, 'single-node');
+
+G6.registerNode('nodeLabel', {
+  drawShape: function (cfg, group) {
+    var rect = group.addShape('rect', {
+      attrs: cfg.row === 1 
+      ? {
+        x: cfg.x - 70,
+        y: cfg.y + 4,
+        width: 50,
+        height: 20,
+        radius: 4,
+        stroke: '#1890FF',
+        fill: '#1890FF',
+        lineWidth: 2,
+      }
+      : {
+        x: cfg.x - 70,
+        y: cfg.y + 4,
+        width: 50,
+        height: 20,
+        radius: 4,
+        stroke: '#13C2C2',
+        fill: '#13C2C2',
+        lineWidth: 2,            
+      }
+    });
+    return rect;
+  },
+  drawLabel: function (cfg, group) {
+    var label = group.addShape('text', {
+      position: 'center',
+      attrs: {
+        x: cfg.x - 45,
+        y: cfg.y + 14,
+        position: 'center',
+        text: cfg.label,
+        textAlign: 'center',
+        textBaseline: 'middle',
+        fill: '#fff',
+        stroke: '#fff',
+        fontSize: 12,
+      }
+    });
+    return label;
+  },
+}, 'single-node');
+
+G6.registerEdge('hh', {
+  draw(cfg, group) {
+    return this.drawShape(cfg, group);
+  },  
+  drawShape(cfg: EdgeConfig, group) {
+    const startPoint = cfg.startPoint;
+    const endPoint = cfg.endPoint;
+
+    const shape = group.addShape('path', {
+      attrs: {
+        stroke: '#41A9FF',
+        endArrow: {
+          path: 'M 0 0 L 0, -5 L -10, 0, L 0, 5 Z',
+          fill: '#41A9FF'
+        },
+        path: [
+          ['M', startPoint.x, startPoint.y],
+          ['L', endPoint.x - 10, endPoint.y]
+        ]
+      }
+    });
+
+    return shape;
+  },
+  drawLabel: function (cfg: EdgeConfig, group) {
+    const endPoint = cfg.endPoint;
+    var label = group.addShape('text', {
+      position: 'right',
+      attrs: {
+        x: endPoint.x - 20,
+        y: endPoint.y,
+        position: 'right',
+        textAlign: 'right',
+        text: cfg.label,
+        textBaseline: 'middle',
+        fill: '#fff',
+        stroke: '#fff',
+        fontSize: 12,
+      }
+    });
+    return label;
+  },
+});
+
+G6.registerEdge('hvh', {
+  draw(cfg, group) {
+    return this.drawShape(cfg, group);
+  },  
+  drawShape(cfg: EdgeConfig, group) {
+    const startPoint = cfg.startPoint;
+    const endPoint = cfg.endPoint;
+
+    const shape = group.addShape('path', {
+      attrs: {
+        stroke: '#13C2C2',
+        endArrow: {
+          path: 'M 0 0 L 0, -5 L -10, 0, L 0, 5 Z',
+          fill: '#13C2C2'
+        },
+        path: [
+          ['M', startPoint.x, startPoint.y],
+          ['L', endPoint.x / 3 + 2 / 3 * startPoint.x , startPoint.y],
+          ['L', endPoint.x / 3 + 2 / 3 * startPoint.x , endPoint.y],
+          ['L', endPoint.x - 10, endPoint.y]
+        ]
+      }
+    });
+
+    return shape;
+  },
+  drawLabel: function (cfg: EdgeConfig, group) {
+    const endPoint = cfg.endPoint;
+    var label = group.addShape('text', {
+      position: 'right',
+      attrs: {
+        x: endPoint.x - 20,
+        y: endPoint.y,
+        position: 'right',
+        textAlign: 'right',
+        text: cfg.label,
+        textBaseline: 'middle',
+        fill: '#fff',
+        stroke: '#fff',
+        fontSize: 12,
+      }
+    });
+    return label;
+  },
+});
+
+const SelfTress = () => {
+  const container = React.useRef();
+  useEffect(() => {
+    if (!graph) {
+      graph = new G6.Graph({
+        container: container.current as string | HTMLElement,
+        width: 1000,
+        height: 500,
+        modes: {
+          default: [
+            'drag-canvas',
+            'zoom-canvas',
+          ],
+        },
+        defaultNode: {
+          shape: 'operation',
+          labelCfg: {
+            position: 'right',
+            style: {
+              fill: '#666',
+              stroke: '#fff',
+              fontSize: 14,
+              fontWeight: 'bold'
+            }
+          }
+        },
+        defaultEdge: {
+          shape: 'hh',
+          style: {
+            stroke: '#41A9FF',
+            lineWidth: 1
+          },
+          labelCfg: {
+            position: 'right',
+            style: {
+              position: 'right',
+              textAligh: 'right',
+              offset: -50,
+              textBaseline: 'middle',
+              fill: '#41A9FF',
+              stroke: '#41A9FF',
+              fontSize: 12
+            }
+          }
+        }
+      });
+      
+      graph.data(data);
+      graph.render();
+    }
+  });
+  return <div ref={container}></div>;
+}
+
+export default SelfTress

--- a/stories/Tree/tree.stories.tsx
+++ b/stories/Tree/tree.stories.tsx
@@ -3,9 +3,11 @@ import { storiesOf } from '@storybook/react';
 import React from 'react';
 import FileSystem from './component/file-system';
 import LargeDataTree from './component/large-data';
+import SlefTree from './component/self-tree'
 
 export default { title: 'Tree' };
 
 storiesOf('Tree', module)
   .add('indented tree file system', () => <FileSystem />)
-  .add('large data custom tree', () => <LargeDataTree />);
+  .add('large data custom tree', () => <LargeDataTree />)
+  .add('register flow tree', () => <SlefTree />)

--- a/tests/unit/behavior/drag-combo-spec.ts
+++ b/tests/unit/behavior/drag-combo-spec.ts
@@ -137,4 +137,166 @@ describe('drag-combo', () => {
     })
     
   })
+
+  it.only('combo example', () => {
+    const data = {
+      nodes: [
+        {
+          id: 'node1',
+          x: 150,
+          y: 150,
+          label: 'node1',
+          comboId: 'A'
+        },
+        {
+          id: 'node2',
+          x: 200,
+          y: 250,
+          label: 'node2',
+          comboId: 'B'
+        },
+        {
+          id: 'node3',
+          x: 100,
+          y: 250,
+          label: 'node3',
+        },
+        {
+          id: 'node4',
+          x: 50,
+          y: 50,
+          label: 'node4',
+          comboId: 'D'
+        },
+        {
+          id: 'node5',
+          x: 100,
+          y: 100,
+          label: 'node5',
+          comboId: 'E'
+        },
+        {
+          id: 'node6',
+          x: 500,
+          y: 200,
+          label: 'node6'
+        },
+        {
+          id: 'node7',
+          x: 600,
+          y: 200,
+          label: 'node7'
+        }
+      ],
+      edges: [
+        {
+          source: 'node1',
+          target: 'node2',
+        },
+        {
+          source: 'node2',
+          target: 'node3',
+        },
+        {
+          source: 'node3',
+          target: 'node1',
+        },
+        {
+          source: 'A',
+          target: 'D'
+        }
+      ],
+      combos: [
+      {
+        id: 'A',
+        parentId: 'B',
+        label: 'gorup A',
+        padding: [50, 30, 10, 10],
+        type: 'rect',
+        style: {
+          stroke: 'red',
+          fill: 'green'
+        }
+      }, {
+        id: 'B',
+        label: 'gorup B',
+        padding: [50, 10, 10, 50],
+        // type: 'custom-combo'
+      },
+      {
+        id: 'D',
+        label: 'gorup D',
+        parentId: 'E',
+      }, 
+      {
+        id: 'E',
+      },
+      {
+        id: 'FF',
+        label: '空分组',
+        type: 'custom-combo',
+        style: {
+          stroke: 'green',
+          lineWidth: 3
+        }
+      }
+      ]
+    };
+
+    const graph = new G6.Graph({
+      container: 'drag-combo-spec',
+      width: 1000,
+      height: 800,
+      groupByTypes: false,
+      modes: {
+        default: [ 'drag-canvas', 'drag-combo', 'drag-node', 'collapse-expand-combo' ]
+      },
+      defaultCombo: {
+        // size: [100, 100],
+        type: 'circle',
+        style: {
+          fill: '#ccc',
+          opacity: 0.9
+        }
+      },
+      comboStateStyles: {
+        hover: {
+          'text-shape': {
+            fill: '#f00',
+            fontSize: 20
+          },
+          fill: '#f00'
+        },
+        active: {
+          stroke: 'red'
+        },
+        state2: {
+          stroke: '#0f0'
+        }
+      },
+      defaultEdge: {
+        style: {
+          stroke: '#f00',
+          lineWidth: 3
+        }
+      }
+    });
+    
+    graph.data(data);
+    graph.render();
+
+    // setTimeout(() => {
+    //   graph.updateComboTree('D')
+    // }, 1000)
+
+    // graph.on('combo:mouseenter', evt => {
+    //   const { item } = evt
+    //   graph.setItemState(item, 'hover', true)
+    // })
+
+    // graph.on('combo:mouseleave', evt => {
+    //   const { item } = evt
+    //   graph.setItemState(item, 'hover', false)
+    // })
+  })
 })


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->
渲染
✅渲染空分组：
✅支持 Circle 及 Rect 两种默认类型，使用默认样式及配置；
✅设置空分组样式、标题；
✅渲染自定义空分组。
✅渲染单层分组：
✅能够渲染 Circle、Rect 两种默认 Combo，使用默认样式；
✅设置标题、边框及填充色；
✅能够设置 Combo 中的间距；
✅能够渲染单层自定义 Combo。
✅渲染嵌套分组：
✅能够设置嵌套分组的类型，比如 Circle Combo 中能嵌套 Rect Combo；
✅设置指定 Combo 的标题、边框及填充色；
✅能够设置 Combo 中的间距；
✅能够渲染嵌套的自定义 Combo。
🔲支持渲染默认收起的分组：需要提供配置项配置是否默认收起。

自定义分组：
✅支持自定义分组，能够指定大小、标题及样式；

创建组合拆分组：
✅创建组：选定元素，生成一个组，可以指定组的类型；
✅选中组，进行拆分，拆分后，删除 combo 数据，但 Combo 中的元素保留。

分组关系（适用于单层及嵌套分组）：
✅分组中节点与节点关系；
✅不同分组中节点的关系；
✅分组收起后分组外的节点连接到分组上；
✅支持分组与分组之间连接；
✅支持分组与节点之间连接；
✅嵌套分组中，收起内部分组后，再收起最外层分组，然后展开外层分组后，内部的保持收起状态；
✅动态改变分组与分组、分组与节点之间的连接。

拖出分组：
✅将子分组拖出父分组；
✅将节点拖出父分组；
✅被拖出元素的父分组高亮；
✅将图元素拖出分组后，支持保留空分组；
✅将节点或分组拖出父分组后，父分组自动改变大小；
🔲动态改变分组大小：提供配置项，拖动分组中节点时是拖出分组还是动态改变分组大小；

拖入分组：
✅将节点拖入到分组中；
✅将分组拖入到分组中；
✅将节点或分组拖入分组结束后，动态改变分组大小；
✅拖入时目标分组高亮。

分组交互：
✅收起分组：隐藏分组中的图元素；
✅展开分组：显示分组中的图元素；
✅拖动分组：分组中的节点跟随拖动，父分组高亮；
✅支持设置分组选中、hover 等交互状态。

删除：
🔲删除分组，与分组相连的边同步删除；
🔲删除分组，是否删除分组中的节点；
🔲删除分组中的图元素。

布局：
✅布局各分组中节点时要考虑其他节点的影响；
✅支持分组的局部布局。

动画效果：
🔲收起分组时，分组中的节点逐步消失；
✅展开分组时，分组中的节点逐步出现。