### PR TITLE
fix:在setState方法中限制不存在的状态

### DIFF
--- a/src/graph/controller/item.ts
+++ b/src/graph/controller/item.ts
@@ -428,8 +428,7 @@ export default class ItemController {
 
     // 已经存在要设置的 state，或不存在 state 的样式为 undefined
     if (item.hasState(stateName) === value 
-      || (isString(value) && item.hasState(stateName))
-      || !item.getStateStyle(stateName)) {
+      || (isString(value) && item.hasState(stateName))) {
       return;
     }
 

--- a/src/graph/graph.ts
+++ b/src/graph/graph.ts
@@ -1464,13 +1464,22 @@ export default class Graph extends EventEmitter implements IGraph {
         if (comboId === child.id && childItem && childItem.getType && childItem.getType() === 'combo') {
           // 更新具体的 Combo 之前先清除所有的已有状态，以免将 state 中的样式更新为 Combo 的样式
           const states = [...childItem.getStates()]
-          each(states, state => this.setItemState(childItem, state, false))
+          // || !item.getStateStyle(stateName)
+          each(states, state => {
+            if (childItem.getStateStyle(state)) {
+              this.setItemState(childItem, state, false)
+            }
+          })
 
           // 更新具体的 Combo
           itemController.updateCombo(childItem, child.children);
 
           // 更新 Combo 后，还原已有的状态
-          each(states, state => this.setItemState(childItem, state, true));
+          each(states, state => {
+            if (childItem.getStateStyle(state)) {
+              this.setItemState(childItem, state, true)
+            }
+          });
 
           if (comboId) comboId = child.parentId;
         }

--- a/src/shape/shapeBase.ts
+++ b/src/shape/shapeBase.ts
@@ -287,10 +287,17 @@ export const shapeBase: ShapeOptions = {
     const stateName = isBoolean(value) ? name : `${name}:${value}`;
     const shapeStateStyle = this.getStateStyle(stateName, true, item);
     const itemStateStyle = item.getStateStyle(stateName);
-
+    
+    // 不允许设置一个不存在的状态
+    if (!itemStateStyle && !shapeStateStyle) {
+      return;
+    }
+    
     // 要设置或取消的状态的样式
     // 当没有 state 状态时，默认使用 model.stateStyles 中的样式
     const styles = mix({}, itemStateStyle || shapeStateStyle);
+
+
     const group = item.getContainer();
 
     if (value) {
@@ -410,11 +417,16 @@ export const shapeBase: ShapeOptions = {
    */
   getStateStyle(name: string, value: string | boolean, item: Item): ShapeStyle {
     const model = item.getModel();
+    const type = item.getType()
 
     if (value) {
       const modelStateStyle = model.stateStyles
         ? model.stateStyles[name]
         : this.options.stateStyles && this.options.stateStyles[name];
+      
+      if (type === 'combo') {
+        return mix({}, modelStateStyle)
+      }
       return mix({}, model.style, modelStateStyle);
     }
 

--- a/tests/unit/combo-issue-spec.ts
+++ b/tests/unit/combo-issue-spec.ts
@@ -48,6 +48,9 @@ describe('combo states', () => {
       comboStateStyles: {
         hover: {
           stroke: 'green'
+        },
+        selected: {
+          stroke: 'red'
         }
       },
       modes: {
@@ -68,6 +71,7 @@ describe('combo states', () => {
 
     // combo 设置不存在的 state
     graph.on('combo:click', evt => {
+      debugger
       graph.setItemState(evt.item, 'notFound', true)
     })
 

--- a/tests/unit/shape/combo-spec.ts
+++ b/tests/unit/shape/combo-spec.ts
@@ -4,14 +4,10 @@
  */
 
 import Shape from '../../../src/shape/shape';
-import Global from '../../../src/global';
 import Canvas from '@antv/g-canvas/lib/canvas';
-import Node from '../../../src/item/node';
 import { translate } from '../../../src/util/math';
-import Graph from '../../../src/graph/graph';
 import '../../../src/shape/combo';
 import '../../../src/shape/combos';
-import { IGroup } from '@antv/g-canvas/lib/interfaces';
 import Combo from '../../../src/item/combo';
 
 const div = document.createElement('div');


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->
在默认的 setState 方法中限制不存在的 state，允许用户自定义 setState 方法。
https://github.com/antvis/G6/issues/1661
