### PR TITLE
docs: fix graphics group doc; add setClip method in doc

### DIFF
--- a/docs/api/Custom.en.md
+++ b/docs/api/Custom.en.md
@@ -26,14 +26,14 @@ G6.registerNode(
     /**
      * Draw this type of node with label
      * @param  {Object} cfg The configurations of this type of node
-     * @param  {G.Group} group The container of this type of node
+     * @param  {G.Group} group Graphics group, the container of the shapes of the node
      * @return {G.Shape} The keyShape of the type of node. The keyShape can be obtained by node.get('keyShape')
      */
     draw(cfg, group) {},
     /**
      * Operations to be executed after drawing. No operation by default
      * @param  {Object} cfg The configurations of this type of node
-     * @param  {G.Group} group The container of this tyep of node
+     * @param  {G.Group} group Graphics group, the container of the shapes of the node
      */
     afterDraw(cfg, group) {},
     /**
@@ -89,14 +89,14 @@ G6.registerEdge(
     /**
      * Draw this type of edge with label
      * @param  {Object} cfg The configurations of this type of edge
-     * @param  {G.Group} group The container of this tyep of edge
+     * @param  {G.Group} group Graphics group, the container of the shapes of the edge
      * @return {G.Shape} The keyShape of the type of edge. The keyShape can be obtained by edge.get('keyShape')
      */
     draw(cfg, group) {},
     /**
      * Operations to be executed after drawing. No operation by default
      * @param  {Object} cfg The configurations of this type of edge
-     * @param  {G.Group} group The container of this tyep of edge
+     * @param  {G.Group} group Graphics group, the container of the shapes of the edge
      */
     afterDraw(cfg, group) {},
     /**
@@ -148,14 +148,14 @@ G6.registerCombo(
     /**
      * Draw this type of combo with label
      * @param  {Object} cfg The configurations of this type of combo
-     * @param  {G.Group} group The container of this type of combo
+     * @param  {G.Group} group Graphics group, the container of the shapes in the combo
      * @return {G.Shape} The keyShape of the type of combo. The keyShape can be obtained by combo.get('keyShape')
      */
     draw(cfg, group) {},
     /**
      * Operations to be executed after drawing. No operation by default
      * @param  {Object} cfg The configurations of this type of combo
-     * @param  {G.Group} group The container of this tyep of combo
+     * @param  {G.Group} group Graphics group, the container of the shapes in the combo
      */
     afterDraw(cfg, group) {},
     /**

--- a/docs/api/Custom.zh.md
+++ b/docs/api/Custom.zh.md
@@ -26,14 +26,14 @@ G6.registerNode(
     /**
      * 绘制节点，包含文本
      * @param  {Object} cfg 节点的配置项
-     * @param  {G.Group} group 节点的容器
+     * @param  {G.Group} group 图形分组，节点中的图形对象的容器
      * @return {G.Shape} 绘制的图形，通过 node.get('keyShape') 可以获取到
      */
     draw(cfg, group) {},
     /**
      * 绘制后的附加操作，默认没有任何操作
      * @param  {Object} cfg 节点的配置项
-     * @param  {G.Group} group 节点的容器
+     * @param  {G.Group} group 图形分组，节点中的图形对象的容器
      */
     afterDraw(cfg, group) {},
     /**
@@ -90,14 +90,14 @@ G6.registerEdge(
     /**
      * 绘制边，包含文本
      * @param  {Object} cfg 边的配置项
-     * @param  {G.Group} group 边的容器
+     * @param  {G.Group} group 图形分组，边中的图形对象的容器
      * @return {G.Shape} 绘制的图形，通过 node.get('keyShape') 可以获取到
      */
     draw(cfg, group) {},
     /**
      * 绘制后的附加操作，默认没有任何操作
      * @param  {Object} cfg 边的配置项
-     * @param  {G.Group} group 边的容器
+     * @param  {G.Group} group 图形分组，边中的图形对象的容器
      */
     afterDraw(cfg, group) {},
     /**
@@ -148,14 +148,14 @@ G6.registerNode(
     /**
      * 绘制 combo，包含文本
      * @param  {Object} cfg combo 的配置项
-     * @param  {G.Group} group combo 的容器
+     * @param  {G.Group} group 图形分组，combo 中的图形对象的容器
      * @return {G.Shape} 绘制的图形，通过 combo.get('keyShape') 可以获取到
      */
     draw(cfg, group) {},
     /**
      * 绘制后的附加操作，默认没有任何操作
      * @param  {Object} cfg combo 的配置项
-     * @param  {G.Group} group combo 的容器
+     * @param  {G.Group} group 图形分组，combo 中的图形对象的容器
      */
     afterDraw(cfg, group) {},
     /**

--- a/docs/api/Group.en.md
+++ b/docs/api/Group.en.md
@@ -5,10 +5,14 @@ order: 11
 
 Graphics Group (hereinafter referred to as Group) in G6 is similar to <a href='https://developer.mozilla.org/zh-CN/docs/Web/SVG/Element/g' target='_blank'> `<g>` tag in SVG </a>: Group a container of a group of graphics. The transformations on a Group such as clipping, rotating, zooming, and translating will be applied to all the children of the Group. The properties like color and position will also be inherited by its children. Besides, Group can be nested for complicated objects. For more information about Group, please refer to [Graphics Group](/en/docs/manual/advanced/keyconcept/graphics-group) document.
 
-## Instance Declaration
+## Get group of item
 
 ```javascript
-const group = new Group(cfgs);
+// Find the graphics group of the item
+const group = item.getContainer();
+
+// equal to
+const group = item.get('group');
 ```
 
 ## Functions

--- a/docs/api/Group.zh.md
+++ b/docs/api/Group.zh.md
@@ -5,10 +5,15 @@ order: 11
 
 图形分组 Graphics Group（下文简称 Group） 类似于 <a href='https://developer.mozilla.org/zh-CN/docs/Web/SVG/Element/g' target='_blank'>SVG 中的 `<g>` 标签</a>：Group  是用来组合图形对象的容器。在 Group  上添加变换（例如剪裁、旋转、放缩、平移等）会应用到其所有的子元素上。在 Group  上添加属性（例如颜色、位置等）会被其所有的子元素继承。此外， Group 可以多层嵌套使用，因此可以用来定义复杂的对象。关于 Group 更详细的介绍请参考 [图形分组 Group](/zh/docs/manual/advanced/keyconcept/graphics-group) 文档。
 
-## 声明实例
+
+## 获取元素的group
 
 ```javascript
-const group = new Group(cfgs);
+// 获取元素(节点/边/Combo)的图形对象的容器
+const group = item.getContainer();
+
+// 等价于
+const group = item.get('group');
 ```
 
 ## 实例方法

--- a/docs/api/nodeEdge/Item.en.md
+++ b/docs/api/nodeEdge/Item.en.md
@@ -130,7 +130,7 @@ Get the container of the item.
 **Return**
 
 - The type of return value: G.Group;
-- Return the group where the item in.
+- Return the graphics group where the item in.
 
 **Usage**
 

--- a/docs/api/nodeEdge/Item.zh.md
+++ b/docs/api/nodeEdge/Item.zh.md
@@ -132,7 +132,7 @@ item.getBBox();
 **返回值**
 
 - 返回值类型：G.Group；
-- 返回元素所在的 group。
+- 返回元素所在的graphics group。
 
 **用法**
 

--- a/docs/api/nodeEdge/shapeProperties.en.md
+++ b/docs/api/nodeEdge/shapeProperties.en.md
@@ -83,6 +83,37 @@ rect.attr({
     stroke: '#666'
 });
 ```
+### setClip(clipCfg)
+Sets and returns the clip object.
+
+`clipCfg` 
+
+
+| Name | Description | Type | Remark |
+| --- | --- | --- | --- |
+| type | The type of shape of clipping | String | Options: `'circle'`, `'rect'`, `'ellipse'` |
+| x | The x coordinate of the clipping shape | Number | 0 by default. Only takes effect when the `type` is `'circle'`, `'rect'`, or `'ellipse'` |
+| y | The y coordinate of the clipping shape | Number | 0 by default. Only takes effect when the `type` is `'circle'`, `'rect'`, or `'ellipse' |
+| show | Whether to clip the image | Boolean | Do not clip by default. |
+| r | The radius of circle clipping | Number | Takes effect when the `type` is `'circle'` |
+| width | The width of the clipping | Number | Takes effect when the `type` is `'rect'` |
+| height | The height of the clipping | Number | Takes effect when the `type` is `'rect'` |
+| rx | The major radius of the ellipse clipping | Number | Takes effect when the `type` is `'ellipse'` |
+| ry | The minor radius of the ellipse clipping | Number | Takes effect when the `type` is `'ellipse'` |
+
+
+```javascript
+shape.setClip({
+  type: 'circle', // circle, rect, ellipse, Polygon, path clip
+  attrs: {
+    r: 10,
+    x: 0,
+    y: 0,
+  },
+```
+
+### getClip()
+Get the clip object.
 
 
 

--- a/docs/api/nodeEdge/shapeProperties.zh.md
+++ b/docs/api/nodeEdge/shapeProperties.zh.md
@@ -81,6 +81,37 @@ rect.attr({
 });
 ```
 
+### setClip(clipCfg)
+设置并返回裁剪对象。
+
+`clipCfg` 配置项
+
+| 名称 | 含义 | 类型 | 备注 |
+| --- | --- | --- | --- |
+| type | 裁剪的图片形状 | String | 支持 `'circle'`、`'rect'`、`'ellipse'` |
+| x | 裁剪图形的 x 坐标 | Number | 默认为 0，类型为 `'circle'`、`'rect'`、`'ellipse'` 时生效 |
+| y | 裁剪图形的 y 坐标 | Number | 默认为 0，类型为 `'circle'`、`'rect'`、`'ellipse'` 时生效 |
+| show | 是否启用裁剪功能 | Boolean | 默认不裁剪，值为 `false` |
+| r | 剪裁圆形的半径 | Number | 剪裁 type 为  `'circle'` 时生效 |
+| width | 剪裁矩形的宽度 | Number | 剪裁 type 为 `'rect'` 时生效 |
+| height | 剪裁矩形的长度 | Number | 剪裁 type 为 `'rect'` 时生效 |
+| rx | 剪裁椭圆的长轴半径 | Number | 剪裁 type 为 `'ellipse'` 时生效 |
+| ry | 剪裁椭圆的短轴半径 | Number | 剪裁 type 为 `'ellipse'` 时生效 |
+
+用法
+
+```javascript
+shape.setClip({
+  type: 'circle', // 支持 circle、rect、ellipse、Polygon 及自定义 path clip
+  attrs: {
+    r: 10,
+    x: 0,
+    y: 0,
+  },
+```
+
+### getClip()
+获取裁剪对象。
 
 ## 圆图形 Circle
 

--- a/docs/manual/advanced/custom-combo.en.md
+++ b/docs/manual/advanced/custom-combo.en.md
@@ -31,7 +31,7 @@ G6.regitserCombo(
      * Draw the shapes of the Combo.
      * Do not need the label shape, it will be added by the extended class
      * @param  {Object} cfg The configurations of the combo
-     * @param  {G.Group} group The container of the combo
+     * @param  {G.Group} group Graphics group, the container of the shapes of the combo
      * @return {G.Shape} The keyShape of the combo. It can be obtained by combo.get('keyShape')
      * More details about keyShape can be found in Middle-Graph Elements-Graphis Shape and keyShape
      */
@@ -39,7 +39,7 @@ G6.regitserCombo(
     /**
      * The extra operations after drawing the combo. There is no operation in this function by default
      * @param  {Object} cfg The configurations of the combo
-     * @param  {G.Group} group The container of the combo
+     * @param  {G.Group} group Graphics group, the container of the shapes of the combo
      */
     afterDraw(cfg, group) {},
     /**

--- a/docs/manual/advanced/custom-combo.zh.md
+++ b/docs/manual/advanced/custom-combo.zh.md
@@ -23,7 +23,7 @@ G6.registerCombo(
     /**
      * 绘制 Combo 中的图形。不需要为默认的 label 增加图形，父类方法会自动增加 label
      * @param  {Object} cfg Combo 的配置项
-     * @param  {G.Group} group Combo 的容器
+     * @param  {G.Group} group 图形分组，Combo 中的图形对象的容器
      * @return {G.Shape} 返回一个绘制的图形作为 keyShape，通过 combo.get('keyShape') 可以获取。
      * 关于 keyShape 可参考文档 核心概念-节点/边/Combo-图形 Shape 与 keyShape
      */
@@ -31,7 +31,7 @@ G6.registerCombo(
     /**
      * 绘制后的附加操作，默认没有任何操作
      * @param  {Object} cfg Combo 的配置项
-     * @param  {G.Group} group Combo 的容器
+     * @param  {G.Group} group 图形分组，Combo 中的图形对象的容器
      */
     afterDraw(cfg, group) {},
     /**

--- a/docs/manual/advanced/custom-node.en.md
+++ b/docs/manual/advanced/custom-node.en.md
@@ -38,14 +38,14 @@ G6.registerNode(
     /**
      * Draw the node with label
      * @param  {Object} cfg The configurations of the node
-     * @param  {G.Group} group The container of the node
+     * @param  {G.Group} group Graphics group, the container of the shapes of the node
      * @return {G.Shape} The keyShape of the node. It can be obtained by node.get('keyShape')
      */
     draw(cfg, group) {},
     /**
      * The extra operations after drawing the node. There is no operation in this function by default
      * @param  {Object} cfg The configurations of the node
-     * @param  {G.Group} group The container of the node
+     * @param  {G.Group} group Graphics group, the container of the shapes of the node
      */
     afterDraw(cfg, group) {},
     /**

--- a/docs/manual/advanced/custom-node.zh.md
+++ b/docs/manual/advanced/custom-node.zh.md
@@ -33,7 +33,7 @@ G6.registerNode(
     /**
      * 绘制节点，包含文本
      * @param  {Object} cfg 节点的配置项
-     * @param  {G.Group} group 节点的容器
+     * @param  {G.Group} group 图形分组，节点中图形对象的容器
      * @return {G.Shape} 返回一个绘制的图形作为 keyShape，通过 node.get('keyShape') 可以获取。
      * 关于 keyShape 可参考文档 核心概念-节点/边/Combo-图形 Shape 与 keyShape
      */
@@ -41,7 +41,7 @@ G6.registerNode(
     /**
      * 绘制后的附加操作，默认没有任何操作
      * @param  {Object} cfg 节点的配置项
-     * @param  {G.Group} group 节点的容器
+     * @param  {G.Group} group 图形分组，节点中图形对象的容器
      */
     afterDraw(cfg, group) {},
     /**

--- a/docs/manual/advanced/keyconcept/graphics-group.en.md
+++ b/docs/manual/advanced/keyconcept/graphics-group.en.md
@@ -37,10 +37,14 @@ Graphics Group is refered by [Custom Node](/en/docs/manual/advanced/custom-node)
 
 The functions below will be used in [Custom Node](/en/docs/manual/advanced/custom-node) and [Custom Edge](/en/docs/manual/advanced/custom-edge).
 
-### Instantiating a Group
+### Get group of item
 
-```
-const group = new Group(cfgs);
+```javascript
+// Find the graphics group of the item
+const group = item.getContainer();
+
+// equal to
+const group = item.get('group');
 ```
 
 ### Functions of Group

--- a/docs/manual/advanced/keyconcept/graphics-group.zh.md
+++ b/docs/manual/advanced/keyconcept/graphics-group.zh.md
@@ -30,13 +30,16 @@ order: 1
 <br />
 
 ## 如何使用图形分组 Group
+图形分组一般会在[自定义节点](/zh/docs/manual/advanced/custom-node)、[自定义边](/zh/docs/manual/advanced/custom-edge)时用到。Group的完整实例方法请参考[Graphics Group API](/zh/docs/api/Group)。
 
-以下方法将会在[自定义节点](/zh/docs/manual/advanced/custom-node)、[自定义边](/zh/docs/manual/advanced/custom-edge)时用到。
+### 获取元素的group
 
-### 声明实例
+```javascript
+// 获取元素(节点/边/Combo)的图形对象的容器
+const group = item.getContainer();
 
-```
-const group = new Group(cfgs);
+// 等价于
+const group = item.get('group');
 ```
 
 ### 实例方法


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->
1. 订正Graphics group的文档：去掉new Group()；
2. 增加shape上的setClip方法说明。
