### PR TITLE
Feat/get custom options

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,15 +50,7 @@
     "site:deploy": "npm run site:build && gh-pages -d public",
     "start": "npm run site:develop",
     "test": "jest",
-<<<<<<< HEAD
-<<<<<<< HEAD
-    "test-live": "DEBUG_MODE=1 jest --watch  ./tests/unit/plugins/toolbar-spec.ts",
-=======
-    "test-live": "DEBUG_MODE=1 jest --watch  ./tests/unit/shape/register-spec.ts",
->>>>>>> test: add extend-circle-spec  test case
-=======
     "test-live": "DEBUG_MODE=1 jest --watch  ./tests/unit/shape/register/extend-triangle-spec.ts",
->>>>>>> test: add test case for all node
     "lint-staged:js": "eslint --ext .js,.jsx,.ts,.tsx",
     "watch": "father build -w",
     "cdn": "antv-bin upload -n @antv/g6"

--- a/package.json
+++ b/package.json
@@ -50,7 +50,11 @@
     "site:deploy": "npm run site:build && gh-pages -d public",
     "start": "npm run site:develop",
     "test": "jest",
+<<<<<<< HEAD
     "test-live": "DEBUG_MODE=1 jest --watch  ./tests/unit/plugins/toolbar-spec.ts",
+=======
+    "test-live": "DEBUG_MODE=1 jest --watch  ./tests/unit/shape/register-spec.ts",
+>>>>>>> test: add extend-circle-spec  test case
     "lint-staged:js": "eslint --ext .js,.jsx,.ts,.tsx",
     "watch": "father build -w",
     "cdn": "antv-bin upload -n @antv/g6"

--- a/package.json
+++ b/package.json
@@ -51,10 +51,14 @@
     "start": "npm run site:develop",
     "test": "jest",
 <<<<<<< HEAD
+<<<<<<< HEAD
     "test-live": "DEBUG_MODE=1 jest --watch  ./tests/unit/plugins/toolbar-spec.ts",
 =======
     "test-live": "DEBUG_MODE=1 jest --watch  ./tests/unit/shape/register-spec.ts",
 >>>>>>> test: add extend-circle-spec  test case
+=======
+    "test-live": "DEBUG_MODE=1 jest --watch  ./tests/unit/shape/register/extend-triangle-spec.ts",
+>>>>>>> test: add test case for all node
     "lint-staged:js": "eslint --ext .js,.jsx,.ts,.tsx",
     "watch": "father build -w",
     "cdn": "antv-bin upload -n @antv/g6"

