### PR TITLE
refactor: use ml-matrix for the mds layout instead of numericJS

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -2,5 +2,3 @@ declare module '*.json' {
   export const version: string;
   export const value: any;
 }
-
-declare module 'numericjs';

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "d3-force": "^2.0.1",
     "dagre": "^0.8.5",
     "lodash": "^4.17.15",
-    "numericjs": "^1.2.6"
+    "ml-matrix": "^6.5.0"
   },
   "devDependencies": {
     "@antv/gatsby-theme-antv": "^0.10.59",

--- a/tests/unit/graph/svg-spec.ts
+++ b/tests/unit/graph/svg-spec.ts
@@ -1588,8 +1588,8 @@ describe('layouts', () => {
     graph.data(data);
     graph.render();
     const item = graph.getNodes()[0];
-    expect(item.getModel().x).toBe(238.07642639877923);
-    expect(item.getModel().y).toBe(250);
+    expect(item.getModel().x).toBe(261.9235736012207);
+    expect(item.getModel().y).toBe(249.99999999999997);
     graph.destroy();
   });
   it('with dagre layout', () => {


### PR DESCRIPTION
##### Checklist
- [x] `npm test` passes
- [x] commit message follows commit guidelines

##### Description of change
Currently, g6 uses [numericjs](https://github.com/sloisel/numeric/) for the mds layouting algorithm.

This library has the following issues:

- it is not maintained since 8 years
- it often uses the `Function` constructor, which is prohibited by applications using CSP unless `unsafe-eval` is set, which is not recommended
- it has 19 open PRs that are unaddressed
- the author himself says that he doesn't have time to fix certain issues
- the SVD algorithm from numericjs that is used by G6 can return incorrect `NaN` outputs: https://github.com/sloisel/numeric/issues/75

We propose to use [ml-matrix](https://www.npmjs.com/package/ml-matrix) instead of numericjs.
This library is actively maintained, also provides the SVD algorithm, and has typescript support.

This pull request implements using `ml-matrix` for the mds layout.

Please note that the Singular Value Decomposition (SVD) of ml-matrix returns different results for the singular vectors u and v than NumericJs. This does not mean that either one is incorrect, as the singular vectors u and v are not uniquely determined. 

For a SVD of a non-zero, non-degenerate matrix, u and v are unique except for uniformly applied change of sign. However this does not hold true in the general case. Here u and v can differ through arbitrary, uniformly applied unitary transformations (transformations which do not change the product of vectors) to the column vectors. The resulting singular vectors of ml-matrix are according to these rules. 

Therefore ml-matrix is mathematically correct even if it may differ fom NumericJS. The resulting graph layouts are identical to the ones produced with NumericJS, except for mirroring or rotation resulting from the different singular vectors.

See the below picture for comparison (graphs are taken from the test suite):
![ML-Matrix vs Numeric](https://user-images.githubusercontent.com/28780372/82064276-d76d9800-96cc-11ea-96ae-c6f88e14dc30.png)

