### PR TITLE
fix: drag-node behavior supports selected states

### DIFF
--- a/src/behavior/click-select.ts
+++ b/src/behavior/click-select.ts
@@ -92,7 +92,7 @@ export default {
     each(selected, node => {
       graph.setItemState(node, this.selectedState, false);
     });
-debugger
+
     const selectedCombos = graph.findAllByState('combo', this.selectedState)
     each(selectedCombos, combo => {
       graph.setItemState(combo, this.selectedState, false);

--- a/src/behavior/drag-combo.ts
+++ b/src/behavior/drag-combo.ts
@@ -37,6 +37,8 @@ export default {
     return {
       enableDelegate: false,
       delegateStyle: {},
+      // 拖动节点过程中是否只改变 Combo 的大小，而不改变其结构
+      onlyChangeComboSize: false,
       // 拖动过程中目标 combo 状态样式
       activeState: '',
       selectedState: 'selected'
@@ -106,8 +108,6 @@ export default {
 
     this.point = {};
     this.originPoint = {};
-
-    this.itemStates = {}
 
     this.origin = {
       x: evt.x,
@@ -200,7 +200,10 @@ export default {
         if (this.activeState) {
           graph.setItemState(item, this.activeState, false)
         }
-        graph.updateComboTree(combo, targetModel.id)
+        // 将 Combo 放置到某个 Combo 上面时，只有当 onlyChangeComboSize 为 false 时候才更新 Combo 结构
+        if (!this.onlyChangeComboSize) {
+          graph.updateComboTree(combo, targetModel.id)
+        }
       }
     })
 
@@ -252,102 +255,107 @@ export default {
     
     const model = item.getModel()
 
-    // 拖动结束时计算拖入还是拖出, 需要更新 combo
-    // 1. 是否将当前 combo 拖出了 父 combo；
-    // 2. 是否将当前 combo 拖入了新的 combo
-    const type = item.getType()
-    if (type === 'combo') {
-      const parentId = model.parentId
-
-      let currentBBox = null
-      const parentCombo = this.getParentCombo(parentId)
-
-      // 当只有存在 parentCombo 时才处理拖出的情况
-      if (parentCombo) {
-        if (this.enableDelegate) {
-          currentBBox = this.delegateShape.getBBox()
-        } else {
-          currentBBox = item.getBBox()
-        }
-        const { x: cx, y: cy, centerX, centerY, width } = currentBBox;
-
-        //判断是否拖出了 combo，需要满足： 
-        // 1、有 parent；
-        // 2、拿拖动的对象和它父parent比较
-
-        const parentBBox = parentCombo.getBBox()
-        const { minX, minY, maxX, maxY, centerX: pcx, centerY: pcy, width: w } = parentBBox;
-
-        // 拖出了父 combo
-        // 如果直接拖出到了 父 combo 周边，则不用计算距离圆心距离
-        if (cx <= minX || cx >= maxX || cy <= minY || cy >= maxY) {
-          if (this.activeState) {
-            graph.setItemState(parentCombo, this.activeState, false)
+    // 拖动 Combo 结束后，如果 onlyChangeComboSize 值为 true 则只更新 Combo 位置，不更新结构
+    if (this.onlyChangeComboSize) {
+      graph.updateCombos()
+    } else {
+      // 拖动结束时计算拖入还是拖出, 需要更新 combo
+      // 1. 是否将当前 combo 拖出了 父 combo；
+      // 2. 是否将当前 combo 拖入了新的 combo
+      const type = item.getType()
+      if (type === 'combo') {
+        const parentId = model.parentId
+  
+        let currentBBox = null
+        const parentCombo = this.getParentCombo(parentId)
+  
+        // 当只有存在 parentCombo 时才处理拖出的情况
+        if (parentCombo) {
+          if (this.enableDelegate) {
+            currentBBox = this.delegateShape.getBBox()
+          } else {
+            currentBBox = item.getBBox()
           }
-          isDragOut = true
-          // 表示正在拖出操作
-          graph.updateComboTree(item as ICombo)
-        } else {
-          // 拖动的 combo 和要进入的 combo 之间的距离
-          const disX = centerX - pcx
-          const disY = centerY - pcy
-          // 圆心距离
-          const distance = 2 * Math.sqrt(disX * disX + disY * disY)
-
-          // 拖出的还在父 combo 包围盒范围内，但实际上已经拖出去了
-          if ((width + w) - distance < 0.8 * width) {
+          const { x: cx, y: cy, centerX, centerY, width } = currentBBox;
+  
+          //判断是否拖出了 combo，需要满足： 
+          // 1、有 parent；
+          // 2、拿拖动的对象和它父parent比较
+  
+          const parentBBox = parentCombo.getBBox()
+          const { minX, minY, maxX, maxY, centerX: pcx, centerY: pcy, width: w } = parentBBox;
+  
+          // 拖出了父 combo
+          // 如果直接拖出到了 父 combo 周边，则不用计算距离圆心距离
+          if (cx <= minX || cx >= maxX || cy <= minY || cy >= maxY) {
             if (this.activeState) {
               graph.setItemState(parentCombo, this.activeState, false)
             }
             isDragOut = true
+            // 表示正在拖出操作
             graph.updateComboTree(item as ICombo)
+          } else {
+            // 拖动的 combo 和要进入的 combo 之间的距离
+            const disX = centerX - pcx
+            const disY = centerY - pcy
+            // 圆心距离
+            const distance = 2 * Math.sqrt(disX * disX + disY * disY)
+  
+            // 拖出的还在父 combo 包围盒范围内，但实际上已经拖出去了
+            if ((width + w) - distance < 0.8 * width) {
+              if (this.activeState) {
+                graph.setItemState(parentCombo, this.activeState, false)
+              }
+              isDragOut = true
+              graph.updateComboTree(item as ICombo)
+            }
           }
         }
-      }
-
-      // 拖入
-      if (!this.endComparison && !isDragOut) {
-        // 判断是否拖入了 父 Combo，需要满足：
-        // 1、拖放最终位置是 combo，且不是父 Combo；
-        // 2、拖动 Combo 进入到非父 Combo 超过 50%；
-        const combos = graph.getCombos()
-        const sourceBBox = item.getBBox()
-
-        const { centerX, centerY, width } = sourceBBox
-
-        // 参与计算的 Combo，需要排除掉：
-        // 1、拖动 combo 自己
-        // 2、拖动 combo 的 parent
-        // 3、拖动 Combo 的 children
-        const calcCombos = combos.filter(combo => {
-          const cmodel = combo.getModel() as ComboConfig
-          // 被拖动的是最外层的 Combo，无 parent，排除自身和子元素
-          if (!model.parentId) {
+  
+        // 拖入
+        if (!this.endComparison && !isDragOut) {
+          // 判断是否拖入了 父 Combo，需要满足：
+          // 1、拖放最终位置是 combo，且不是父 Combo；
+          // 2、拖动 Combo 进入到非父 Combo 超过 50%；
+          const combos = graph.getCombos()
+          const sourceBBox = item.getBBox()
+  
+          const { centerX, centerY, width } = sourceBBox
+  
+          // 参与计算的 Combo，需要排除掉：
+          // 1、拖动 combo 自己
+          // 2、拖动 combo 的 parent
+          // 3、拖动 Combo 的 children
+          const calcCombos = combos.filter(combo => {
+            const cmodel = combo.getModel() as ComboConfig
+            // 被拖动的是最外层的 Combo，无 parent，排除自身和子元素
+            if (!model.parentId) {
+              return cmodel.id !== model.id && !this.currentItemChildCombos.includes(cmodel.id)
+            }
             return cmodel.id !== model.id && !this.currentItemChildCombos.includes(cmodel.id)
-          }
-          return cmodel.id !== model.id && !this.currentItemChildCombos.includes(cmodel.id)
-        })
-
-        calcCombos.map(combo => {
-          const current = combo.getModel()
-          const { centerX: cx, centerY: cy, width: w } = combo.getBBox()
-
-          // 拖动的 combo 和要进入的 combo 之间的距离
-          const disX = centerX - cx
-          const disY = centerY - cy
-          // 圆心距离
-          const distance = 2 * Math.sqrt(disX * disX + disY * disY)
-
-          if (this.activeState) {
-            graph.setItemState(combo, this.activeState, false)
-          }
-
-          if ((width + w) - distance >  0.8 * width) {
-            graph.updateComboTree(item as ICombo, current.id)
-          }
-        })
+          })
+  
+          calcCombos.map(combo => {
+            const current = combo.getModel()
+            const { centerX: cx, centerY: cy, width: w } = combo.getBBox()
+  
+            // 拖动的 combo 和要进入的 combo 之间的距离
+            const disX = centerX - cx
+            const disY = centerY - cy
+            // 圆心距离
+            const distance = 2 * Math.sqrt(disX * disX + disY * disY)
+  
+            if (this.activeState) {
+              graph.setItemState(combo, this.activeState, false)
+            }
+  
+            if ((width + w) - distance >  0.8 * width) {
+              graph.updateComboTree(item as ICombo, current.id)
+            }
+          })
+        }
+  
       }
-
     }
 
     // 删除delegate shape
@@ -357,11 +365,6 @@ export default {
       this.delegateShape = null
     }
 
-    for(let itemId in this.itemStates) {
-      const states = this.itemStates[itemId]
-      each(states, state => graph.setItemState(item, state, true))
-    }
-    
     const parentCombo = this.getParentCombo(model.parentId)
     if (parentCombo && this.activeState) {
       graph.setItemState(parentCombo, this.activeState, false)
@@ -372,7 +375,6 @@ export default {
     this.origin = null
     this.originPoint = null
     this.targets.length = 0
-    this.itemStates = {}
   },
 
   /**
@@ -428,12 +430,6 @@ export default {
 
     const x: number = evt.x - origin.x + this.point[itemId].x;
     const y: number = evt.y - origin.y + this.point[itemId].y;
-    
-    if (item.getStates().length > 0) {
-      const states = item.getStates()
-      this.itemStates[itemId] = [...states]
-      each(states, state => graph.setItemState(item, state, false))
-    }
 
     graph.updateItem(item, { x, y });
   },

--- a/src/behavior/drag-node.ts
+++ b/src/behavior/drag-node.ts
@@ -19,6 +19,8 @@ export default {
       delegateStyle: {},
       // 是否开启delegate
       enableDelegate: false,
+      // 拖动节点过程中是否只改变 Combo 的大小，而不改变其结构
+      onlyChangeComboSize: false,
       // 拖动过程中目标 combo 状态样式
       comboActiveState: '',
       selectedState: 'selected'
@@ -162,24 +164,31 @@ export default {
       this.targets.map(node => this.update(node, evt));
     }
 
-    // 拖放到了最外面，如果targets中有 combo，则删除掉
     const graph: IGraph = this.graph
-    if (!this.targetCombo) {
-      this.targets.map((node: INode) => {
-        // 拖动的节点有 comboId，即是从其他 combo 中拖出时才处理
-        const model = node.getModel()
-        if (model.comboId) {
-          graph.updateComboTree(node)
-        }
-      })
+
+    // 拖动结束后是动态改变 Combo 大小还是将节点从 Combo 中删除
+    if (this.onlyChangeComboSize) {
+      // 拖动节点结束后，动态改变 Combo 的大小
+      graph.updateCombos()
     } else {
-      const targetComboModel = this.targetCombo.getModel()
-      this.targets.map((node: INode) => {
-        const nodeModel = node.getModel()
-        if (nodeModel.comboId !== targetComboModel.id) {
-          graph.updateComboTree(node, targetComboModel.id)
-        }
-      })
+      // 拖放到了最外面，如果targets中有 combo，则删除掉
+      if (!this.targetCombo) {
+        this.targets.map((node: INode) => {
+          // 拖动的节点有 comboId，即是从其他 combo 中拖出时才处理
+          const model = node.getModel()
+          if (model.comboId) {
+            graph.updateComboTree(node)
+          }
+        })
+      } else {
+        const targetComboModel = this.targetCombo.getModel()
+        this.targets.map((node: INode) => {
+          const nodeModel = node.getModel()
+          if (nodeModel.comboId !== targetComboModel.id) {
+            graph.updateComboTree(node, targetComboModel.id)
+          }
+        })
+      }
     }
 
     this.point = {};

--- a/src/behavior/drag-node.ts
+++ b/src/behavior/drag-node.ts
@@ -20,7 +20,8 @@ export default {
       // 是否开启delegate
       enableDelegate: false,
       // 拖动过程中目标 combo 状态样式
-      activeState: ''
+      comboActiveState: '',
+      selectedState: 'selected'
     };
   },
   getEvents(): { [key in G6Event]?: string } {
@@ -82,7 +83,7 @@ export default {
     this.targetCombo = null
 
     // 获取所有选中的元素
-    const nodes = graph.findAllByState('node', 'selected');
+    const nodes = graph.findAllByState('node', this.selectedState);
 
     const currentNodeId = item.get('id');
 
@@ -197,8 +198,8 @@ export default {
 
     const graph: IGraph = this.graph
 
-    if (this.activeState) {
-      graph.setItemState(item, this.activeState, false)
+    if (this.comboActiveState) {
+      graph.setItemState(item, this.comboActiveState, false)
     }
 
     this.targetCombo = item
@@ -212,8 +213,8 @@ export default {
     this.validationCombo(item)
 
     const graph: IGraph = this.graph
-    if (this.activeState) {
-      graph.setItemState(item, this.activeState, true)
+    if (this.comboActiveState) {
+      graph.setItemState(item, this.comboActiveState, true)
     }
   },
   /**
@@ -225,8 +226,8 @@ export default {
     this.validationCombo(item)
 
     const graph: IGraph = this.graph
-    if (this.activeState) {
-      graph.setItemState(item, this.activeState, false)
+    if (this.comboActiveState) {
+      graph.setItemState(item, this.comboActiveState, false)
     }
   },
   /**
@@ -299,7 +300,7 @@ export default {
   calculationGroupPosition(evt: IG6GraphEvent) {
     const { graph } = this;
 
-    const nodes = graph.findAllByState('node', 'selected');
+    const nodes = graph.findAllByState('node', this.selectedState);
     if (nodes.length === 0) {
       nodes.push(evt.item)
     }

--- a/src/graph/graph.ts
+++ b/src/graph/graph.ts
@@ -934,7 +934,23 @@ export default class Graph extends EventEmitter implements IGraph {
    */
   public updateItem(item: Item | string, cfg: Partial<NodeConfig> | EdgeConfig): void {
     const itemController: ItemController = this.get('itemController');
-    itemController.updateItem(item, cfg);
+    let currentItem
+    if (isString(item)) {
+      currentItem = this.findById(item)
+    } else {
+      currentItem = item
+    }
+
+    const type = currentItem.getType()
+    const states = [...currentItem.getStates()]
+    if (type === 'combo') {
+      each(states, state => this.setItemState(currentItem, state, false))
+    }
+    itemController.updateItem(currentItem, cfg);
+
+    if (type === 'combo') {
+      each(states, state => this.setItemState(currentItem, state, true))
+    }
   }
 
   /**
@@ -1355,7 +1371,15 @@ export default class Graph extends EventEmitter implements IGraph {
         }
         const childItem = itemMap[child.id];
         if (childItem && childItem.getType() === 'combo') {
+          // 更新具体的 Combo 之前先清除所有的已有状态，以免将 state 中的样式更新为 Combo 的样式
+          const states = [...childItem.getStates()]
+          each(states, state => this.setItemState(childItem, state, false))
+
+          // 更新具体的 Combo
           itemController.updateCombo(childItem, child.children);
+          
+          // 更新 Combo 后，还原已有的状态
+          each(states, state => this.setItemState(childItem, state, true))
         }
         return true;
       });
@@ -1400,6 +1424,7 @@ export default class Graph extends EventEmitter implements IGraph {
     if (parentId) {
       const parentCombo = this.findById(parentId) as ICombo
       if (parentCombo) {
+        // 将元素添加到 parentCombo 中
         parentCombo.addChild(uItem as ICombo | INode)
       }
     }
@@ -1407,6 +1432,7 @@ export default class Graph extends EventEmitter implements IGraph {
     if (oldParentId) {
       const parentCombo = this.findById(oldParentId) as ICombo
       if (parentCombo) {
+        // 将元素从 parentCombo 中移除
         parentCombo.removeChild(uItem as ICombo | INode)
       }
     }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -120,6 +120,7 @@ export interface ModeOption {
   activeState?: string;
   comboActiveState?: string;
   selectedState?: string;
+  onlyChangeComboSize?: boolean;
   includeEdges?: boolean;
   direction?: 'x' | 'y';
   shouldUpdate?: (e: IG6GraphEvent) => boolean;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -117,7 +117,8 @@ export interface ModeOption {
   enableOptimize?: boolean;
   optimizeZoom?: number;
   multiple?: boolean;
-  activeState: string;
+  activeState?: string;
+  comboActiveState?: string;
   selectedState?: string;
   includeEdges?: boolean;
   direction?: 'x' | 'y';

--- a/tests/unit/behavior/drag-combo-spec.ts
+++ b/tests/unit/behavior/drag-combo-spec.ts
@@ -238,32 +238,32 @@ describe('drag-combo', () => {
         }
       ],
       combos: [
-      // {
-      //   id: 'A',
-      //   parentId: 'B',
-      //   label: 'gorup A',
-      //   padding: [50, 30, 10, 10],
-      //   type: 'rect',
-      //   style: {
-      //     stroke: 'red',
-      //     fill: 'green'
-      //   },
-      //   // collapsed: true
-      // }, {
-      //   id: 'B',
-      //   label: 'gorup B',
-      //   padding: [50, 10, 10, 50],
-      //   // type: 'custom-combo'
-      // },
-      // {
-      //   id: 'D',
-      //   label: 'gorup D',
-      //   parentId: 'E',
-      // }, 
-      // {
-      //   id: 'E',
-      //   // collapsed: true
-      // },
+      {
+        id: 'A',
+        parentId: 'B',
+        label: 'gorup A',
+        padding: [50, 30, 10, 10],
+        type: 'rect',
+        style: {
+          stroke: 'red',
+          fill: 'green'
+        },
+        // collapsed: true
+      }, {
+        id: 'B',
+        label: 'gorup B',
+        padding: [50, 10, 10, 50],
+        // type: 'custom-combo'
+      },
+      {
+        id: 'D',
+        label: 'gorup D',
+        parentId: 'E',
+      }, 
+      {
+        id: 'E',
+        // collapsed: true
+      },
       {
         id: 'FF',
         label: '空分组',
@@ -285,7 +285,10 @@ describe('drag-combo', () => {
         default: [ 'drag-canvas', {
           type: 'drag-combo',
           activeState: 'active'
-        }, 'drag-node', 'collapse-expand-combo', 'click-select' ]
+        }, {
+          type: 'drag-node',
+          comboActiveState: 'active'
+        }, 'collapse-expand-combo', 'click-select' ]
       },
       defaultCombo: {
         // size: [100, 100],

--- a/tests/unit/behavior/drag-combo-spec.ts
+++ b/tests/unit/behavior/drag-combo-spec.ts
@@ -304,7 +304,7 @@ describe('drag-combo', () => {
           //   fill: '#f00',
           //   fontSize: 20
           // },
-          stroke: '#f00'
+          stroke: 'blue'
         },
         active: {
           stroke: 'red'


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->
1. drag-node behavior 中支持用户配置选中状态的状态值，默认为 selected；
2. drag-node behavior 中支持用户配置拖动节点时 combo 高亮的状态值，默认为空；
3. drag-node behavior 支持用户配置，拖动节点是将节点拖出 combo 还是 combo 动态变化。