--- a/src/interface/shape.ts
+++ b/src/interface/shape.ts
@@ -29,6 +29,7 @@ export type ShapeOptions = Partial<{
    */
   draw(cfg?: ModelConfig, group?: GGroup): IShape;
 
+  getCustomConfig(cfg: ModelConfig): ModelConfig;
   drawShape(cfg?: ModelConfig, group?: GGroup): IShape;
   drawLabel(cfg: ModelConfig, group: GGroup): IShape;
   getLabelStyleByPosition(cfg: ModelConfig, labelCfg: ILabelConfig, group?: GGroup): LabelStyle;

--- a/src/shape/node.ts
+++ b/src/shape/node.ts
@@ -186,12 +186,12 @@ const singleNode: ShapeOptions = {
    * @param {Group} group Item所在的group
    */
   updateLinkPoints(cfg: NodeConfig, group: GGroup) {
-    const { linkPoints: defaultLinkPoints } = this.options as ModelConfig;
+    const { linkPoints: defaultLinkPoints } = this.getOptions(cfg) as ModelConfig;
 
-    const markLeft = group.find(element => element.get('className') === 'link-point-left');
-    const markRight = group.find(element => element.get('className') === 'link-point-right');
-    const markTop = group.find(element => element.get('className') === 'link-point-top');
-    const markBottom = group.find(element => element.get('className') === 'link-point-bottom');
+    const markLeft = group.find((element) => element.get('className') === 'link-point-left');
+    const markRight = group.find((element) => element.get('className') === 'link-point-right');
+    const markTop = group.find((element) => element.get('className') === 'link-point-top');
+    const markBottom = group.find((element) => element.get('className') === 'link-point-bottom');
 
     let currentLinkPoints;
     if (markLeft) {
@@ -332,15 +332,16 @@ const singleNode: ShapeOptions = {
   },
   updateIcon(cfg: NodeConfig, item: Item) {
     const group = item.getContainer();
-    const { icon: defaultIcon } = this.options as NodeConfig;
-    const icon = mix({}, defaultIcon, cfg.icon);
+    const { icon } = this.getOptions(cfg) as NodeConfig;
     const { show } = cfg.icon ? cfg.icon : { show: undefined };
-    const iconShape = group.find(element => element.get('className') === `${this.type}-icon`);
+    const iconShape = group.find((element) => element.get('className') === `${this.type}-icon`);
+    // console.log(1111, 'updateIcon', iconShape, this.type, show);
     if (iconShape) {
       // 若原先存在 icon
       if (show || show === undefined) {
+        // console.log('若传入 show: true, 或没有设置，则更新原有的 icon 样式');
         // 若传入 show: true, 或没有设置，则更新原有的 icon 样式
-        const iconConfig = mix({}, defaultIcon, iconShape.attr(), cfg.icon);
+        const iconConfig = mix({}, iconShape.attr(), icon);
         const { width: w, height: h } = iconConfig;
         iconShape.attr({
           ...iconConfig,
@@ -348,10 +349,12 @@ const singleNode: ShapeOptions = {
           y: -h / 2,
         });
       } else {
+        // console.log('若传入了 show: false 则删除原先的 icon');
         // 若传入了 show: false 则删除原先的 icon
         iconShape.remove();
       }
     } else if (show) {
+      // console.log('如果原先不存在 icon，但传入了 show: true，则新增 icon', this.type);
       // 如果原先不存在 icon，但传入了 show: true，则新增 icon
       const { width: w, height: h } = icon;
       group.addShape('image', {
@@ -364,7 +367,7 @@ const singleNode: ShapeOptions = {
         name: `${this.type}-icon`,
       });
       // to ensure the label is on the top of all the shapes
-      const labelShape = group.find(element => element.get('className') === `node-label`);
+      const labelShape = group.find((element) => element.get('className') === `node-label`);
       if (labelShape) {
         labelShape.toFront();
       }

--- a/src/shape/node.ts
+++ b/src/shape/node.ts
@@ -34,7 +34,7 @@ const singleNode: ShapeOptions = {
    * @return {Array} 宽高
    */
   getSize(cfg: ModelConfig): number[] {
-    let size: number | number[] = cfg.size || this.options!.size || Global.defaultNode.size;
+    let size: number | number[] = cfg.size || this.getOptions({})!.size || Global.defaultNode.size;
 
     // size 是数组，但长度为1，则补长度为2
     if (isArray(size) && size.length === 1) {
@@ -335,11 +335,9 @@ const singleNode: ShapeOptions = {
     const { icon } = this.getOptions(cfg) as NodeConfig;
     const { show } = cfg.icon ? cfg.icon : { show: undefined };
     const iconShape = group.find((element) => element.get('className') === `${this.type}-icon`);
-    // console.log(1111, 'updateIcon', iconShape, this.type, show);
     if (iconShape) {
       // 若原先存在 icon
       if (show || show === undefined) {
-        // console.log('若传入 show: true, 或没有设置，则更新原有的 icon 样式');
         // 若传入 show: true, 或没有设置，则更新原有的 icon 样式
         const iconConfig = mix({}, iconShape.attr(), icon);
         const { width: w, height: h } = iconConfig;
@@ -349,12 +347,10 @@ const singleNode: ShapeOptions = {
           y: -h / 2,
         });
       } else {
-        // console.log('若传入了 show: false 则删除原先的 icon');
         // 若传入了 show: false 则删除原先的 icon
         iconShape.remove();
       }
     } else if (show) {
-      // console.log('如果原先不存在 icon，但传入了 show: true，则新增 icon', this.type);
       // 如果原先不存在 icon，但传入了 show: true，则新增 icon
       const { width: w, height: h } = icon;
       group.addShape('image', {

--- a/src/shape/nodes/circle.ts
+++ b/src/shape/nodes/circle.ts
@@ -58,8 +58,9 @@ Shape.registerNode(
       return deepMix({}, this.options, this.getCustomConfig(cfg) || {}, cfg);
     },
     drawShape(cfg: NodeConfig, group: GGroup): IShape {
-      const { icon } = this.getOptions(cfg) as ModelConfig & Exclude<NodeConfig, 'id'>;
+      const { icon: defaultIcon } = this.getOptions(cfg) as ModelConfig & Exclude<NodeConfig, 'id'>;
       const style = this.getShapeStyle!(cfg);
+      const icon = deepMix({}, defaultIcon, cfg.icon);
       const keyShape: IShape = group.addShape('circle', {
         attrs: style,
         className: `${this.type}-keyShape`,

--- a/src/shape/nodes/circle.ts
+++ b/src/shape/nodes/circle.ts
@@ -5,7 +5,6 @@ import { Item, NodeConfig, ShapeStyle, ModelConfig } from '../../types';
 import Global from '../../global';
 import Shape from '../shape';
 import { ShapeOptions } from '../../interface/shape';
-import { isNumber, isArray } from '@antv/util';
 
 // 带有图标的圆，可用于拓扑图中
 Shape.registerNode(
@@ -52,10 +51,15 @@ Shape.registerNode(
     shapeType: 'circle',
     // 文本位置
     labelPosition: 'center',
+    getCustomConfig(cfg: NodeConfig): ModelConfig {
+      return {};
+    },
+    getOptions(cfg: NodeConfig): ModelConfig {
+      return deepMix({}, this.options, this.getCustomConfig(cfg) || {}, cfg);
+    },
     drawShape(cfg: NodeConfig, group: GGroup): IShape {
-      const { icon: defaultIcon } = this.options as ModelConfig;
+      const { icon } = this.getOptions(cfg) as ModelConfig & Exclude<NodeConfig, 'id'>;
       const style = this.getShapeStyle!(cfg);
-      const icon = deepMix({}, defaultIcon, cfg.icon);
       const keyShape: IShape = group.addShape('circle', {
         attrs: style,
         className: `${this.type}-keyShape`,
@@ -86,8 +90,7 @@ Shape.registerNode(
      * @param {Group} group Group实例
      */
     drawLinkPoints(cfg: NodeConfig, group: GGroup) {
-      const { linkPoints: defaultLinkPoints } = this.options as ModelConfig;
-      const linkPoints = deepMix({}, defaultLinkPoints, cfg.linkPoints);
+      const { linkPoints } = this.getOptions(cfg) as ModelConfig & Exclude<NodeConfig, 'id'>;
 
       const { top, left, right, bottom, size: markSize, r: markR, ...markStyle } = linkPoints;
       const size = this.getSize!(cfg);
@@ -158,12 +161,12 @@ Shape.registerNode(
      * @return {Object} 节点的样式
      */
     getShapeStyle(cfg: NodeConfig): ShapeStyle {
-      const { style: defaultStyle } = this.options as ModelConfig;
+      // 如果设置了color，则覆盖默认的stroke属性
       const strokeStyle = {
         stroke: cfg.color,
       };
-      // 如果设置了color，则覆盖默认的stroke属性
-      const style = deepMix({}, defaultStyle, strokeStyle, cfg.style);
+      const { style } = this.getOptions(cfg, { style: strokeStyle }) as ModelConfig &
+        Exclude<NodeConfig, 'id'>;
       const size = (this as ShapeOptions).getSize!(cfg);
       const r = size[0] / 2;
       const styles = Object.assign(

--- a/src/shape/nodes/circle.ts
+++ b/src/shape/nodes/circle.ts
@@ -51,14 +51,8 @@ Shape.registerNode(
     shapeType: 'circle',
     // 文本位置
     labelPosition: 'center',
-    getCustomConfig(cfg: NodeConfig): ModelConfig {
-      return {};
-    },
-    getOptions(cfg: NodeConfig): ModelConfig {
-      return deepMix({}, this.options, this.getCustomConfig(cfg) || {}, cfg);
-    },
     drawShape(cfg: NodeConfig, group: GGroup): IShape {
-      const { icon: defaultIcon } = this.getOptions(cfg) as ModelConfig & Exclude<NodeConfig, 'id'>;
+      const { icon: defaultIcon } = this.getOptions(cfg) as NodeConfig;
       const style = this.getShapeStyle!(cfg);
       const icon = deepMix({}, defaultIcon, cfg.icon);
       const keyShape: IShape = group.addShape('circle', {
@@ -91,7 +85,7 @@ Shape.registerNode(
      * @param {Group} group Group实例
      */
     drawLinkPoints(cfg: NodeConfig, group: GGroup) {
-      const { linkPoints } = this.getOptions(cfg) as ModelConfig & Exclude<NodeConfig, 'id'>;
+      const { linkPoints } = this.getOptions(cfg) as NodeConfig;
 
       const { top, left, right, bottom, size: markSize, r: markR, ...markStyle } = linkPoints;
       const size = this.getSize!(cfg);

--- a/src/shape/nodes/circle.ts
+++ b/src/shape/nodes/circle.ts
@@ -1,7 +1,7 @@
 import GGroup from '@antv/g-canvas/lib/group';
 import { IShape } from '@antv/g-canvas/lib/interfaces';
 import deepMix from '@antv/util/lib/deep-mix';
-import { Item, NodeConfig, ShapeStyle, ModelConfig } from '../../types';
+import { Item, NodeConfig, ShapeStyle } from '../../types';
 import Global from '../../global';
 import Shape from '../shape';
 import { ShapeOptions } from '../../interface/shape';
@@ -156,8 +156,7 @@ Shape.registerNode(
      * @return {Object} 节点的样式
      */
     getShapeStyle(cfg: NodeConfig): ShapeStyle {
-      const { style: defaultStyle } = this.getOptions(cfg) as ModelConfig &
-        Exclude<NodeConfig, 'id'>;
+      const { style: defaultStyle } = this.getOptions(cfg) as NodeConfig;
       const strokeStyle = {
         stroke: cfg.color,
       };

--- a/src/shape/nodes/circle.ts
+++ b/src/shape/nodes/circle.ts
@@ -161,12 +161,13 @@ Shape.registerNode(
      * @return {Object} 节点的样式
      */
     getShapeStyle(cfg: NodeConfig): ShapeStyle {
-      // 如果设置了color，则覆盖默认的stroke属性
+      const { style: defaultStyle } = this.getOptions(cfg) as ModelConfig &
+        Exclude<NodeConfig, 'id'>;
       const strokeStyle = {
         stroke: cfg.color,
       };
-      const { style } = this.getOptions(cfg, { style: strokeStyle }) as ModelConfig &
-        Exclude<NodeConfig, 'id'>;
+      // 如果设置了color，则覆盖默认的stroke属性
+      const style = deepMix({}, defaultStyle, strokeStyle);
       const size = (this as ShapeOptions).getSize!(cfg);
       const r = size[0] / 2;
       const styles = Object.assign(

--- a/src/shape/nodes/diamond.ts
+++ b/src/shape/nodes/diamond.ts
@@ -49,14 +49,8 @@ Shape.registerNode(
     shapeType: 'circle',
     // 文本位置
     labelPosition: 'center',
-    getCustomConfig(cfg: NodeConfig): ModelConfig {
-      return {};
-    },
-    getOptions(cfg: NodeConfig): ModelConfig {
-      return deepMix({}, this.options, this.getCustomConfig(cfg) || {}, cfg);
-    },
     drawShape(cfg: NodeConfig, group: GGroup): IShape {
-      const { icon } = this.getOptions(cfg) as ModelConfig & Exclude<NodeConfig, 'id'>;
+      const { icon } = this.getOptions(cfg) as NodeConfig;
       const style = this.getShapeStyle!(cfg);
 
       const keyShape = group.addShape('path', {
@@ -90,7 +84,7 @@ Shape.registerNode(
      * @param {Group} group Group实例
      */
     drawLinkPoints(cfg: NodeConfig, group: GGroup) {
-      const { linkPoints } = this.getOptions(cfg) as ModelConfig & Exclude<NodeConfig, 'id'>;
+      const { linkPoints } = this.getOptions(cfg) as NodeConfig;
 
       const { top, left, right, bottom, size: markSize, r: markR, ...markStyle } = linkPoints;
       const size = this.getSize!(cfg);

--- a/src/shape/nodes/diamond.ts
+++ b/src/shape/nodes/diamond.ts
@@ -1,7 +1,7 @@
 import GGroup from '@antv/g-canvas/lib/group';
 import { IShape } from '@antv/g-canvas/lib/interfaces';
-import { mix, deepMix } from '@antv/util';
-import { Item, NodeConfig, ShapeStyle, ModelConfig } from '../../types';
+import { mix } from '@antv/util';
+import { Item, NodeConfig, ShapeStyle } from '../../types';
 import Global from '../../global';
 import Shape from '../shape';
 
@@ -169,8 +169,7 @@ Shape.registerNode(
      * @return {Object} 节点的样式
      */
     getShapeStyle(cfg: NodeConfig): ShapeStyle {
-      const { style: defaultStyle } = this.getOptions(cfg) as ModelConfig &
-        Exclude<NodeConfig, 'id'>;
+      const { style: defaultStyle } = this.getOptions(cfg) as NodeConfig;
       const strokeStyle: ShapeStyle = {
         stroke: cfg.color,
       };
@@ -183,7 +182,7 @@ Shape.registerNode(
     update(cfg: NodeConfig, item: Item) {
       const group = item.getContainer();
       // 这里不传 cfg 参数是因为 cfg.style 需要最后覆盖样式
-      const { style: defaultStyle } = this.getOptions({}) as ModelConfig;
+      const { style: defaultStyle } = this.getOptions({}) as NodeConfig;
       const path = (this as any).getPath(cfg);
       // 下面这些属性需要覆盖默认样式与目前样式，但若在 cfg 中有指定则应该被 cfg 的相应配置覆盖。
       const strokeStyle = {

--- a/src/shape/nodes/diamond.ts
+++ b/src/shape/nodes/diamond.ts
@@ -189,7 +189,7 @@ Shape.registerNode(
     update(cfg: NodeConfig, item: Item) {
       const group = item.getContainer();
       // 这里不传 cfg 参数是因为 cfg.style 需要最后覆盖样式
-      const { style: defaultStyle } = this.getOptions() as ModelConfig;
+      const { style: defaultStyle } = this.getOptions({}) as ModelConfig;
       const path = (this as any).getPath(cfg);
       // 下面这些属性需要覆盖默认样式与目前样式，但若在 cfg 中有指定则应该被 cfg 的相应配置覆盖。
       const strokeStyle = {

--- a/src/shape/nodes/ellipse.ts
+++ b/src/shape/nodes/ellipse.ts
@@ -81,7 +81,11 @@ Shape.registerNode(
           },
           className: `${this.type}-icon`,
           name: `${this.type}-icon`,
+<<<<<<< HEAD
           draggable: true
+=======
+          draggable: true,
+>>>>>>> test: add test case for all node
         });
       }
 

--- a/src/shape/nodes/ellipse.ts
+++ b/src/shape/nodes/ellipse.ts
@@ -193,7 +193,8 @@ Shape.registerNode(
     update(cfg: NodeConfig, item: Item) {
       const group = item.getContainer();
       // 这里不传 cfg 参数是因为 cfg.style 需要最后覆盖样式
-      const { style: defaultStyle } = this.getOptions() as ModelConfig & Exclude<NodeConfig, 'id'>;
+      const { style: defaultStyle } = this.getOptions({}) as ModelConfig &
+        Exclude<NodeConfig, 'id'>;
       const size = this.getSize!(cfg);
 
       const strokeStyle = {

--- a/src/shape/nodes/ellipse.ts
+++ b/src/shape/nodes/ellipse.ts
@@ -54,14 +54,8 @@ Shape.registerNode(
     shapeType: 'ellipse',
     // 文本位置
     labelPosition: 'center',
-    getCustomConfig(cfg: NodeConfig): ModelConfig {
-      return {};
-    },
-    getOptions(cfg: NodeConfig): ModelConfig {
-      return deepMix({}, this.options, this.getCustomConfig(cfg) || {}, cfg);
-    },
     drawShape(cfg: NodeConfig, group: GGroup): IShape {
-      const { icon } = this.getOptions(cfg) as ModelConfig & Exclude<NodeConfig, 'id'>;
+      const { icon } = this.getOptions(cfg) as NodeConfig;
       const style = this.getShapeStyle!(cfg);
 
       const keyShape = group.addShape('ellipse', {
@@ -95,7 +89,7 @@ Shape.registerNode(
      * @param {Group} group Group实例
      */
     drawLinkPoints(cfg: NodeConfig, group: GGroup) {
-      const { linkPoints } = this.getOptions(cfg) as ModelConfig & Exclude<NodeConfig, 'id'>;
+      const { linkPoints } = this.getOptions(cfg) as NodeConfig;
 
       const { top, left, right, bottom, size: markSize, r: markR, ...markStyle } = linkPoints;
       const size = this.getSize!(cfg);

--- a/src/shape/nodes/ellipse.ts
+++ b/src/shape/nodes/ellipse.ts
@@ -81,11 +81,7 @@ Shape.registerNode(
           },
           className: `${this.type}-icon`,
           name: `${this.type}-icon`,
-<<<<<<< HEAD
-          draggable: true
-=======
           draggable: true,
->>>>>>> test: add test case for all node
         });
       }
 

--- a/src/shape/nodes/ellipse.ts
+++ b/src/shape/nodes/ellipse.ts
@@ -1,10 +1,9 @@
 import GGroup from '@antv/g-canvas/lib/group';
 import { IShape } from '@antv/g-canvas/lib/interfaces';
-import { mix, deepMix } from '@antv/util';
-import { Item, NodeConfig, ModelConfig, ShapeStyle } from '../../types';
+import { mix } from '@antv/util';
+import { Item, NodeConfig, ShapeStyle } from '../../types';
 import Global from '../../global';
 import Shape from '../shape';
-import { ShapeOptions } from '../../interface/shape';
 
 /**
  * 基本的椭圆，可以添加文本，默认文本居中
@@ -162,8 +161,7 @@ Shape.registerNode(
      * @return {Object} 节点的样式
      */
     getShapeStyle(cfg: NodeConfig): ShapeStyle {
-      const { style: defaultStyle } = this.getOptions(cfg) as ModelConfig &
-        Exclude<NodeConfig, 'id'>;
+      const { style: defaultStyle } = this.getOptions(cfg) as NodeConfig;
       const strokeStyle: ShapeStyle = {
         stroke: cfg.color,
       };
@@ -187,8 +185,7 @@ Shape.registerNode(
     update(cfg: NodeConfig, item: Item) {
       const group = item.getContainer();
       // 这里不传 cfg 参数是因为 cfg.style 需要最后覆盖样式
-      const { style: defaultStyle } = this.getOptions({}) as ModelConfig &
-        Exclude<NodeConfig, 'id'>;
+      const { style: defaultStyle } = this.getOptions({}) as NodeConfig;
       const size = this.getSize!(cfg);
 
       const strokeStyle = {

--- a/src/shape/nodes/image.ts
+++ b/src/shape/nodes/image.ts
@@ -51,12 +51,6 @@ Shape.registerNode(
     },
     shapeType: 'image',
     labelPosition: 'bottom',
-    getCustomConfig(cfg: NodeConfig): ModelConfig {
-      return {};
-    },
-    getOptions(cfg: NodeConfig): ModelConfig {
-      return deepMix({}, this.options, this.getCustomConfig(cfg) || {}, cfg);
-    },
     drawShape(cfg: NodeConfig, group: GGroup): IShape {
       const { shapeType } = this; // || this.type，都已经加了 shapeType
       const style = this.getShapeStyle!(cfg);

--- a/src/shape/nodes/image.ts
+++ b/src/shape/nodes/image.ts
@@ -1,7 +1,8 @@
 import Shape from '../shape';
-import { NodeConfig, Item } from '../../types';
+import { NodeConfig, Item, ModelConfig } from '../../types';
 import GGroup from '@antv/g-canvas/lib/group';
 import { IShape } from '@antv/g-canvas/lib/interfaces';
+import { deepMix } from '@antv/util';
 
 /**
  * 基本的图片，可以添加文本，默认文本在图片的下面
@@ -50,6 +51,12 @@ Shape.registerNode(
     },
     shapeType: 'image',
     labelPosition: 'bottom',
+    getCustomConfig(cfg: NodeConfig): ModelConfig {
+      return {};
+    },
+    getOptions(cfg: NodeConfig): ModelConfig {
+      return deepMix({}, this.options, this.getCustomConfig(cfg) || {}, cfg);
+    },
     drawShape(cfg: NodeConfig, group: GGroup): IShape {
       const { shapeType } = this; // || this.type，都已经加了 shapeType
       const style = this.getShapeStyle!(cfg);
@@ -64,7 +71,7 @@ Shape.registerNode(
       return shape;
     },
     drawClip(cfg: NodeConfig, shape: IShape) {
-      const clip = Object.assign({}, this.options!.clipCfg, cfg.clipCfg);
+      const { clipCfg: clip } = this.getOptions(cfg);
 
       if (!clip.show) {
         return;
@@ -80,7 +87,7 @@ Shape.registerNode(
             x,
             y,
             ...style,
-          }
+          },
         });
       } else if (type === 'rect') {
         const { width, height } = clip;
@@ -94,7 +101,7 @@ Shape.registerNode(
             width,
             height,
             ...style,
-          }
+          },
         });
       } else if (type === 'ellipse') {
         const { rx, ry } = clip;
@@ -106,7 +113,7 @@ Shape.registerNode(
             rx,
             ry,
             ...style,
-          }
+          },
         });
       } else if (type === 'polygon') {
         const { points } = clip;
@@ -115,7 +122,7 @@ Shape.registerNode(
           attrs: {
             points,
             ...style,
-          }
+          },
         });
       } else if (type === 'path') {
         const { path } = clip;
@@ -124,13 +131,13 @@ Shape.registerNode(
           attrs: {
             path,
             ...style,
-          }
+          },
         });
       }
     },
     getShapeStyle(cfg: NodeConfig) {
       const size = this.getSize!(cfg);
-      const img = cfg.img || this.options!.img;
+      const { img } = this.getOptions(cfg);
       let width = size[0];
       let height = size[1];
       if (cfg.style) {
@@ -153,7 +160,8 @@ Shape.registerNode(
     updateShapeStyle(cfg: NodeConfig, item: Item) {
       const group = item.getContainer();
       const shapeClassName = `${this.itemType}-shape`;
-      const shape = group.find(element => element.get('className') === shapeClassName) || item.getKeyShape();
+      const shape =
+        group.find((element) => element.get('className') === shapeClassName) || item.getKeyShape();
       const shapeStyle = this.getShapeStyle!(cfg);
       if (shape) {
         shape.attr(shapeStyle);

--- a/src/shape/nodes/image.ts
+++ b/src/shape/nodes/image.ts
@@ -136,13 +136,14 @@ Shape.registerNode(
       }
     },
     getShapeStyle(cfg: NodeConfig) {
+      const { style: defaultStyle } = this.getOptions(cfg);
       const size = this.getSize!(cfg);
       const { img } = this.getOptions(cfg);
       let width = size[0];
       let height = size[1];
-      if (cfg.style) {
-        width = cfg.style.width || size[0];
-        height = cfg.style.height || size[1];
+      if (defaultStyle) {
+        width = defaultStyle.width || size[0];
+        height = defaultStyle.height || size[1];
       }
       const style = Object.assign(
         {},
@@ -153,7 +154,7 @@ Shape.registerNode(
           height,
           img,
         },
-        cfg.style,
+        defaultStyle,
       );
       return style;
     },

--- a/src/shape/nodes/image.ts
+++ b/src/shape/nodes/image.ts
@@ -1,8 +1,7 @@
 import Shape from '../shape';
-import { NodeConfig, Item, ModelConfig } from '../../types';
+import { NodeConfig, Item } from '../../types';
 import GGroup from '@antv/g-canvas/lib/group';
 import { IShape } from '@antv/g-canvas/lib/interfaces';
-import { deepMix } from '@antv/util';
 
 /**
  * 基本的图片，可以添加文本，默认文本在图片的下面

--- a/src/shape/nodes/modelRect.ts
+++ b/src/shape/nodes/modelRect.ts
@@ -1,8 +1,7 @@
 import GGroup from '@antv/g-canvas/lib/group';
 import { IShape } from '@antv/g-canvas/lib/interfaces';
-import deepMix from '@antv/util/lib/deep-mix';
 import { mix, isString } from '@antv/util';
-import { Item, NodeConfig, ModelConfig, ShapeStyle } from '../../types';
+import { Item, NodeConfig, ShapeStyle } from '../../types';
 import Shape from '../shape';
 import Global from '../../global';
 import { ShapeOptions } from '../../interface/shape';
@@ -251,8 +250,7 @@ Shape.registerNode(
       }
     },
     drawLabel(cfg: NodeConfig, group: GGroup): IShape {
-      const { labelCfg, logoIcon, descriptionCfg } = this.getOptions(cfg) as ModelConfig &
-        Exclude<NodeConfig, 'id'>;
+      const { labelCfg, logoIcon, descriptionCfg } = this.getOptions(cfg) as NodeConfig;
 
       const size = (this as ShapeOptions).getSize!(cfg);
       const width = size[0];
@@ -311,8 +309,7 @@ Shape.registerNode(
      * @return {Object} 节点的样式
      */
     getShapeStyle(cfg: NodeConfig) {
-      const { style: defaultStyle } = this.getOptions(cfg) as ModelConfig &
-        Exclude<NodeConfig, 'id'>;
+      const { style: defaultStyle } = this.getOptions(cfg) as NodeConfig;
       const strokeStyle: ShapeStyle = {
         stroke: cfg.color,
       };
@@ -334,8 +331,7 @@ Shape.registerNode(
       return styles;
     },
     update(cfg: NodeConfig, item: Item) {
-      const { style, labelCfg, descriptionCfg } = this.getOptions(cfg) as ModelConfig &
-        Exclude<NodeConfig, 'id'>;
+      const { style, labelCfg, descriptionCfg } = this.getOptions(cfg) as NodeConfig;
       const size = (this as ShapeOptions).getSize!(cfg);
       const width = size[0];
       const height = size[1];

--- a/src/shape/nodes/modelRect.ts
+++ b/src/shape/nodes/modelRect.ts
@@ -89,14 +89,8 @@ Shape.registerNode(
       ],
     },
     shapeType: 'modelRect',
-    getCustomConfig(cfg: NodeConfig): ModelConfig {
-      return {};
-    },
-    getOptions(cfg: NodeConfig): ModelConfig & Exclude<NodeConfig, 'id'> {
-      return deepMix({}, this.options, this.getCustomConfig(cfg) || {}, cfg);
-    },
     drawShape(cfg: NodeConfig, group: GGroup): IShape {
-      const { preRect } = this.getOptions(cfg) as ModelConfig & Exclude<NodeConfig, 'id'>;
+      const { preRect } = this.getOptions(cfg) as NodeConfig;
       const style = this.getShapeStyle!(cfg);
       const size = (this as ShapeOptions).getSize!(cfg);
       const width = size[0];
@@ -137,7 +131,7 @@ Shape.registerNode(
      * @param {Group} group Group实例
      */
     drawLogoIcon(cfg: NodeConfig, group: GGroup) {
-      const { logoIcon } = this.getOptions(cfg) as ModelConfig & Exclude<NodeConfig, 'id'>;
+      const { logoIcon } = this.getOptions(cfg) as NodeConfig;
       const size = (this as ShapeOptions).getSize!(cfg);
       const width = size[0];
 
@@ -163,7 +157,7 @@ Shape.registerNode(
      * @param {Group} group Group实例
      */
     drawStateIcon(cfg: NodeConfig, group: GGroup) {
-      const { stateIcon } = this.getOptions(cfg) as ModelConfig & Exclude<NodeConfig, 'id'>;
+      const { stateIcon } = this.getOptions(cfg) as NodeConfig;
       const size = (this as ShapeOptions).getSize!(cfg);
       const width = size[0];
 
@@ -189,7 +183,7 @@ Shape.registerNode(
      * @param {Group} group Group实例
      */
     drawLinkPoints(cfg: NodeConfig, group: GGroup) {
-      const { linkPoints } = this.getOptions(cfg) as ModelConfig & Exclude<NodeConfig, 'id'>;
+      const { linkPoints } = this.getOptions(cfg) as NodeConfig;
 
       const { top, left, right, bottom, size: markSize, r: markR, ...markStyle } = linkPoints;
       const size = (this as ShapeOptions).getSize!(cfg);

--- a/src/shape/nodes/modelRect.ts
+++ b/src/shape/nodes/modelRect.ts
@@ -89,8 +89,14 @@ Shape.registerNode(
       ],
     },
     shapeType: 'modelRect',
+    getCustomConfig(cfg: NodeConfig): ModelConfig {
+      return {};
+    },
+    getOptions(cfg: NodeConfig): ModelConfig & Exclude<NodeConfig, 'id'> {
+      return deepMix({}, this.options, this.getCustomConfig(cfg) || {}, cfg);
+    },
     drawShape(cfg: NodeConfig, group: GGroup): IShape {
-      const { preRect: defaultPreRect } = this.options as ModelConfig;
+      const { preRect } = this.getOptions(cfg) as ModelConfig & Exclude<NodeConfig, 'id'>;
       const style = this.getShapeStyle!(cfg);
       const size = (this as ShapeOptions).getSize!(cfg);
       const width = size[0];
@@ -103,7 +109,6 @@ Shape.registerNode(
         draggable: true,
       });
 
-      const preRect = mix({}, defaultPreRect, cfg.preRect);
       const { show: preRectShow, ...preRectStyle } = preRect;
       if (preRectShow) {
         group.addShape('rect', {
@@ -115,7 +120,7 @@ Shape.registerNode(
           },
           className: 'pre-rect',
           name: 'pre-rect',
-          draggable: true
+          draggable: true,
         });
       }
 
@@ -132,8 +137,7 @@ Shape.registerNode(
      * @param {Group} group Group实例
      */
     drawLogoIcon(cfg: NodeConfig, group: GGroup) {
-      const { logoIcon: defaultLogoIcon } = this.options as ModelConfig;
-      const logoIcon = mix({}, defaultLogoIcon, cfg.logoIcon);
+      const { logoIcon } = this.getOptions(cfg) as ModelConfig & Exclude<NodeConfig, 'id'>;
       const size = (this as ShapeOptions).getSize!(cfg);
       const width = size[0];
 
@@ -149,7 +153,7 @@ Shape.registerNode(
           },
           className: 'rect-logo-icon',
           name: 'rect-logo-icon',
-          draggable: true
+          draggable: true,
         });
       }
     },
@@ -159,8 +163,7 @@ Shape.registerNode(
      * @param {Group} group Group实例
      */
     drawStateIcon(cfg: NodeConfig, group: GGroup) {
-      const { stateIcon: defaultStateIcon } = this.options as ModelConfig;
-      const stateIcon = mix({}, defaultStateIcon, cfg.stateIcon);
+      const { stateIcon } = this.getOptions(cfg) as ModelConfig & Exclude<NodeConfig, 'id'>;
       const size = (this as ShapeOptions).getSize!(cfg);
       const width = size[0];
 
@@ -176,7 +179,7 @@ Shape.registerNode(
           },
           className: 'rect-state-icon',
           name: 'rect-state-icon',
-          draggable: true
+          draggable: true,
         });
       }
     },
@@ -186,8 +189,7 @@ Shape.registerNode(
      * @param {Group} group Group实例
      */
     drawLinkPoints(cfg: NodeConfig, group: GGroup) {
-      const { linkPoints: defaultLinkPoints } = this.options as ModelConfig;
-      const linkPoints = mix({}, defaultLinkPoints, cfg.linkPoints);
+      const { linkPoints } = this.getOptions(cfg) as ModelConfig & Exclude<NodeConfig, 'id'>;
 
       const { top, left, right, bottom, size: markSize, r: markR, ...markStyle } = linkPoints;
       const size = (this as ShapeOptions).getSize!(cfg);
@@ -255,17 +257,8 @@ Shape.registerNode(
       }
     },
     drawLabel(cfg: NodeConfig, group: GGroup): IShape {
-      const {
-        labelCfg: defaultLabelCfg,
-        logoIcon: defaultLogoIcon,
-        descriptionCfg: defaultDescritionCfg,
-      } = this.options as ModelConfig;
-
-      const logoIcon = mix({}, defaultLogoIcon, cfg.logoIcon);
-
-      const labelCfg = deepMix({}, defaultLabelCfg, cfg.labelCfg);
-
-      const descriptionCfg = deepMix({}, defaultDescritionCfg, cfg.descriptionCfg);
+      const { labelCfg, logoIcon, descriptionCfg } = this.getOptions(cfg) as ModelConfig &
+        Exclude<NodeConfig, 'id'>;
 
       const size = (this as ShapeOptions).getSize!(cfg);
       const width = size[0];
@@ -291,19 +284,19 @@ Shape.registerNode(
           },
           className: 'text-shape',
           name: 'text-shape',
-          draggable: true
+          draggable: true,
         });
 
         group.addShape('text', {
           attrs: {
             ...descriptionStyle,
             x: offsetX,
-            y: 17 + descriptionPaddingTop,
+            y: 17 + (descriptionPaddingTop as any),
             text: cfg.description,
           },
           className: 'rect-description',
           name: 'rect-description',
-          draggable: true
+          draggable: true,
         });
       } else {
         label = group.addShape('text', {
@@ -311,9 +304,9 @@ Shape.registerNode(
             ...fontStyle,
             x: offsetX,
             y: 7,
-            text: cfg.label
+            text: cfg.label,
           },
-          draggable: true
+          draggable: true,
         });
       }
       return label;
@@ -324,12 +317,13 @@ Shape.registerNode(
      * @return {Object} 节点的样式
      */
     getShapeStyle(cfg: NodeConfig) {
-      const { style: defaultStyle } = this.options as ModelConfig;
+      const { style: defaultStyle } = this.getOptions(cfg) as ModelConfig &
+        Exclude<NodeConfig, 'id'>;
       const strokeStyle: ShapeStyle = {
         stroke: cfg.color,
       };
       // 如果设置了color，则覆盖默认的stroke属性
-      const style: ShapeStyle = mix({}, defaultStyle, strokeStyle, cfg.style);
+      const style: ShapeStyle = mix({}, defaultStyle, strokeStyle);
       const size = (this as ShapeOptions).getSize!(cfg);
       const width = style.width || size[0];
       const height = style.height || size[1];
@@ -346,12 +340,8 @@ Shape.registerNode(
       return styles;
     },
     update(cfg: NodeConfig, item: Item) {
-      const {
-        style: defaultStyle,
-        labelCfg: defaultLabelCfg,
-        descriptionCfg: defaultDescritionCfg,
-      } = this.options as ModelConfig;
-      const style = mix({}, defaultStyle, cfg.style);
+      const { style, labelCfg, descriptionCfg } = this.getOptions(cfg) as ModelConfig &
+        Exclude<NodeConfig, 'id'>;
       const size = (this as ShapeOptions).getSize!(cfg);
       const width = size[0];
       const height = size[1];
@@ -366,9 +356,7 @@ Shape.registerNode(
 
       const group = item.getContainer();
 
-      const labelCfg = deepMix({}, defaultLabelCfg, cfg.labelCfg);
-
-      const logoIconShape = group.find(element => element.get('className') === 'rect-logo-icon');
+      const logoIconShape = group.find((element) => element.get('className') === 'rect-logo-icon');
       const currentLogoIconAttr = logoIconShape ? logoIconShape.attr() : {};
 
       const logoIcon = mix({}, currentLogoIconAttr, cfg.logoIcon);
@@ -386,8 +374,8 @@ Shape.registerNode(
         offsetX = -width / 2 + offset;
       }
 
-      const label = group.find(element => element.get('className') === 'node-label');
-      const description = group.find(element => element.get('className') === 'rect-description');
+      const label = group.find((element) => element.get('className') === 'node-label');
+      const description = group.find((element) => element.get('className') === 'rect-description');
       if (cfg.label) {
         if (!label) {
           group.addShape('text', {
@@ -399,7 +387,7 @@ Shape.registerNode(
             },
             className: 'node-label',
             name: 'node-label',
-            draggable: true
+            draggable: true,
           });
         } else {
           const cfgStyle = cfg.labelCfg ? cfg.labelCfg.style : {};
@@ -418,19 +406,18 @@ Shape.registerNode(
         }
       }
       if (isString(cfg.description)) {
-        const descriptionCfg = deepMix({}, defaultDescritionCfg, cfg.descriptionCfg);
         const { paddingTop } = descriptionCfg;
         if (!description) {
           group.addShape('text', {
             attrs: {
               ...descriptionCfg.style,
               x: offsetX,
-              y: 17 + paddingTop,
+              y: 17 + (paddingTop as any),
               text: cfg.description,
             },
             className: 'rect-description',
             name: 'rect-description',
-            draggable: true
+            draggable: true,
           });
         } else {
           const cfgStyle = cfg.descriptionCfg ? cfg.descriptionCfg.style : {};
@@ -440,12 +427,12 @@ Shape.registerNode(
           description.resetMatrix();
           description.attr({
             ...descriptionStyle,
-            y: 17 + paddingTop,
+            y: 17 + (paddingTop as any),
           });
         }
       }
 
-      const preRectShape = group.find(element => element.get('className') === 'pre-rect');
+      const preRectShape = group.find((element) => element.get('className') === 'pre-rect');
       if (preRectShape) {
         const preRect = mix({}, preRectShape.attr(), cfg.preRect);
         preRectShape.attr({
@@ -473,7 +460,9 @@ Shape.registerNode(
         (this as any).drawLogoIcon(cfg, group);
       }
 
-      const stateIconShape = group.find(element => element.get('className') === 'rect-state-icon');
+      const stateIconShape = group.find(
+        (element) => element.get('className') === 'rect-state-icon',
+      );
       const currentStateIconAttr = stateIconShape ? stateIconShape.attr() : {};
       const stateIcon = mix({}, currentStateIconAttr, cfg.stateIcon);
       if (stateIconShape) {

--- a/src/shape/nodes/rect.ts
+++ b/src/shape/nodes/rect.ts
@@ -170,7 +170,8 @@ Shape.registerNode(
     update(cfg: NodeConfig, item: Item) {
       const group = item.getContainer();
       // 这里不传 cfg 参数是因为 cfg.style 需要最后覆盖样式
-      const { style: defaultStyle } = this.getOptions() as ModelConfig & Exclude<NodeConfig, 'id'>;
+      const { style: defaultStyle } = this.getOptions({}) as ModelConfig &
+        Exclude<NodeConfig, 'id'>;
       const size = (this as ShapeOptions).getSize!(cfg);
       const keyShape = item.get('keyShape');
       if (!cfg.size) {

--- a/src/shape/nodes/rect.ts
+++ b/src/shape/nodes/rect.ts
@@ -47,12 +47,6 @@ Shape.registerNode(
     },
     shapeType: 'rect',
     labelPosition: 'center',
-    getCustomConfig(cfg: NodeConfig): ModelConfig {
-      return {};
-    },
-    getOptions(cfg: NodeConfig): ModelConfig {
-      return deepMix({}, this.options, this.getCustomConfig(cfg) || {}, cfg);
-    },
     drawShape(cfg: NodeConfig, group: GGroup): IShape {
       const style = this.getShapeStyle!(cfg);
 
@@ -72,7 +66,7 @@ Shape.registerNode(
      * @param {Group} group Group实例
      */
     drawLinkPoints(cfg: NodeConfig, group: GGroup) {
-      const { linkPoints } = this.getOptions(cfg) as ModelConfig & Exclude<NodeConfig, 'id'>;
+      const { linkPoints } = this.getOptions(cfg) as NodeConfig;
 
       const { top, left, right, bottom, size: markSize, r: markR, ...markStyle } = linkPoints;
       const size = (this as ShapeOptions).getSize!(cfg);

--- a/src/shape/nodes/rect.ts
+++ b/src/shape/nodes/rect.ts
@@ -1,7 +1,7 @@
 import GGroup from '@antv/g-canvas/lib/group';
 import { IShape } from '@antv/g-canvas/lib/interfaces';
-import { mix, deepMix } from '@antv/util';
-import { Item, NodeConfig, ModelConfig, ShapeStyle } from '../../types';
+import { mix } from '@antv/util';
+import { Item, NodeConfig, ShapeStyle } from '../../types';
 import Global from '../../global';
 import Shape from '../shape';
 import { ShapeOptions } from '../../interface/shape';
@@ -139,8 +139,7 @@ Shape.registerNode(
      * @return {Object} 节点的样式
      */
     getShapeStyle(cfg: NodeConfig) {
-      const { style: defaultStyle } = this.getOptions(cfg) as ModelConfig &
-        Exclude<NodeConfig, 'id'>;
+      const { style: defaultStyle } = this.getOptions(cfg) as NodeConfig;
       const strokeStyle: ShapeStyle = {
         stroke: cfg.color,
       };
@@ -164,8 +163,7 @@ Shape.registerNode(
     update(cfg: NodeConfig, item: Item) {
       const group = item.getContainer();
       // 这里不传 cfg 参数是因为 cfg.style 需要最后覆盖样式
-      const { style: defaultStyle } = this.getOptions({}) as ModelConfig &
-        Exclude<NodeConfig, 'id'>;
+      const { style: defaultStyle } = this.getOptions({}) as NodeConfig;
       const size = (this as ShapeOptions).getSize!(cfg);
       const keyShape = item.get('keyShape');
       if (!cfg.size) {

--- a/src/shape/nodes/star.ts
+++ b/src/shape/nodes/star.ts
@@ -1,7 +1,7 @@
 import GGroup from '@antv/g-canvas/lib/group';
 import { IShape } from '@antv/g-canvas/lib/interfaces';
-import { mix, deepMix } from '@antv/util';
-import { Item, NodeConfig, ShapeStyle, ModelConfig } from '../../types';
+import { mix } from '@antv/util';
+import { Item, NodeConfig, ShapeStyle } from '../../types';
 import Global from '../../global';
 import Shape from '../shape';
 import { ShapeOptions } from '../../interface/shape';
@@ -221,8 +221,7 @@ Shape.registerNode(
      * @return {Object} 节点的样式
      */
     getShapeStyle(cfg: NodeConfig): ShapeStyle {
-      const { style: defaultStyle } = this.getOptions(cfg) as ModelConfig &
-        Exclude<NodeConfig, 'id'>;
+      const { style: defaultStyle } = this.getOptions(cfg) as NodeConfig;
       const strokeStyle: ShapeStyle = {
         stroke: cfg.color,
       };
@@ -235,8 +234,7 @@ Shape.registerNode(
     update(cfg: NodeConfig, item: Item) {
       const group = item.getContainer();
       // 这里不传 cfg 参数是因为 cfg.style 需要最后覆盖样式
-      const { style: defaultStyle } = this.getOptions({}) as ModelConfig &
-        Exclude<NodeConfig, 'id'>;
+      const { style: defaultStyle } = this.getOptions({}) as NodeConfig;
       const path = (this as any).getPath(cfg);
       // 下面这些属性需要覆盖默认样式与目前样式，但若在 cfg 中有指定则应该被 cfg 的相应配置覆盖。
       const strokeStyle = {
@@ -258,7 +256,7 @@ Shape.registerNode(
      * @param {Group} group Item所在的group
      */
     updateLinkPoints(cfg: NodeConfig, group: GGroup) {
-      const { linkPoints: defaultLinkPoints } = this.options as ModelConfig;
+      const { linkPoints: defaultLinkPoints } = this.getOptions({}) as NodeConfig;
       const markLeft = group.find((element) => element.get('className') === 'link-point-left');
       const markRight = group.find((element) => element.get('className') === 'link-point-right');
       const markTop = group.find((element) => element.get('className') === 'link-point-top');

--- a/src/shape/nodes/star.ts
+++ b/src/shape/nodes/star.ts
@@ -78,11 +78,7 @@ Shape.registerNode(
           },
           className: `${this.type}-icon`,
           name: `${this.type}-icon`,
-<<<<<<< HEAD
           draggable: true
-=======
-          draggable: true,
->>>>>>> test: add test case for all node
         });
       }
 

--- a/src/shape/nodes/star.ts
+++ b/src/shape/nodes/star.ts
@@ -78,7 +78,11 @@ Shape.registerNode(
           },
           className: `${this.type}-icon`,
           name: `${this.type}-icon`,
+<<<<<<< HEAD
           draggable: true
+=======
+          draggable: true,
+>>>>>>> test: add test case for all node
         });
       }
 
@@ -265,7 +269,6 @@ Shape.registerNode(
      */
     updateLinkPoints(cfg: NodeConfig, group: GGroup) {
       const { linkPoints: defaultLinkPoints } = this.options as ModelConfig;
-
       const markLeft = group.find((element) => element.get('className') === 'link-point-left');
       const markRight = group.find((element) => element.get('className') === 'link-point-right');
       const markTop = group.find((element) => element.get('className') === 'link-point-top');

--- a/src/shape/nodes/star.ts
+++ b/src/shape/nodes/star.ts
@@ -241,7 +241,8 @@ Shape.registerNode(
     update(cfg: NodeConfig, item: Item) {
       const group = item.getContainer();
       // 这里不传 cfg 参数是因为 cfg.style 需要最后覆盖样式
-      const { style: defaultStyle } = this.getOptions() as ModelConfig & Exclude<NodeConfig, 'id'>;
+      const { style: defaultStyle } = this.getOptions({}) as ModelConfig &
+        Exclude<NodeConfig, 'id'>;
       const path = (this as any).getPath(cfg);
       // 下面这些属性需要覆盖默认样式与目前样式，但若在 cfg 中有指定则应该被 cfg 的相应配置覆盖。
       const strokeStyle = {

--- a/src/shape/nodes/star.ts
+++ b/src/shape/nodes/star.ts
@@ -51,14 +51,8 @@ Shape.registerNode(
     shapeType: 'star',
     // 文本位置
     labelPosition: 'center',
-    getCustomConfig(cfg: NodeConfig): ModelConfig {
-      return {};
-    },
-    getOptions(cfg: NodeConfig): ModelConfig {
-      return deepMix({}, this.options, this.getCustomConfig(cfg) || {}, cfg);
-    },
     drawShape(cfg: NodeConfig, group: GGroup): IShape {
-      const { icon } = this.getOptions(cfg) as ModelConfig & Exclude<NodeConfig, 'id'>;
+      const { icon } = this.getOptions(cfg) as NodeConfig;
       const style = this.getShapeStyle!(cfg);
 
       const keyShape = group.addShape('path', {
@@ -92,7 +86,7 @@ Shape.registerNode(
      * @param {Group} group Group实例
      */
     drawLinkPoints(cfg: NodeConfig, group: GGroup) {
-      const { linkPoints } = this.getOptions(cfg) as ModelConfig & Exclude<NodeConfig, 'id'>;
+      const { linkPoints } = this.getOptions(cfg) as NodeConfig;
 
       const {
         top,

--- a/src/shape/nodes/triangle.ts
+++ b/src/shape/nodes/triangle.ts
@@ -53,12 +53,6 @@ Shape.registerNode(
     shapeType: 'triangle',
     // 文本位置
     labelPosition: 'bottom',
-    getCustomConfig(cfg: NodeConfig): ModelConfig {
-      return {};
-    },
-    getOptions(cfg: NodeConfig): ModelConfig {
-      return deepMix({}, this.options, this.getCustomConfig(cfg) || {}, cfg);
-    },
     drawShape(cfg: NodeConfig, group: GGroup): IShape {
       const { icon, direction: defaultDirection } = this.getOptions(cfg) as ModelConfig &
         Exclude<NodeConfig, 'id'>;
@@ -311,7 +305,7 @@ Shape.registerNode(
     updateLinkPoints(cfg: NodeConfig, group: GGroup) {
       const { linkPoints: defaultLinkPoints, direction: defaultDirection } = this.getOptions(
         {},
-      ) as ModelConfig & Exclude<NodeConfig, 'id'>;
+      ) as NodeConfig;
 
       const direction = cfg.direction || defaultDirection;
 

--- a/src/shape/nodes/triangle.ts
+++ b/src/shape/nodes/triangle.ts
@@ -287,7 +287,8 @@ Shape.registerNode(
     update(cfg: NodeConfig, item: Item) {
       const group = item.getContainer();
       // 这里不传 cfg 参数是因为 cfg.style 需要最后覆盖样式
-      const { style: defaultStyle } = this.getOptions() as ModelConfig & Exclude<NodeConfig, 'id'>;
+      const { style: defaultStyle } = this.getOptions({}) as ModelConfig &
+        Exclude<NodeConfig, 'id'>;
       const path = (this as any).getPath(cfg);
       // 下面这些属性需要覆盖默认样式与目前样式，但若在 cfg 中有指定则应该被 cfg 的相应配置覆盖。
       const strokeStyle = {
@@ -308,10 +309,9 @@ Shape.registerNode(
      * @param {Group} group Item所在的group
      */
     updateLinkPoints(cfg: NodeConfig, group: GGroup) {
-      const {
-        linkPoints: defaultLinkPoints,
-        direction: defaultDirection,
-      } = this.getOptions() as ModelConfig & Exclude<NodeConfig, 'id'>;
+      const { linkPoints: defaultLinkPoints, direction: defaultDirection } = this.getOptions(
+        {},
+      ) as ModelConfig & Exclude<NodeConfig, 'id'>;
 
       const direction = cfg.direction || defaultDirection;
 

--- a/src/shape/nodes/triangle.ts
+++ b/src/shape/nodes/triangle.ts
@@ -1,5 +1,5 @@
 import Shape from '../shape';
-import { mix, deepMix } from '@antv/util';
+import { mix } from '@antv/util';
 import Global from '../../global';
 import GGroup from '@antv/g-canvas/lib/group';
 import { IShape } from '@antv/g-canvas/lib/interfaces';
@@ -54,8 +54,7 @@ Shape.registerNode(
     // 文本位置
     labelPosition: 'bottom',
     drawShape(cfg: NodeConfig, group: GGroup): IShape {
-      const { icon, direction: defaultDirection } = this.getOptions(cfg) as ModelConfig &
-        Exclude<NodeConfig, 'id'>;
+      const { icon, direction: defaultDirection } = this.getOptions(cfg) as NodeConfig;
       const style = this.getShapeStyle!(cfg);
       const direction = cfg.direction || defaultDirection;
 
@@ -98,8 +97,7 @@ Shape.registerNode(
      * @param {Group} group Group实例
      */
     drawLinkPoints(cfg: NodeConfig, group: GGroup) {
-      const { linkPoints, direction: defaultDirection } = this.getOptions(cfg) as ModelConfig &
-        Exclude<NodeConfig, 'id'>;
+      const { linkPoints, direction: defaultDirection } = this.getOptions(cfg) as NodeConfig;
 
       const direction = cfg.direction || defaultDirection;
 
@@ -221,8 +219,7 @@ Shape.registerNode(
       }
     },
     getPath(cfg: ModelConfig) {
-      const { direction: defaultDirection } = this.getOptions(cfg) as ModelConfig &
-        Exclude<NodeConfig, 'id'>;
+      const { direction: defaultDirection } = this.getOptions(cfg) as NodeConfig;
 
       const direction = cfg.direction || defaultDirection;
       const size = (this as ShapeOptions).getSize!(cfg);
@@ -267,8 +264,7 @@ Shape.registerNode(
      * @return {Object} 节点的样式
      */
     getShapeStyle(cfg: NodeConfig) {
-      const { style: defaultStyle } = this.getOptions(cfg) as ModelConfig &
-        Exclude<NodeConfig, 'id'>;
+      const { style: defaultStyle } = this.getOptions(cfg) as NodeConfig;
       const strokeStyle: ShapeStyle = {
         stroke: cfg.color,
       };
@@ -281,8 +277,7 @@ Shape.registerNode(
     update(cfg: NodeConfig, item: Item) {
       const group = item.getContainer();
       // 这里不传 cfg 参数是因为 cfg.style 需要最后覆盖样式
-      const { style: defaultStyle } = this.getOptions({}) as ModelConfig &
-        Exclude<NodeConfig, 'id'>;
+      const { style: defaultStyle } = this.getOptions({}) as NodeConfig;
       const path = (this as any).getPath(cfg);
       // 下面这些属性需要覆盖默认样式与目前样式，但若在 cfg 中有指定则应该被 cfg 的相应配置覆盖。
       const strokeStyle = {

--- a/src/shape/shapeBase.ts
+++ b/src/shape/shapeBase.ts
@@ -23,7 +23,12 @@ export const shapeBase: ShapeOptions = {
    * 形状的类型，例如 circle，ellipse，polyline...
    */
   type: '',
-
+  getCustomConfig(cfg: ModelConfig): ModelConfig {
+    return {};
+  },
+  getOptions(cfg: ModelConfig): ModelConfig {
+    return deepMix({}, this.options, this.getCustomConfig(cfg) || {}, cfg);
+  },
   /**
    * 绘制节点/边，包含文本
    * @override
@@ -46,14 +51,14 @@ export const shapeBase: ShapeOptions = {
    * @param group
    * @param keyShape
    */
-  afterDraw(cfg?: ModelConfig, group?: GGroup, keyShape?: IShape) { },
+  afterDraw(cfg?: ModelConfig, group?: GGroup, keyShape?: IShape) {},
   drawShape(cfg?: ModelConfig, group?: GGroup): IShape {
     return null as any;
   },
   drawLabel(cfg: ModelConfig, group: GGroup): IShape {
-    const { labelCfg: defaultLabelCfg } = this.options as ModelConfig;
-
-    const labelCfg = mix({}, defaultLabelCfg, cfg.labelCfg) as ILabelConfig;
+    const { labelCfg: defaultLabelCfg } = this.getOptions(cfg) as ModelConfig;
+    // image的情况下有可能为null
+    const labelCfg = (defaultLabelCfg || {}) as ILabelConfig;
     const labelStyle = this.getLabelStyle!(cfg, labelCfg, group);
     const rotate = labelStyle.rotate;
     delete labelStyle.rotate;
@@ -175,7 +180,7 @@ export const shapeBase: ShapeOptions = {
       const style = shapeStyle[key];
       if (isPlainObject(style)) {
         // 更新图元素样式，支持更新子元素
-        const subShape = group.find(element => element.get('name') === key);
+        const subShape = group.find((element) => element.get('name') === key);
         if (subShape) {
           subShape.attr(style);
         }
@@ -189,12 +194,11 @@ export const shapeBase: ShapeOptions = {
 
   updateLabel(cfg: ModelConfig, item: Item) {
     const group = item.getContainer();
-    const { labelCfg: defaultLabelCfg } = this.options as ModelConfig;
+    const { labelCfg: defaultLabelCfg } = this.getOptions({}) as ModelConfig;
     const labelClassName = this.itemType + CLS_LABEL_SUFFIX;
-    const label = group.find(element => element.get('className') === labelClassName);
+    const label = group.find((element) => element.get('className') === labelClassName);
     const labelBgClassname = this.itemType + CLS_LABEL_BG_SUFFIX;
-    let labelBg = group.find(element => element.get('classname') === labelBgClassname);
-
+    let labelBg = group.find((element) => element.get('classname') === labelBgClassname);
     // 防止 cfg.label = "" 的情况
     if (cfg.label || cfg.label === '') {
       // 若传入的新配置中有 label，（用户没传入但原先有 label，label 也会有值）
@@ -209,6 +213,7 @@ export const shapeBase: ShapeOptions = {
         if (item.getModel) {
           currentLabelCfg = item.getModel().labelCfg;
         }
+        // 这里不能去掉
         const labelCfg = deepMix({}, defaultLabelCfg, currentLabelCfg, cfg.labelCfg);
 
         // 获取位置信息
@@ -267,7 +272,7 @@ export const shapeBase: ShapeOptions = {
   },
 
   // update(cfg, item) // 默认不定义
-  afterUpdate(cfg?: ModelConfig, item?: Item) { },
+  afterUpdate(cfg?: ModelConfig, item?: Item) {},
   /**
    * 设置节点的状态，主要是交互状态，业务状态请在 draw 方法中实现
    * 单图形的节点仅考虑 selected、active 状态，有其他状态需求的用户自己复写这个方法
@@ -282,21 +287,20 @@ export const shapeBase: ShapeOptions = {
       return;
     }
 
-    const type = item.getType()
+    const type = item.getType();
 
     const stateName = isBoolean(value) ? name : `${name}:${value}`;
     const shapeStateStyle = this.getStateStyle(stateName, true, item);
     const itemStateStyle = item.getStateStyle(stateName);
-    
+
     // 不允许设置一个不存在的状态
     if (!itemStateStyle && !shapeStateStyle) {
       return;
     }
-    
+
     // 要设置或取消的状态的样式
     // 当没有 state 状态时，默认使用 model.stateStyles 中的样式
     const styles = mix({}, itemStateStyle || shapeStateStyle);
-
 
     const group = item.getContainer();
 
@@ -305,7 +309,7 @@ export const shapeBase: ShapeOptions = {
       for (const key in styles) {
         const style = styles[key];
         if (isPlainObject(style)) {
-          const subShape = group.find(element => element.get('name') === key);
+          const subShape = group.find((element) => element.get('name') === key);
           if (subShape) {
             subShape.attr(style);
           }
@@ -333,7 +337,7 @@ export const shapeBase: ShapeOptions = {
       for (const p in styles) {
         const style = styles[p];
         if (isPlainObject(style)) {
-          const subShape = group.find(element => element.get('name') === p);
+          const subShape = group.find((element) => element.get('name') === p);
           if (subShape) {
             const subShapeStyles = subShape.attr();
             // const current = subShapeStyles[p]
@@ -386,16 +390,17 @@ export const shapeBase: ShapeOptions = {
       for (const originKey in originstyles) {
         const style = originstyles[originKey];
         if (isPlainObject(style)) {
-          const subShape = group.find(element => element.get('name') === originKey);
+          const subShape = group.find((element) => element.get('name') === originKey);
           if (subShape) {
             subShape.attr(style);
           }
         } else {
           // 当更新 combo 状态时，当不存在 keyShapeName 时候，则认为是设置到 keyShape 上面的
           if (type === 'combo') {
-            !keyShapeName && shape.attr({
-              [originKey]: style,
-            });
+            !keyShapeName &&
+              shape.attr({
+                [originKey]: style,
+              });
           } else {
             shape.attr({
               [originKey]: style,
@@ -416,15 +421,15 @@ export const shapeBase: ShapeOptions = {
    */
   getStateStyle(name: string, value: string | boolean, item: Item): ShapeStyle {
     const model = item.getModel();
-    const type = item.getType()
-
+    const type = item.getType();
+    const { stateStyles } = this.getOptions(model);
     if (value) {
       const modelStateStyle = model.stateStyles
         ? model.stateStyles[name]
-        : this.options.stateStyles && this.options.stateStyles[name];
-      
+        : stateStyles && stateStyles[name];
+
       if (type === 'combo') {
-        return mix({}, modelStateStyle)
+        return mix({}, modelStateStyle);
       }
       return mix({}, model.style, modelStateStyle);
     }
@@ -445,8 +450,7 @@ export const shapeBase: ShapeOptions = {
    * @return {Array|null} 锚点的数组,如果为 null，则没有锚点
    */
   getAnchorPoints(cfg: ModelConfig): number[][] | undefined {
-    const { anchorPoints: defaultAnchorPoints } = this.options as ModelConfig;
-    const anchorPoints = cfg.anchorPoints || defaultAnchorPoints;
+    const { anchorPoints } = this.getOptions(cfg) as ModelConfig;
     return anchorPoints;
   },
 };

--- a/tests/unit/shape/extend/extend-circle-spec.ts
+++ b/tests/unit/shape/extend/extend-circle-spec.ts
@@ -1,0 +1,627 @@
+import G6 from '../../../../src';
+
+const div = document.createElement('div');
+div.id = 'graph-spec';
+document.body.appendChild(div);
+
+describe('register node with getCustomConfig function, extend circle', () => {
+  const data = {
+    nodes: [
+      {
+        id: 'node1',
+        label: 'node1',
+        x: 50,
+        y: 50,
+      },
+      {
+        id: 'node2',
+        label: 'node2',
+        x: 250,
+        y: 50,
+      },
+    ],
+    edges: [
+      {
+        source: 'node1',
+        target: 'node2',
+      },
+    ],
+  };
+  it('getCustomConfig return new style', () => {
+    G6.registerNode(
+      'custom-node',
+      {
+        getCustomConfig() {
+          return {
+            style: {
+              fill: 'red',
+              stroke: 'blue',
+              lineWidth: 10,
+            },
+          };
+        },
+      },
+      'circle',
+    );
+    const graph = new G6.Graph({
+      container: div,
+      width: 500,
+      height: 500,
+      defaultNode: {
+        type: 'custom-node',
+      },
+    });
+    graph.data(data);
+    graph.render();
+    const node = graph.getNodes()[0];
+    const keyShape = node.getKeyShape();
+    expect(keyShape.attr('r')).toEqual(10);
+    expect(keyShape.attr('stroke')).toEqual('blue');
+    expect(keyShape.attr('fill')).toEqual('red');
+    expect(keyShape.attr('lineWidth')).toEqual(10);
+    graph.destroy();
+  });
+  it('getCustomConfig return new icon', () => {
+    G6.registerNode(
+      'custom-node',
+      {
+        getCustomConfig() {
+          return {
+            icon: {
+              show: true,
+              img: 'customsrc',
+              width: 20,
+              height: 20,
+            },
+          };
+        },
+      },
+      'circle',
+    );
+    const graph = new G6.Graph({
+      container: div,
+      width: 500,
+      height: 500,
+      defaultNode: {
+        type: 'custom-node',
+      },
+    });
+    graph.data(data);
+    graph.render();
+    const node = graph.getNodes()[0];
+    const group = node.get('group');
+    const keyShape = node.getKeyShape();
+    expect(keyShape.attr('r')).toEqual(10);
+    expect(keyShape.attr('stroke')).toEqual('#5B8FF9');
+    expect(keyShape.attr('fill')).toEqual('#C6E5FF');
+    expect(keyShape.attr('lineWidth')).toEqual(1);
+
+    const icon = group.find((g) => {
+      return g.get('className') === 'custom-node-icon';
+    });
+    expect(icon).not.toBe(undefined);
+    expect(icon.attr('img')).toEqual('customsrc');
+    expect(icon.attr('width')).toEqual(20);
+    expect(icon.attr('height')).toEqual(20);
+    graph.destroy();
+  });
+  it('getCustomConfig return new labelCfg style', () => {
+    G6.registerNode(
+      'custom-node',
+      {
+        getCustomConfig() {
+          return {
+            labelCfg: {
+              style: {
+                fill: 'red',
+              },
+            },
+          };
+        },
+      },
+      'circle',
+    );
+    const graph = new G6.Graph({
+      container: div,
+      width: 500,
+      height: 500,
+      defaultNode: {
+        type: 'custom-node',
+      },
+    });
+    graph.data(data);
+    graph.render();
+    const node = graph.getNodes()[0];
+    const group = node.get('group');
+    const keyShape = node.getKeyShape();
+    expect(keyShape.attr('r')).toEqual(10);
+    expect(keyShape.attr('stroke')).toEqual('#5B8FF9');
+    expect(keyShape.attr('fill')).toEqual('#C6E5FF');
+    expect(keyShape.attr('lineWidth')).toEqual(1);
+
+    const label = group.find((g) => {
+      return g.get('className') === 'node-label';
+    });
+    expect(label).not.toBe(undefined);
+    expect(label.attr('fill')).toEqual('red');
+    const type = label.get('type');
+    expect(type).toEqual('text');
+    graph.destroy();
+  });
+  it('getCustomConfig return new linkPoints', () => {
+    G6.registerNode(
+      'custom-node',
+      {
+        getCustomConfig() {
+          return {
+            linkPoints: {
+              top: true,
+              bottom: true,
+              left: true,
+              fill: 'red',
+              size: 20,
+            },
+          };
+        },
+      },
+      'circle',
+    );
+    const graph = new G6.Graph({
+      container: div,
+      width: 500,
+      height: 500,
+      defaultNode: {
+        type: 'custom-node',
+      },
+    });
+    graph.data(data);
+    graph.render();
+
+    const nodes = graph.getNodes();
+    const node = nodes[0];
+    const group = node.get('group');
+
+    expect(group.getCount()).toEqual(5);
+
+    const keyShape = node.getKeyShape();
+    expect(keyShape.attr('fill')).toEqual('#C6E5FF');
+    expect(keyShape.attr('stroke')).toEqual('#5B8FF9');
+    expect(keyShape.attr('r')).toEqual(10);
+    expect(keyShape.attr('lineWidth')).toEqual(1);
+
+    const markTop = group.find((g) => {
+      return g.get('className') === 'link-point-top';
+    });
+    expect(markTop).not.toBe(null);
+    expect(markTop.attr('r')).toEqual(10);
+    expect(markTop.attr('fill')).toEqual('red');
+
+    const markBottom = group.find((g) => {
+      return g.get('className') === 'link-point-bottom';
+    });
+    expect(markBottom).not.toBe(null);
+
+    let hasTrigger = false;
+    expect(hasTrigger).toBe(false);
+    graph.on('node:mouseenter', (evt) => {
+      hasTrigger = evt.hasTrigger;
+      graph.setItemState(evt.item, 'hover', true);
+    });
+    graph.emit('node:mouseenter', { hasTrigger: true, item: node });
+
+    expect(hasTrigger).toBe(true);
+    expect(keyShape.attr('lineWidth')).toEqual(1);
+
+    graph.destroy();
+  });
+  describe('update', () => {
+    it('update styles', () => {
+      G6.registerNode(
+        'custom-node',
+        {
+          getCustomConfig() {
+            return {
+              size: 50,
+              style: {
+                fill: 'red',
+                stroke: '#ccc',
+                lineWidth: 5,
+              },
+              icon: {
+                show: true,
+              },
+            };
+          },
+        },
+        'circle',
+      );
+      const graph = new G6.Graph({
+        container: div,
+        width: 500,
+        height: 500,
+        defaultNode: {
+          type: 'custom-node',
+        },
+      });
+      graph.data(data);
+      graph.render();
+
+      const nodes = graph.getNodes();
+      const node = nodes[0];
+      node.update({
+        size: 30,
+        color: 'black',
+        style: {
+          fill: 'steelblue',
+        },
+      });
+      const group = node.get('group');
+      expect(group.getCount()).toEqual(3);
+      const keyShape = node.getKeyShape();
+      expect(keyShape.attr('r')).toBe(15);
+      expect(keyShape.attr('fill')).toBe('steelblue');
+      expect(keyShape.attr('lineWidth')).toBe(5);
+
+      graph.destroy();
+      expect(graph.destroyed).toBe(true);
+    });
+    it('update icon', () => {
+      G6.registerNode(
+        'custom-node',
+        {
+          getCustomConfig() {
+            return {
+              icon: {
+                show: true,
+                width: 20,
+                height: 20,
+              },
+            };
+          },
+        },
+        'circle',
+      );
+      const graph = new G6.Graph({
+        container: div,
+        width: 500,
+        height: 500,
+        defaultNode: {
+          type: 'custom-node',
+        },
+      });
+      graph.data(data);
+      graph.render();
+
+      const nodes = graph.getNodes();
+      const node = nodes[0];
+      let group = node.get('group');
+
+      expect(group.getCount()).toEqual(3);
+      let icon = group.find((g) => {
+        return g.get('className') === 'custom-node-icon';
+      });
+      expect(icon.attr('width')).toEqual(20);
+      expect(icon.attr('x')).toEqual(-10);
+      expect(icon.attr('y')).toEqual(-10);
+      expect(icon.attr('img')).toEqual(
+        'https://gw.alipayobjects.com/zos/basement_prod/012bcf4f-423b-4922-8c24-32a89f8c41ce.svg',
+      );
+
+      const newImg =
+        'https://gw.alipayobjects.com/mdn/rms_f8c6a0/afts/img/A*mt47RKxGy8kAAAAAAAAAAABkARQnAQ';
+      node.update({
+        icon: {
+          show: true,
+          img: newImg,
+          width: 50,
+          height: 50,
+        },
+      });
+      // 更新之后的名字变成了 custom-node-icon
+      icon = group.find((g) => {
+        return g.get('className') === 'custom-node-icon';
+      });
+      expect(group.getCount()).toEqual(3);
+      expect(icon.attr('width')).toEqual(50);
+      expect(icon.attr('x')).toEqual(-25);
+      expect(icon.attr('y')).toEqual(-25);
+      expect(icon.attr('img')).toEqual(newImg);
+
+      node.update({
+        icon: {
+          width: 80,
+        },
+      });
+      group = node.get('group');
+      expect(group.getCount()).toEqual(3);
+      expect(icon.attr('width')).toEqual(80);
+      expect(icon.attr('x')).toEqual(-40);
+
+      node.update({
+        icon: {
+          show: false,
+        },
+      });
+      group = node.get('group');
+      expect(group.getCount()).toEqual(2);
+      graph.destroy();
+      expect(graph.destroyed).toBe(true);
+    });
+    it('update label', () => {
+      G6.registerNode(
+        'custom-node',
+        {
+          getCustomConfig() {
+            return {
+              labelCfg: {
+                style: {
+                  fill: 'red',
+                },
+              },
+            };
+          },
+        },
+        'circle',
+      );
+      const graph = new G6.Graph({
+        container: div,
+        width: 500,
+        height: 500,
+        defaultNode: {
+          type: 'custom-node',
+        },
+      });
+      graph.data(data);
+      graph.render();
+
+      const nodes = graph.getNodes();
+      const node = nodes[0];
+      const group = node.get('group');
+      const label = group.find((g) => {
+        return g.get('className') === 'node-label';
+      });
+      expect(label).not.toEqual(null);
+      expect(label.attr('text')).toEqual('node1');
+      expect(label.attr('fill')).toEqual('red');
+
+      node.update({
+        label: '',
+        labelCfg: {
+          style: {
+            fill: '#ff0',
+          },
+        },
+      });
+
+      expect(label).not.toEqual(null);
+      expect(label.attr('text')).toEqual('');
+      expect(label.attr('fill')).toEqual('#ff0');
+
+      node.update({
+        label: 'new circle label',
+      });
+      // test if it will keep the current fill without setting
+      node.update({
+        labelCfg: {
+          position: 'center',
+          style: {
+            stroke: 'black',
+            lineWidth: 3,
+          },
+        },
+      });
+      expect(label.attr('text')).toEqual('new circle label');
+      expect(label.attr('fill')).toEqual('#ff0');
+      expect(label.attr('stroke')).toEqual('black');
+      expect(label.attr('lineWidth')).toEqual(3);
+
+      graph.destroy();
+      expect(graph.destroyed).toBe(true);
+    });
+    it('update label from none', () => {
+      G6.registerNode(
+        'custom-node',
+        {
+          getCustomConfig() {
+            return {
+              labelCfg: {
+                style: {
+                  fill: 'red',
+                },
+              },
+            };
+          },
+        },
+        'circle',
+      );
+      const graph = new G6.Graph({
+        container: div,
+        width: 500,
+        height: 500,
+        defaultNode: {
+          type: 'custom-node',
+        },
+      });
+      const data = {
+        nodes: [
+          {
+            id: 'node',
+            x: 200,
+            y: 100,
+          },
+        ],
+      };
+      graph.data(data);
+      graph.render();
+
+      const nodes = graph.getNodes();
+      const node = nodes[0];
+      const group = node.get('group');
+      let label = group.find((g) => {
+        return g.get('className') === 'node-label';
+      });
+      expect(label).toEqual(null);
+
+      node.update({
+        label: 'new circle label',
+      });
+      label = group.find((g) => {
+        return g.get('className') === 'node-label';
+      });
+      expect(label).not.toEqual(null);
+      expect(label.attr('text')).toEqual('new circle label');
+      expect(label.attr('fill')).toEqual('red');
+
+      node.update({
+        labelCfg: {
+          style: {
+            fill: '#ff0',
+          },
+        },
+      });
+      label = group.find((g) => {
+        return g.get('className') === 'node-label';
+      });
+      expect(label.attr('text')).toEqual('new circle label');
+      expect(label.attr('fill')).toEqual('#ff0');
+      graph.destroy();
+      expect(graph.destroyed).toBe(true);
+    });
+    it('update label, linkPoints, icon from none', () => {
+      G6.registerNode(
+        'custom-node',
+        {
+          getCustomConfig() {
+            return {
+              icon: {
+                img:
+                  'https://gw.alipayobjects.com/mdn/rms_f8c6a0/afts/img/A*mt47RKxGy8kAAAAAAAAAAABkARQnAQ',
+              },
+            };
+          },
+        },
+        'circle',
+      );
+      const graph = new G6.Graph({
+        container: div,
+        width: 500,
+        height: 500,
+        defaultNode: {
+          size: 50,
+          type: 'custom-node',
+        },
+      });
+      const data = {
+        nodes: [
+          {
+            id: 'node',
+            x: 200,
+            y: 100,
+          },
+        ],
+      };
+      graph.data(data);
+      graph.render();
+
+      graph.on('node:mouseenter', (e) => {
+        const item = e.item;
+        item.update({
+          label: 'Circle',
+          labelCfg: {
+            position: 'bottom',
+            offset: 10,
+            style: {
+              fill: '#333',
+            },
+          },
+          linkPoints: {
+            top: true,
+            bottom: true,
+            left: true,
+            right: true,
+            fill: '#fff',
+            size: 5,
+          },
+          icon: {
+            show: true,
+          },
+        });
+      });
+
+      graph.on('node:mouseleave', (e) => {
+        const item = e.item;
+        item.update({
+          label: ' ',
+          labelCfg: {
+            style: {
+              fill: '#333',
+            },
+          },
+          linkPoints: {
+            top: false,
+            bottom: false,
+            left: false,
+            right: false,
+            fill: '#fff',
+            size: 5,
+          },
+          icon: {
+            show: false,
+          },
+        });
+      });
+    });
+    it('update label, linkPoints, icon from none', () => {
+      const graph = new G6.Graph({
+        container: div,
+        width: 500,
+        height: 500,
+        // defaultNode: {
+        //   size: 50
+        // }
+      });
+      const data = {
+        nodes: [
+          {
+            id: 'node',
+            type: 'modelRect',
+            label: 'modelRect',
+            description: 'description',
+            x: 200,
+            y: 100,
+          },
+        ],
+      };
+      graph.data(data);
+      graph.render();
+
+      graph.on('node:mouseenter', (e) => {
+        const item = e.item;
+        item.update({
+          descriptionCfg: {
+            style: {
+              fill: 'steelblue',
+            },
+          },
+          stateIcon: {
+            show: true,
+          },
+        });
+      });
+
+      graph.on('node:mouseleave', (e) => {
+        const item = e.item;
+        item.update({
+          descriptionCfg: {
+            style: {
+              fill: '#bfbfbf',
+            },
+          },
+          stateIcon: {
+            show: false,
+          },
+        });
+      });
+    });
+  });
+});

--- a/tests/unit/shape/extend/extend-diamond-spec.ts
+++ b/tests/unit/shape/extend/extend-diamond-spec.ts
@@ -4,7 +4,7 @@ const div = document.createElement('div');
 div.id = 'graph-spec';
 document.body.appendChild(div);
 
-describe('register node with getCustomConfig function, extend circle', () => {
+describe('register node with getCustomConfig function, extend diamond', () => {
   const data = {
     nodes: [
       {
@@ -41,7 +41,7 @@ describe('register node with getCustomConfig function, extend circle', () => {
           };
         },
       },
-      'circle',
+      'diamond',
     );
     const graph = new G6.Graph({
       container: div,
@@ -55,7 +55,6 @@ describe('register node with getCustomConfig function, extend circle', () => {
     graph.render();
     const node = graph.getNodes()[0];
     const keyShape = node.getKeyShape();
-    expect(keyShape.attr('r')).toEqual(10);
     expect(keyShape.attr('stroke')).toEqual('blue');
     expect(keyShape.attr('fill')).toEqual('red');
     expect(keyShape.attr('lineWidth')).toEqual(10);
@@ -76,7 +75,7 @@ describe('register node with getCustomConfig function, extend circle', () => {
           };
         },
       },
-      'circle',
+      'diamond',
     );
     const graph = new G6.Graph({
       container: div,
@@ -91,7 +90,6 @@ describe('register node with getCustomConfig function, extend circle', () => {
     const node = graph.getNodes()[0];
     const group = node.get('group');
     const keyShape = node.getKeyShape();
-    expect(keyShape.attr('r')).toEqual(10);
     expect(keyShape.attr('stroke')).toEqual('#5B8FF9');
     expect(keyShape.attr('fill')).toEqual('#C6E5FF');
     expect(keyShape.attr('lineWidth')).toEqual(1);
@@ -119,7 +117,7 @@ describe('register node with getCustomConfig function, extend circle', () => {
           };
         },
       },
-      'circle',
+      'diamond',
     );
     const graph = new G6.Graph({
       container: div,
@@ -134,7 +132,6 @@ describe('register node with getCustomConfig function, extend circle', () => {
     const node = graph.getNodes()[0];
     const group = node.get('group');
     const keyShape = node.getKeyShape();
-    expect(keyShape.attr('r')).toEqual(10);
     expect(keyShape.attr('stroke')).toEqual('#5B8FF9');
     expect(keyShape.attr('fill')).toEqual('#C6E5FF');
     expect(keyShape.attr('lineWidth')).toEqual(1);
@@ -164,7 +161,7 @@ describe('register node with getCustomConfig function, extend circle', () => {
           };
         },
       },
-      'circle',
+      'diamond',
     );
     const graph = new G6.Graph({
       container: div,
@@ -186,7 +183,6 @@ describe('register node with getCustomConfig function, extend circle', () => {
     const keyShape = node.getKeyShape();
     expect(keyShape.attr('fill')).toEqual('#C6E5FF');
     expect(keyShape.attr('stroke')).toEqual('#5B8FF9');
-    expect(keyShape.attr('r')).toEqual(10);
     expect(keyShape.attr('lineWidth')).toEqual(1);
 
     const markTop = group.find((g) => {
@@ -233,7 +229,7 @@ describe('register node with getCustomConfig function, extend circle', () => {
             };
           },
         },
-        'circle',
+        'diamond',
       );
       const graph = new G6.Graph({
         container: div,
@@ -258,7 +254,6 @@ describe('register node with getCustomConfig function, extend circle', () => {
       const group = node.get('group');
       expect(group.getCount()).toEqual(3);
       const keyShape = node.getKeyShape();
-      expect(keyShape.attr('r')).toBe(15);
       expect(keyShape.attr('fill')).toBe('steelblue');
       expect(keyShape.attr('lineWidth')).toBe(5);
 
@@ -279,7 +274,7 @@ describe('register node with getCustomConfig function, extend circle', () => {
             };
           },
         },
-        'circle',
+        'diamond',
       );
       const graph = new G6.Graph({
         container: div,
@@ -361,7 +356,7 @@ describe('register node with getCustomConfig function, extend circle', () => {
             };
           },
         },
-        'circle',
+        'diamond',
       );
       const graph = new G6.Graph({
         container: div,
@@ -398,7 +393,7 @@ describe('register node with getCustomConfig function, extend circle', () => {
       expect(label.attr('fill')).toEqual('#ff0');
 
       node.update({
-        label: 'new circle label',
+        label: 'new diamond label',
       });
       // test if it will keep the current fill without setting
       node.update({
@@ -410,7 +405,7 @@ describe('register node with getCustomConfig function, extend circle', () => {
           },
         },
       });
-      expect(label.attr('text')).toEqual('new circle label');
+      expect(label.attr('text')).toEqual('new diamond label');
       expect(label.attr('fill')).toEqual('#ff0');
       expect(label.attr('stroke')).toEqual('black');
       expect(label.attr('lineWidth')).toEqual(3);
@@ -432,7 +427,7 @@ describe('register node with getCustomConfig function, extend circle', () => {
             };
           },
         },
-        'circle',
+        'diamond',
       );
       const graph = new G6.Graph({
         container: div,
@@ -463,13 +458,13 @@ describe('register node with getCustomConfig function, extend circle', () => {
       expect(label).toEqual(null);
 
       node.update({
-        label: 'new circle label',
+        label: 'new diamond label',
       });
       label = group.find((g) => {
         return g.get('className') === 'node-label';
       });
       expect(label).not.toEqual(null);
-      expect(label.attr('text')).toEqual('new circle label');
+      expect(label.attr('text')).toEqual('new diamond label');
       expect(label.attr('fill')).toEqual('red');
 
       node.update({
@@ -482,7 +477,7 @@ describe('register node with getCustomConfig function, extend circle', () => {
       label = group.find((g) => {
         return g.get('className') === 'node-label';
       });
-      expect(label.attr('text')).toEqual('new circle label');
+      expect(label.attr('text')).toEqual('new diamond label');
       expect(label.attr('fill')).toEqual('#ff0');
       graph.destroy();
       expect(graph.destroyed).toBe(true);
@@ -500,7 +495,7 @@ describe('register node with getCustomConfig function, extend circle', () => {
             };
           },
         },
-        'circle',
+        'diamond',
       );
       const graph = new G6.Graph({
         container: div,
@@ -571,7 +566,6 @@ describe('register node with getCustomConfig function, extend circle', () => {
         });
       });
     });
-
     it('update label, linkPoints, icon from none', () => {
       const graph = new G6.Graph({
         container: div,

--- a/tests/unit/shape/extend/extend-ellipse-spec.ts
+++ b/tests/unit/shape/extend/extend-ellipse-spec.ts
@@ -1,0 +1,622 @@
+import G6 from '../../../../src';
+
+const div = document.createElement('div');
+div.id = 'graph-spec';
+document.body.appendChild(div);
+
+describe('register node with getCustomConfig function, extend ellipse', () => {
+  const data = {
+    nodes: [
+      {
+        id: 'node1',
+        label: 'node1',
+        x: 50,
+        y: 50,
+      },
+      {
+        id: 'node2',
+        label: 'node2',
+        x: 250,
+        y: 50,
+      },
+    ],
+    edges: [
+      {
+        source: 'node1',
+        target: 'node2',
+      },
+    ],
+  };
+  it('getCustomConfig return new style', () => {
+    G6.registerNode(
+      'custom-node',
+      {
+        getCustomConfig() {
+          return {
+            style: {
+              fill: 'red',
+              stroke: 'blue',
+              lineWidth: 10,
+            },
+          };
+        },
+      },
+      'ellipse',
+    );
+    const graph = new G6.Graph({
+      container: div,
+      width: 500,
+      height: 500,
+      defaultNode: {
+        type: 'custom-node',
+      },
+    });
+    graph.data(data);
+    graph.render();
+    const node = graph.getNodes()[0];
+    const keyShape = node.getKeyShape();
+    expect(keyShape.attr('stroke')).toEqual('blue');
+    expect(keyShape.attr('fill')).toEqual('red');
+    expect(keyShape.attr('lineWidth')).toEqual(10);
+    graph.destroy();
+  });
+  it('getCustomConfig return new icon', () => {
+    G6.registerNode(
+      'custom-node',
+      {
+        getCustomConfig() {
+          return {
+            icon: {
+              show: true,
+              img: 'customsrc',
+              width: 20,
+              height: 20,
+            },
+          };
+        },
+      },
+      'ellipse',
+    );
+    const graph = new G6.Graph({
+      container: div,
+      width: 500,
+      height: 500,
+      defaultNode: {
+        type: 'custom-node',
+      },
+    });
+    graph.data(data);
+    graph.render();
+    const node = graph.getNodes()[0];
+    const group = node.get('group');
+    const keyShape = node.getKeyShape();
+    expect(keyShape.attr('stroke')).toEqual('#5B8FF9');
+    expect(keyShape.attr('fill')).toEqual('#C6E5FF');
+    expect(keyShape.attr('lineWidth')).toEqual(1);
+
+    const icon = group.find((g) => {
+      return g.get('className') === 'custom-node-icon';
+    });
+    expect(icon).not.toBe(undefined);
+    expect(icon.attr('img')).toEqual('customsrc');
+    expect(icon.attr('width')).toEqual(20);
+    expect(icon.attr('height')).toEqual(20);
+    graph.destroy();
+  });
+  it('getCustomConfig return new labelCfg style', () => {
+    G6.registerNode(
+      'custom-node',
+      {
+        getCustomConfig() {
+          return {
+            labelCfg: {
+              style: {
+                fill: 'red',
+              },
+            },
+          };
+        },
+      },
+      'ellipse',
+    );
+    const graph = new G6.Graph({
+      container: div,
+      width: 500,
+      height: 500,
+      defaultNode: {
+        type: 'custom-node',
+      },
+    });
+    graph.data(data);
+    graph.render();
+    const node = graph.getNodes()[0];
+    const group = node.get('group');
+    const keyShape = node.getKeyShape();
+    expect(keyShape.attr('stroke')).toEqual('#5B8FF9');
+    expect(keyShape.attr('fill')).toEqual('#C6E5FF');
+    expect(keyShape.attr('lineWidth')).toEqual(1);
+
+    const label = group.find((g) => {
+      return g.get('className') === 'node-label';
+    });
+    expect(label).not.toBe(undefined);
+    expect(label.attr('fill')).toEqual('red');
+    const type = label.get('type');
+    expect(type).toEqual('text');
+    graph.destroy();
+  });
+  it('getCustomConfig return new linkPoints', () => {
+    G6.registerNode(
+      'custom-node',
+      {
+        getCustomConfig() {
+          return {
+            linkPoints: {
+              top: true,
+              bottom: true,
+              left: true,
+              fill: 'red',
+              size: 20,
+            },
+          };
+        },
+      },
+      'ellipse',
+    );
+    const graph = new G6.Graph({
+      container: div,
+      width: 500,
+      height: 500,
+      defaultNode: {
+        type: 'custom-node',
+      },
+    });
+    graph.data(data);
+    graph.render();
+
+    const nodes = graph.getNodes();
+    const node = nodes[0];
+    const group = node.get('group');
+
+    expect(group.getCount()).toEqual(5);
+
+    const keyShape = node.getKeyShape();
+    expect(keyShape.attr('fill')).toEqual('#C6E5FF');
+    expect(keyShape.attr('stroke')).toEqual('#5B8FF9');
+    expect(keyShape.attr('lineWidth')).toEqual(1);
+
+    const markTop = group.find((g) => {
+      return g.get('className') === 'link-point-top';
+    });
+    expect(markTop).not.toBe(null);
+    expect(markTop.attr('r')).toEqual(10);
+    expect(markTop.attr('fill')).toEqual('red');
+
+    const markBottom = group.find((g) => {
+      return g.get('className') === 'link-point-bottom';
+    });
+    expect(markBottom).not.toBe(null);
+
+    let hasTrigger = false;
+    expect(hasTrigger).toBe(false);
+    graph.on('node:mouseenter', (evt) => {
+      hasTrigger = evt.hasTrigger;
+      graph.setItemState(evt.item, 'hover', true);
+    });
+    graph.emit('node:mouseenter', { hasTrigger: true, item: node });
+
+    expect(hasTrigger).toBe(true);
+    expect(keyShape.attr('lineWidth')).toEqual(1);
+
+    graph.destroy();
+  });
+  describe('update', () => {
+    it('update styles', () => {
+      G6.registerNode(
+        'custom-node',
+        {
+          getCustomConfig() {
+            return {
+              size: 50,
+              style: {
+                fill: 'red',
+                stroke: '#ccc',
+                lineWidth: 5,
+              },
+              icon: {
+                show: true,
+              },
+            };
+          },
+        },
+        'ellipse',
+      );
+      const graph = new G6.Graph({
+        container: div,
+        width: 500,
+        height: 500,
+        defaultNode: {
+          type: 'custom-node',
+        },
+      });
+      graph.data(data);
+      graph.render();
+
+      const nodes = graph.getNodes();
+      const node = nodes[0];
+      node.update({
+        size: 30,
+        color: 'black',
+        style: {
+          fill: 'steelblue',
+        },
+      });
+      const group = node.get('group');
+      expect(group.getCount()).toEqual(3);
+      const keyShape = node.getKeyShape();
+      expect(keyShape.attr('fill')).toBe('steelblue');
+      expect(keyShape.attr('lineWidth')).toBe(5);
+
+      graph.destroy();
+      expect(graph.destroyed).toBe(true);
+    });
+    it('update icon', () => {
+      G6.registerNode(
+        'custom-node',
+        {
+          getCustomConfig() {
+            return {
+              icon: {
+                show: true,
+                width: 20,
+                height: 20,
+              },
+            };
+          },
+        },
+        'ellipse',
+      );
+      const graph = new G6.Graph({
+        container: div,
+        width: 500,
+        height: 500,
+        defaultNode: {
+          type: 'custom-node',
+        },
+      });
+      graph.data(data);
+      graph.render();
+
+      const nodes = graph.getNodes();
+      const node = nodes[0];
+      let group = node.get('group');
+
+      expect(group.getCount()).toEqual(3);
+      let icon = group.find((g) => {
+        return g.get('className') === 'custom-node-icon';
+      });
+      expect(icon.attr('width')).toEqual(20);
+      expect(icon.attr('x')).toEqual(-10);
+      expect(icon.attr('y')).toEqual(-10);
+      expect(icon.attr('img')).toEqual(
+        'https://gw.alipayobjects.com/zos/basement_prod/012bcf4f-423b-4922-8c24-32a89f8c41ce.svg',
+      );
+
+      const newImg =
+        'https://gw.alipayobjects.com/mdn/rms_f8c6a0/afts/img/A*mt47RKxGy8kAAAAAAAAAAABkARQnAQ';
+      node.update({
+        icon: {
+          show: true,
+          img: newImg,
+          width: 50,
+          height: 50,
+        },
+      });
+      // 更新之后的名字变成了 custom-node-icon
+      icon = group.find((g) => {
+        return g.get('className') === 'custom-node-icon';
+      });
+      expect(group.getCount()).toEqual(3);
+      expect(icon.attr('width')).toEqual(50);
+      expect(icon.attr('x')).toEqual(-25);
+      expect(icon.attr('y')).toEqual(-25);
+      expect(icon.attr('img')).toEqual(newImg);
+
+      node.update({
+        icon: {
+          width: 80,
+        },
+      });
+      group = node.get('group');
+      expect(group.getCount()).toEqual(3);
+      expect(icon.attr('width')).toEqual(80);
+      expect(icon.attr('x')).toEqual(-40);
+
+      node.update({
+        icon: {
+          show: false,
+        },
+      });
+      group = node.get('group');
+      expect(group.getCount()).toEqual(2);
+      graph.destroy();
+      expect(graph.destroyed).toBe(true);
+    });
+    it('update label', () => {
+      G6.registerNode(
+        'custom-node',
+        {
+          getCustomConfig() {
+            return {
+              labelCfg: {
+                style: {
+                  fill: 'red',
+                },
+              },
+            };
+          },
+        },
+        'ellipse',
+      );
+      const graph = new G6.Graph({
+        container: div,
+        width: 500,
+        height: 500,
+        defaultNode: {
+          type: 'custom-node',
+        },
+      });
+      graph.data(data);
+      graph.render();
+
+      const nodes = graph.getNodes();
+      const node = nodes[0];
+      const group = node.get('group');
+      const label = group.find((g) => {
+        return g.get('className') === 'node-label';
+      });
+      expect(label).not.toEqual(null);
+      expect(label.attr('text')).toEqual('node1');
+      expect(label.attr('fill')).toEqual('red');
+
+      node.update({
+        label: '',
+        labelCfg: {
+          style: {
+            fill: '#ff0',
+          },
+        },
+      });
+
+      expect(label).not.toEqual(null);
+      expect(label.attr('text')).toEqual('');
+      expect(label.attr('fill')).toEqual('#ff0');
+
+      node.update({
+        label: 'new ellipse label',
+      });
+      // test if it will keep the current fill without setting
+      node.update({
+        labelCfg: {
+          position: 'center',
+          style: {
+            stroke: 'black',
+            lineWidth: 3,
+          },
+        },
+      });
+      expect(label.attr('text')).toEqual('new ellipse label');
+      expect(label.attr('fill')).toEqual('#ff0');
+      expect(label.attr('stroke')).toEqual('black');
+      expect(label.attr('lineWidth')).toEqual(3);
+
+      graph.destroy();
+      expect(graph.destroyed).toBe(true);
+    });
+    it('update label from none', () => {
+      G6.registerNode(
+        'custom-node',
+        {
+          getCustomConfig() {
+            return {
+              labelCfg: {
+                style: {
+                  fill: 'red',
+                },
+              },
+            };
+          },
+        },
+        'ellipse',
+      );
+      const graph = new G6.Graph({
+        container: div,
+        width: 500,
+        height: 500,
+        defaultNode: {
+          type: 'custom-node',
+        },
+      });
+      const data = {
+        nodes: [
+          {
+            id: 'node',
+            x: 200,
+            y: 100,
+          },
+        ],
+      };
+      graph.data(data);
+      graph.render();
+
+      const nodes = graph.getNodes();
+      const node = nodes[0];
+      const group = node.get('group');
+      let label = group.find((g) => {
+        return g.get('className') === 'node-label';
+      });
+      expect(label).toEqual(null);
+
+      node.update({
+        label: 'new ellipse label',
+      });
+      label = group.find((g) => {
+        return g.get('className') === 'node-label';
+      });
+      expect(label).not.toEqual(null);
+      expect(label.attr('text')).toEqual('new ellipse label');
+      expect(label.attr('fill')).toEqual('red');
+
+      node.update({
+        labelCfg: {
+          style: {
+            fill: '#ff0',
+          },
+        },
+      });
+      label = group.find((g) => {
+        return g.get('className') === 'node-label';
+      });
+      expect(label.attr('text')).toEqual('new ellipse label');
+      expect(label.attr('fill')).toEqual('#ff0');
+      graph.destroy();
+      expect(graph.destroyed).toBe(true);
+    });
+    it('update label, linkPoints, icon from none', () => {
+      G6.registerNode(
+        'custom-node',
+        {
+          getCustomConfig() {
+            return {
+              icon: {
+                img:
+                  'https://gw.alipayobjects.com/mdn/rms_f8c6a0/afts/img/A*mt47RKxGy8kAAAAAAAAAAABkARQnAQ',
+              },
+            };
+          },
+        },
+        'ellipse',
+      );
+      const graph = new G6.Graph({
+        container: div,
+        width: 500,
+        height: 500,
+        defaultNode: {
+          size: 50,
+          type: 'custom-node',
+        },
+      });
+      const data = {
+        nodes: [
+          {
+            id: 'node',
+            x: 200,
+            y: 100,
+          },
+        ],
+      };
+      graph.data(data);
+      graph.render();
+
+      graph.on('node:mouseenter', (e) => {
+        const item = e.item;
+        item.update({
+          label: 'Circle',
+          labelCfg: {
+            position: 'bottom',
+            offset: 10,
+            style: {
+              fill: '#333',
+            },
+          },
+          linkPoints: {
+            top: true,
+            bottom: true,
+            left: true,
+            right: true,
+            fill: '#fff',
+            size: 5,
+          },
+          icon: {
+            show: true,
+          },
+        });
+      });
+
+      graph.on('node:mouseleave', (e) => {
+        const item = e.item;
+        item.update({
+          label: ' ',
+          labelCfg: {
+            style: {
+              fill: '#333',
+            },
+          },
+          linkPoints: {
+            top: false,
+            bottom: false,
+            left: false,
+            right: false,
+            fill: '#fff',
+            size: 5,
+          },
+          icon: {
+            show: false,
+          },
+        });
+      });
+    });
+    it('update label, linkPoints, icon from none', () => {
+      const graph = new G6.Graph({
+        container: div,
+        width: 500,
+        height: 500,
+        // defaultNode: {
+        //   size: 50
+        // }
+      });
+      const data = {
+        nodes: [
+          {
+            id: 'node',
+            type: 'modelRect',
+            label: 'modelRect',
+            description: 'description',
+            x: 200,
+            y: 100,
+          },
+        ],
+      };
+      graph.data(data);
+      graph.render();
+
+      graph.on('node:mouseenter', (e) => {
+        const item = e.item;
+        item.update({
+          descriptionCfg: {
+            style: {
+              fill: 'steelblue',
+            },
+          },
+          stateIcon: {
+            show: true,
+          },
+        });
+      });
+
+      graph.on('node:mouseleave', (e) => {
+        const item = e.item;
+        item.update({
+          descriptionCfg: {
+            style: {
+              fill: '#bfbfbf',
+            },
+          },
+          stateIcon: {
+            show: false,
+          },
+        });
+      });
+    });
+  });
+});

--- a/tests/unit/shape/extend/extend-image-spec.ts
+++ b/tests/unit/shape/extend/extend-image-spec.ts
@@ -1,0 +1,610 @@
+import G6 from '../../../../src';
+
+const div = document.createElement('div');
+div.id = 'graph-spec';
+document.body.appendChild(div);
+
+describe('register node with getCustomConfig function, extend image', () => {
+  it('getCustomConfig return new size', () => {
+    const data = {
+      nodes: [
+        {
+          id: 'node',
+          x: 100,
+          y: 100,
+        },
+      ],
+    };
+    G6.registerNode(
+      'custom-node',
+      {
+        getCustomConfig() {
+          return {
+            size: 300,
+          };
+        },
+      },
+      'image',
+    );
+    const graph = new G6.Graph({
+      container: div,
+      width: 500,
+      height: 500,
+      defaultNode: {
+        type: 'custom-node',
+      },
+    });
+    graph.data(data);
+    graph.render();
+    const nodes = graph.getNodes();
+    expect(nodes.length).toEqual(1);
+    const node = nodes[0];
+    const keyShape = node.getKeyShape();
+    expect(keyShape.attr('width')).toEqual(300);
+    expect(keyShape.attr('img')).toEqual(
+      'https://gw.alipayobjects.com/mdn/rms_f8c6a0/afts/img/A*eD7nT6tmYgAAAAAAAAAAAABkARQnAQ',
+    );
+    graph.destroy();
+  });
+  it('getCustomConfig return new labelCfg style', () => {
+    const data = {
+      nodes: [
+        {
+          id: 'node',
+          label: 'image',
+          x: 200,
+          y: 100,
+        },
+      ],
+    };
+    G6.registerNode(
+      'custom-node',
+      {
+        getCustomConfig() {
+          return {
+            labelCfg: {
+              style: {
+                fill: 'red',
+              },
+            },
+          };
+        },
+      },
+      'image',
+    );
+    const graph = new G6.Graph({
+      container: div,
+      width: 500,
+      height: 500,
+      defaultNode: {
+        type: 'custom-node',
+      },
+    });
+    graph.data(data);
+    graph.render();
+    const nodes = graph.getNodes();
+    expect(nodes.length).toEqual(1);
+    const node = nodes[0];
+    const group = node.get('group');
+    expect(group.getCount()).toEqual(2);
+
+    const label = group.find((g) => {
+      return g.get('className') === 'node-label';
+    });
+    expect(label).not.toBe(undefined);
+    expect(label.attr('fill')).toEqual('red');
+    const type = label.get('type');
+    expect(type).toEqual('text');
+    graph.destroy();
+    expect(graph.destroyed).toBe(true);
+  });
+
+  describe('clip', () => {
+    it('default clip', () => {
+      const data = {
+        nodes: [
+          {
+            id: 'node',
+            label: 'image',
+            x: 200,
+            y: 100,
+          },
+        ],
+      };
+      G6.registerNode(
+        'custom-node',
+        {
+          getCustomConfig() {
+            return {
+              size: 150,
+              clipCfg: {
+                show: true,
+              },
+              style: {
+                shadowColor: '#ccc',
+                shadowBlur: 10,
+              },
+            };
+          },
+        },
+        'image',
+      );
+      const graph = new G6.Graph({
+        container: div,
+        width: 500,
+        height: 500,
+        defaultNode: {
+          type: 'custom-node',
+        },
+      });
+      graph.data(data);
+      graph.render();
+
+      const nodes = graph.getNodes();
+      const node = nodes[0];
+      const nodeShape = node.get('group').get('children')[0];
+      expect(nodeShape.get('clipShape').attr('r')).toEqual(50);
+
+      graph.destroy();
+      expect(graph.destroyed).toBe(true);
+    });
+    it('circle clip and update', () => {
+      const data = {
+        nodes: [
+          {
+            id: 'node',
+            label: 'image',
+            x: 200,
+            y: 100,
+          },
+        ],
+      };
+      G6.registerNode(
+        'custom-node',
+        {
+          getCustomConfig() {
+            return {
+              clipCfg: {
+                show: true,
+                type: 'circle',
+                r: 10,
+              },
+            };
+          },
+        },
+        'image',
+      );
+      const graph = new G6.Graph({
+        container: div,
+        width: 500,
+        height: 500,
+        defaultNode: {
+          type: 'custom-node',
+          size: 150,
+        },
+      });
+      graph.data(data);
+      graph.render();
+
+      const nodes = graph.getNodes();
+      const node = nodes[0];
+      const nodeShape = node.get('group').get('children')[0];
+      expect(nodeShape.get('clipShape').attr('r')).toEqual(10);
+
+      graph.destroy();
+      expect(graph.destroyed).toBe(true);
+    });
+
+    it('rect clip and update', () => {
+      const data = {
+        nodes: [
+          {
+            id: 'node',
+            label: 'image',
+            x: 200,
+            y: 100,
+          },
+        ],
+      };
+      G6.registerNode(
+        'custom-node',
+        {
+          getCustomConfig() {
+            return {
+              clipCfg: {
+                show: true,
+                type: 'rect',
+                width: 100,
+                height: 50,
+                x: -50,
+              },
+            };
+          },
+        },
+        'image',
+      );
+      const graph = new G6.Graph({
+        container: div,
+        width: 500,
+        height: 500,
+        defaultNode: {
+          type: 'custom-node',
+          size: 150,
+        },
+      });
+      graph.data(data);
+      graph.render();
+
+      const nodes = graph.getNodes();
+      const node = nodes[0];
+      const nodeShape = node.get('group').get('children')[0];
+      expect(nodeShape.get('clipShape').attr('width')).toEqual(100);
+      expect(nodeShape.get('clipShape').attr('height')).toEqual(50);
+      expect(nodeShape.get('clipShape').attr('x')).toEqual(-100);
+
+      graph.destroy();
+      expect(graph.destroyed).toBe(true);
+    });
+
+    it('ellipse clip and update', () => {
+      const data = {
+        nodes: [
+          {
+            id: 'node',
+            label: 'image',
+            x: 200,
+            y: 100,
+          },
+        ],
+      };
+      G6.registerNode(
+        'custom-node',
+        {
+          getCustomConfig() {
+            return {
+              clipCfg: {
+                show: true,
+                type: 'ellipse',
+                rx: 100,
+                ry: 50,
+                x: -50,
+              },
+            };
+          },
+        },
+        'image',
+      );
+      const graph = new G6.Graph({
+        container: div,
+        width: 500,
+        height: 500,
+        defaultNode: {
+          type: 'custom-node',
+          size: 150,
+        },
+      });
+      graph.data(data);
+      graph.render();
+
+      const nodes = graph.getNodes();
+      const node = nodes[0];
+      const nodeShape = node.get('group').get('children')[0];
+      expect(nodeShape.get('clipShape').attr('rx')).toEqual(100);
+      expect(nodeShape.get('clipShape').attr('ry')).toEqual(50);
+      expect(nodeShape.get('clipShape').attr('x')).toEqual(-50);
+
+      graph.destroy();
+      expect(graph.destroyed).toBe(true);
+    });
+
+    it('polygon clip and update', () => {
+      const data = {
+        nodes: [
+          {
+            id: 'node',
+            label: 'image',
+            x: 200,
+            y: 100,
+          },
+        ],
+      };
+      G6.registerNode(
+        'custom-node',
+        {
+          getCustomConfig() {
+            return {
+              clipCfg: {
+                show: true,
+                type: 'polygon',
+                points: [
+                  [10, 20],
+                  [15, 15],
+                  [30, 12],
+                  [40, 50],
+                  [10, 20],
+                ],
+              },
+            };
+          },
+        },
+        'image',
+      );
+      const graph = new G6.Graph({
+        container: div,
+        width: 500,
+        height: 500,
+        defaultNode: {
+          type: 'custom-node',
+          size: 150,
+        },
+      });
+      graph.data(data);
+      graph.render();
+
+      const nodes = graph.getNodes();
+      const node = nodes[0];
+      const nodeShape = node.get('group').get('children')[0];
+      expect(nodeShape.get('clipShape').attr('points')).toEqual([
+        [10, 20],
+        [15, 15],
+        [30, 12],
+        [40, 50],
+        [10, 20],
+      ]);
+
+      graph.destroy();
+      expect(graph.destroyed).toBe(true);
+    });
+
+    it('path clip and update', () => {
+      const data = {
+        nodes: [
+          {
+            id: 'node',
+            label: 'image',
+            x: 200,
+            y: 100,
+          },
+        ],
+      };
+      const clipPath = [['M', 0, 0], ['L', -75, 200], ['L', 75, 200], ['Z']];
+      G6.registerNode(
+        'custom-node',
+        {
+          getCustomConfig() {
+            return {
+              clipCfg: {
+                show: true,
+                type: 'path',
+                path: clipPath,
+              },
+            };
+          },
+        },
+        'image',
+      );
+      const graph = new G6.Graph({
+        container: div,
+        width: 500,
+        height: 500,
+        defaultNode: {
+          type: 'custom-node',
+          size: 150,
+        },
+      });
+      graph.data(data);
+      graph.render();
+
+      const nodes = graph.getNodes();
+      const node = nodes[0];
+      const nodeShape = node.get('group').get('children')[0];
+      expect(nodeShape.get('clipShape').attr('path')).toEqual(clipPath);
+
+      graph.destroy();
+      expect(graph.destroyed).toBe(true);
+    });
+  });
+
+  describe('update', () => {
+    it('update style', () => {
+      const data = {
+        nodes: [
+          {
+            id: 'node',
+            label: 'image',
+            x: 200,
+            y: 100,
+          },
+        ],
+      };
+      G6.registerNode(
+        'custom-node',
+        {
+          getCustomConfig() {
+            return {
+              size: 150,
+              style: {
+                shadowColor: '#ccc',
+                shadowBlur: 10,
+              },
+            };
+          },
+        },
+        'image',
+      );
+      const graph = new G6.Graph({
+        container: div,
+        width: 500,
+        height: 500,
+        defaultNode: {
+          type: 'custom-node',
+
+          style: {
+            shadowColor: '#ccc',
+            shadowBlur: 10,
+          },
+        },
+      });
+
+      graph.data(data);
+      graph.render();
+
+      const nodes = graph.getNodes();
+      const node = nodes[0];
+      const group = node.get('group');
+      expect(group.getCount()).toEqual(2);
+      const keyShape = node.getKeyShape();
+      expect(keyShape.attr('width')).toBe(150);
+      expect(keyShape.attr('height')).toBe(150);
+      expect(keyShape.attr('shadowColor')).toBe('#ccc');
+
+      node.update({
+        size: 30,
+        style: {
+          shadowColor: '#f00',
+        },
+      });
+      expect(keyShape.attr('width')).toBe(30);
+      expect(keyShape.attr('height')).toBe(30);
+      expect(keyShape.attr('shadowColor')).toBe('#f00');
+
+      graph.destroy();
+      expect(graph.destroyed).toBe(true);
+    });
+    it('update label', () => {
+      const data = {
+        nodes: [
+          {
+            id: 'node',
+            label: 'old image label',
+            x: 200,
+            y: 100,
+          },
+        ],
+      };
+      G6.registerNode(
+        'custom-node',
+        {
+          getCustomConfig() {
+            return {
+              labelCfg: {
+                style: {
+                  fill: 'red',
+                },
+              },
+            };
+          },
+        },
+        'image',
+      );
+      const graph = new G6.Graph({
+        container: div,
+        width: 500,
+        height: 500,
+        defaultNode: {
+          type: 'custom-node',
+        },
+      });
+      graph.data(data);
+      graph.render();
+
+      const nodes = graph.getNodes();
+      const node = nodes[0];
+      const group = node.get('group');
+      const label = group.find((g) => {
+        return g.get('className') === 'node-label';
+      });
+      expect(label).not.toEqual(null);
+      expect(label.attr('text')).toEqual('old image label');
+      expect(label.attr('fill')).toEqual('red');
+
+      node.update({
+        label: 'new image label',
+        labelCfg: {
+          style: {
+            fill: '#ff0',
+          },
+        },
+      });
+
+      expect(label).not.toEqual(null);
+      expect(label.attr('text')).toEqual('new image label');
+      expect(label.attr('fill')).toEqual('#ff0');
+
+      // test if it will keep the current fill without setting
+      node.update({
+        labelCfg: {
+          position: 'center',
+          style: {
+            stroke: 'black',
+            lineWidth: 3,
+          },
+        },
+      });
+      expect(label.attr('text')).toEqual('new image label');
+      expect(label.attr('lineWidth')).toEqual(3);
+      expect(label.attr('stroke')).toEqual('black');
+
+      graph.destroy();
+      expect(graph.destroyed).toBe(true);
+    });
+    it('update label from none', () => {
+      const data = {
+        nodes: [
+          {
+            id: 'node',
+            x: 200,
+            y: 100,
+          },
+        ],
+      };
+      G6.registerNode(
+        'custom-node',
+        {
+          getCustomConfig() {
+            return {
+              labelCfg: {
+                style: {
+                  fill: 'red',
+                },
+              },
+            };
+          },
+        },
+        'image',
+      );
+      const graph = new G6.Graph({
+        container: div,
+        width: 500,
+        height: 500,
+        defaultNode: {
+          type: 'custom-node',
+        },
+      });
+      graph.data(data);
+      graph.render();
+
+      const nodes = graph.getNodes();
+      const node = nodes[0];
+      const group = node.get('group');
+      node.update({
+        label: 'new image label',
+        labelCfg: {
+          style: {
+            fill: '#ff0',
+          },
+        },
+      });
+
+      const label = group.find((g) => {
+        return g.get('className') === 'node-label';
+      });
+      expect(label).not.toEqual(null);
+      expect(label.attr('text')).toEqual('new image label');
+      expect(label.attr('fill')).toEqual('#ff0');
+
+      graph.destroy();
+      expect(graph.destroyed).toBe(true);
+    });
+  });
+});

--- a/tests/unit/shape/extend/extend-modelRect-spec.ts
+++ b/tests/unit/shape/extend/extend-modelRect-spec.ts
@@ -1,0 +1,850 @@
+import G6 from '../../../../src';
+
+const div = document.createElement('div');
+div.id = 'graph-spec';
+document.body.appendChild(div);
+
+describe('register node with getCustomConfig function, extend modelRect', () => {
+  it('getCustomConfig return new style,preRect,logoIcon,labelCfg', () => {
+    const data = {
+      nodes: [
+        {
+          id: 'node',
+          label: '主题是modelRect',
+          description: '这里是一段很长很长很长的描述文本',
+          x: 100,
+          y: 100,
+        },
+      ],
+    };
+    G6.registerNode(
+      'custom-node',
+      {
+        getCustomConfig() {
+          return {
+            style: {
+              fill: 'red',
+              stroke: 'blue',
+              lineWidth: 10,
+              radius: 10,
+            },
+            preRect: {
+              fill: '#ff0',
+            },
+            logoIcon: {
+              img: 'old-img',
+            },
+            labelCfg: {
+              style: {
+                fill: '#ccc',
+              },
+            },
+          };
+        },
+      },
+      'modelRect',
+    );
+    const graph = new G6.Graph({
+      container: div,
+      width: 500,
+      height: 500,
+      defaultNode: {
+        type: 'custom-node',
+      },
+    });
+    graph.data(data);
+    graph.render();
+
+    const nodes = graph.getNodes();
+    const node = nodes[0];
+    const group = node.get('group');
+    // modelRect + label + description + logoIcon + stateIcon + preRect
+    expect(group.getCount()).toEqual(6);
+    const keyShape = node.getKeyShape();
+    expect(keyShape.attr('width')).toEqual(185);
+    expect(keyShape.attr('height')).toEqual(70);
+    expect(keyShape.attr('fill')).toEqual('red');
+    expect(keyShape.attr('stroke')).toEqual('blue');
+    expect(keyShape.attr('lineWidth')).toEqual(10);
+    expect(keyShape.attr('radius')).toEqual(10);
+
+    const preRect = group.find((g) => {
+      return g.get('className') === 'pre-rect';
+    });
+    expect(preRect).not.toBe(null);
+    expect(preRect.attr('x')).toEqual(-92.5);
+    expect(preRect.attr('y')).toEqual(-35);
+    expect(preRect.attr('width')).toEqual(4);
+    expect(preRect.attr('fill')).toEqual('#ff0');
+
+    const logoIcon = group.find((g) => {
+      return g.get('className') === 'rect-logo-icon';
+    });
+    expect(logoIcon).not.toBe(null);
+    expect(logoIcon.attr('width')).toEqual(16);
+    expect(logoIcon.attr('img')).toEqual('old-img');
+
+    const stateIcon = group.find((g) => {
+      return g.get('className') === 'rect-state-icon';
+    });
+    expect(stateIcon).not.toBe(null);
+    expect(stateIcon.attr('width')).toEqual(16);
+    expect(stateIcon.attr('img')).toEqual(
+      'https://gw.alipayobjects.com/zos/basement_prod/300a2523-67e0-4cbf-9d4a-67c077b40395.svg',
+    );
+
+    const label = group.find((g) => {
+      return g.get('className') === 'node-label';
+    });
+    expect(label).not.toBe(null);
+    expect(label.attr('fill')).toEqual('#ccc');
+    expect(label.attr('fontSize')).toEqual(14);
+
+    graph.destroy();
+    expect(graph.destroyed).toBe(true);
+  });
+  it('update keyShape style and not description text', () => {
+    const data = {
+      nodes: [
+        {
+          id: 'node',
+          label: '主题是modelRect',
+          x: 100,
+          y: 100,
+        },
+      ],
+    };
+    G6.registerNode(
+      'custom-node',
+      {
+        getCustomConfig() {
+          return {
+            style: {
+              fill: 'red',
+            },
+            preRect: {
+              width: 6,
+            },
+          };
+        },
+      },
+      'modelRect',
+    );
+    const graph = new G6.Graph({
+      container: div,
+      width: 500,
+      height: 500,
+      defaultNode: {
+        type: 'custom-node',
+      },
+    });
+
+    graph.data(data);
+    graph.render();
+
+    const nodes = graph.getNodes();
+    const node = nodes[0];
+    const group = node.get('group');
+    // modelRect + label + logoIcon + stateIcon + preRect
+    expect(group.getCount()).toEqual(5);
+    const keyShape = node.getKeyShape();
+    expect(keyShape.attr('fill')).toEqual('red');
+
+    const preRect = group.find((g) => {
+      return g.get('className') === 'pre-rect';
+    });
+    expect(preRect).not.toBe(null);
+    expect(preRect.attr('width')).toEqual(6);
+    graph.destroy();
+    expect(graph.destroyed).toBe(true);
+  });
+  it('update label and description from none to show', () => {
+    const data = {
+      nodes: [
+        {
+          id: 'node',
+          x: 100,
+          y: 100,
+        },
+      ],
+    };
+    G6.registerNode(
+      'custom-node',
+      {
+        getCustomConfig() {
+          return {
+            style: {
+              fill: 'red',
+            },
+            labelCfg: {
+              style: {
+                fill: '#0f0',
+              },
+            },
+          };
+        },
+      },
+      'modelRect',
+    );
+    const graph = new G6.Graph({
+      container: div,
+      width: 500,
+      height: 500,
+      defaultNode: {
+        type: 'custom-node',
+      },
+    });
+
+    graph.data(data);
+    graph.render();
+
+    const item = graph.getNodes()[0];
+    const group = item.get('group');
+    expect(group.getCount()).toEqual(4);
+    const descriptionPaddingTop = 5;
+
+    const labelShapeBeforeUpdated = group.find((g) => {
+      return g.get('className') === 'node-label';
+    });
+    expect(labelShapeBeforeUpdated).toBe(null);
+    const descriptionShapeBeforeUpdated = group.find((g) => {
+      return g.get('className') === 'rect-description';
+    });
+    expect(descriptionShapeBeforeUpdated).toBe(null);
+
+    item.update({
+      label: '主题是modelRect',
+      description: '这里是一段很长很长很长的描述文本',
+      descriptionCfg: {
+        style: {
+          fill: '#f00',
+          fontSize: 20,
+        },
+        paddingTop: descriptionPaddingTop,
+      },
+    });
+
+    // // modelRect + label + description + logoIcon + stateIcon + preRect
+    expect(group.getCount()).toEqual(6);
+
+    const labelShape = group.find((g) => {
+      return g.get('className') === 'node-label';
+    });
+    expect(labelShape).not.toBe(null);
+    expect(labelShape.attr('fill')).toEqual('#0f0');
+    expect(labelShape.attr('fontSize')).toEqual(14);
+    expect(labelShape.attr('x')).toEqual(-46.5);
+    expect(labelShape.attr('y')).toEqual(-5);
+
+    const descriptionShape = group.find((g) => {
+      return g.get('className') === 'rect-description';
+    });
+    expect(descriptionShape).not.toBe(null);
+    expect(descriptionShape.attr('fill')).toEqual('#f00');
+    expect(descriptionShape.attr('fontSize')).toEqual(20);
+    expect(descriptionShape.attr('x')).toEqual(-46.5);
+    expect(descriptionShape.attr('y')).toEqual(17 + descriptionPaddingTop);
+
+    const logoIcon = group.find((g) => {
+      return g.get('className') === 'rect-logo-icon';
+    });
+    expect(logoIcon).not.toBe(null);
+    expect(logoIcon.attr('width')).toEqual(16);
+    expect(logoIcon.attr('img')).toEqual(
+      'https://gw.alipayobjects.com/zos/basement_prod/4f81893c-1806-4de4-aff3-9a6b266bc8a2.svg',
+    );
+
+    const stateIcon = group.find((g) => {
+      return g.get('className') === 'rect-state-icon';
+    });
+    expect(stateIcon).not.toBe(null);
+    expect(stateIcon.attr('width')).toEqual(16);
+    expect(stateIcon.attr('img')).toEqual(
+      'https://gw.alipayobjects.com/zos/basement_prod/300a2523-67e0-4cbf-9d4a-67c077b40395.svg',
+    );
+
+    graph.destroy();
+    expect(graph.destroyed).toBe(true);
+  });
+  it('update label, description, and logoIcon', () => {
+    const data = {
+      nodes: [
+        {
+          id: 'node',
+          label: 'old label',
+          description: 'old description',
+          x: 100,
+          y: 100,
+        },
+      ],
+    };
+    G6.registerNode(
+      'custom-node',
+      {
+        getCustomConfig() {
+          return {
+            style: {
+              fill: 'red',
+            },
+            labelCfg: {
+              style: {
+                fill: '#0f0',
+              },
+            },
+            descriptionCfg: {
+              style: {
+                fill: '#f00',
+              },
+            },
+          };
+        },
+      },
+      'modelRect',
+    );
+    const graph = new G6.Graph({
+      container: div,
+      width: 500,
+      height: 500,
+      defaultNode: {
+        type: 'custom-node',
+      },
+    });
+
+    graph.data(data);
+    graph.render();
+
+    const item = graph.getNodes()[0];
+    const group = item.get('group');
+    expect(group.getCount()).toEqual(6);
+
+    const labelShapeBeforeUpdated = group.find((g) => {
+      return g.get('className') === 'node-label';
+    });
+    expect(labelShapeBeforeUpdated).not.toBe(null);
+    expect(labelShapeBeforeUpdated.attr('text')).toBe('old label');
+    const descriptionShapeBeforeUpdated = group.find((g) => {
+      return g.get('className') === 'rect-description';
+    });
+    expect(descriptionShapeBeforeUpdated).not.toBe(null);
+    expect(descriptionShapeBeforeUpdated.attr('text')).toBe('old description');
+
+    item.update({
+      label: 'new label',
+      description: 'new description',
+      logoIcon: {
+        show: false,
+      },
+    });
+
+    // modelRect + label + description + logoIcon + stateIcon + preRect
+    expect(group.getCount()).toEqual(5);
+
+    const labelShape = group.find((g) => {
+      return g.get('className') === 'node-label';
+    });
+    expect(labelShape).not.toBe(null);
+    expect(labelShape.attr('fill')).toEqual('#0f0');
+    expect(labelShape.attr('text')).toEqual('new label');
+    expect(labelShape.attr('fontSize')).toEqual(14);
+    expect(labelShape.attr('x')).toEqual(-62.5);
+    expect(labelShape.attr('y')).toEqual(-5);
+
+    const descriptionShape = group.find((g) => {
+      return g.get('className') === 'rect-description';
+    });
+    expect(descriptionShape).not.toBe(null);
+    expect(descriptionShape.attr('fill')).toEqual('#f00');
+    expect(descriptionShape.attr('text')).toEqual('new description');
+    expect(descriptionShape.attr('x')).toEqual(-62.5);
+    expect(descriptionShape.attr('y')).toEqual(17);
+
+    const logoIcon = group.find((g) => {
+      return g.get('className') === 'rect-logo-icon';
+    });
+    expect(logoIcon).toBe(null);
+
+    const stateIcon = group.find((g) => {
+      return g.get('className') === 'rect-state-icon';
+    });
+    expect(stateIcon).not.toBe(null);
+    expect(stateIcon.attr('width')).toEqual(16);
+    expect(stateIcon.attr('img')).toEqual(
+      'https://gw.alipayobjects.com/zos/basement_prod/300a2523-67e0-4cbf-9d4a-67c077b40395.svg',
+    );
+
+    graph.destroy();
+    expect(graph.destroyed).toBe(true);
+  });
+
+  it('update label and description, keep the current unchanged part', () => {
+    const data = {
+      nodes: [
+        {
+          id: 'node',
+          label: 'old label',
+          description: 'old description',
+          x: 100,
+          y: 100,
+        },
+      ],
+    };
+    G6.registerNode(
+      'custom-node',
+      {
+        getCustomConfig() {
+          return {
+            style: {
+              fill: 'red',
+            },
+            labelCfg: {
+              style: {
+                fill: '#ff0',
+              },
+            },
+            descriptionCfg: {
+              style: {
+                fill: '#f00',
+              },
+            },
+          };
+        },
+      },
+      'modelRect',
+    );
+    const graph = new G6.Graph({
+      container: div,
+      width: 500,
+      height: 500,
+      defaultNode: {
+        type: 'custom-node',
+      },
+    });
+
+    graph.data(data);
+    graph.render();
+
+    const node = graph.getNodes()[0];
+    const group = node.get('group');
+
+    node.update({
+      label: 'new label',
+      descriptionCfg: {
+        style: {
+          fill: '#000',
+          shadowColor: '#000',
+          shadowBlur: 5,
+        },
+      },
+    });
+
+    const label = group.find((g) => {
+      return g.get('className') === 'node-label';
+    });
+    const description = group.find((g) => {
+      return g.get('className') === 'rect-description';
+    });
+    expect(label).not.toEqual(null);
+    expect(label.attr('text')).toEqual('new label');
+    expect(label.attr('fill')).toEqual('#ff0');
+    expect(description.attr('fill')).toEqual('#000');
+    expect(description.attr('shadowBlur')).toEqual(5);
+
+    // test if it will keep the current fill without setting
+    node.update({
+      labelCfg: {
+        position: 'center',
+        style: {
+          stroke: 'black',
+          lineWidth: 3,
+        },
+      },
+      descriptionCfg: {
+        style: {
+          shadowOffsetX: 10,
+          shadowOffsetY: 10,
+        },
+      },
+    });
+    expect(label.attr('text')).toEqual('new label');
+    expect(label.attr('fill')).toEqual('#ff0');
+    expect(label.attr('stroke')).toEqual('black');
+    expect(label.attr('lineWidth')).toEqual(3);
+    expect(description.attr('fill')).toEqual('#000');
+    expect(description.attr('shadowBlur')).toEqual(5);
+    expect(description.attr('shadowOffsetX')).toEqual(10);
+
+    graph.destroy();
+    expect(graph.destroyed).toBe(true);
+  });
+
+  describe('icon and linkPoint test', () => {
+    it('icon and linkPoints(top bottom)', () => {
+      const data = {
+        nodes: [
+          {
+            id: 'node',
+            label: '主题是modelRect',
+            description: '这里是很长很长很长的一段长文本',
+            x: 300,
+            y: 100,
+          },
+        ],
+      };
+      G6.registerNode(
+        'custom-node',
+        {
+          getCustomConfig() {
+            return {
+              logoIcon: {
+                show: false,
+              },
+              stateIcon: {
+                width: 25,
+                height: 25,
+              },
+              linkPoints: {
+                top: true,
+                bottom: true,
+              },
+            };
+          },
+        },
+        'modelRect',
+      );
+      const graph = new G6.Graph({
+        container: div,
+        width: 500,
+        height: 500,
+        defaultNode: {
+          type: 'custom-node',
+        },
+      });
+      graph.data(data);
+      graph.render();
+
+      const nodes = graph.getNodes();
+      const node = nodes[0];
+      const group = node.get('group');
+      // modelRect + label + description + stateIcon + preRect + linkPoints * 2
+      expect(group.getCount()).toEqual(7);
+      const logoIcon = group.find((g) => {
+        return g.get('className') === 'rect-logo-icon';
+      });
+      expect(logoIcon).toBe(null);
+
+      const stateIcon = group.find((g) => {
+        return g.get('className') === 'rect-state-icon';
+      });
+      expect(stateIcon).not.toBe(null);
+      expect(stateIcon.attr('width')).toEqual(25);
+      expect(stateIcon.attr('height')).toEqual(25);
+
+      const markLeft = group.find((g) => {
+        return g.get('className') === 'link-point-left';
+      });
+      expect(markLeft).toBe(null);
+
+      const markTop = group.find((g) => {
+        return g.get('className') === 'link-point-top';
+      });
+      expect(markTop).not.toBe(null);
+      expect(markTop.attr('r')).toEqual(5);
+      expect(markTop.attr('y')).toEqual(-35);
+
+      const markBottom = group.find((g) => {
+        return g.get('className') === 'link-point-bottom';
+      });
+      expect(markBottom).not.toBe(null);
+      expect(markBottom.attr('y')).toEqual(35);
+      graph.destroy();
+      expect(graph.destroyed).toBe(true);
+    });
+    it('icon and linkPoints(left right)', () => {
+      const data = {
+        nodes: [
+          {
+            id: 'node',
+            label: '主题是modelRect',
+            description: '这里是很长很长很长的一段长文本',
+            x: 300,
+            y: 100,
+          },
+        ],
+      };
+      G6.registerNode(
+        'custom-node',
+        {
+          getCustomConfig() {
+            return {
+              linkPoints: {
+                left: true,
+                right: true,
+              },
+            };
+          },
+        },
+        'modelRect',
+      );
+      const graph = new G6.Graph({
+        container: div,
+        width: 500,
+        height: 500,
+        defaultNode: {
+          type: 'custom-node',
+        },
+      });
+      graph.data(data);
+      graph.render();
+
+      const nodes = graph.getNodes();
+      const node = nodes[0];
+      const group = node.get('group');
+      // modelRect + label + description + stateIcon + logoIcon + preRect + linkPoints * 2
+      expect(group.getCount()).toEqual(8);
+      const markLeft = group.find((g) => {
+        return g.get('className') === 'link-point-left';
+      });
+      expect(markLeft).not.toBe(null);
+      expect(markLeft.attr('r')).toEqual(5);
+      expect(markLeft.attr('y')).toEqual(0);
+
+      const markTop = group.find((g) => {
+        return g.get('className') === 'link-point-top';
+      });
+      expect(markTop).toBe(null);
+
+      const markBottom = group.find((g) => {
+        return g.get('className') === 'link-point-bottom';
+      });
+      expect(markBottom).toBe(null);
+
+      graph.destroy();
+      expect(graph.destroyed).toBe(true);
+    });
+    it('linkPoints update from show to hide', () => {
+      G6.registerNode(
+        'custom-node',
+        {
+          getCustomConfig() {
+            return {
+              linkPoints: {
+                fill: 'red',
+                stroke: 'green',
+              },
+            };
+          },
+        },
+        'modelRect',
+      );
+      const graph = new G6.Graph({
+        container: div,
+        width: 500,
+        height: 500,
+        defaultNode: {
+          type: 'custom-node',
+        },
+      });
+      const data = {
+        nodes: [
+          {
+            id: 'node',
+            label: '主题是modelRect',
+            description: '这里是很长很长很长的一段长文本',
+            linkPoints: {
+              top: true,
+              bottom: true,
+            },
+            x: 100,
+            y: 200,
+          },
+        ],
+      };
+      graph.data(data);
+      graph.render();
+
+      const node = graph.getNodes()[0];
+      const group = node.get('group');
+      // modelRect + label + description + stateIcon + logoIcon + preRect + linkPoints * 2
+      expect(group.getCount()).toEqual(8);
+
+      node.update({
+        linkPoints: {
+          top: false,
+        },
+      });
+      const topPoint = group.find((g) => {
+        return g.get('className') === 'link-point-top';
+      });
+      expect(topPoint).toBe(null);
+      const bottomPoint = group.find((g) => {
+        return g.get('className') === 'link-point-bottom';
+      });
+      expect(bottomPoint).not.toBe(null);
+
+      node.update({
+        linkPoints: {
+          left: true,
+          right: true,
+          size: 10,
+          lineWidth: 2,
+        },
+      });
+      const leftPoint = group.find((g) => {
+        return g.get('className') === 'link-point-left';
+      });
+      expect(leftPoint).not.toBe(null);
+      expect(leftPoint.attr('r')).toBe(5);
+      expect(leftPoint.attr('fill')).toBe('red');
+      expect(leftPoint.attr('stroke')).toBe('green');
+      expect(leftPoint.attr('lineWidth')).toBe(2);
+      const rightPoint = group.find((g) => {
+        return g.get('className') === 'link-point-right';
+      });
+      expect(rightPoint).not.toBe(null);
+
+      node.update({
+        linkPoints: {
+          left: false,
+          top: true,
+          size: 10,
+          fill: '#f00',
+          stroke: '#0f0',
+          lineWidth: 2,
+        },
+      });
+      const leftPoint2 = group.find((g) => {
+        return g.get('className') === 'link-point-left';
+      });
+      expect(leftPoint2).toBe(null);
+      const topPoint2 = group.find((g) => {
+        return g.get('className') === 'link-point-top';
+      });
+      expect(topPoint2).not.toBe(null);
+      const rightPoint2 = group.find((g) => {
+        return g.get('className') === 'link-point-right';
+      });
+      expect(rightPoint2).not.toBe(null);
+
+      node.update({
+        linkPoints: {
+          stroke: '#000',
+        },
+      });
+      const bottomPoint2 = group.find((g) => {
+        return g.get('className') === 'link-point-bottom';
+      });
+      expect(bottomPoint2.attr('r')).toBe(5);
+      expect(bottomPoint2.attr('fill')).toBe('#f00');
+      expect(bottomPoint2.attr('stroke')).toBe('#000');
+
+      graph.destroy();
+      expect(graph.destroyed).toBe(true);
+    });
+    it('icons update', () => {
+      G6.registerNode(
+        'custom-node',
+        {
+          getCustomConfig() {
+            return {
+              logoIcon: {
+                show: false,
+              },
+            };
+          },
+        },
+        'modelRect',
+      );
+      const graph = new G6.Graph({
+        container: div,
+        width: 500,
+        height: 500,
+        defaultNode: {
+          type: 'custom-node',
+        },
+      });
+      const data = {
+        nodes: [
+          {
+            id: 'node',
+            label: '主题是modelRect',
+            description: '这里是很长很长很长的一段长文本',
+            stateIcon: {
+              show: true,
+            },
+
+            x: 100,
+            y: 200,
+          },
+        ],
+      };
+      graph.data(data);
+      graph.render();
+
+      const node = graph.getNodes()[0];
+      const group = node.get('group');
+      // modelRect + label + description + stateIcon  + preRect
+      expect(group.getCount()).toEqual(5);
+
+      node.update({
+        stateIcon: {
+          show: false,
+        },
+        logoIcon: {
+          show: true,
+        },
+      });
+      const stateIcon = group.find((g) => {
+        return g.get('className') === 'rect-state-icon';
+      });
+      expect(stateIcon).toBe(null);
+
+      const logoIcon = group.find((g) => {
+        return g.get('className') === 'rect-logo-icon';
+      });
+      expect(logoIcon).not.toBe(null);
+      expect(logoIcon.attr('x')).toBe(-76.5);
+
+      node.update({
+        stateIcon: {
+          show: true,
+        },
+      });
+      const stateIcon2 = group.find((g) => {
+        return g.get('className') === 'rect-state-icon';
+      });
+      expect(stateIcon2).not.toBe(null);
+      expect(stateIcon2.attr('x')).toBe(71.5);
+
+      // update the stateIcon
+      node.update({
+        stateIcon: {
+          offset: -10,
+          // to use the offset
+          x: null,
+          y: null,
+        },
+        logoIcon: {
+          offset: 30,
+          // to use the offset
+          x: null,
+          y: null,
+        },
+        labelCfg: {
+          offset: 60,
+        },
+      });
+      const stateIcon3 = group.find((g) => {
+        return g.get('className') === 'rect-state-icon';
+      });
+      expect(stateIcon3.attr('x')).toBe(66.5);
+
+      const logoIcon3 = group.find((g) => {
+        return g.get('className') === 'rect-logo-icon';
+      });
+      expect(logoIcon3.attr('x')).toBe(-46.5);
+
+      graph.destroy();
+      expect(graph.destroyed).toBe(true);
+    });
+  });
+});

--- a/tests/unit/shape/extend/extend-rect-spec.ts
+++ b/tests/unit/shape/extend/extend-rect-spec.ts
@@ -1,0 +1,357 @@
+import G6 from '../../../../src';
+
+const div = document.createElement('div');
+div.id = 'graph-spec';
+document.body.appendChild(div);
+
+describe('register node with getCustomConfig function, extend rect', () => {
+  const data = {
+    nodes: [
+      {
+        id: 'node1',
+        label: 'node1',
+        x: 50,
+        y: 50,
+      },
+      {
+        id: 'node2',
+        label: 'node2',
+        x: 250,
+        y: 50,
+      },
+    ],
+    edges: [
+      {
+        source: 'node1',
+        target: 'node2',
+      },
+    ],
+  };
+  it('getCustomConfig return new style', () => {
+    G6.registerNode(
+      'custom-node',
+      {
+        getCustomConfig() {
+          return {
+            style: {
+              fill: 'red',
+              stroke: 'blue',
+              lineWidth: 10,
+            },
+          };
+        },
+      },
+      'rect',
+    );
+    const graph = new G6.Graph({
+      container: div,
+      width: 500,
+      height: 500,
+      defaultNode: {
+        type: 'custom-node',
+      },
+    });
+    graph.data(data);
+    graph.render();
+    const node = graph.getNodes()[0];
+    const keyShape = node.getKeyShape();
+    expect(keyShape.attr('stroke')).toEqual('blue');
+    expect(keyShape.attr('fill')).toEqual('red');
+    expect(keyShape.attr('lineWidth')).toEqual(10);
+    graph.destroy();
+  });
+  it('getCustomConfig return new labelCfg style', () => {
+    G6.registerNode(
+      'custom-node',
+      {
+        getCustomConfig() {
+          return {
+            labelCfg: {
+              style: {
+                fill: 'red',
+              },
+            },
+          };
+        },
+      },
+      'rect',
+    );
+    const graph = new G6.Graph({
+      container: div,
+      width: 500,
+      height: 500,
+      defaultNode: {
+        type: 'custom-node',
+      },
+    });
+    graph.data(data);
+    graph.render();
+    const node = graph.getNodes()[0];
+    const group = node.get('group');
+    const keyShape = node.getKeyShape();
+    expect(keyShape.attr('stroke')).toEqual('#5B8FF9');
+    expect(keyShape.attr('fill')).toEqual('#C6E5FF');
+    expect(keyShape.attr('lineWidth')).toEqual(1);
+
+    const label = group.find((g) => {
+      return g.get('className') === 'node-label';
+    });
+    expect(label).not.toBe(undefined);
+    expect(label.attr('fill')).toEqual('red');
+    const type = label.get('type');
+    expect(type).toEqual('text');
+    graph.destroy();
+  });
+  it('getCustomConfig return new linkPoints', () => {
+    G6.registerNode(
+      'custom-node',
+      {
+        getCustomConfig() {
+          return {
+            linkPoints: {
+              top: true,
+              bottom: true,
+              left: true,
+              fill: 'red',
+              size: 20,
+            },
+          };
+        },
+      },
+      'rect',
+    );
+    const graph = new G6.Graph({
+      container: div,
+      width: 500,
+      height: 500,
+      defaultNode: {
+        type: 'custom-node',
+      },
+    });
+    graph.data(data);
+    graph.render();
+
+    const nodes = graph.getNodes();
+    const node = nodes[0];
+    const group = node.get('group');
+
+    expect(group.getCount()).toEqual(5);
+
+    const keyShape = node.getKeyShape();
+    expect(keyShape.attr('fill')).toEqual('#C6E5FF');
+    expect(keyShape.attr('stroke')).toEqual('#5B8FF9');
+    expect(keyShape.attr('lineWidth')).toEqual(1);
+
+    const markTop = group.find((g) => {
+      return g.get('className') === 'link-point-top';
+    });
+    expect(markTop).not.toBe(null);
+    expect(markTop.attr('fill')).toEqual('red');
+
+    const markBottom = group.find((g) => {
+      return g.get('className') === 'link-point-bottom';
+    });
+    expect(markBottom).not.toBe(null);
+
+    let hasTrigger = false;
+    expect(hasTrigger).toBe(false);
+    graph.on('node:mouseenter', (evt) => {
+      hasTrigger = evt.hasTrigger;
+      graph.setItemState(evt.item, 'hover', true);
+    });
+    graph.emit('node:mouseenter', { hasTrigger: true, item: node });
+
+    expect(hasTrigger).toBe(true);
+    expect(keyShape.attr('lineWidth')).toEqual(1);
+
+    graph.destroy();
+  });
+  describe('update', () => {
+    it('update styles', () => {
+      G6.registerNode(
+        'custom-node',
+        {
+          getCustomConfig() {
+            return {
+              size: 50,
+              style: {
+                fill: 'red',
+                stroke: '#ccc',
+                lineWidth: 5,
+              },
+            };
+          },
+        },
+        'rect',
+      );
+      const graph = new G6.Graph({
+        container: div,
+        width: 500,
+        height: 500,
+        defaultNode: {
+          type: 'custom-node',
+        },
+      });
+      graph.data(data);
+      graph.render();
+
+      const nodes = graph.getNodes();
+      const node = nodes[0];
+      node.update({
+        size: 30,
+        color: 'black',
+        style: {
+          fill: 'steelblue',
+        },
+      });
+      const group = node.get('group');
+      expect(group.getCount()).toEqual(2);
+      const keyShape = node.getKeyShape();
+      expect(keyShape.attr('fill')).toBe('steelblue');
+      expect(keyShape.attr('lineWidth')).toBe(5);
+
+      graph.destroy();
+      expect(graph.destroyed).toBe(true);
+    });
+    it('update label', () => {
+      G6.registerNode(
+        'custom-node',
+        {
+          getCustomConfig() {
+            return {
+              labelCfg: {
+                style: {
+                  fill: 'red',
+                },
+              },
+            };
+          },
+        },
+        'rect',
+      );
+      const graph = new G6.Graph({
+        container: div,
+        width: 500,
+        height: 500,
+        defaultNode: {
+          type: 'custom-node',
+        },
+      });
+      graph.data(data);
+      graph.render();
+
+      const nodes = graph.getNodes();
+      const node = nodes[0];
+      const group = node.get('group');
+      const label = group.find((g) => {
+        return g.get('className') === 'node-label';
+      });
+      expect(label).not.toEqual(null);
+      expect(label.attr('text')).toEqual('node1');
+      expect(label.attr('fill')).toEqual('red');
+
+      node.update({
+        label: '',
+        labelCfg: {
+          style: {
+            fill: '#ff0',
+          },
+        },
+      });
+
+      expect(label).not.toEqual(null);
+      expect(label.attr('text')).toEqual('');
+      expect(label.attr('fill')).toEqual('#ff0');
+
+      node.update({
+        label: 'new rect label',
+      });
+      // test if it will keep the current fill without setting
+      node.update({
+        labelCfg: {
+          position: 'center',
+          style: {
+            stroke: 'black',
+            lineWidth: 3,
+          },
+        },
+      });
+      expect(label.attr('text')).toEqual('new rect label');
+      expect(label.attr('fill')).toEqual('#ff0');
+      expect(label.attr('stroke')).toEqual('black');
+      expect(label.attr('lineWidth')).toEqual(3);
+
+      graph.destroy();
+      expect(graph.destroyed).toBe(true);
+    });
+    it('update label from none', () => {
+      G6.registerNode(
+        'custom-node',
+        {
+          getCustomConfig() {
+            return {
+              labelCfg: {
+                style: {
+                  fill: 'red',
+                },
+              },
+            };
+          },
+        },
+        'rect',
+      );
+      const graph = new G6.Graph({
+        container: div,
+        width: 500,
+        height: 500,
+        defaultNode: {
+          type: 'custom-node',
+        },
+      });
+      const data = {
+        nodes: [
+          {
+            id: 'node',
+            x: 200,
+            y: 100,
+          },
+        ],
+      };
+      graph.data(data);
+      graph.render();
+
+      const nodes = graph.getNodes();
+      const node = nodes[0];
+      const group = node.get('group');
+      let label = group.find((g) => {
+        return g.get('className') === 'node-label';
+      });
+      expect(label).toEqual(null);
+
+      node.update({
+        label: 'new rect label',
+      });
+      label = group.find((g) => {
+        return g.get('className') === 'node-label';
+      });
+      expect(label).not.toEqual(null);
+      expect(label.attr('text')).toEqual('new rect label');
+      expect(label.attr('fill')).toEqual('red');
+
+      node.update({
+        labelCfg: {
+          style: {
+            fill: '#ff0',
+          },
+        },
+      });
+      label = group.find((g) => {
+        return g.get('className') === 'node-label';
+      });
+      expect(label.attr('text')).toEqual('new rect label');
+      expect(label.attr('fill')).toEqual('#ff0');
+      graph.destroy();
+      expect(graph.destroyed).toBe(true);
+    });
+  });
+});

--- a/tests/unit/shape/extend/extend-star-spec.ts
+++ b/tests/unit/shape/extend/extend-star-spec.ts
@@ -1,0 +1,507 @@
+import G6 from '../../../../src';
+
+const div = document.createElement('div');
+div.id = 'graph-spec';
+document.body.appendChild(div);
+
+describe('register node with getCustomConfig function, extend star', () => {
+  const data = {
+    nodes: [
+      {
+        id: 'node',
+        label: 'star',
+        x: 100,
+        y: 100,
+      },
+    ],
+  };
+  it('getCustomConfig return new style', () => {
+    G6.registerNode(
+      'custom-node',
+      {
+        getCustomConfig() {
+          return {
+            style: {
+              fill: 'red',
+              stroke: 'blue',
+              lineWidth: 10,
+            },
+          };
+        },
+      },
+      'star',
+    );
+    const graph = new G6.Graph({
+      container: div,
+      width: 500,
+      height: 500,
+      defaultNode: {
+        type: 'custom-node',
+      },
+    });
+    graph.data(data);
+    graph.render();
+    const node = graph.getNodes()[0];
+    const keyShape = node.getKeyShape();
+    expect(keyShape.attr('stroke')).toEqual('blue');
+    expect(keyShape.attr('fill')).toEqual('red');
+    expect(keyShape.attr('lineWidth')).toEqual(10);
+    graph.destroy();
+  });
+  it('getCustomConfig return new linkPoints', () => {
+    G6.registerNode(
+      'custom-node',
+      {
+        getCustomConfig() {
+          return {
+            linkPoints: {
+              right: true,
+              leftBottom: true,
+              rightBottom: true,
+              fill: 'red',
+              size: 20,
+            },
+          };
+        },
+      },
+      'star',
+    );
+    const graph = new G6.Graph({
+      container: div,
+      width: 500,
+      height: 500,
+      defaultNode: {
+        type: 'custom-node',
+      },
+    });
+    graph.data(data);
+    graph.render();
+
+    const nodes = graph.getNodes();
+    const node = nodes[0];
+    const group = node.get('group');
+    // star + label
+    expect(group.getCount()).toEqual(5);
+    const keyShape = node.getKeyShape();
+    expect(keyShape.attr('fill')).toEqual('#C6E5FF');
+
+    const leftbottom = group.find((g) => {
+      return g.get('className') === 'link-point-left-bottom';
+    });
+    expect(leftbottom).not.toBe(null);
+    expect(leftbottom.attr('fill')).toEqual('red');
+
+    const rightbottom = group.find((g) => {
+      return g.get('className') === 'link-point-right-bottom';
+    });
+    expect(rightbottom).not.toBe(null);
+    expect(rightbottom.attr('fill')).toEqual('red');
+
+    const right = group.find((g) => {
+      return g.get('className') === 'link-point-right';
+    });
+    expect(right).not.toBe(null);
+    expect(right.attr('fill')).toEqual('red');
+
+    graph.destroy();
+    expect(graph.destroyed).toBe(true);
+  });
+  describe('linkPoint test', () => {
+    it('linkPoints update from show to hide', () => {
+      G6.registerNode(
+        'custom-node',
+        {
+          getCustomConfig() {
+            return {
+              linkPoints: {
+                top: true,
+                left: true,
+              },
+            };
+          },
+        },
+        'star',
+      );
+      const graph = new G6.Graph({
+        container: div,
+        width: 500,
+        height: 500,
+        defaultNode: {
+          type: 'custom-node',
+        },
+      });
+      const data = {
+        nodes: [
+          {
+            id: 'node',
+            label: 'star',
+            x: 100,
+            y: 200,
+          },
+        ],
+      };
+      graph.data(data);
+      graph.render();
+
+      const node = graph.getNodes()[0];
+      const group = node.get('group');
+      // star + label + linkPoints * 2
+      expect(group.getCount()).toEqual(4);
+
+      node.update({
+        linkPoints: {
+          top: false,
+          leftBottom: true,
+        },
+      });
+      const topPoint = group.find((g) => {
+        return g.get('className') === 'link-point-top';
+      });
+      expect(topPoint).toBe(null);
+      const bottomPoint = group.find((g) => {
+        return g.get('className') === 'link-point-left-bottom';
+      });
+      expect(bottomPoint).not.toBe(null);
+
+      node.update({
+        linkPoints: {
+          left: false,
+          right: true,
+          size: 10,
+          fill: '#f00',
+          stroke: '#0f0',
+          lineWidth: 2,
+        },
+      });
+      const leftPoint = group.find((g) => {
+        return g.get('className') === 'link-point-left';
+      });
+      expect(leftPoint).toBe(null);
+      const rightPoint = group.find((g) => {
+        return g.get('className') === 'link-point-right';
+      });
+      expect(rightPoint).not.toBe(null);
+      expect(rightPoint.attr('r')).toBe(5);
+      expect(rightPoint.attr('fill')).toBe('#f00');
+      expect(rightPoint.attr('stroke')).toBe('#0f0');
+      expect(rightPoint.attr('lineWidth')).toBe(2);
+      const bottomPoint2 = group.find((g) => {
+        return g.get('className') === 'link-point-left-bottom';
+      });
+      expect(bottomPoint2).not.toBe(null);
+
+      node.update({
+        linkPoints: {
+          left: false,
+          top: true,
+          size: 20,
+          fill: '#f00',
+          stroke: '#0f0',
+          lineWidth: 2,
+        },
+      });
+      const leftPoint2 = group.find((g) => {
+        return g.get('className') === 'link-point-left';
+      });
+      expect(leftPoint2).toBe(null);
+      const topPoint2 = group.find((g) => {
+        return g.get('className') === 'link-point-top';
+      });
+      expect(topPoint2).not.toBe(null);
+      const rightPoint2 = group.find((g) => {
+        return g.get('className') === 'link-point-right';
+      });
+      expect(rightPoint2).not.toBe(null);
+
+      node.update({
+        linkPoints: {
+          stroke: '#000',
+        },
+      });
+      const bottomPoint3 = group.find((g) => {
+        return g.get('className') === 'link-point-left-bottom';
+      });
+      expect(bottomPoint3.attr('r')).toBe(10);
+      expect(bottomPoint3.attr('fill')).toBe('#f00');
+      expect(bottomPoint3.attr('stroke')).toBe('#000');
+
+      graph.destroy();
+      expect(graph.destroyed).toBe(true);
+    });
+  });
+  describe('update', () => {
+    it('update styles', () => {
+      G6.registerNode(
+        'custom-node',
+        {
+          getCustomConfig() {
+            return {};
+          },
+        },
+        'star',
+      );
+      const graph = new G6.Graph({
+        container: div,
+        width: 500,
+        height: 500,
+        defaultNode: {
+          type: 'custom-node',
+          size: 50,
+          style: {
+            fill: 'red',
+            stroke: '#ccc',
+          },
+          icon: {
+            show: true,
+          },
+        },
+      });
+      const data = {
+        nodes: [
+          {
+            id: 'node',
+            label: 'star',
+            x: 200,
+            y: 100,
+            color: '#00f',
+            style: {
+              lineWidth: 3,
+            },
+          },
+        ],
+      };
+      graph.data(data);
+      graph.render();
+
+      const nodes = graph.getNodes();
+      const node = nodes[0];
+      node.update({
+        color: '#0ff',
+        style: {
+          fill: 'black',
+        },
+      });
+      const group = node.get('group');
+      expect(group.getCount()).toEqual(3);
+      const keyShape = node.getKeyShape();
+      expect(keyShape.attr('stroke')).toBe('#0ff');
+      expect(keyShape.attr('fill')).toBe('black');
+      // expect the un-reset attribute to be kept as previous
+      expect(keyShape.attr('lineWidth')).toBe(3);
+
+      graph.destroy();
+      expect(graph.destroyed).toBe(true);
+    });
+    it('update label', () => {
+      const data = {
+        nodes: [
+          {
+            id: 'node',
+            label: 'old star label',
+            x: 200,
+            y: 100,
+          },
+        ],
+      };
+      G6.registerNode(
+        'custom-node',
+        {
+          getCustomConfig() {
+            return {
+              labelCfg: {
+                style: {
+                  fill: 'red',
+                },
+              },
+            };
+          },
+        },
+        'star',
+      );
+      const graph = new G6.Graph({
+        container: div,
+        width: 500,
+        height: 500,
+        defaultNode: {
+          type: 'custom-node',
+        },
+      });
+      graph.data(data);
+      graph.render();
+
+      const nodes = graph.getNodes();
+      const node = nodes[0];
+      const group = node.get('group');
+      const label = group.find((g) => {
+        return g.get('className') === 'node-label';
+      });
+      expect(label).not.toEqual(null);
+      expect(label.attr('text')).toEqual('old star label');
+      expect(label.attr('fill')).toEqual('red');
+
+      node.update({
+        label: 'new star label',
+        labelCfg: {
+          style: {
+            fill: '#ff0',
+          },
+        },
+      });
+      expect(label).not.toEqual(null);
+      expect(label.attr('text')).toEqual('new star label');
+      expect(label.attr('fill')).toEqual('#ff0');
+
+      // test if it will keep the current fill without setting
+      node.update({
+        labelCfg: {
+          position: 'center',
+          style: {
+            stroke: 'black',
+            lineWidth: 3,
+          },
+        },
+      });
+      expect(label.attr('text')).toEqual('new star label');
+      expect(label.attr('fill')).toEqual('#ff0');
+      expect(label.attr('stroke')).toEqual('black');
+      expect(label.attr('lineWidth')).toEqual(3);
+
+      graph.destroy();
+      expect(graph.destroyed).toBe(true);
+    });
+    it('update label from none', () => {
+      const data = {
+        nodes: [
+          {
+            id: 'node',
+            x: 200,
+            y: 100,
+          },
+        ],
+      };
+      G6.registerNode(
+        'custom-node',
+        {
+          getCustomConfig() {
+            return {};
+          },
+        },
+        'star',
+      );
+      const graph = new G6.Graph({
+        container: div,
+        width: 500,
+        height: 500,
+        defaultNode: {
+          type: 'custom-node',
+        },
+      });
+      graph.data(data);
+      graph.render();
+
+      const nodes = graph.getNodes();
+      const node = nodes[0];
+      const group = node.get('group');
+      node.update({
+        label: 'new star label',
+        labelCfg: {
+          style: {
+            fill: '#ff0',
+          },
+        },
+      });
+
+      const label = group.find((g) => {
+        return g.get('className') === 'node-label';
+      });
+      expect(label).not.toEqual(null);
+      expect(label.attr('text')).toEqual('new star label');
+      expect(label.attr('fill')).toEqual('#ff0');
+
+      graph.destroy();
+      expect(graph.destroyed).toBe(true);
+    });
+    it('update icon', () => {
+      const newImg =
+        'https://gw.alipayobjects.com/mdn/rms_f8c6a0/afts/img/A*mt47RKxGy8kAAAAAAAAAAABkARQnAQ';
+      const data = {
+        nodes: [
+          {
+            id: 'node',
+            x: 200,
+            y: 100,
+          },
+        ],
+      };
+      G6.registerNode(
+        'custom-node',
+        {
+          getCustomConfig() {
+            return {
+              icon: {
+                img: 'old-img',
+              },
+            };
+          },
+        },
+        'star',
+      );
+      const graph = new G6.Graph({
+        container: div,
+        width: 500,
+        height: 500,
+        defaultNode: {
+          type: 'custom-node',
+        },
+      });
+      graph.data(data);
+      graph.render();
+
+      const nodes = graph.getNodes();
+      const node = nodes[0];
+      const group = node.get('group');
+      let icon = group.find((g) => {
+        return g.get('className') === 'custom-node-icon';
+      });
+      expect(icon).toEqual(null);
+
+      node.update({
+        icon: {
+          show: true,
+          width: 50,
+          height: 50,
+          img: newImg,
+        },
+      });
+      expect(group.getCount()).toEqual(2);
+      icon = group.find((g) => {
+        return g.get('className') === 'custom-node-icon';
+      });
+      expect(icon).not.toEqual(null);
+      expect(icon.attr('width')).toEqual(50);
+      expect(icon.attr('img')).toEqual(newImg);
+      expect(icon.attr('x')).toEqual(-25);
+      expect(icon.attr('y')).toEqual(-25);
+
+      node.update({
+        icon: {
+          width: 80,
+          height: 80,
+        },
+      });
+      expect(icon.attr('width')).toEqual(80);
+      expect(icon.attr('x')).toEqual(-40);
+      expect(icon.attr('y')).toEqual(-40);
+
+      node.update({
+        icon: {
+          show: false,
+        },
+      });
+      expect(group.getCount()).toEqual(1);
+
+      graph.destroy();
+      expect(graph.destroyed).toBe(true);
+    });
+  });
+});

--- a/tests/unit/shape/extend/extend-triangle-spec.ts
+++ b/tests/unit/shape/extend/extend-triangle-spec.ts
@@ -1,0 +1,523 @@
+import G6 from '../../../../src';
+
+const div = document.createElement('div');
+div.id = 'graph-spec';
+document.body.appendChild(div);
+
+describe('register node with getCustomConfig function, extend triangle', () => {
+  it('getCustomConfig return new style', () => {
+    const data = {
+      nodes: [
+        {
+          id: 'node',
+          label: 'triangle',
+          x: 100,
+          y: 100,
+        },
+      ],
+    };
+    G6.registerNode(
+      'custom-node',
+      {
+        getCustomConfig() {
+          return {
+            style: {
+              fill: 'red',
+              stroke: 'blue',
+              lineWidth: 10,
+            },
+          };
+        },
+      },
+      'triangle',
+    );
+    const graph = new G6.Graph({
+      container: div,
+      width: 500,
+      height: 500,
+      defaultNode: {
+        type: 'custom-node',
+      },
+    });
+    graph.data(data);
+    graph.render();
+    const nodes = graph.getNodes();
+    const node = nodes[0];
+    const group = node.get('group');
+    // modelRect + label + description + logoIcon + stateIcon + preRect
+    expect(group.getCount()).toEqual(2);
+    const keyShape = node.getKeyShape();
+    expect(keyShape.attr('fill')).toEqual('red');
+    expect(keyShape.attr('stroke')).toEqual('blue');
+    expect(keyShape.attr('lineWidth')).toEqual(10);
+
+    const label = group.find((g) => {
+      return g.get('className') === 'node-label';
+    });
+    expect(label).not.toBe(null);
+    expect(label.attr('fill')).toEqual('#595959');
+    expect(label.attr('fontSize')).toEqual(12);
+
+    graph.destroy();
+    expect(graph.destroyed).toBe(true);
+  });
+  it('getCustomConfig return new labelCfg style', () => {
+    const data = {
+      nodes: [
+        {
+          id: 'node',
+          label: 'triangle',
+          x: 100,
+          y: 100,
+        },
+      ],
+    };
+    G6.registerNode(
+      'custom-node',
+      {
+        getCustomConfig() {
+          return {
+            labelCfg: {
+              style: {
+                fill: 'red',
+              },
+            },
+          };
+        },
+      },
+      'triangle',
+    );
+    const graph = new G6.Graph({
+      container: div,
+      width: 500,
+      height: 500,
+      defaultNode: {
+        type: 'custom-node',
+      },
+    });
+    graph.data(data);
+    graph.render();
+    const node = graph.getNodes()[0];
+    const group = node.get('group');
+    const keyShape = node.getKeyShape();
+    expect(keyShape.attr('stroke')).toEqual('#5B8FF9');
+    expect(keyShape.attr('fill')).toEqual('#C6E5FF');
+    expect(keyShape.attr('lineWidth')).toEqual(1);
+
+    const label = group.find((g) => {
+      return g.get('className') === 'node-label';
+    });
+    expect(label).not.toBe(undefined);
+    expect(label.attr('fill')).toEqual('red');
+    const type = label.get('type');
+    expect(type).toEqual('text');
+    graph.destroy();
+  });
+  it('getCustomConfig return new icon', () => {
+    const data = {
+      nodes: [
+        {
+          id: 'node',
+          label: 'triangle',
+          x: 100,
+          y: 100,
+        },
+      ],
+    };
+    G6.registerNode(
+      'custom-node',
+      {
+        getCustomConfig() {
+          return {
+            icon: {
+              show: true,
+              img: 'customsrc',
+              width: 20,
+              height: 20,
+            },
+          };
+        },
+      },
+      'triangle',
+    );
+    const graph = new G6.Graph({
+      container: div,
+      width: 500,
+      height: 500,
+      defaultNode: {
+        type: 'custom-node',
+      },
+    });
+    graph.data(data);
+    graph.render();
+    const node = graph.getNodes()[0];
+    const group = node.get('group');
+    const keyShape = node.getKeyShape();
+    expect(keyShape.attr('stroke')).toEqual('#5B8FF9');
+    expect(keyShape.attr('fill')).toEqual('#C6E5FF');
+    expect(keyShape.attr('lineWidth')).toEqual(1);
+
+    const icon = group.find((g) => {
+      return g.get('className') === 'custom-node-icon';
+    });
+    expect(icon).not.toBe(undefined);
+    expect(icon.attr('img')).toEqual('customsrc');
+    expect(icon.attr('width')).toEqual(20);
+    expect(icon.attr('height')).toEqual(20);
+    graph.destroy();
+  });
+  it('update keyShape style', () => {
+    const data = {
+      nodes: [
+        {
+          id: 'node',
+          label: 'triangle',
+          x: 100,
+          y: 100,
+        },
+      ],
+    };
+    G6.registerNode(
+      'custom-node',
+      {
+        getCustomConfig() {
+          return {
+            style: {
+              fill: 'red',
+            },
+          };
+        },
+      },
+      'triangle',
+    );
+    const graph = new G6.Graph({
+      container: div,
+      width: 500,
+      height: 500,
+      defaultNode: {
+        type: 'custom-node',
+      },
+    });
+    graph.data(data);
+    graph.render();
+
+    const nodes = graph.getNodes();
+    const node = nodes[0];
+    const group = node.get('group');
+    // triangle + label
+    expect(group.getCount()).toEqual(2);
+    const keyShape = node.getKeyShape();
+    expect(keyShape.attr('fill')).toEqual('red');
+
+    node.update({
+      label: 'new label',
+      style: {
+        fill: 'blue',
+        lineWidth: 2,
+      },
+    });
+    const label = node.get('group').get('children')[1];
+    expect(label.attr('text')).toEqual('new label');
+    expect(keyShape.attr('fill')).toEqual('blue');
+
+    graph.destroy();
+    expect(graph.destroyed).toBe(true);
+  });
+  describe('linkPoint test', () => {
+    it('draw linkPoints with up direction', () => {
+      const data = {
+        nodes: [
+          {
+            id: 'node',
+            label: 'triangle',
+            x: 100,
+            y: 200,
+          },
+        ],
+      };
+      G6.registerNode(
+        'custom-node',
+        {
+          getCustomConfig() {
+            return {
+              linkPoints: {
+                top: true,
+                left: true,
+                right: true,
+              },
+            };
+          },
+        },
+        'triangle',
+      );
+      const graph = new G6.Graph({
+        container: div,
+        width: 500,
+        height: 500,
+        defaultNode: {
+          type: 'custom-node',
+        },
+      });
+      graph.data(data);
+      graph.render();
+
+      const node = graph.getNodes()[0];
+      const group = node.get('group');
+      // triangle + label + linkPoints * 3
+      expect(group.getCount()).toEqual(5);
+      graph.destroy();
+      expect(graph.destroyed).toBe(true);
+    });
+    it('draw linkPoints with down direction', () => {
+      const data = {
+        nodes: [
+          {
+            id: 'node',
+            label: 'triangle',
+            x: 100,
+            y: 200,
+          },
+        ],
+      };
+      G6.registerNode(
+        'custom-node',
+        {
+          getCustomConfig() {
+            return {
+              direction: 'down',
+              linkPoints: {
+                bottom: true,
+                left: true,
+                right: true,
+              },
+            };
+          },
+        },
+        'triangle',
+      );
+      const graph = new G6.Graph({
+        container: div,
+        width: 500,
+        height: 500,
+        defaultNode: {
+          type: 'custom-node',
+        },
+      });
+      graph.data(data);
+      graph.render();
+
+      const node = graph.getNodes()[0];
+      const group = node.get('group');
+      // triangle + label + linkPoints * 3
+      expect(group.getCount()).toEqual(5);
+      graph.destroy();
+      expect(graph.destroyed).toBe(true);
+    });
+    it('draw linkPoints with left direction', () => {
+      const data = {
+        nodes: [
+          {
+            id: 'node',
+            label: 'triangle',
+            x: 100,
+            y: 200,
+          },
+        ],
+      };
+      G6.registerNode(
+        'custom-node',
+        {
+          getCustomConfig() {
+            return {
+              direction: 'left',
+              linkPoints: {
+                bottom: true,
+                left: true,
+                top: true,
+              },
+            };
+          },
+        },
+        'triangle',
+      );
+      const graph = new G6.Graph({
+        container: div,
+        width: 500,
+        height: 500,
+        defaultNode: {
+          type: 'custom-node',
+        },
+      });
+      graph.data(data);
+      graph.render();
+
+      const node = graph.getNodes()[0];
+      const group = node.get('group');
+      // triangle + label + linkPoints * 3
+      expect(group.getCount()).toEqual(5);
+      graph.destroy();
+      expect(graph.destroyed).toBe(true);
+    });
+    it('draw linkPoints with right direction', () => {
+      const data = {
+        nodes: [
+          {
+            id: 'node',
+            label: 'triangle',
+            x: 100,
+            y: 200,
+          },
+        ],
+      };
+      G6.registerNode(
+        'custom-node',
+        {
+          getCustomConfig() {
+            return {
+              direction: 'right',
+              linkPoints: {
+                bottom: true,
+                right: true,
+                top: true,
+              },
+            };
+          },
+        },
+        'triangle',
+      );
+      const graph = new G6.Graph({
+        container: div,
+        width: 500,
+        height: 500,
+        defaultNode: {
+          type: 'custom-node',
+        },
+      });
+      graph.data(data);
+      graph.render();
+
+      const node = graph.getNodes()[0];
+      const group = node.get('group');
+      // triangle + label + linkPoints * 3
+      expect(group.getCount()).toEqual(5);
+      graph.destroy();
+      expect(graph.destroyed).toBe(true);
+    });
+
+    it('linkPoints update from show to hide', () => {
+      G6.registerNode(
+        'custom-node',
+        {
+          getCustomConfig() {
+            return {
+              linkPoints: {
+                top: true,
+                left: true,
+                fill: 'red',
+                stroke: 'green',
+              },
+            };
+          },
+        },
+        'triangle',
+      );
+      const graph = new G6.Graph({
+        container: div,
+        width: 500,
+        height: 500,
+        defaultNode: {
+          type: 'custom-node',
+        },
+      });
+      const data = {
+        nodes: [
+          {
+            id: 'node',
+            label: 'triangle',
+            x: 100,
+            y: 200,
+          },
+        ],
+      };
+      graph.data(data);
+      graph.render();
+
+      const node = graph.getNodes()[0];
+      const group = node.get('group');
+      // triangle + label + linkPoints * 2
+      expect(group.getCount()).toEqual(4);
+
+      node.update({
+        linkPoints: {
+          top: false,
+        },
+      });
+      const topPoint = group.find((g) => {
+        return g.get('className') === 'link-point-top';
+      });
+      expect(topPoint).toBe(null);
+
+      node.update({
+        direction: 'down',
+        linkPoints: {
+          left: false,
+          right: true,
+          bottom: true,
+          size: 10,
+
+          lineWidth: 2,
+        },
+      });
+      const leftPoint = group.find((g) => {
+        return g.get('className') === 'link-point-left';
+      });
+      expect(leftPoint).toBe(null);
+      const rightPoint = group.find((g) => {
+        return g.get('className') === 'link-point-right';
+      });
+      expect(rightPoint).not.toBe(null);
+      expect(rightPoint.attr('r')).toBe(5);
+      expect(rightPoint.attr('fill')).toBe('red');
+      expect(rightPoint.attr('stroke')).toBe('green');
+      expect(rightPoint.attr('lineWidth')).toBe(2);
+      const bottomPoint = group.find((g) => {
+        return g.get('className') === 'link-point-bottom';
+      });
+      expect(bottomPoint).not.toBe(null);
+
+      node.update({
+        direction: 'left',
+        linkPoints: {
+          left: false,
+          top: true,
+          size: 10,
+          fill: '#f00',
+          stroke: '#0f0',
+          lineWidth: 2,
+        },
+      });
+      const leftPoint2 = group.find((g) => {
+        return g.get('className') === 'link-point-left';
+      });
+      expect(leftPoint2).toBe(null);
+      const topPoint2 = group.find((g) => {
+        return g.get('className') === 'link-point-top';
+      });
+      expect(topPoint2).not.toBe(null);
+      const rightPoint2 = group.find((g) => {
+        return g.get('className') === 'link-point-right';
+      });
+      expect(rightPoint2).not.toBe(null);
+
+      node.update({
+        direction: 'right',
+        linkPoints: {
+          stroke: '#000',
+        },
+      });
+
+      graph.destroy();
+      expect(graph.destroyed).toBe(true);
+    });
+  });
+});

--- a/tests/unit/shape/findByClassName-spec.ts
+++ b/tests/unit/shape/findByClassName-spec.ts
@@ -30,7 +30,7 @@ describe('register node', () => {
       },
     ],
   };
-  it('shape test wihout extended shape and draw function', () => {
+  it('shape test without extended shape and draw function', () => {
     G6.registerNode(
       'custom-node',
       {

--- a/tests/unit/shape/node-spec.ts
+++ b/tests/unit/shape/node-spec.ts
@@ -64,8 +64,8 @@ describe('shape node test', () => {
           color: 'blue',
           label: '你好，我好，大家好',
           labelCfg: {
-            position: 'top'
-          }
+            position: 'top',
+          },
         },
         group,
       );
@@ -209,8 +209,8 @@ describe('shape node test', () => {
 
       item.update({
         style: {
-          fill: 'steelblue'
-        }
+          fill: 'steelblue',
+        },
       });
       expect(shape.attr('fill')).toBe('steelblue');
       canvas.draw();
@@ -286,7 +286,7 @@ describe('shape node test', () => {
         group,
       });
 
-      const label = group.get('children')[1];
+      let label = group.get('children')[1];
       expect(label.attr('x')).toBe(0);
       expect(label.attr('y')).toBe(-10 - Global.nodeLabel.offset);
 
@@ -294,7 +294,7 @@ describe('shape node test', () => {
         'ellipse',
         {
           size: [60, 20],
-          color: 'green',
+          color: 'red',
           label: 'ellipse position',
           labelCfg: {
             position: 'left',
@@ -302,6 +302,8 @@ describe('shape node test', () => {
         },
         item,
       );
+      label = group.get('children')[1];
+
       expect(label.attr('y')).toBe(0);
       expect(label.attr('x')).toBe(-30 - Global.nodeLabel.offset);
 
@@ -391,11 +393,11 @@ describe('shape node test', () => {
           top: false,
         },
       });
-      const topPoint = group.find(g => {
+      const topPoint = group.find((g) => {
         return g.get('className') === 'link-point-top';
       });
       expect(topPoint).toBe(null);
-      const bottomPoint = group.find(g => {
+      const bottomPoint = group.find((g) => {
         return g.get('className') === 'link-point-bottom';
       });
       expect(bottomPoint).not.toBe(null);
@@ -410,7 +412,7 @@ describe('shape node test', () => {
           lineWidth: 2,
         },
       });
-      const leftPoint = group.find(g => {
+      const leftPoint = group.find((g) => {
         return g.get('className') === 'link-point-left';
       });
       expect(leftPoint).not.toBe(null);
@@ -418,7 +420,7 @@ describe('shape node test', () => {
       expect(leftPoint.attr('fill')).toBe('#f00');
       expect(leftPoint.attr('stroke')).toBe('#0f0');
       expect(leftPoint.attr('lineWidth')).toBe(2);
-      const rightPoint = group.find(g => {
+      const rightPoint = group.find((g) => {
         return g.get('className') === 'link-point-right';
       });
       expect(rightPoint).not.toBe(null);
@@ -433,15 +435,15 @@ describe('shape node test', () => {
           lineWidth: 2,
         },
       });
-      const leftPoint2 = group.find(g => {
+      const leftPoint2 = group.find((g) => {
         return g.get('className') === 'link-point-left';
       });
       expect(leftPoint2).toBe(null);
-      const topPoint2 = group.find(g => {
+      const topPoint2 = group.find((g) => {
         return g.get('className') === 'link-point-top';
       });
       expect(topPoint2).not.toBe(null);
-      const rightPoint2 = group.find(g => {
+      const rightPoint2 = group.find((g) => {
         return g.get('className') === 'link-point-right';
       });
       expect(rightPoint2).not.toBe(null);
@@ -451,7 +453,7 @@ describe('shape node test', () => {
           stroke: '#000',
         },
       });
-      const bottomPoint2 = group.find(g => {
+      const bottomPoint2 = group.find((g) => {
         return g.get('className') === 'link-point-bottom';
       });
       expect(bottomPoint2.attr('r')).toBe(5);
@@ -496,11 +498,11 @@ describe('shape node test', () => {
           top: false,
         },
       });
-      const topPoint = group.find(g => {
+      const topPoint = group.find((g) => {
         return g.get('className') === 'link-point-top';
       });
       expect(topPoint).toBe(null);
-      const bottomPoint = group.find(g => {
+      const bottomPoint = group.find((g) => {
         return g.get('className') === 'link-point-bottom';
       });
       expect(bottomPoint).not.toBe(null);
@@ -515,7 +517,7 @@ describe('shape node test', () => {
           lineWidth: 2,
         },
       });
-      const leftPoint = group.find(g => {
+      const leftPoint = group.find((g) => {
         return g.get('className') === 'link-point-left';
       });
       expect(leftPoint).not.toBe(null);
@@ -523,7 +525,7 @@ describe('shape node test', () => {
       expect(leftPoint.attr('fill')).toBe('#f00');
       expect(leftPoint.attr('stroke')).toBe('#0f0');
       expect(leftPoint.attr('lineWidth')).toBe(2);
-      const rightPoint = group.find(g => {
+      const rightPoint = group.find((g) => {
         return g.get('className') === 'link-point-right';
       });
       expect(rightPoint).not.toBe(null);
@@ -538,15 +540,15 @@ describe('shape node test', () => {
           lineWidth: 2,
         },
       });
-      const leftPoint2 = group.find(g => {
+      const leftPoint2 = group.find((g) => {
         return g.get('className') === 'link-point-left';
       });
       expect(leftPoint2).toBe(null);
-      const topPoint2 = group.find(g => {
+      const topPoint2 = group.find((g) => {
         return g.get('className') === 'link-point-top';
       });
       expect(topPoint2).not.toBe(null);
-      const rightPoint2 = group.find(g => {
+      const rightPoint2 = group.find((g) => {
         return g.get('className') === 'link-point-right';
       });
       expect(rightPoint2).not.toBe(null);
@@ -556,7 +558,7 @@ describe('shape node test', () => {
           stroke: '#000',
         },
       });
-      const bottomPoint2 = group.find(g => {
+      const bottomPoint2 = group.find((g) => {
         return g.get('className') === 'link-point-bottom';
       });
       expect(bottomPoint2.attr('r')).toBe(5);
@@ -601,11 +603,11 @@ describe('shape node test', () => {
           top: false,
         },
       });
-      const topPoint = group.find(g => {
+      const topPoint = group.find((g) => {
         return g.get('className') === 'link-point-top';
       });
       expect(topPoint).toBe(null);
-      const bottomPoint = group.find(g => {
+      const bottomPoint = group.find((g) => {
         return g.get('className') === 'link-point-bottom';
       });
       expect(bottomPoint).not.toBe(null);
@@ -620,7 +622,7 @@ describe('shape node test', () => {
           lineWidth: 2,
         },
       });
-      const leftPoint = group.find(g => {
+      const leftPoint = group.find((g) => {
         return g.get('className') === 'link-point-left';
       });
       expect(leftPoint).not.toBe(null);
@@ -628,7 +630,7 @@ describe('shape node test', () => {
       expect(leftPoint.attr('fill')).toBe('#f00');
       expect(leftPoint.attr('stroke')).toBe('#0f0');
       expect(leftPoint.attr('lineWidth')).toBe(2);
-      const rightPoint = group.find(g => {
+      const rightPoint = group.find((g) => {
         return g.get('className') === 'link-point-right';
       });
       expect(rightPoint).not.toBe(null);
@@ -643,15 +645,15 @@ describe('shape node test', () => {
           lineWidth: 2,
         },
       });
-      const leftPoint2 = group.find(g => {
+      const leftPoint2 = group.find((g) => {
         return g.get('className') === 'link-point-left';
       });
       expect(leftPoint2).toBe(null);
-      const topPoint2 = group.find(g => {
+      const topPoint2 = group.find((g) => {
         return g.get('className') === 'link-point-top';
       });
       expect(topPoint2).not.toBe(null);
-      const rightPoint2 = group.find(g => {
+      const rightPoint2 = group.find((g) => {
         return g.get('className') === 'link-point-right';
       });
       expect(rightPoint2).not.toBe(null);
@@ -661,7 +663,7 @@ describe('shape node test', () => {
           stroke: '#000',
         },
       });
-      const bottomPoint2 = group.find(g => {
+      const bottomPoint2 = group.find((g) => {
         return g.get('className') === 'link-point-bottom';
       });
       expect(bottomPoint2.attr('r')).toBe(5);
@@ -706,11 +708,11 @@ describe('shape node test', () => {
           top: false,
         },
       });
-      const topPoint = group.find(g => {
+      const topPoint = group.find((g) => {
         return g.get('className') === 'link-point-top';
       });
       expect(topPoint).toBe(null);
-      const bottomPoint = group.find(g => {
+      const bottomPoint = group.find((g) => {
         return g.get('className') === 'link-point-bottom';
       });
       expect(bottomPoint).not.toBe(null);
@@ -725,7 +727,7 @@ describe('shape node test', () => {
           lineWidth: 2,
         },
       });
-      const leftPoint = group.find(g => {
+      const leftPoint = group.find((g) => {
         return g.get('className') === 'link-point-left';
       });
       expect(leftPoint).not.toBe(null);
@@ -733,7 +735,7 @@ describe('shape node test', () => {
       expect(leftPoint.attr('fill')).toBe('#f00');
       expect(leftPoint.attr('stroke')).toBe('#0f0');
       expect(leftPoint.attr('lineWidth')).toBe(2);
-      const rightPoint = group.find(g => {
+      const rightPoint = group.find((g) => {
         return g.get('className') === 'link-point-right';
       });
       expect(rightPoint).not.toBe(null);
@@ -748,15 +750,15 @@ describe('shape node test', () => {
           lineWidth: 2,
         },
       });
-      const leftPoint2 = group.find(g => {
+      const leftPoint2 = group.find((g) => {
         return g.get('className') === 'link-point-left';
       });
       expect(leftPoint2).toBe(null);
-      const topPoint2 = group.find(g => {
+      const topPoint2 = group.find((g) => {
         return g.get('className') === 'link-point-top';
       });
       expect(topPoint2).not.toBe(null);
-      const rightPoint2 = group.find(g => {
+      const rightPoint2 = group.find((g) => {
         return g.get('className') === 'link-point-right';
       });
       expect(rightPoint2).not.toBe(null);
@@ -766,7 +768,7 @@ describe('shape node test', () => {
           stroke: '#000',
         },
       });
-      const bottomPoint2 = group.find(g => {
+      const bottomPoint2 = group.find((g) => {
         return g.get('className') === 'link-point-bottom';
       });
       expect(bottomPoint2.attr('r')).toBe(5);

--- a/tests/unit/shape/nodes/circle-spec.ts
+++ b/tests/unit/shape/nodes/circle-spec.ts
@@ -59,7 +59,7 @@ describe('circle test', () => {
       const group = node.get('group');
       expect(group.getCount()).toEqual(2);
 
-      const label = group.find(g => {
+      const label = group.find((g) => {
         return g.get('className') === 'node-label';
       });
       expect(label).not.toBe(undefined);
@@ -112,7 +112,7 @@ describe('circle test', () => {
       expect(keyShape.attr('stroke')).toEqual('#ccc');
       expect(keyShape.attr('r')).toEqual(25);
 
-      const icon = group.find(g => {
+      const icon = group.find((g) => {
         return g.get('className') === 'circle-icon';
       });
       expect(icon).not.toBe(undefined);
@@ -172,21 +172,21 @@ describe('circle test', () => {
       expect(keyShape.attr('r')).toEqual(17.5);
       expect(keyShape.attr('lineWidth')).toEqual(1);
 
-      const markTop = group.find(g => {
+      const markTop = group.find((g) => {
         return g.get('className') === 'link-point-top';
       });
       expect(markTop).not.toBe(null);
       expect(markTop.attr('r')).toEqual(5);
       expect(markTop.attr('fill')).toEqual('#fff');
 
-      const markBottom = group.find(g => {
+      const markBottom = group.find((g) => {
         return g.get('className') === 'link-point-bottom';
       });
       expect(markBottom).not.toBe(null);
 
       let hasTrigger = false;
       expect(hasTrigger).toBe(false);
-      graph.on('node:mouseenter', evt => {
+      graph.on('node:mouseenter', (evt) => {
         hasTrigger = evt.hasTrigger;
         graph.setItemState(evt.item, 'hover', true);
       });
@@ -284,7 +284,7 @@ describe('circle test', () => {
       });
       let group = node.get('group');
       expect(group.getCount()).toEqual(3);
-      const icon = group.find(g => {
+      const icon = group.find((g) => {
         return g.get('className') === 'circle-icon';
       });
       expect(icon.attr('width')).toEqual(50);
@@ -343,7 +343,7 @@ describe('circle test', () => {
         },
       });
 
-      const label = group.find(g => {
+      const label = group.find((g) => {
         return g.get('className') === 'node-label';
       });
       expect(label).not.toEqual(null);
@@ -401,7 +401,7 @@ describe('circle test', () => {
         },
       });
 
-      const label = group.find(g => {
+      const label = group.find((g) => {
         return g.get('className') === 'node-label';
       });
       expect(label).not.toEqual(null);
@@ -432,7 +432,7 @@ describe('circle test', () => {
       graph.data(data);
       graph.render();
 
-      graph.on('node:mouseenter', e => {
+      graph.on('node:mouseenter', (e) => {
         const item = e.item;
         item.update({
           label: 'Circle',
@@ -457,7 +457,7 @@ describe('circle test', () => {
         });
       });
 
-      graph.on('node:mouseleave', e => {
+      graph.on('node:mouseleave', (e) => {
         const item = e.item;
         item.update({
           label: ' ',
@@ -505,7 +505,7 @@ describe('circle test', () => {
       graph.data(data);
       graph.render();
 
-      graph.on('node:mouseenter', e => {
+      graph.on('node:mouseenter', (e) => {
         const item = e.item;
         item.update({
           descriptionCfg: {
@@ -519,7 +519,7 @@ describe('circle test', () => {
         });
       });
 
-      graph.on('node:mouseleave', e => {
+      graph.on('node:mouseleave', (e) => {
         const item = e.item;
         item.update({
           descriptionCfg: {

--- a/tests/unit/shape/register-spec.ts
+++ b/tests/unit/shape/register-spec.ts
@@ -30,7 +30,7 @@ describe('register node', () => {
       },
     ],
   };
-  it('shape test wihout extended shape and draw function, update the node', () => {
+  it('shape test without extended shape and draw function, update the node', () => {
     G6.registerNode('custom-node', {
       drawShape(cfg, group) {
         let fill = '#87e8de';
@@ -47,7 +47,7 @@ describe('register node', () => {
         });
 
         return keyShape;
-      }
+      },
     });
     const graph = new G6.Graph({
       container: div,
@@ -70,7 +70,7 @@ describe('register node', () => {
     expect(node.get('group').get('children')[0].attr('fill')).toBe('steelblue');
     graph.destroy();
   });
-  it('register node wihout draw and drawShape, extend circle', () => {
+  it('register node without draw and drawShape, extend circle', () => {
     G6.registerNode(
       'custom-node',
       {
@@ -98,12 +98,12 @@ describe('register node', () => {
     });
     graph.data(data);
     graph.render();
-    graph.on('node:click', evt => {
+    graph.on('node:click', (evt) => {
       const { item } = evt;
       graph.setItemState(item, 'active', true);
     });
-    graph.on('canvas:click', evt => {
-      graph.getNodes().forEach(node => {
+    graph.on('canvas:click', (evt) => {
+      graph.getNodes().forEach((node) => {
         graph.setItemState(node, 'active', false);
       });
     });
@@ -111,7 +111,7 @@ describe('register node', () => {
     expect(graph.getNodes()[0].getModel().y).not.toBe(undefined);
     graph.destroy();
   });
-  it('register edge wihout draw and drawShape function, extend quadratic', () => {
+  it('register edge without draw and drawShape function, extend quadratic', () => {
     G6.registerEdge(
       'custom-edge',
       {
@@ -139,5 +139,6 @@ describe('register node', () => {
     graph.render();
     expect(graph.getNodes()[0].getModel().x).not.toBe(undefined);
     expect(graph.getNodes()[0].getModel().y).not.toBe(undefined);
+    graph.destroy();
   });
 });

--- a/tests/unit/shape/register/extend-circle-spec.ts
+++ b/tests/unit/shape/register/extend-circle-spec.ts
@@ -1,0 +1,628 @@
+import G6 from '../../../../src';
+
+const div = document.createElement('div');
+div.id = 'graph-spec';
+document.body.appendChild(div);
+
+describe('register node with getCustomConfig function, extend circle', () => {
+  const data = {
+    nodes: [
+      {
+        id: 'node1',
+        label: 'node1',
+        x: 50,
+        y: 50,
+      },
+      {
+        id: 'node2',
+        label: 'node2',
+        x: 250,
+        y: 50,
+      },
+    ],
+    edges: [
+      {
+        source: 'node1',
+        target: 'node2',
+      },
+    ],
+  };
+  it('getCustomConfig return new style', () => {
+    G6.registerNode(
+      'custom-node',
+      {
+        getCustomConfig() {
+          return {
+            style: {
+              fill: 'red',
+              stroke: 'blue',
+              lineWidth: 10,
+            },
+          };
+        },
+      },
+      'circle',
+    );
+    const graph = new G6.Graph({
+      container: div,
+      width: 500,
+      height: 500,
+      defaultNode: {
+        type: 'custom-node',
+      },
+    });
+    graph.data(data);
+    graph.render();
+    const node = graph.getNodes()[0];
+    const keyShape = node.getKeyShape();
+    expect(keyShape.attr('r')).toEqual(10);
+    expect(keyShape.attr('stroke')).toEqual('blue');
+    expect(keyShape.attr('fill')).toEqual('red');
+    expect(keyShape.attr('lineWidth')).toEqual(10);
+    graph.destroy();
+  });
+  it('getCustomConfig return new icon', () => {
+    G6.registerNode(
+      'custom-node',
+      {
+        getCustomConfig() {
+          return {
+            icon: {
+              show: true,
+              img: 'customsrc',
+              width: 20,
+              height: 20,
+            },
+          };
+        },
+      },
+      'circle',
+    );
+    const graph = new G6.Graph({
+      container: div,
+      width: 500,
+      height: 500,
+      defaultNode: {
+        type: 'custom-node',
+      },
+    });
+    graph.data(data);
+    graph.render();
+    const node = graph.getNodes()[0];
+    const group = node.get('group');
+    const keyShape = node.getKeyShape();
+    expect(keyShape.attr('r')).toEqual(10);
+    expect(keyShape.attr('stroke')).toEqual('#5B8FF9');
+    expect(keyShape.attr('fill')).toEqual('#C6E5FF');
+    expect(keyShape.attr('lineWidth')).toEqual(1);
+
+    const icon = group.find((g) => {
+      return g.get('className') === 'custom-node-icon';
+    });
+    expect(icon).not.toBe(undefined);
+    expect(icon.attr('img')).toEqual('customsrc');
+    expect(icon.attr('width')).toEqual(20);
+    expect(icon.attr('height')).toEqual(20);
+    graph.destroy();
+  });
+  it('getCustomConfig return new labelCfg style', () => {
+    G6.registerNode(
+      'custom-node',
+      {
+        getCustomConfig() {
+          return {
+            labelCfg: {
+              style: {
+                fill: 'red',
+              },
+            },
+          };
+        },
+      },
+      'circle',
+    );
+    const graph = new G6.Graph({
+      container: div,
+      width: 500,
+      height: 500,
+      defaultNode: {
+        type: 'custom-node',
+      },
+    });
+    graph.data(data);
+    graph.render();
+    const node = graph.getNodes()[0];
+    const group = node.get('group');
+    const keyShape = node.getKeyShape();
+    expect(keyShape.attr('r')).toEqual(10);
+    expect(keyShape.attr('stroke')).toEqual('#5B8FF9');
+    expect(keyShape.attr('fill')).toEqual('#C6E5FF');
+    expect(keyShape.attr('lineWidth')).toEqual(1);
+
+    const label = group.find((g) => {
+      return g.get('className') === 'node-label';
+    });
+    expect(label).not.toBe(undefined);
+    expect(label.attr('fill')).toEqual('red');
+    const type = label.get('type');
+    expect(type).toEqual('text');
+    graph.destroy();
+  });
+  it('getCustomConfig return new linkPoints', () => {
+    G6.registerNode(
+      'custom-node',
+      {
+        getCustomConfig() {
+          return {
+            linkPoints: {
+              top: true,
+              bottom: true,
+              left: true,
+              fill: 'red',
+              size: 20,
+            },
+          };
+        },
+      },
+      'circle',
+    );
+    const graph = new G6.Graph({
+      container: div,
+      width: 500,
+      height: 500,
+      defaultNode: {
+        type: 'custom-node',
+      },
+    });
+    graph.data(data);
+    graph.render();
+
+    const nodes = graph.getNodes();
+    const node = nodes[0];
+    const group = node.get('group');
+
+    expect(group.getCount()).toEqual(5);
+
+    const keyShape = node.getKeyShape();
+    expect(keyShape.attr('fill')).toEqual('#C6E5FF');
+    expect(keyShape.attr('stroke')).toEqual('#5B8FF9');
+    expect(keyShape.attr('r')).toEqual(10);
+    expect(keyShape.attr('lineWidth')).toEqual(1);
+
+    const markTop = group.find((g) => {
+      return g.get('className') === 'link-point-top';
+    });
+    expect(markTop).not.toBe(null);
+    expect(markTop.attr('r')).toEqual(10);
+    expect(markTop.attr('fill')).toEqual('red');
+
+    const markBottom = group.find((g) => {
+      return g.get('className') === 'link-point-bottom';
+    });
+    expect(markBottom).not.toBe(null);
+
+    let hasTrigger = false;
+    expect(hasTrigger).toBe(false);
+    graph.on('node:mouseenter', (evt) => {
+      hasTrigger = evt.hasTrigger;
+      graph.setItemState(evt.item, 'hover', true);
+    });
+    graph.emit('node:mouseenter', { hasTrigger: true, item: node });
+
+    expect(hasTrigger).toBe(true);
+    expect(keyShape.attr('lineWidth')).toEqual(1);
+
+    graph.destroy();
+  });
+  describe('update', () => {
+    it('update styles', () => {
+      G6.registerNode(
+        'custom-node',
+        {
+          getCustomConfig() {
+            return {
+              size: 50,
+              style: {
+                fill: 'red',
+                stroke: '#ccc',
+                lineWidth: 5,
+              },
+              icon: {
+                show: true,
+              },
+            };
+          },
+        },
+        'circle',
+      );
+      const graph = new G6.Graph({
+        container: div,
+        width: 500,
+        height: 500,
+        defaultNode: {
+          type: 'custom-node',
+        },
+      });
+      graph.data(data);
+      graph.render();
+
+      const nodes = graph.getNodes();
+      const node = nodes[0];
+      node.update({
+        size: 30,
+        color: 'black',
+        style: {
+          fill: 'steelblue',
+        },
+      });
+      const group = node.get('group');
+      expect(group.getCount()).toEqual(3);
+      const keyShape = node.getKeyShape();
+      expect(keyShape.attr('r')).toBe(15);
+      expect(keyShape.attr('fill')).toBe('steelblue');
+      expect(keyShape.attr('lineWidth')).toBe(5);
+
+      graph.destroy();
+      expect(graph.destroyed).toBe(true);
+    });
+    it('update icon', () => {
+      G6.registerNode(
+        'custom-node',
+        {
+          getCustomConfig() {
+            return {
+              icon: {
+                show: true,
+                width: 20,
+                height: 20,
+              },
+            };
+          },
+        },
+        'circle',
+      );
+      const graph = new G6.Graph({
+        container: div,
+        width: 500,
+        height: 500,
+        defaultNode: {
+          type: 'custom-node',
+        },
+      });
+      graph.data(data);
+      graph.render();
+
+      const nodes = graph.getNodes();
+      const node = nodes[0];
+      let group = node.get('group');
+
+      expect(group.getCount()).toEqual(3);
+      let icon = group.find((g) => {
+        return g.get('className') === 'custom-node-icon';
+      });
+      expect(icon.attr('width')).toEqual(20);
+      expect(icon.attr('x')).toEqual(-10);
+      expect(icon.attr('y')).toEqual(-10);
+      expect(icon.attr('img')).toEqual(
+        'https://gw.alipayobjects.com/zos/basement_prod/012bcf4f-423b-4922-8c24-32a89f8c41ce.svg',
+      );
+
+      const newImg =
+        'https://gw.alipayobjects.com/mdn/rms_f8c6a0/afts/img/A*mt47RKxGy8kAAAAAAAAAAABkARQnAQ';
+      node.update({
+        icon: {
+          show: true,
+          img: newImg,
+          width: 50,
+          height: 50,
+        },
+      });
+      // 更新之后的名字变成了 custom-node-icon
+      icon = group.find((g) => {
+        return g.get('className') === 'custom-node-icon';
+      });
+      expect(group.getCount()).toEqual(3);
+      expect(icon.attr('width')).toEqual(50);
+      expect(icon.attr('x')).toEqual(-25);
+      expect(icon.attr('y')).toEqual(-25);
+      expect(icon.attr('img')).toEqual(newImg);
+
+      node.update({
+        icon: {
+          width: 80,
+        },
+      });
+      group = node.get('group');
+      expect(group.getCount()).toEqual(3);
+      expect(icon.attr('width')).toEqual(80);
+      expect(icon.attr('x')).toEqual(-40);
+
+      node.update({
+        icon: {
+          show: false,
+        },
+      });
+      group = node.get('group');
+      expect(group.getCount()).toEqual(2);
+      graph.destroy();
+      expect(graph.destroyed).toBe(true);
+    });
+    it('update label', () => {
+      G6.registerNode(
+        'custom-node',
+        {
+          getCustomConfig() {
+            return {
+              labelCfg: {
+                style: {
+                  fill: 'red',
+                },
+              },
+            };
+          },
+        },
+        'circle',
+      );
+      const graph = new G6.Graph({
+        container: div,
+        width: 500,
+        height: 500,
+        defaultNode: {
+          type: 'custom-node',
+        },
+      });
+      graph.data(data);
+      graph.render();
+
+      const nodes = graph.getNodes();
+      const node = nodes[0];
+      const group = node.get('group');
+      const label = group.find((g) => {
+        return g.get('className') === 'node-label';
+      });
+      expect(label).not.toEqual(null);
+      expect(label.attr('text')).toEqual('node1');
+      expect(label.attr('fill')).toEqual('red');
+
+      node.update({
+        label: '',
+        labelCfg: {
+          style: {
+            fill: '#ff0',
+          },
+        },
+      });
+
+      expect(label).not.toEqual(null);
+      expect(label.attr('text')).toEqual('');
+      expect(label.attr('fill')).toEqual('#ff0');
+
+      node.update({
+        label: 'new circle label',
+      });
+      // test if it will keep the current fill without setting
+      node.update({
+        labelCfg: {
+          position: 'center',
+          style: {
+            stroke: 'black',
+            lineWidth: 3,
+          },
+        },
+      });
+      expect(label.attr('text')).toEqual('new circle label');
+      expect(label.attr('fill')).toEqual('#ff0');
+      expect(label.attr('stroke')).toEqual('black');
+      expect(label.attr('lineWidth')).toEqual(3);
+
+      graph.destroy();
+      expect(graph.destroyed).toBe(true);
+    });
+    it('update label from none', () => {
+      G6.registerNode(
+        'custom-node',
+        {
+          getCustomConfig() {
+            return {
+              labelCfg: {
+                style: {
+                  fill: 'red',
+                },
+              },
+            };
+          },
+        },
+        'circle',
+      );
+      const graph = new G6.Graph({
+        container: div,
+        width: 500,
+        height: 500,
+        defaultNode: {
+          type: 'custom-node',
+        },
+      });
+      const data = {
+        nodes: [
+          {
+            id: 'node',
+            x: 200,
+            y: 100,
+          },
+        ],
+      };
+      graph.data(data);
+      graph.render();
+
+      const nodes = graph.getNodes();
+      const node = nodes[0];
+      const group = node.get('group');
+      let label = group.find((g) => {
+        return g.get('className') === 'node-label';
+      });
+      expect(label).toEqual(null);
+
+      node.update({
+        label: 'new circle label',
+      });
+      label = group.find((g) => {
+        return g.get('className') === 'node-label';
+      });
+      expect(label).not.toEqual(null);
+      expect(label.attr('text')).toEqual('new circle label');
+      expect(label.attr('fill')).toEqual('red');
+
+      node.update({
+        labelCfg: {
+          style: {
+            fill: '#ff0',
+          },
+        },
+      });
+      label = group.find((g) => {
+        return g.get('className') === 'node-label';
+      });
+      expect(label.attr('text')).toEqual('new circle label');
+      expect(label.attr('fill')).toEqual('#ff0');
+      graph.destroy();
+      expect(graph.destroyed).toBe(true);
+    });
+    it('update label, linkPoints, icon from none', () => {
+      G6.registerNode(
+        'custom-node',
+        {
+          getCustomConfig() {
+            return {
+              icon: {
+                img:
+                  'https://gw.alipayobjects.com/mdn/rms_f8c6a0/afts/img/A*mt47RKxGy8kAAAAAAAAAAABkARQnAQ',
+              },
+            };
+          },
+        },
+        'circle',
+      );
+      const graph = new G6.Graph({
+        container: div,
+        width: 500,
+        height: 500,
+        defaultNode: {
+          size: 50,
+          type: 'custom-node',
+        },
+      });
+      const data = {
+        nodes: [
+          {
+            id: 'node',
+            x: 200,
+            y: 100,
+          },
+        ],
+      };
+      graph.data(data);
+      graph.render();
+
+      graph.on('node:mouseenter', (e) => {
+        const item = e.item;
+        item.update({
+          label: 'Circle',
+          labelCfg: {
+            position: 'bottom',
+            offset: 10,
+            style: {
+              fill: '#333',
+            },
+          },
+          linkPoints: {
+            top: true,
+            bottom: true,
+            left: true,
+            right: true,
+            fill: '#fff',
+            size: 5,
+          },
+          icon: {
+            show: true,
+          },
+        });
+      });
+
+      graph.on('node:mouseleave', (e) => {
+        const item = e.item;
+        item.update({
+          label: ' ',
+          labelCfg: {
+            style: {
+              fill: '#333',
+            },
+          },
+          linkPoints: {
+            top: false,
+            bottom: false,
+            left: false,
+            right: false,
+            fill: '#fff',
+            size: 5,
+          },
+          icon: {
+            show: false,
+          },
+        });
+      });
+    });
+
+    it('update label, linkPoints, icon from none', () => {
+      const graph = new G6.Graph({
+        container: div,
+        width: 500,
+        height: 500,
+        // defaultNode: {
+        //   size: 50
+        // }
+      });
+      const data = {
+        nodes: [
+          {
+            id: 'node',
+            type: 'modelRect',
+            label: 'modelRect',
+            description: 'description',
+            x: 200,
+            y: 100,
+          },
+        ],
+      };
+      graph.data(data);
+      graph.render();
+
+      graph.on('node:mouseenter', (e) => {
+        const item = e.item;
+        item.update({
+          descriptionCfg: {
+            style: {
+              fill: 'steelblue',
+            },
+          },
+          stateIcon: {
+            show: true,
+          },
+        });
+      });
+
+      graph.on('node:mouseleave', (e) => {
+        const item = e.item;
+        item.update({
+          descriptionCfg: {
+            style: {
+              fill: '#bfbfbf',
+            },
+          },
+          stateIcon: {
+            show: false,
+          },
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change
* 支持在注册自定义节点时通过 `getCustomConfig` 方法部分覆盖默认节点的内置options。
* 所有内置节点都增加了`getCustomConfig` 和 `getOptions` 方法
* 修复部分测试用例单词拼写错误 **wihout -> without**
* 增加继承所有内置节点的自定义节点测试用例
* 修复 #1709 中提到的 classname 问题
<!-- Provide a description of the change below this comment. -->
