### PR TITLE
feat: hide edge & label when drag canvas

### DIFF
--- a/docs/manual/middle/states/defaultBehavior.en.md
+++ b/docs/manual/middle/states/defaultBehavior.en.md
@@ -100,6 +100,7 @@ const graph = new G6.Graph({
 - Configurations: 
   - `type: 'drag-canvas'`;
   - `direction`: The direction of dragging that is allowed. Options: `'x'`, `'y'`, `'both'`. `'both'` by default;
+  - `enableOptimize`: whether enable optimize, `true` by default, when drag canvas will auto hide all edges and the part of node that is not keyShape;
   - `shouldBegin(e)`: Whether allow the behavior happen on the current item (e.item).
 - Related timing events:
   - `canvas:dragstart`: Triggered when drag start. Listened by `graph.on('canvas:dragstart', e => {...})`;

--- a/docs/manual/middle/states/defaultBehavior.zh.md
+++ b/docs/manual/middle/states/defaultBehavior.zh.md
@@ -100,6 +100,7 @@ const graph = new G6.Graph({
 - 配置项：
   - `type: 'drag-canvas'`；
   - `direction`：允许拖拽方向，支持`'x'`，`'y'`，`'both'`，默认方向为 `'both'`；
+  - `enableOptimize`：是否开启优化，开启后拖动画布过程中隐藏所有的边及节点上非 keyShape 部分，默认开启；
   - `shouldBegin(e)`：是否允许触发该操作。
 - 相关时机事件：
   - `canvas:dragstart`：画布拖拽开始时触发，使用 `graph.on('canvas:dragstart', e => {...})` 监听；

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@antv/dom-util": "^2.0.1",
     "@antv/event-emitter": "~0.1.0",
     "@antv/g-base": "^0.4.1",
-    "@antv/g-canvas": "^0.4.3",
+    "@antv/g-canvas": "^0.4.14",
     "@antv/g-math": "^0.1.1",
     "@antv/g-svg": "^0.4.1",
     "@antv/hierarchy": "^0.6.2",

--- a/src/behavior/drag-canvas.ts
+++ b/src/behavior/drag-canvas.ts
@@ -1,5 +1,6 @@
 import { G6Event, IG6GraphEvent } from '../types';
 import { cloneEvent, isNaN } from '../util/base';
+import { IGraph } from '../interface/graph';
 
 const { abs } = Math;
 const DRAG_OFFSET = 10;
@@ -9,6 +10,7 @@ export default {
   getDefaultCfg(): object {
     return {
       direction: 'both',
+      enableOptimize: true
     };
   },
   getEvents(): { [key in G6Event]?: string } {
@@ -69,6 +71,30 @@ export default {
 
     self.origin = { x: e.clientX, y: e.clientY };
     self.dragging = false;
+
+    if (this.enableOptimize) {
+      // 开始拖动时关闭局部渲染
+      this.graph.get('canvas').set('localRefresh', false)
+  
+      // 拖动 canvas 过程中隐藏所有的边及label
+      const graph: IGraph = this.graph
+      const edges = graph.getEdges()
+      for (let i = 0, len = edges.length; i < len; i++) {
+        graph.hideItem(edges[i])
+      }
+  
+      const nodes = graph.getNodes()
+      for (let j = 0, nodeLen = nodes.length; j < nodeLen; j++) {
+        const container = nodes[j].getContainer()
+        const children = container.get('children')
+        for (let child of children) {
+          const isKeyShape = child.get('isKeyShape')
+          if (!isKeyShape) {
+            child.set('visible', false)
+          }
+        }
+      }
+    }
   },
   onMouseMove(e: IG6GraphEvent) {
     const { graph } = this;
@@ -101,8 +127,34 @@ export default {
   },
   onMouseUp(e: IG6GraphEvent) {
     const { graph } = this;
+
     if (this.keydown || e.shape) {
       return;
+    }
+
+    if (this.enableOptimize) {
+      // 拖动结束后显示所有的边
+      const edges = graph.getEdges()
+      for (let i = 0, len = edges.length; i < len; i++) {
+        graph.showItem(edges[i])
+      }
+  
+      const nodes = graph.getNodes()
+      for (let j = 0, nodeLen = nodes.length; j < nodeLen; j++) {
+        const container = nodes[j].getContainer()
+        const children = container.get('children')
+        for (let child of children) {
+          const isKeyShape = child.get('isKeyShape')
+          if (!isKeyShape) {
+            child.set('visible', true)
+          }
+        }
+      }
+
+      setTimeout(() => {
+        // 拖动结束后开启局部渲染
+        graph.get('canvas').set('localRefresh', true)
+      }, 16)
     }
 
     if (!this.dragging) {

--- a/src/graph/controller/event.ts
+++ b/src/graph/controller/event.ts
@@ -195,7 +195,7 @@ export default class EventController {
   private handleMouseMove(evt: IG6GraphEvent, type: string) {
     const { graph, preItem } = this;
     const canvas: Canvas = graph.get('canvas');
-    const item = evt.target === canvas ? null : evt.item;
+    const item = (evt.target as any) === canvas ? null : evt.item;
 
     evt = cloneEvent(evt) as IG6GraphEvent;
 

--- a/tests/unit/behavior/index-spec.ts
+++ b/tests/unit/behavior/index-spec.ts
@@ -99,7 +99,7 @@ describe('Default Behavior', () => {
 
     const dragCanvas: IBehavior = new DragCanvas();
     const config = dragCanvas.getDefaultCfg();
-    expect(config).toEqual({ direction: 'both' });
+    expect(config).toEqual({ direction: 'both', enableOptimize: true });
 
     const events = dragCanvas.getEvents();
     const keys = Object.keys(events);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->
drag-canvas Behavior 增加 enableOptimize 配置项，开启后拖动画布过程中隐藏所有的边及节点上非 keyShape 部分，默认开启。