### PR TITLE
fix: cannot read property getModel of null problem of menu plugin

### DIFF
--- a/src/plugins/menu/index.ts
+++ b/src/plugins/menu/index.ts
@@ -94,8 +94,8 @@ export default class Menu extends Base {
 
     const bbox = container.getBoundingClientRect();
 
-    let x = e.item.getModel().x;
-    let y = e.item.getModel().y;
+    let x = e.item?.getModel().x || e.x; // 当在canvas上非node / edge 元素上点击的时候会报错 TypeError: Cannot read property 'getModel' of null
+    let y = e.item?.getModel().y || e.y; // 当无法获取modal时，使用鼠标在画布位置代替modal位置
 
     // 若菜单超出画布范围，反向
     if (x + bbox.width > width) {


### PR DESCRIPTION
当在canvas上非node / edge 元素上点击的时候会报错 TypeError: Cannot read property 'getModel' of null。
改为当无法获取modal时，使用鼠标在画布位置代替modal位置

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->
