### PR TITLE
feat: add hull to support using contour to include some items

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "site:deploy": "npm run site:build && gh-pages -d public",
     "start": "npm run site:develop",
     "test": "jest",
-    "test-live": "DEBUG_MODE=1 jest --watch  ./tests/unit/plugins/minimap-spec",
+    "test-live": "DEBUG_MODE=1 jest --watch  ./tests/unit/graph/graph-hull-spec.ts",
     "lint-staged:js": "eslint --ext .js,.jsx,.ts,.tsx",
     "watch": "father build -w",
     "cdn": "antv-bin upload -n @antv/g6"

--- a/src/graph/graph.ts
+++ b/src/graph/graph.ts
@@ -3025,7 +3025,7 @@ export default class Graph extends EventEmitter implements IGraph {
     this.undoStack = null
   }
 
-  public addHull(cfg: HullCfg) {
+  public createHull(cfg: HullCfg) {
     let parent = this.get('hullGroup');
     let hullMap = this.get('hullMap')
     if (!hullMap) {
@@ -3039,16 +3039,21 @@ export default class Graph extends EventEmitter implements IGraph {
       parent.toBack()
       this.set('hullGroup', parent)
     }
-    const group = parent.addGroup({
-      id: `${cfg.id}-container`
-    });
-    const hull = new Hull(this, {
-      ...cfg,
-      group
-    })
-    const hullId = hull.id
-    hullMap[hullId] = hull
-    return hull
+    if (hullMap[cfg.id]) {
+      console.warn('Existed hull id.')
+      return hullMap[cfg.id]
+    } else {
+      const group = parent.addGroup({
+        id: `${cfg.id}-container`
+      });
+      const hull = new Hull(this, {
+        ...cfg,
+        group
+      })
+      const hullId = hull.id
+      hullMap[hullId] = hull
+      return hull
+    }
   }
 
   public getHulls() {

--- a/src/graph/graph.ts
+++ b/src/graph/graph.ts
@@ -25,7 +25,8 @@ import {
   ModeOption,
   ModeType,
   States,
-  ComboTree
+  ComboTree,
+  HullCfg
 } from '../types';
 import { getAllNodeInGroups } from '../util/group';
 import { move } from '../util/math';
@@ -46,6 +47,8 @@ import degree from '../algorithm/degree';
 import Stack from '../algorithm/structs/stack'
 import adjMatrix from '../algorithm/adjacent-matrix';
 import floydWarshall from '../algorithm/floydWarshall'
+
+import Hull from '../item/hull'
 
 const NODE = 'node';
 const SVG = 'svg';
@@ -1210,7 +1213,7 @@ export default class Graph extends EventEmitter implements IGraph {
       self.add('edge', edge, false);
     });
 
-    let animate = self.get('animate');
+    const animate = self.get('animate');
     if (self.get('fitView') || self.get('fitCenter')) {
       self.set('animate', false);
     }
@@ -3020,5 +3023,51 @@ export default class Graph extends EventEmitter implements IGraph {
     this.destroyed = true;
     this.redoStack = null
     this.undoStack = null
+  }
+
+  public addHull(cfg: HullCfg) {
+    let parent = this.get('hullGroup');
+    let hullMap = this.get('hullMap')
+    if (!hullMap) {
+      hullMap = {}
+      this.set('hullMap', hullMap)
+    }
+    if (!parent) {
+      parent = this.get('group').addGroup({
+        id: 'hullGroup'
+      })
+      parent.toBack()
+      this.set('hullGroup', parent)
+    }
+    const group = parent.addGroup({
+      id: `${cfg.id}-container`
+    });
+    const hull = new Hull(this, {
+      ...cfg,
+      group
+    })
+    const hullId = hull.id
+    hullMap[hullId] = hull
+    return hull
+  }
+
+  public getHulls() {
+    return this.get('hullMap')
+  }
+
+  public getHullById(hullId: string) {
+    return this.get('hullMap')[hullId]
+  }
+
+  public removeHull(hull: Hull | string) {
+    let hullInstance: Hull;
+    if (isString(hull)) {
+      hullInstance = this.getHullById(hull)
+    } else {
+      hullInstance = hull
+    }
+    let hullMap = this.get('hullMap')
+    delete hullMap[hullInstance.id];
+    hullInstance.destroy()
   }
 }

--- a/src/item/hull.ts
+++ b/src/item/hull.ts
@@ -26,8 +26,8 @@ export default class Hull {
     this.graph = graph
     this.id = this.cfg.id
     this.group = this.cfg.group
-    this.members = cfg.members || []
-    this.nonMembers = cfg.nonMembers || []
+    this.members = this.cfg.members.map(item => isString(item) ? graph.findById(item) : item)
+    this.nonMembers = this.cfg.nonMembers.map(item => isString(item) ? graph.findById(item) : item)
 
     const nodeSize = this.members.length && this.members[0].getKeyShape().getCanvasBBox().width / 2
     this.padding = this.cfg.padding > 0 ? this.cfg.padding + nodeSize : 10 + nodeSize;

--- a/src/item/hull.ts
+++ b/src/item/hull.ts
@@ -1,0 +1,219 @@
+import { IGroup } from '@antv/g-base';
+import { deepMix, isString } from '@antv/util';
+import { Item, BubblesetCfg, HullCfg } from '../types';
+import { getSpline, pathToPoints } from '../util/path';
+import { isPolygonsIntersect } from '../util/math';
+import { IGraph } from '../interface/graph';
+
+import { genConvexHull } from '../shape/hull/convexHull';
+import { genBubbleSet } from '../shape/hull/bubbleset';
+
+export default class Hull {
+  id: string;
+  graph: IGraph;
+  cfg: any;
+  path: any[][];
+  group: IGroup;
+  members: Item[];
+  nonMembers: Item[];
+  bubbleCfg: BubblesetCfg;
+
+  constructor(graph: IGraph, cfg: HullCfg) {
+    this.cfg = deepMix(this.getDefaultCfg(), cfg)
+    this.graph = graph
+    this.id = this.cfg.id
+    this.group = this.cfg.group
+    this.members = cfg.members || []
+    this.nonMembers = cfg.nonMembers || []
+    !isNaN(this.cfg.padding) && (this.cfg.bubbleCfg = {
+      nodeR0: this.cfg.padding,
+      nodeR1: this.cfg.padding * 2,
+      morphBuffer: this.cfg.padding
+    })
+    this.path = this.calcPath(this.members, this.nonMembers)
+    this.render()
+
+    if (this.cfg.autoUpdate) {
+      graph.on('afterremoveitem', e => {
+        this.removeMember(e.item)
+        this.removeNonMember(e.item)
+      })
+      graph.on('afterupdateitem', e => {
+        if (e.item.getContainer().get('capture') && this.members.indexOf(e.item) > -1 || this.nonMembers.indexOf(e.item) > -1) {
+          this.updateData(this.members, this.nonMembers)
+        }
+      })
+      graph.on('node:dragend', e => {
+        const item = e.item;
+        const memberIdx = this.members.indexOf(item)
+        if (memberIdx > -1) {
+          // 如果移出原hull范围，则去掉
+          if (!this.contain(item)) {
+            this.removeMember(item)
+          }
+          else {
+            this.updateData(this.members, this.nonMembers)
+          }
+        } else {
+          if (this.contain(item)) this.addMember(item)
+        }
+      })
+    }
+  }
+
+  public getDefaultCfg(): HullCfg {
+    return {
+      id: 'g6-hull',
+      mode: 'bubble', // 'convex' or 'bubble'
+      name: 'g6-hull',
+      members: [],
+      nonMembers: [],
+      style: {
+        fill: 'lightblue',
+        stroke: 'blue',
+        opacity: 0.2,
+      },
+      autoUpdate: false,
+      bubbleCfg: {
+        nodeR0: 5,
+        nodeR1: 10,
+        morphBuffer: 5
+      }
+    }
+  }
+
+  calcPath(members: Item[], nonMembers: Item[],) {
+    let contour = []
+    if (this.cfg.mode === 'convex') {
+      contour = genConvexHull(members)
+    } else if (this.cfg.mode === 'bubble') {
+      contour = genBubbleSet(members, nonMembers, this.cfg.bubbleCfg)
+    } else {
+      console.warn('Set mode to convex or bubble.')
+    }
+    const path = contour.length >= 2 && getSpline(contour)
+    return path
+  }
+
+  render() {
+    this.group.addShape('path', {
+      attrs: {
+        path: this.path,
+        ...this.cfg.style
+      },
+      id: this.id,
+      name: this.cfg.name,
+    })
+    this.group.toBack()
+  }
+
+  /**
+   * 增加hull的成员，同时如果该成员原先在nonMembers中，则从nonMembers中去掉
+   * @param item 节点实例
+   * @return boolean 添加成功返回 true，否则返回 false
+   */
+  public addMember(item: Item): boolean {
+    if (!item) return;
+    this.members.push(item)
+    const index = this.nonMembers.indexOf(item);
+    if (index > -1) {
+      this.nonMembers.splice(index, 1);
+    }
+    this.updateData(this.members, this.nonMembers)
+    return true;
+  }
+
+  /**
+   * 增加hull需要排除的节点，同时如果该成员原先在members中，则从members中去掉
+   * @param item 节点实例
+   * @return boolean 添加成功返回 true，否则返回 false
+   */
+  public addNonMember(item: Item): boolean {
+    if (!item) return;
+    this.nonMembers.push(item)
+    const index = this.members.indexOf(item);
+    if (index > -1) {
+      this.members.splice(index, 1);
+    }
+    this.updateData(this.members, this.nonMembers)
+    return true;
+  }
+
+  /**
+  * 移除hull中的成员，且添加到nonMembers中
+  * @param node 节点实例
+  * @return boolean 移除成功返回 true，否则返回 false
+  */
+  public removeMember(item: Item): boolean {
+    if (!item) return;
+    const index = this.members.indexOf(item);
+    if (index > -1) {
+      this.members.splice(index, 1);
+      this.nonMembers.push(item)
+      this.updateData(this.members, this.nonMembers)
+      return true;
+    }
+    return false;
+  }
+
+  /**
+  * @param node 节点实例
+  * @return boolean 移除成功返回 true，否则返回 false
+  */
+  public removeNonMember(item: Item): boolean {
+    if (!item) return;
+    const index = this.nonMembers.indexOf(item);
+    if (index > -1) {
+      this.nonMembers.splice(index, 1);
+      this.updateData(this.members, this.nonMembers)
+      return true;
+    }
+    return false;
+  }
+
+  public updateData(members: Item[], nonMembers: Item[]) {
+    this.group.findById(this.id).remove()
+    this.members = members
+    this.nonMembers = nonMembers
+    this.path = this.calcPath(members, nonMembers)
+    this.render()
+  }
+
+  public updateStyle(cfg: HullCfg["style"]) {
+    const path = this.group.findById(this.id)
+    path.attr({
+      ...cfg
+    });
+  }
+
+  /**
+   * 判断是否在hull内部
+   * @param item 
+   */
+  public contain(item: Item | string): boolean {
+    let nodeItem: Item;
+    if (isString(item)) {
+      nodeItem = this.graph.findById(item)
+    } else {
+      nodeItem = item;
+    }
+    let shapePoints;
+    const shape = nodeItem.getKeyShape()
+    if (nodeItem.get('type') === 'path') {
+      shapePoints = pathToPoints(shape.attr('path'))
+    } else {
+      const shapeBBox = shape.getCanvasBBox();
+      shapePoints = [[shapeBBox.minX, shapeBBox.minY], [shapeBBox.maxX, shapeBBox.minY], [shapeBBox.maxX, shapeBBox.maxY], [shapeBBox.minX, shapeBBox.maxY]];
+    }
+    shapePoints = shapePoints.map(canvasPoint => {
+      const point = this.graph.getPointByCanvas(canvasPoint[0], canvasPoint[1])
+      return [point.x, point.y]
+    })
+    return isPolygonsIntersect(shapePoints, pathToPoints(this.path))
+  }
+
+  public destroy() {
+    this.group.remove()
+    this.cfg = null;
+  }
+}

--- a/src/shape/hull/bubbleset.ts
+++ b/src/shape/hull/bubbleset.ts
@@ -1,0 +1,564 @@
+import { IPoint, IBBox, Item, BubblesetCfg } from '../../types'
+import { squareDist, pointLineDist, itemIntersectByLine, getPointsCenter, fractionToLine, isPointsOverlap, getRectDistSq, Line, isPointInPolygon } from '../../util/math'
+
+const defauleOps = {
+  maxRoutingIterations: 100,  // number of times to run the algorithm to refine the path finding in difficult areas
+  maxMarchingIterations: 100, // number of times to refine the boundary
+  pixelGroupSize: 4, // the resolution of the algorithm in square pixels
+  edgeR0: 5, // the distance from edges at which energy is 1 (full influence)
+  edgeR1: 10, // the distance from edges at which energy is 0 (no influence)
+  nodeR0: 5, // the distance from nodes which energy is 1 (full influence)
+  nodeR1: 10, // the distance from nodes at which energy is 0 (no influence)
+  morphBuffer: 5,// DEFAULT_NODE_R0; the amount of space to move the virtual edge when wrapping around obstacles
+  threshold: 0.001,
+  skip: 8,
+  nodeInfluenceFactor: 1,
+  edgeInfluenceFactor: 1,
+  negativeNodeInfluenceFactor: -0.5,
+}
+
+/**
+ * Marching square algorithm for traching the contour of a pixel group
+ * https://www.emanueleferonato.com/2013/03/01/using-marching-squares-algorithm-to-trace-the-contour-of-an-image/
+ * @param potentialArea 
+ * @param threshold 
+ */
+function MarchingSquares(contour, potentialArea, threshold) {
+  let marched = false;
+  const getVal = (x: number, y: number) => {
+    return potentialArea.cells[x + y * potentialArea.width]
+  }
+
+  const getState = (x: number, y: number) => {
+    let squareVal = 0
+    if (getVal(x - 1, y - 1) >= threshold) {
+      squareVal += 1;
+    }
+    if (getVal(x, y - 1) > threshold) {
+      squareVal += 2;
+    }
+    if (getVal(x - 1, y) > threshold) {
+      squareVal += 4;
+    }
+    if (getVal(x, y) > threshold) {
+      squareVal += 8;
+    }
+    return squareVal;
+  }
+
+  const doMarch = (xPos: number, yPos: number) => {
+    let x = xPos;
+    let y = yPos;
+    let prevX;
+    let prevY;
+
+    for (let i = 0; i < potentialArea.width * potentialArea.height; i++) {
+      prevX = x
+      prevY = y
+      if (contour.findIndex(item => item.x === x && item.y === y) > -1) {
+        if (contour[0].x !== x || contour[0].y !== y) {
+          // encountered a loop but haven't returned to start: change direction using conditionals and continue back to start
+        } else {
+          return true;
+        }
+      } else {
+        contour.push({ x, y });
+      }
+
+      const state = getState(x, y);
+      // assign the move direction according to state of the square
+      switch (state) {
+        case -1:
+          console.warn('Marched out of bounds')
+          return true;
+        case 0:
+        case 3:
+        case 2:
+        case 7:
+          x++; // go right
+          break;
+        case 12:
+        case 14:
+        case 4:
+          x--; // go left
+          break;
+        case 6: // go left if come from up else go right
+          (prevX === 0 && prevY === -1) ? x-- : x++
+          break;
+        case 1:
+        case 13:
+        case 5:
+          y--; // go up
+          break;
+        case 9: // go up if come from right else go down
+          (prevX === 1 && prevY === 0) ? y-- : y++
+          break;
+        case 10:
+        case 8:
+        case 11:
+          y++; // go down
+          break;
+        default:
+          console.warn(`Marching squares invalid state: ${state}`);
+          return true;
+      }
+    }
+  }
+
+  this.march = function () {
+    for (let x = 0; x < potentialArea.width && !marched; x += 1) {
+      for (let y = 0; y < potentialArea.height && !marched; y += 1) {
+        if (getVal(x, y) > threshold && getState(x, y) !== 15) {
+          marched = doMarch(x, y);
+        }
+      }
+    }
+    return marched
+  }
+}
+
+/**
+ * Space partition & assign value to each cell
+ * @param points 
+ */
+const initGridCells = (width: number, height: number, pixelGroupSize: number) => {
+  const scaleWidth = Math.ceil(width / pixelGroupSize);
+  const scaleHeight = Math.ceil(height / pixelGroupSize);
+  const gridCells = new Float32Array(Math.max(0, scaleWidth * scaleHeight)).fill(0)
+  return {
+    cells: gridCells,
+    width: scaleWidth,
+    height: scaleHeight
+  }
+}
+
+/**
+ * Find the optimal already visited member to item;
+   Optimal: minimize cost(j) = distance(i,j) ∗ countObstacles(i,j) 
+ * @param item 
+ * @param visited 
+ */
+const pickBestNeighbor = (item: Item, visited: Item[], nonMembers: Item[]): Item | null => {
+  let closestNeighbour = null;
+  let minCost = Number.POSITIVE_INFINITY;
+
+  visited.forEach(neighbourItem => {
+    const itemP = { x: item.getModel().x, y: item.getModel().y }
+    const neighbourItemP = { x: neighbourItem.getModel().x, y: neighbourItem.getModel().y }
+    const dist = squareDist(itemP, neighbourItemP);
+    const directLine = new Line(itemP.x, itemP.y, neighbourItemP.x, neighbourItemP.y);
+    const numberObstacles = nonMembers.reduce((count, _item) => {
+      if (fractionToLine(_item, directLine) > 0) {
+        return count + 1;
+      }
+      return count;
+    }, 0);
+    // console.log(item.getID(), neighbourItem.getID(), numberObstacles)
+    if (dist * ((numberObstacles + 1) ** 2) < minCost) {
+      closestNeighbour = neighbourItem;
+      minCost = dist * ((numberObstacles + 1) ** 2);
+    }
+  });
+  return closestNeighbour
+}
+
+/**
+ * 返回和线相交的item中，离边的起点最近的item
+ * @param items 
+ * @param line 
+ */
+const getIntersectItem = (items: Item[], line: Line): Item | null => {
+  let minDistance = Number.POSITIVE_INFINITY;
+  let closestItem = null;
+
+  items.forEach(item => {
+    const distance = fractionToLine(item, line);
+    // find closest intersection
+    if (distance >= 0 && distance < minDistance) {
+      closestItem = item;
+      minDistance = distance;
+    }
+  });
+  return closestItem;
+}
+
+/**
+ * Modify the directLine and Route virtual edges around obstacles
+ */
+const computeRoute = (directLine: Line, nonMembers: Item[], maxRoutingIterations: number, morphBuffer: number): Line[] => {
+  const checkedLines: Line[] = []
+  const linesToCheck: Line[] = []
+  linesToCheck.push(directLine);
+
+  let hasIntersection = true;
+  let iterations = 0;
+
+  const pointExists = (point: IPoint, lines: Line[]) => {
+    let flag = false
+    lines.forEach((line) => {
+      if (flag) return;
+      if (isPointsOverlap(point, { x: line.x1, y: line.y1 }) || isPointsOverlap(point, { x: line.x2, y: line.y2 })) {
+        flag = true;
+      }
+    });
+    return flag
+  }
+  const isPointInNonMembers = (point: IPoint, _nonMembers: Item[]) => {
+    for (const item of _nonMembers) {
+      const bbox = item.getBBox()
+      const itemContour = [[bbox.x, bbox.y], [bbox.x + bbox.width, bbox.y],
+      [bbox.x, bbox.y + bbox.height], [bbox.x + bbox.width, bbox.y + bbox.height]]
+      if (isPointInPolygon(itemContour, point.x, point.y)) {
+        return true
+      }
+    }
+    return false
+  }
+
+  // outer loop end when no more intersections or out of iterations
+  while (hasIntersection && iterations < maxRoutingIterations) {
+    hasIntersection = false;
+    // inner loop end when out of lines or found an intersection
+    while (!hasIntersection && linesToCheck.length) {
+      const line = linesToCheck.pop();
+      const closestItem = getIntersectItem(nonMembers, line);
+      if (closestItem) {
+        const [intersections, countIntersections] = itemIntersectByLine(closestItem, line)
+        // if line passes through item
+        if (countIntersections === 2) {
+          const testReroute = (isFirst: boolean) => {
+            let tempMorphBuffer = morphBuffer;
+            let virtualNode = rerouteLine(closestItem, tempMorphBuffer, intersections, isFirst);
+            // test the virtualNode already exists
+            let exist = pointExists(virtualNode, linesToCheck) || pointExists(virtualNode, checkedLines);
+            let pointInside = isPointInNonMembers(virtualNode, nonMembers);
+
+            while (!exist && pointInside && (tempMorphBuffer >= 1)) {
+              // try a smaller buffer
+              tempMorphBuffer /= 1.5;
+              virtualNode = rerouteLine(closestItem, tempMorphBuffer, intersections, isFirst);
+              exist = pointExists(virtualNode, linesToCheck) || pointExists(virtualNode, checkedLines);
+              pointInside = isPointInNonMembers(virtualNode, nonMembers);
+            }
+
+            // 第二次route时不要求pointInside
+            if (virtualNode && (!exist) && (!isFirst || !pointInside)) {
+              // add 2 rerouted lines to check
+              linesToCheck.push(new Line(line.x1, line.y1, virtualNode.x, virtualNode.y));
+              linesToCheck.push(new Line(virtualNode.x, virtualNode.y, line.x2, line.y2));
+              hasIntersection = true;
+            }
+          }
+
+          testReroute(true)
+          if (!hasIntersection) { // if we didn't find a valid point around the first corner, try the second
+            testReroute(false)
+          }
+        }
+      }
+
+      // no intersection found, mark this line as completed
+      if (!hasIntersection) {
+        checkedLines.push(line);
+      }
+      iterations += 1;
+    }
+  }
+
+  // 加入剩余的线
+  while (linesToCheck.length) {
+    checkedLines.push(linesToCheck.pop());
+  }
+  return checkedLines
+}
+
+/**
+ *  Connect item with visited members using direct line or virtual edges
+ */
+function getRoute(item: Item, nonMembers: Item[], visited: Item[], maxRoutingIterations: number, morphBuffer: number) {
+  const optimalNeighbor = pickBestNeighbor(item, visited, nonMembers)
+  if (optimalNeighbor === null) {
+    return []
+  }
+
+  //  merge the consecutive lines
+  const mergeLines = (checkedLines: Line[]): Line[] => {
+    const finalRoute: Line[] = [];
+    while (checkedLines.length > 0) {
+      const line1 = checkedLines.pop()!;
+      if (checkedLines.length === 0) {
+        finalRoute.push(line1);
+        break;
+      }
+      const line2 = checkedLines.pop()!;
+      const mergeLine = new Line(line1.x1, line1.y1, line2.x2, line2.y2);
+      const closestItem = getIntersectItem(nonMembers, mergeLine);
+      // merge most recent line and previous line
+      if (!closestItem) {
+        checkedLines.push(mergeLine);
+      } else {
+        finalRoute.push(line1);
+        checkedLines.push(line2);
+      }
+    }
+    return finalRoute;
+  }
+  const directLine = new Line(item.getModel().x, item.getModel().y, optimalNeighbor.getModel().x, optimalNeighbor.getModel().y);
+  const checkedLines = computeRoute(directLine, nonMembers, maxRoutingIterations, morphBuffer);
+  const finalRoute = mergeLines(checkedLines);
+  return finalRoute;
+}
+
+/**
+ * Calculate the countor that includes the  selected items and exclues the non-selected items
+ * @param graph 
+ * @param members 
+ * @param nonMembers 
+ * @param options 
+ */
+export const genBubbleSet = (members: Item[], nonMembers: Item[], ops?: BubblesetCfg) => {
+  // eslint-disable-next-line no-redeclare
+  const options = Object.assign(defauleOps, ops)
+  const centroid = getPointsCenter(members.map(item => ({ x: item.getModel().x, y: item.getModel().y })));
+  // 按照到中心距离远近排序
+  members = members.sort((a, b) => (squareDist({ x: a.getModel().x, y: a.getModel().y }, centroid) - squareDist({ x: b.getModel().x, y: b.getModel().y }, centroid)))
+  const visited: Item[] = [];
+  const virtualEdges: Line[] = [];
+  members.forEach(item => {
+    const lines = getRoute(item, nonMembers, visited, options.maxRoutingIterations, options.morphBuffer);
+    lines.forEach(l => {
+      virtualEdges.push(l);
+    });
+    visited.push(item);
+  });
+  // 由于edge也可以作为member和nonMember传入，暂时不考虑把edges作为参数传入genBubbleSet
+  // edges && edges.forEach(e => {
+  //   virtualEdges.push(new Line(e.getSource().getModel().x, e.getSource().getModel().y, e.getTarget().getModel().x, e.getTarget().getModel().y));
+  // });
+
+  const activeRegion = getActiveRregion(members, virtualEdges, options.nodeR0);
+  const potentialArea = initGridCells(activeRegion.width, activeRegion.height, options.pixelGroupSize)
+
+  // Use march squares to generate contour
+  let contour = [];
+  let hull = [];
+  for (let iterations = 0; iterations < options.maxMarchingIterations; iterations++) {
+    fillPotentialArea(members, nonMembers, virtualEdges, activeRegion, potentialArea, options);
+    contour = []
+    hull = []
+    if (!new MarchingSquares(contour, potentialArea, options.threshold).march()) continue;
+    const marchedPath = contour.map(point => ({ x: Math.round(point.x * options.pixelGroupSize + activeRegion.minX), y: Math.round(point.y * options.pixelGroupSize + activeRegion.minY) }))
+    // const marchedPath = marchingSquares(potentialArea, options.threshold).map(point => ({ x: Math.round(point.x * options.pixelGroupSize + activeRegion.minX), y: Math.round(point.y * options.pixelGroupSize + activeRegion.minY) }))
+    if (marchedPath) {
+      let size = marchedPath.length;
+      if (options.skip > 1) {
+        size = Math.floor(marchedPath.length / options.skip);
+        // if we reduced too much (fewer than three points in reduced surface) reduce skip and try again
+        while ((size < 3) && (options.skip > 1)) {
+          options.skip -= 1;
+          size = Math.floor(marchedPath.length / options.skip);
+        }
+      }
+      // copy hull values
+      for (let i = 0, j = 0; j < size; j += 1, i += options.skip) {
+        hull.push({ x: marchedPath[i].x, y: marchedPath[i].y });
+      }
+      hull.push(hull[0])
+    }
+
+    const isContourValid = () => {
+      for (const item of members) {
+        const hullPoints = hull.map(point => [point.x, point.y])
+        if (!isPointInPolygon(hullPoints, item.getBBox().centerX, item.getBBox().centerY)) return false
+      }
+      // 不强制要求所有nonMembers都没有包含在内
+      // for (const item of nonMembers) {
+      //   if (isPointInPolygon({ x: item.getBBox().centerX, y: item.getBBox().centerY }, contour)) return false
+      // }
+      return true
+    }
+
+    if (hull && isContourValid()) {
+      return hull
+    }
+
+    // update parameters for next iteraction
+    options.threshold *= 0.9;
+    if (iterations <= options.maxMarchingIterations * 0.5) {
+      options.memberInfluenceFactor *= 1.2;
+      options.edgeInfluenceFactor *= 1.2;
+    } else if (options.nonMemberInfluenceFactor !== 0 && nonMembers.length > 0) {
+      // after half the iterations, start increasing positive energy and lowering the threshold
+      options.nonMemberInfluenceFactor *= 0.8;
+    } else {
+      break;
+    }
+  }
+  return hull
+}
+
+/**
+ * unionboundingbox
+ * @param members 
+ * @param edges 
+ */
+function getActiveRregion(members: Item[], edges: Line[], offset: number): IBBox {
+  const activeRegion = {
+    minX: Number.POSITIVE_INFINITY,
+    minY: Number.POSITIVE_INFINITY,
+    maxX: Number.NEGATIVE_INFINITY,
+    maxY: Number.NEGATIVE_INFINITY,
+    width: 0,
+    height: 0,
+    x: 0,
+    y: 0
+  }
+  const bboxes = []
+
+  members.forEach(item => {
+    bboxes.push(item.getBBox())
+  })
+  edges.forEach(l => {
+    bboxes.push(l.getBBox());
+  });
+
+  for (const bbox of bboxes) {
+    activeRegion.minX = (bbox.minX < activeRegion.minX ? bbox.minX : activeRegion.minX) - offset;
+    activeRegion.minY = (bbox.minY < activeRegion.minY ? bbox.minY : activeRegion.minY) - offset;
+    activeRegion.maxX = (bbox.maxX > activeRegion.maxX ? bbox.maxX : activeRegion.maxX) + offset;
+    activeRegion.maxY = (bbox.maxY > activeRegion.maxY ? bbox.maxY : activeRegion.maxY) + offset;
+  }
+  activeRegion.width = activeRegion.maxX - activeRegion.minX
+  activeRegion.height = activeRegion.maxY - activeRegion.minY
+  activeRegion.x = activeRegion.minX
+  activeRegion.y = activeRegion.minY
+  return activeRegion
+}
+
+function fillPotentialArea(members: Item[], nonMembers: Item[], edges: Line[], activeRegion: IBBox, potentialArea, options: BubblesetCfg) {
+  function pos2GridIx(x, offset) {
+    const gridIx = Math.floor((x - offset) / options.pixelGroupSize)
+    return gridIx < 0 ? 0 : gridIx
+  }
+
+  function gridIx2Pos(x, offset) {
+    return x * options.pixelGroupSize + offset
+  }
+
+  // using inverse a for numerical stability
+  const nodeInfA = (options.nodeR0 - options.nodeR1) * (options.nodeR0 - options.nodeR1);
+  const edgeInfA = (options.edgeR0 - options.edgeR1) * (options.edgeR0 - options.edgeR1);
+
+  const getAffectedRegion = (bbox, thresholdR) => {
+    const startX = Math.min(pos2GridIx(bbox.minX, thresholdR + activeRegion.minX), potentialArea.width);
+    const startY = Math.min(pos2GridIx(bbox.minY, thresholdR + activeRegion.minY), potentialArea.height);
+    const endX = Math.min(pos2GridIx(bbox.maxX, -thresholdR + activeRegion.minX), potentialArea.width);
+    const endY = Math.min(pos2GridIx(bbox.maxY, -thresholdR + activeRegion.minY), potentialArea.height);
+    return [startX, startY, endX, endY]
+  }
+  const addItemInfluence = (item: Item, influenceFactor: number) => {
+    const bbox = item.getBBox();
+    const [startX, startY, endX, endY] = getAffectedRegion(bbox, options.nodeR1)
+    // console.log(startX, startY, endX, endY)
+    // calculate item influence for each cell
+    for (let y = startY; y < endY; y += 1) {
+      for (let x = startX; x < endX; x += 1) {
+        if (influenceFactor < 0 && potentialArea[x + y * potentialArea.width] <= 0) {
+          continue;
+        }
+        const tempX = gridIx2Pos(x, activeRegion.minX);
+        const tempY = gridIx2Pos(y, activeRegion.minY);
+        const distanceSq = getRectDistSq(item, tempX, tempY);
+        // console.log(distanceSq)
+        // only influence if less than r1
+        if (distanceSq < options.nodeR1 ** 2) {
+          const dr = Math.sqrt(distanceSq) - options.nodeR1;
+          potentialArea.cells[x + y * potentialArea.width] += influenceFactor * dr * dr;
+        }
+      }
+    }
+  }
+
+  const addEdgeInfluence = (line: Line, influenceFactor: number) => {
+    const bbox = line.getBBox();
+    const [startX, startY, endX, endY] = getAffectedRegion(bbox, options.edgeR1)
+    // for every point in active part of potentialArea, calculate distance to nearest point on line and add influence
+    for (let y = startY; y < endY; y += 1) {
+      for (let x = startX; x < endX; x += 1) {
+        if (influenceFactor < 0 && potentialArea.cells[x + y * potentialArea.width] <= 0) {
+          continue;
+        }
+        const tempX = gridIx2Pos(x, activeRegion.minX);
+        const tempY = gridIx2Pos(y, activeRegion.minY);
+        const minDistanceSq = pointLineDist({ x: tempX, y: tempY }, line);
+        // only influence if less than r1
+        if (minDistanceSq < options.edgeR1 ** 2) {
+          const mdr = Math.sqrt(minDistanceSq) - options.edgeR1;
+          potentialArea.cells[x + y * potentialArea.width] += influenceFactor * mdr * mdr;
+        }
+      }
+    }
+  }
+
+  if (options.nodeInfluenceFactor) {
+    members.forEach(item => {
+      addItemInfluence(item, options.nodeInfluenceFactor / nodeInfA)
+    });
+  }
+
+  if (options.edgeInfluenceFactor) {
+    edges.forEach(edge => {
+      addEdgeInfluence(edge, options.edgeInfluenceFactor / edgeInfA)
+    })
+  }
+  if (options.negativeNodeInfluenceFactor) {
+    nonMembers.forEach(item => {
+      addItemInfluence(item, options.negativeNodeInfluenceFactor / nodeInfA)
+    });
+  }
+}
+
+function rerouteLine(item, buffer: number, intersections: IPoint[], wrapNormal: boolean): IPoint {
+  const bbox = item.getBBox();
+  const [topIntersect, leftIntersect, bottomIntersect, rightIntersect] = intersections;
+  const cornerPos = {
+    'topLeft': { x: bbox.minX - buffer, y: bbox.minY - buffer },
+    'topRight': { x: bbox.maxX + buffer, y: bbox.minY - buffer },
+    'bottomLeft': { x: bbox.minX - buffer, y: bbox.maxY + buffer },
+    'bottomRight': { x: bbox.maxX + buffer, y: bbox.maxY + buffer }
+  }
+
+  const totalArea = bbox.height * bbox.width;
+  function calcHalfArea(intersect1, intersect2) {
+    return bbox.width * (((intersect1.y - bbox.minY) + (intersect2.y - bbox.minY)) * 0.5)
+  }
+
+  // 根据线和boundingbox相交的情况，确定control point的位置
+  if (leftIntersect) {
+    // 相交区域有三角形
+    if (topIntersect) return wrapNormal ? cornerPos.topLeft : cornerPos.bottomRight;
+    if (bottomIntersect) return wrapNormal ? cornerPos.bottomLeft : cornerPos.topRight;
+    // 相交区域分成上下两个梯形，比较面积
+    const topArea = calcHalfArea(leftIntersect, rightIntersect);
+    if (topArea < totalArea * 0.5) {
+      if (leftIntersect.y > rightIntersect.y) return wrapNormal ? cornerPos.topLeft : cornerPos.bottomRight;
+      return wrapNormal ? cornerPos.topRight : cornerPos.bottomLeft;
+    }
+    if (leftIntersect.y < rightIntersect.y) return wrapNormal ? cornerPos.bottomLeft : cornerPos.topRight;
+    return wrapNormal ? cornerPos.bottomRight : cornerPos.topLeft;
+  }
+
+  if (rightIntersect) {
+    if (topIntersect) return wrapNormal ? cornerPos.topRight : cornerPos.bottomLeft;
+    if (bottomIntersect) return wrapNormal ? cornerPos.bottomRight : cornerPos.topLeft;
+  }
+
+  // 相交区域分成左右两个梯形
+  const leftArea = calcHalfArea(topIntersect, bottomIntersect);;
+  if (leftArea < totalArea * 0.5) {
+    if (topIntersect.x > bottomIntersect.x) return wrapNormal ? cornerPos.topLeft : cornerPos.bottomRight;
+    return wrapNormal ? cornerPos.bottomLeft : cornerPos.topRight;
+  }
+  if (topIntersect.x < bottomIntersect.x) return wrapNormal ? cornerPos.topRight : cornerPos.bottomLeft;
+  return wrapNormal ? cornerPos.bottomRight : cornerPos.topLeft;
+}

--- a/src/shape/hull/bubbleset.ts
+++ b/src/shape/hull/bubbleset.ts
@@ -4,14 +4,14 @@ import { squareDist, pointLineDist, itemIntersectByLine, getPointsCenter, fracti
 const defauleOps = {
   maxRoutingIterations: 100,  // number of times to run the algorithm to refine the path finding in difficult areas
   maxMarchingIterations: 100, // number of times to refine the boundary
-  pixelGroupSize: 4, // the resolution of the algorithm in square pixels
-  edgeR0: 5, // the distance from edges at which energy is 1 (full influence)
+  pixelGroupSize: 2, // the resolution of the algorithm in square pixels
+  edgeR0: 10, // the distance from edges at which energy is 1 (full influence)
   edgeR1: 10, // the distance from edges at which energy is 0 (no influence)
   nodeR0: 5, // the distance from nodes which energy is 1 (full influence)
   nodeR1: 10, // the distance from nodes at which energy is 0 (no influence)
   morphBuffer: 5,// DEFAULT_NODE_R0; the amount of space to move the virtual edge when wrapping around obstacles
   threshold: 0.001,
-  skip: 8,
+  skip: 16,
   nodeInfluenceFactor: 1,
   edgeInfluenceFactor: 1,
   negativeNodeInfluenceFactor: -0.5,
@@ -363,7 +363,6 @@ export const genBubbleSet = (members: Item[], nonMembers: Item[], ops?: Bubblese
       for (let i = 0, j = 0; j < size; j += 1, i += options.skip) {
         hull.push({ x: marchedPath[i].x, y: marchedPath[i].y });
       }
-      hull.push(hull[0])
     }
 
     const isContourValid = () => {

--- a/src/shape/hull/convexHull.ts
+++ b/src/shape/hull/convexHull.ts
@@ -1,0 +1,41 @@
+import { IPoint, Item } from '../../types'
+
+/**
+ * Use cross product to judge the direction of the turn.
+ * Returns a positive value, if OAB makes a clockwise turn, 
+ * negative for counter-clockwise turn, and zero if the points are collinear.
+ */
+export const cross = (a: IPoint, b: IPoint, o: IPoint) => {
+  return (a.y - o.y) * (b.x - o.x) - (a.x - o.x) * (b.y - o.y)
+}
+
+/**
+ * Generate a convex hull of given points. Andrew's monotone chain algorithm. 
+ * @param points An array of [x, y] representing the coordinates of points.
+ * @return a list of vertices of the convex hull in counter-clockwise order,
+ */
+export const genConvexHull = (items: Item[]) => {
+  const points: IPoint[] = items.map(item => ({ x: item.getModel().x, y: item.getModel().y }))
+  points.sort((a, b) => {
+    return a.x === b.x ? a.y - b.y : a.x - b.x;
+  });
+
+  // build the lower hull 
+  const lower = []
+  for (let i = 0; i < points.length; i++) {
+    while (lower.length >= 2 && cross(lower[lower.length - 2], lower[lower.length - 1], points[i]) <= 0) {
+      lower.pop();
+    }
+    lower.push(points[i]);
+  }
+
+  // build the upper hull
+  const upper = [];
+  for (let i = points.length - 1; i >= 0; i--) {
+    while (upper.length >= 2 && cross(upper[upper.length - 2], upper[upper.length - 1], points[i]) <= 0) {
+      upper.pop();
+    }
+    upper.push(points[i]);
+  }
+  return lower.concat(upper);
+}

--- a/src/shape/hull/convexHull.ts
+++ b/src/shape/hull/convexHull.ts
@@ -37,5 +37,8 @@ export const genConvexHull = (items: Item[]) => {
     }
     upper.push(points[i]);
   }
-  return lower.concat(upper);
+  upper.pop();
+  lower.pop();
+  const strictHull = lower.concat(upper);
+  return strictHull;
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -673,7 +673,7 @@ export interface HullCfg {
   members?: Item[],
   nonMembers?: Item[],
   group?: Group,
-  mode?: string, // 'convex' or 'bubble'
+  type?: string, // 'round-convex' /'smooth-convex' / 'bubble'
   name?: string,
   padding?: number,
   style?: {
@@ -681,7 +681,7 @@ export interface HullCfg {
     stroke?: string,
     opacity?: number
   },
-  autoUpdate?: boolean, // 是否支持拖动和更新节点时，对hull进行动态更新
+  update?: string, // 'auto' / 'drag' / 'none' : 自动更新/ 拖拽调整member / 不更新
   bubbleCfg?: BubblesetCfg
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -6,7 +6,7 @@ import Node from '../item/node';
 import { IGraph } from '../interface/graph';
 import { IEdge, INode, ICombo } from '../interface/item';
 import { ILabelConfig } from '../interface/shape';
-import Group from '@antv/g-canvas/lib/group';
+import { IGroup } from '@antv/g-base'
 
 // Math types
 export interface IPoint {
@@ -672,32 +672,29 @@ export interface HullCfg {
   id: string,
   members?: Item[] | string[], // 节点实例或节点 Id 数组
   nonMembers?: Item[] | string[],
-  group?: Group,
-  type?: string, // 'round-convex' /'smooth-convex' / 'bubble'
-  name?: string,
-  padding?: number,
+  group?: IGroup,
+  type?: string, // 'round-convex'(圆角凸包) /'smooth-convex'(平滑凸包) / 'bubble'(平滑凹包),
+  padding?: number, // 轮廓边缘和内部成员间距
   style?: {
     fill?: string,
     stroke?: string,
     opacity?: number
   },
-  update?: string, // 'auto' / 'drag' / 'none' : 自动更新/ 拖拽调整member / 不更新
-  bubbleCfg?: BubblesetCfg
+  bubbleCfg?: BubblesetCfg // 用于更精细控制bubble的效果（点和边轮廓的松弛程度，轮廓粒度），一般不需要配置
 }
 
 export interface BubblesetCfg {
-  morphBuffer?: number;
-  threshold?: number;
-  pixelGroupSize?: number;
-  maxMarchingIterations?: number;
-  maxRoutingIterations?: number;
-  nodeR0?: number;
-  nodeR1?: number;
-  edgeR0?: number;
-  edgeR1?: number;
-  nodeInfluenceFactor?: number;
-  edgeInfluenceFactor?: number;
-  negativeNodeInfluenceFactor?: number;
-  memberInfluenceFactor?: number;
-  nonMemberInfluenceFactor?: number;
+  morphBuffer?: number; // DEFAULT_NODE_R0; the amount of space to move the virtual edge when wrapping around obstacles
+  pixelGroupSize?: number; // the resolution of the algorithm in square pixels, 4 by default
+  maxMarchingIterations?: number; // number of times to refine the boundary, 100 by default
+  maxRoutingIterations?: number;  // number of times to run the algorithm to refine the path finding in difficult areas
+  nodeR0?: number; // the distance from nodes which energy is 1 (full influence)
+  nodeR1?: number;  // the distance from nodes at which energy is 0 (no influence)
+  edgeR0?: number; // the distance from edges at which energy is 1 (full influence)
+  edgeR1?: number; // the distance from edges at which energy is 0 (no influence)
+  nodeInfluenceFactor?: number; // node influence factor
+  negativeNodeInfluenceFactor?: number; // negativeNode influence factor
+  edgeInfluenceFactor?: number; // edge influence factor
+  memberInfluenceFactor?: number; // member influence factor
+  nonMemberInfluenceFactor?: number; // nonMember influence factor
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -6,6 +6,7 @@ import Node from '../item/node';
 import { IGraph } from '../interface/graph';
 import { IEdge, INode, ICombo } from '../interface/item';
 import { ILabelConfig } from '../interface/shape';
+import Group from '@antv/g-canvas/lib/group';
 
 // Math types
 export interface IPoint {
@@ -665,4 +666,38 @@ export interface IAlgorithmCallbacks {
 export interface StackData {
   action: string;
   data: GraphData;
+}
+
+export interface HullCfg {
+  id: string,
+  members?: Item[],
+  nonMembers?: Item[],
+  group?: Group,
+  mode?: string, // 'convex' or 'bubble'
+  name?: string,
+  padding?: number,
+  style?: {
+    fill?: string,
+    stroke?: string,
+    opacity?: number
+  },
+  autoUpdate?: boolean, // 是否支持拖动和更新节点时，对hull进行动态更新
+  bubbleCfg?: BubblesetCfg
+}
+
+export interface BubblesetCfg {
+  morphBuffer?: number;
+  threshold?: number;
+  pixelGroupSize?: number;
+  maxMarchingIterations?: number;
+  maxRoutingIterations?: number;
+  nodeR0?: number;
+  nodeR1?: number;
+  edgeR0?: number;
+  edgeR1?: number;
+  nodeInfluenceFactor?: number;
+  edgeInfluenceFactor?: number;
+  negativeNodeInfluenceFactor?: number;
+  memberInfluenceFactor?: number;
+  nonMemberInfluenceFactor?: number;
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -670,8 +670,8 @@ export interface StackData {
 
 export interface HullCfg {
   id: string,
-  members?: Item[],
-  nonMembers?: Item[],
+  members?: Item[] | string[], // 节点实例或节点 Id 数组
+  nonMembers?: Item[] | string[],
   group?: Group,
   type?: string, // 'round-convex' /'smooth-convex' / 'bubble'
   name?: string,

--- a/src/util/math.ts
+++ b/src/util/math.ts
@@ -2,8 +2,9 @@ import { Point } from '@antv/g-base/lib/types';
 import { IGroup } from '@antv/g-canvas/lib/interfaces';
 import { mat3, transform, vec3 } from '@antv/matrix-util';
 import isArray from '@antv/util/lib/is-array';
-import { GraphData, ICircle, IEllipse, IRect, Matrix, EdgeConfig, NodeIdxMap, IBBox } from '../types';
+import { GraphData, ICircle, IEllipse, IRect, Matrix, EdgeConfig, NodeIdxMap, IBBox, Item, IPoint } from '../types';
 import { each } from '@antv/util';
+
 
 /**
  * 是否在区间内
@@ -22,7 +23,7 @@ const isBetween = (value: number, min: number, max: number) => value >= min && v
  * @param  {Point}  p3 第二条线段终点
  * @return {Point}  交点
  */
-const getLineIntersect = (p0: Point, p1: Point, p2: Point, p3: Point): Point | null => {
+export const getLineIntersect = (p0: Point, p1: Point, p2: Point, p3: Point): Point | null => {
   const tolerance = 0.001;
 
   const E: Point = {
@@ -569,4 +570,153 @@ export const isPolygonsIntersect = (points1: number[][], points2: number[][]): b
     }
   });
   return isIntersect;
+}
+
+export class Line {
+  public x1: number;
+  public y1: number;
+  public x2: number;
+  public y2: number;
+  constructor(x1, y1, x2, y2) {
+    this.x1 = x1;
+    this.y1 = y1;
+    this.x2 = x2;
+    this.y2 = y2;
+  }
+  public getBBox() {
+    const minX = Math.min(this.x1, this.x2);
+    const minY = Math.min(this.y1, this.y2);
+    const maxX = Math.max(this.x1, this.x2);
+    const maxY = Math.max(this.y1, this.y2);
+    const res = {
+      x: minX,
+      y: minY,
+      minX,
+      minY,
+      maxX,
+      maxY,
+      width: maxX - minX,
+      height: maxY - minY,
+    };
+    return res;
+  }
+}
+
+export const getBBoxBoundLine = (bbox: IBBox, direction: string) => {
+  const bounds = {
+    'top': [bbox.minX, bbox.minY, bbox.maxX, bbox.minY],
+    'left': [bbox.minX, bbox.minY, bbox.minX, bbox.maxY],
+    'bottom': [bbox.minX, bbox.maxY, bbox.maxX, bbox.maxY],
+    'right': [bbox.maxX, bbox.minY, bbox.maxX, bbox.maxY]
+  }
+  return bounds[direction]
+}
+
+/**
+ * 计算两条线段相交时，相交点对第一条线段上的分割比例
+ */
+const fractionAlongLineA = (la: Line, lb: Line) => {
+  const uaT = (lb.x2 - lb.x1) * (la.y1 - lb.y1) - (lb.y2 - lb.y1) * (la.x1 - lb.x1);
+  const ubT = (la.x2 - la.x1) * (la.y1 - lb.y1) - (la.y2 - la.y1) * (la.x1 - lb.x1);
+  const uB = (lb.y2 - lb.y1) * (la.x2 - la.x1) - (lb.x2 - lb.x1) * (la.y2 - la.y1);
+  if (uB) {
+    const ua = uaT / uB;
+    const ub = ubT / uB;
+    if (ua >= 0 && ua <= 1 && ub >= 0 && ub <= 1) {
+      return ua;
+    }
+  }
+  return Number.POSITIVE_INFINITY;
+}
+
+export const itemIntersectByLine = (item: Item, line: Line): [IPoint[], number] => {
+  const directions = ['top', 'left', 'bottom', 'right']
+  const bbox = item.getBBox();
+  let countIntersections = 0;
+  const intersections = []
+
+  for (let i = 0; i < 4; i++) {
+    const [x1, y1, x2, y2] = getBBoxBoundLine(bbox, directions[i])
+    intersections[i] = getLineIntersect({ x: line.x1, y: line.y1 }, { x: line.x2, y: line.y2 }, { x: x1, y: y1 }, { x: x2, y: y2 });
+    if (intersections[i]) {
+      countIntersections += 1;
+    }
+  }
+  return [intersections, countIntersections]
+}
+
+export const fractionToLine = (item: Item, line: Line) => {
+  const directions = ['top', 'left', 'bottom', 'right']
+  const bbox = item.getBBox();
+  let minDistance = Number.POSITIVE_INFINITY;
+  let countIntersections = 0;
+  for (let i = 0; i < 4; i++) {
+    const [x1, y1, x2, y2] = getBBoxBoundLine(bbox, directions[i])
+    let testDistance = fractionAlongLineA(line, new Line(x1, y1, x2, y2));
+    testDistance = Math.abs(testDistance - 0.5);
+    if ((testDistance >= 0) && (testDistance <= 1)) {
+      countIntersections += 1;
+      minDistance = testDistance < minDistance ? testDistance : minDistance;
+    }
+  }
+
+  if (countIntersections === 0) return -1;
+  return minDistance;
+}
+
+export const getPointsCenter = (points: IPoint[]): IPoint => {
+  let centerX = 0;
+  let centerY = 0;
+  if (points.length > 0) {
+    for (const point of points) {
+      centerX += point.x
+      centerY += point.y
+    }
+    centerX /= points.length
+    centerY /= points.length
+  }
+  return { x: centerX, y: centerY }
+}
+
+export const squareDist = (a: IPoint, b: IPoint): number => {
+  return (a.x - b.x) ** 2 + (a.y - b.y) ** 2
+}
+
+export const pointLineDist = (point: IPoint, line: Line) => {
+  const x1 = line.x1;
+  const y1 = line.y1;
+  const x2 = line.x2 - x1;
+  const y2 = line.y2 - y1;
+  let px = point.x - x1;
+  let py = point.y - y1;
+  let dotprod = px * x2 + py * y2;
+  let projlenSq;
+  if (dotprod <= 0) {
+    projlenSq = 0;
+  } else {
+    px = x2 - px;
+    py = y2 - py;
+    dotprod = px * x2 + py * y2;
+    if (dotprod <= 0) {
+      projlenSq = 0;
+    } else {
+      projlenSq = dotprod * dotprod / (x2 * x2 + y2 * y2);
+    }
+  }
+  let lenSq = px * px + py * py - projlenSq;
+  if (lenSq < 0) {
+    lenSq = 0;
+  }
+  return lenSq;
+}
+
+export const isPointsOverlap = (p1, p2, e = 1e-3) => {
+  return (p1.x - p2.x) ** 2 + (p1.y - p2.y) ** 2 < e ** 2
+}
+
+export const getRectDistSq = (item: Item, x: number, y: number) => {
+  const rect = item.getBBox()
+  const dx = Math.max(rect.minX - x, 0, x - rect.maxX);
+  const dy = Math.max(rect.minY - y, 0, y - rect.maxY);
+  return Math.sqrt(dx * dx + dy * dy);
 }

--- a/src/util/math.ts
+++ b/src/util/math.ts
@@ -577,7 +577,7 @@ export class Line {
   public y1: number;
   public x2: number;
   public y2: number;
-  constructor(x1, y1, x2, y2) {
+  constructor(x1: number, y1: number, x2: number, y2: number) {
     this.x1 = x1;
     this.y1 = y1;
     this.x2 = x2;

--- a/src/util/path.ts
+++ b/src/util/path.ts
@@ -138,20 +138,20 @@ export const getClosedSpline = (points: IPoint[]) => {
   points.push(second)
 
   let closedPath = []
-  for (var i = 1; i < points.length - 2; i += 1) {
-    var x0 = points[i - 1].x;
-    var y0 = points[i - 1].y;
-    var x1 = points[i].x;
-    var y1 = points[i].y;
-    var x2 = points[i + 1].x;
-    var y2 = points[i + 1].y;
-    var x3 = i !== points.length - 2 ? points[i + 2].x : x2;
-    var y3 = i !== points.length - 2 ? points[i + 2].y : y2;
+  for (let i = 1; i < points.length - 2; i += 1) {
+    let x0 = points[i - 1].x;
+    let y0 = points[i - 1].y;
+    let x1 = points[i].x;
+    let y1 = points[i].y;
+    let x2 = points[i + 1].x;
+    let y2 = points[i + 1].y;
+    let x3 = i !== points.length - 2 ? points[i + 2].x : x2;
+    let y3 = i !== points.length - 2 ? points[i + 2].y : y2;
 
-    var cp1x = x1 + (x2 - x0) / 6;
-    var cp1y = y1 + (y2 - y0) / 6;
-    var cp2x = x2 - (x3 - x1) / 6;
-    var cp2y = y2 - (y3 - y1) / 6;
+    let cp1x = x1 + (x2 - x0) / 6;
+    let cp1y = y1 + (y2 - y0) / 6;
+    let cp2x = x2 - (x3 - x1) / 6;
+    let cp2y = y2 - (y3 - y1) / 6;
     closedPath.push(["C", cp1x, cp1y, cp2x, cp2y, x2, y2]);
   }
   closedPath.unshift(['M', last.x, last.y]);
@@ -164,8 +164,11 @@ const vecScaleTo = (v: number[], length: number) => { // Vector with direction o
 
 const unitNormal = (p0: number[], p1: number[]) => {
   // Returns the unit normal to the line segment from p0 to p1.
-  var n = [p0[1] - p1[1], p1[0] - p0[0]];
-  var nLength = Math.sqrt(n[0] * n[0] + n[1] * n[1]);
+  let n = [p0[1] - p1[1], p1[0] - p0[0]];
+  let nLength = Math.sqrt(n[0] * n[0] + n[1] * n[1]);
+  if (nLength === 0) {
+    throw new Error('p0 should not be equal to p1')
+  }
   return [n[0] / nLength, n[1] / nLength];
 };
 
@@ -179,28 +182,24 @@ const vecFrom = (p0: number[], p1: number[]) => {               // Vector from p
  */
 export function roundedHull(polyPoints: number[][], padding: number) {
   // The rounded hull path around a single point
-  const roundedHull1 = (polyPoints) => {
-    var p1 = [polyPoints[0][0], polyPoints[0][1] - padding];
-    var p2 = [polyPoints[0][0], polyPoints[0][1] + padding];
+  const roundedHull1 = (polyPoints: number[][]) => {
+    let p1 = [polyPoints[0][0], polyPoints[0][1] - padding];
+    let p2 = [polyPoints[0][0], polyPoints[0][1] + padding];
 
-    return 'M ' + p1
-      + ' A ' + [padding, padding, '0,0,0', p2].join(',')
-      + ' A ' + [padding, padding, '0,0,0', p1].join(',');
+    return `M ${p1} A ${padding},${padding},0,0,0,${p2} A ${padding},${padding},0,0,0,${p1}`;
   };
 
   // The rounded hull path around two points
-  const roundedHull2 = (polyPoints) => {
-    var offsetVector = vec2.scale([], unitNormal(polyPoints[0], polyPoints[1]), padding);
-    var invOffsetVector = vec2.scale([], offsetVector, -1);
+  const roundedHull2 = (polyPoints: number[][]) => {
+    let offsetVector = vec2.scale([], unitNormal(polyPoints[0], polyPoints[1]), padding);
+    let invOffsetVector = vec2.scale([], offsetVector, -1);
 
-    var p0 = vec2.add([], polyPoints[0], offsetVector);
-    var p1 = vec2.add([], polyPoints[1], offsetVector);
-    var p2 = vec2.add([], polyPoints[1], invOffsetVector);
-    var p3 = vec2.add([], polyPoints[0], invOffsetVector);
+    let p0 = vec2.add([], polyPoints[0], offsetVector);
+    let p1 = vec2.add([], polyPoints[1], offsetVector);
+    let p2 = vec2.add([], polyPoints[1], invOffsetVector);
+    let p3 = vec2.add([], polyPoints[0], invOffsetVector);
 
-    return 'M ' + p0
-      + ' L ' + p1 + ' A ' + [padding, padding, '0,0,0', p2].join(',')
-      + ' L ' + p3 + ' A ' + [padding, padding, '0,0,0', p0].join(',');
+    return `M ${p0} L ${p1} A ${[padding, padding, '0,0,0', p2].join(',')} L ${p3} A ${[padding, padding, '0,0,0', p0].join(',')}`;
   };
 
   // 特殊情况处理：节点数小于等于2
@@ -208,25 +207,25 @@ export function roundedHull(polyPoints: number[][], padding: number) {
   if (polyPoints.length === 1) return roundedHull1(polyPoints);
   if (polyPoints.length === 2) return roundedHull2(polyPoints);
 
-  var segments = new Array(polyPoints.length);
+  let segments = new Array(polyPoints.length);
 
   // Calculate each offset (outwards) segment of the convex hull.
-  for (var segmentIndex = 0; segmentIndex < segments.length; ++segmentIndex) {
-    var p0 = (segmentIndex === 0) ? polyPoints[polyPoints.length - 1] : polyPoints[segmentIndex - 1];
-    var p1 = polyPoints[segmentIndex];
+  for (let segmentIndex = 0; segmentIndex < segments.length; ++segmentIndex) {
+    let p0 = (segmentIndex === 0) ? polyPoints[polyPoints.length - 1] : polyPoints[segmentIndex - 1];
+    let p1 = polyPoints[segmentIndex];
 
     // Compute the offset vector for the line segment, with length = padding.
-    var offset = vec2.scale([], unitNormal(p0, p1), padding);
+    let offset = vec2.scale([], unitNormal(p0, p1), padding);
 
     segments[segmentIndex] = [vec2.add([], p0, offset), vec2.add([], p1, offset)];
   }
 
-  var arcData = 'A ' + [padding, padding, '0,0,0,'].join(',');
+  let arcData = `A ${[padding, padding, '0,0,0,'].join(',')}`;
 
   segments = segments.map(function (segment, index) {
-    var pathFragment = "";
+    let pathFragment = "";
     if (index === 0) {
-      var pathFragment = 'M ' + segments[segments.length - 1][1] + ' ';
+      pathFragment = `M ${segments[segments.length - 1][1]} `;
     }
     pathFragment += arcData + segment[0] + ' L ' + segment[1];
 
@@ -238,39 +237,34 @@ export function roundedHull(polyPoints: number[][], padding: number) {
 
 // Returns the SVG path data string representing the polygon, expanded and smoothed.
 export function paddedHull(polyPoints: number[][], padding: number) {
-  var pointCount = polyPoints.length;
+  let pointCount = polyPoints.length;
 
   const smoothHull1 = (polyPoints) => {
     // Returns the path for a circular hull around a single point.
 
-    var p1 = [polyPoints[0][0], polyPoints[0][1] - padding];
-    var p2 = [polyPoints[0][0], polyPoints[0][1] + padding];
+    let p1 = [polyPoints[0][0], polyPoints[0][1] - padding];
+    let p2 = [polyPoints[0][0], polyPoints[0][1] + padding];
 
-    return 'M ' + p1
-      + ' A ' + [padding, padding, '0,0,0', p2].join(',')
-      + ' A ' + [padding, padding, '0,0,0', p1].join(',');
+    return `M ${p1} A ${[padding, padding, '0,0,0', p2].join(',')} A ${[padding, padding, '0,0,0', p1].join(',')}`;
   };
 
   // Returns the path for a rounded hull around two points.
   const smoothHull2 = (polyPoints) => {
-    var v = vecFrom(polyPoints[0], polyPoints[1]);
-    var extensionVec = vecScaleTo(v, padding);
+    let v = vecFrom(polyPoints[0], polyPoints[1]);
+    let extensionVec = vecScaleTo(v, padding);
 
-    var extension0 = vec2.add([], polyPoints[0], vec2.scale([], extensionVec, -1));
-    var extension1 = vec2.add([], polyPoints[1], extensionVec);
+    let extension0 = vec2.add([], polyPoints[0], vec2.scale([], extensionVec, -1));
+    let extension1 = vec2.add([], polyPoints[1], extensionVec);
 
-    var tangentHalfLength = 1.2 * padding;
-    var controlDelta = vecScaleTo(vec2.normalize([], v), tangentHalfLength);
-    var invControlDelta = vec2.scale([], controlDelta, -1);
+    let tangentHalfLength = 1.2 * padding;
+    let controlDelta = vecScaleTo(vec2.normalize([], v), tangentHalfLength);
+    let invControlDelta = vec2.scale([], controlDelta, -1);
 
-    var control0 = vec2.add([], extension0, invControlDelta);
-    var control1 = vec2.add([], extension1, invControlDelta);
-    var control3 = vec2.add([], extension0, controlDelta);
+    let control0 = vec2.add([], extension0, invControlDelta);
+    let control1 = vec2.add([], extension1, invControlDelta);
+    let control3 = vec2.add([], extension0, controlDelta);
 
-    return 'M ' + extension0
-      + ' C ' + [control0, control1, extension1].join(',')
-      + ' S ' + [control3, extension0].join(',')
-      + ' Z';
+    return `M ${extension0} C ${[control0, control1, extension1].join(',')} S ${[control3, extension0].join(',')} Z`;
   };
 
   // Handle special cases
@@ -279,7 +273,7 @@ export function paddedHull(polyPoints: number[][], padding: number) {
   if (pointCount === 2) return smoothHull2(polyPoints);
 
   let hullPoints = polyPoints.map(function (point, index) {
-    var pNext = polyPoints[(index + 1) % pointCount];
+    let pNext = polyPoints[(index + 1) % pointCount];
     return {
       p: point,
       v: vec2.normalize([], vecFrom(point, pNext))
@@ -287,9 +281,9 @@ export function paddedHull(polyPoints: number[][], padding: number) {
   });
 
   // Compute the expanded hull points, and the nearest prior control point for each.
-  for (var i = 0; i < hullPoints.length; ++i) {
-    var priorIndex = (i > 0) ? (i - 1) : (pointCount - 1);
-    var extensionVec = vec2.normalize([], vec2.add([], hullPoints[priorIndex].v, vec2.scale([], hullPoints[i].v, -1)));
+  for (let i = 0; i < hullPoints.length; ++i) {
+    let priorIndex = (i > 0) ? (i - 1) : (pointCount - 1);
+    let extensionVec = vec2.normalize([], vec2.add([], hullPoints[priorIndex].v, vec2.scale([], hullPoints[i].v, -1)));
     hullPoints[i].p = vec2.add([], hullPoints[i].p, vec2.scale([], extensionVec, padding));
   }
 

--- a/src/util/path.ts
+++ b/src/util/path.ts
@@ -118,3 +118,183 @@ export const pathToPoints = (path: any[]) => {
   });
   return points;
 }
+
+/**
+ * 生成平滑的闭合曲线
+ * @param points
+ */
+export const getClosedSpline = (points: IPoint[]) => {
+  if (points.length < 2) {
+    throw new Error(`point length must largn than 2, now it's ${points.length}`);
+  }
+  let first = points[0];
+  let second = points[1];
+  let last = points[points.length - 1]
+  let lastSecond = points[points.length - 2]
+
+  points.unshift(last)
+  points.unshift(lastSecond)
+  points.push(first)
+  points.push(second)
+
+  let closedPath = []
+  for (var i = 1; i < points.length - 2; i += 1) {
+    var x0 = points[i - 1].x;
+    var y0 = points[i - 1].y;
+    var x1 = points[i].x;
+    var y1 = points[i].y;
+    var x2 = points[i + 1].x;
+    var y2 = points[i + 1].y;
+    var x3 = i !== points.length - 2 ? points[i + 2].x : x2;
+    var y3 = i !== points.length - 2 ? points[i + 2].y : y2;
+
+    var cp1x = x1 + (x2 - x0) / 6;
+    var cp1y = y1 + (y2 - y0) / 6;
+    var cp2x = x2 - (x3 - x1) / 6;
+    var cp2y = y2 - (y3 - y1) / 6;
+    closedPath.push(["C", cp1x, cp1y, cp2x, cp2y, x2, y2]);
+  }
+  closedPath.unshift(['M', last.x, last.y]);
+  return closedPath;
+}
+
+const vecScaleTo = (v: number[], length: number) => { // Vector with direction of v with specified length
+  return vec2.scale([], vec2.normalize([], v), length);
+}
+
+const unitNormal = (p0: number[], p1: number[]) => {
+  // Returns the unit normal to the line segment from p0 to p1.
+  var n = [p0[1] - p1[1], p1[0] - p0[0]];
+  var nLength = Math.sqrt(n[0] * n[0] + n[1] * n[1]);
+  return [n[0] / nLength, n[1] / nLength];
+};
+
+const vecFrom = (p0: number[], p1: number[]) => {               // Vector from p0 to p1
+  return [p1[0] - p0[0], p1[1] - p0[1]];
+}
+
+/**
+ * 生成有圆角的多边形
+ * 
+ */
+export function roundedHull(polyPoints: number[][], padding: number) {
+  // The rounded hull path around a single point
+  const roundedHull1 = (polyPoints) => {
+    var p1 = [polyPoints[0][0], polyPoints[0][1] - padding];
+    var p2 = [polyPoints[0][0], polyPoints[0][1] + padding];
+
+    return 'M ' + p1
+      + ' A ' + [padding, padding, '0,0,0', p2].join(',')
+      + ' A ' + [padding, padding, '0,0,0', p1].join(',');
+  };
+
+  // The rounded hull path around two points
+  const roundedHull2 = (polyPoints) => {
+    var offsetVector = vec2.scale([], unitNormal(polyPoints[0], polyPoints[1]), padding);
+    var invOffsetVector = vec2.scale([], offsetVector, -1);
+
+    var p0 = vec2.add([], polyPoints[0], offsetVector);
+    var p1 = vec2.add([], polyPoints[1], offsetVector);
+    var p2 = vec2.add([], polyPoints[1], invOffsetVector);
+    var p3 = vec2.add([], polyPoints[0], invOffsetVector);
+
+    return 'M ' + p0
+      + ' L ' + p1 + ' A ' + [padding, padding, '0,0,0', p2].join(',')
+      + ' L ' + p3 + ' A ' + [padding, padding, '0,0,0', p0].join(',');
+  };
+
+  // 特殊情况处理：节点数小于等于2
+  if (!polyPoints || polyPoints.length < 1) return "";
+  if (polyPoints.length === 1) return roundedHull1(polyPoints);
+  if (polyPoints.length === 2) return roundedHull2(polyPoints);
+
+  var segments = new Array(polyPoints.length);
+
+  // Calculate each offset (outwards) segment of the convex hull.
+  for (var segmentIndex = 0; segmentIndex < segments.length; ++segmentIndex) {
+    var p0 = (segmentIndex === 0) ? polyPoints[polyPoints.length - 1] : polyPoints[segmentIndex - 1];
+    var p1 = polyPoints[segmentIndex];
+
+    // Compute the offset vector for the line segment, with length = padding.
+    var offset = vec2.scale([], unitNormal(p0, p1), padding);
+
+    segments[segmentIndex] = [vec2.add([], p0, offset), vec2.add([], p1, offset)];
+  }
+
+  var arcData = 'A ' + [padding, padding, '0,0,0,'].join(',');
+
+  segments = segments.map(function (segment, index) {
+    var pathFragment = "";
+    if (index === 0) {
+      var pathFragment = 'M ' + segments[segments.length - 1][1] + ' ';
+    }
+    pathFragment += arcData + segment[0] + ' L ' + segment[1];
+
+    return pathFragment;
+  });
+
+  return segments.join(' ');
+}
+
+// Returns the SVG path data string representing the polygon, expanded and smoothed.
+export function paddedHull(polyPoints: number[][], padding: number) {
+  var pointCount = polyPoints.length;
+
+  const smoothHull1 = (polyPoints) => {
+    // Returns the path for a circular hull around a single point.
+
+    var p1 = [polyPoints[0][0], polyPoints[0][1] - padding];
+    var p2 = [polyPoints[0][0], polyPoints[0][1] + padding];
+
+    return 'M ' + p1
+      + ' A ' + [padding, padding, '0,0,0', p2].join(',')
+      + ' A ' + [padding, padding, '0,0,0', p1].join(',');
+  };
+
+  // Returns the path for a rounded hull around two points.
+  const smoothHull2 = (polyPoints) => {
+    var v = vecFrom(polyPoints[0], polyPoints[1]);
+    var extensionVec = vecScaleTo(v, padding);
+
+    var extension0 = vec2.add([], polyPoints[0], vec2.scale([], extensionVec, -1));
+    var extension1 = vec2.add([], polyPoints[1], extensionVec);
+
+    var tangentHalfLength = 1.2 * padding;
+    var controlDelta = vecScaleTo(vec2.normalize([], v), tangentHalfLength);
+    var invControlDelta = vec2.scale([], controlDelta, -1);
+
+    var control0 = vec2.add([], extension0, invControlDelta);
+    var control1 = vec2.add([], extension1, invControlDelta);
+    var control3 = vec2.add([], extension0, controlDelta);
+
+    return 'M ' + extension0
+      + ' C ' + [control0, control1, extension1].join(',')
+      + ' S ' + [control3, extension0].join(',')
+      + ' Z';
+  };
+
+  // Handle special cases
+  if (!polyPoints || pointCount < 1) return "";
+  if (pointCount === 1) return smoothHull1(polyPoints);
+  if (pointCount === 2) return smoothHull2(polyPoints);
+
+  let hullPoints = polyPoints.map(function (point, index) {
+    var pNext = polyPoints[(index + 1) % pointCount];
+    return {
+      p: point,
+      v: vec2.normalize([], vecFrom(point, pNext))
+    };
+  });
+
+  // Compute the expanded hull points, and the nearest prior control point for each.
+  for (var i = 0; i < hullPoints.length; ++i) {
+    var priorIndex = (i > 0) ? (i - 1) : (pointCount - 1);
+    var extensionVec = vec2.normalize([], vec2.add([], hullPoints[priorIndex].v, vec2.scale([], hullPoints[i].v, -1)));
+    hullPoints[i].p = vec2.add([], hullPoints[i].p, vec2.scale([], extensionVec, padding));
+  }
+
+  return hullPoints.map(obj => {
+    const point = obj.p
+    return { x: point[0], y: point[1] }
+  });
+}

--- a/stories/Hull/component/hull.tsx
+++ b/stories/Hull/component/hull.tsx
@@ -91,15 +91,15 @@ const HullDemo = () => {
       let centerNodes = graph.getNodes().filter(node => !node.getModel().isLeaf);
 
       graph.on('afterlayout', () => {
-        graph.addHull({
+        const hull1 = graph.createHull({
           id: 'centerNode-hull',
           type: 'bubble',
           members: centerNodes,
           padding: 10
         })
 
-        graph.addHull({
-          id: 'centerNode-hull',
+        const hull2 = graph.createHull({
+          id: 'leafNode-hull1',
           members: ['node6', 'node7'],
           padding: 10,
           style: {
@@ -108,8 +108,8 @@ const HullDemo = () => {
           }
         })
 
-        graph.addHull({
-          id: 'centerNode-hull',
+        const hull3 = graph.createHull({
+          id: 'leafNode-hull2',
           members: ['node8', 'node9', 'node10', 'node11', 'node12'],
           padding: 10,
           style: {
@@ -117,6 +117,13 @@ const HullDemo = () => {
             stroke: 'green',
           }
         })
+
+        graph.on('afterupdateitem', e => {
+          hull1.updateData(hull1.members)
+          hull2.updateData(hull2.members)
+          hull3.updateData(hull3.members)
+        })
+
       })
 
     }

--- a/stories/Hull/component/hull.tsx
+++ b/stories/Hull/component/hull.tsx
@@ -1,0 +1,210 @@
+import React, { useEffect } from 'react';
+import { Graph } from '../../../src';
+
+let graph = null;
+const data = {
+  nodes: [
+    {
+      id: '1',
+      label: '公司1',
+      group: 1
+    },
+    {
+      id: '2',
+      label: '公司2',
+      group: 1
+    },
+    {
+      id: '3',
+      label: '公司3',
+      group: 1
+    },
+    {
+      id: '4',
+      label: '公司4',
+      group: 1
+    },
+    {
+      id: '5',
+      label: '公司5',
+      group: 2
+    },
+    {
+      id: '6',
+      label: '公司6',
+      group: 2
+    },
+    {
+      id: '7',
+      label: '公司7',
+      group: 2
+    },
+    {
+      id: '8',
+      label: '公司8',
+      group: 2
+    },
+    {
+      id: '9',
+      label: '公司9',
+      group: 2
+    },
+  ],
+  edges: [
+    {
+      source: '1',
+      target: '1',
+      type: 'loop'
+    },
+    {
+      source: '2',
+      target: '2',
+      type: 'loop'
+    },
+    {
+      source: '1',
+      target: '2',
+      data: {
+        type: 'A',
+        amount: '100,000 元',
+        date: '2019-08-03',
+      },
+    },
+    {
+      source: '1',
+      target: '3',
+      data: {
+        type: 'B',
+        amount: '100,000 元',
+        date: '2019-08-03',
+      },
+    },
+    {
+      source: '2',
+      target: '5',
+      data: {
+        type: 'C',
+        amount: '100,000 元',
+        date: '2019-08-03',
+      },
+    },
+    {
+      source: '5',
+      target: '6',
+      data: {
+        type: 'B',
+        amount: '100,000 元',
+        date: '2019-08-03',
+      },
+    },
+    {
+      source: '3',
+      target: '4',
+      data: {
+        type: 'C',
+        amount: '100,000 元',
+        date: '2019-08-03',
+      },
+    },
+    {
+      source: '4',
+      target: '7',
+      data: {
+        type: 'B',
+        amount: '100,000 元',
+        date: '2019-08-03',
+      },
+    },
+    {
+      source: '1',
+      target: '8',
+      data: {
+        type: 'B',
+        amount: '100,000 元',
+        date: '2019-08-03',
+      },
+    },
+    {
+      source: '1',
+      target: '9',
+      data: {
+        type: 'C',
+        amount: '100,000 元',
+        date: '2019-08-03',
+      },
+    },
+  ],
+};
+
+const HullDemo = () => {
+  const container = React.useRef();
+  useEffect(() => {
+    if (!graph) {
+      graph = new Graph({
+        container: container.current as string | HTMLElement,
+        width: 500,
+        height: 500,
+        modes: {
+          default: ['drag-canvas', 'zoom-canvas', 'drag-node']
+        },
+      });
+      graph.data(data);
+      graph.render();
+
+      let members = graph.getNodes().filter(node => node.getModel().group === 2);
+      let nonMembers = graph.getNodes().filter(node => node.getModel().group === 1);
+
+      const hull = graph.addHull({
+        id: 'hull1',
+        mode: 'convex',
+        members: nonMembers,
+      })
+      const hull2 = graph.addHull({
+        id: 'hull2',
+        members,
+        nonMembers,
+        padding: 10,
+        style: {
+          fill: 'pink',
+          stroke: 'red',
+        },
+        autoUpdate: true
+      })
+
+      graph.on('canvas:click', ev => {
+        const item = graph.addItem('node', {
+          x: ev.x,
+          y: ev.y,
+          id: Math.random(),
+          group: 1
+        })
+        nonMembers.push(item)
+        hull.addMember(item)
+        hull2.addNonMember(item)
+      })
+      graph.on('canvas:contextmenu', ev => {
+        ev.preventDefault()
+        ev.stopPropagation();
+        const item = graph.addItem('node', {
+          x: ev.x,
+          y: ev.y,
+          id: Math.random(),
+          group: 2
+        })
+        console.log(hull2.contain(item))
+        members.push(item);
+        hull.addNonMember(item)
+        hull2.addMember(item)
+        console.log(hull2.contain(item))
+      })
+
+      graph.on('dblclick', () => {
+        hull2.destroy()
+      })
+    }
+  })
+
+  return <div ref={container}></div>;
+}
+
+export default HullDemo

--- a/stories/Hull/component/hull.tsx
+++ b/stories/Hull/component/hull.tsx
@@ -100,7 +100,7 @@ const HullDemo = () => {
 
         graph.addHull({
           id: 'centerNode-hull',
-          members: [graph.findById('node6'), graph.findById('node7')],
+          members: ['node6', 'node7'],
           padding: 10,
           style: {
             fill: 'lightgreen',
@@ -110,7 +110,7 @@ const HullDemo = () => {
 
         graph.addHull({
           id: 'centerNode-hull',
-          members: [graph.findById('node8'), graph.findById('node9'), graph.findById('node10'), graph.findById('node11'), graph.findById('node12')],
+          members: ['node8', 'node9', 'node10', 'node11', 'node12'],
           padding: 10,
           style: {
             fill: 'lightgreen',

--- a/stories/Hull/component/hull.tsx
+++ b/stories/Hull/component/hull.tsx
@@ -4,203 +4,121 @@ import { Graph } from '../../../src';
 let graph = null;
 const data = {
   nodes: [
-    {
-      id: '1',
-      label: '公司1',
-      group: 1
-    },
-    {
-      id: '2',
-      label: '公司2',
-      group: 1
-    },
-    {
-      id: '3',
-      label: '公司3',
-      group: 1
-    },
-    {
-      id: '4',
-      label: '公司4',
-      group: 1
-    },
-    {
-      id: '5',
-      label: '公司5',
-      group: 2
-    },
-    {
-      id: '6',
-      label: '公司6',
-      group: 2
-    },
-    {
-      id: '7',
-      label: '公司7',
-      group: 2
-    },
-    {
-      id: '8',
-      label: '公司8',
-      group: 2
-    },
-    {
-      id: '9',
-      label: '公司9',
-      group: 2
-    },
+    { id: 'node0', size: 50 },
+    { id: 'node1', size: 30 },
+    { id: 'node2', size: 30 },
+    { id: 'node3', size: 30 },
+    { id: 'node4', size: 30, isLeaf: true },
+    { id: 'node5', size: 30, isLeaf: true },
+    { id: 'node6', size: 15, isLeaf: true },
+    { id: 'node7', size: 15, isLeaf: true },
+    { id: 'node8', size: 15, isLeaf: true },
+    { id: 'node9', size: 15, isLeaf: true },
+    { id: 'node10', size: 15, isLeaf: true },
+    { id: 'node11', size: 15, isLeaf: true },
+    { id: 'node12', size: 15, isLeaf: true },
+    { id: 'node13', size: 15, isLeaf: true },
+    { id: 'node14', size: 15, isLeaf: true },
+    { id: 'node15', size: 15, isLeaf: true },
+    { id: 'node16', size: 15, isLeaf: true },
   ],
   edges: [
-    {
-      source: '1',
-      target: '1',
-      type: 'loop'
-    },
-    {
-      source: '2',
-      target: '2',
-      type: 'loop'
-    },
-    {
-      source: '1',
-      target: '2',
-      data: {
-        type: 'A',
-        amount: '100,000 元',
-        date: '2019-08-03',
-      },
-    },
-    {
-      source: '1',
-      target: '3',
-      data: {
-        type: 'B',
-        amount: '100,000 元',
-        date: '2019-08-03',
-      },
-    },
-    {
-      source: '2',
-      target: '5',
-      data: {
-        type: 'C',
-        amount: '100,000 元',
-        date: '2019-08-03',
-      },
-    },
-    {
-      source: '5',
-      target: '6',
-      data: {
-        type: 'B',
-        amount: '100,000 元',
-        date: '2019-08-03',
-      },
-    },
-    {
-      source: '3',
-      target: '4',
-      data: {
-        type: 'C',
-        amount: '100,000 元',
-        date: '2019-08-03',
-      },
-    },
-    {
-      source: '4',
-      target: '7',
-      data: {
-        type: 'B',
-        amount: '100,000 元',
-        date: '2019-08-03',
-      },
-    },
-    {
-      source: '1',
-      target: '8',
-      data: {
-        type: 'B',
-        amount: '100,000 元',
-        date: '2019-08-03',
-      },
-    },
-    {
-      source: '1',
-      target: '9',
-      data: {
-        type: 'C',
-        amount: '100,000 元',
-        date: '2019-08-03',
-      },
-    },
+    { source: 'node0', target: 'node1' },
+    { source: 'node0', target: 'node2' },
+    { source: 'node0', target: 'node3' },
+    { source: 'node0', target: 'node4' },
+    { source: 'node0', target: 'node5' },
+    { source: 'node1', target: 'node6' },
+    { source: 'node1', target: 'node7' },
+    { source: 'node2', target: 'node8' },
+    { source: 'node2', target: 'node9' },
+    { source: 'node2', target: 'node10' },
+    { source: 'node2', target: 'node11' },
+    { source: 'node2', target: 'node12' },
+    { source: 'node2', target: 'node13' },
+    { source: 'node3', target: 'node14' },
+    { source: 'node3', target: 'node15' },
+    { source: 'node3', target: 'node16' },
   ],
 };
+const nodes = data.nodes;
+
 
 const HullDemo = () => {
   const container = React.useRef();
   useEffect(() => {
     if (!graph) {
+
       graph = new Graph({
         container: container.current as string | HTMLElement,
         width: 500,
         height: 500,
         modes: {
-          default: ['drag-canvas', 'zoom-canvas', 'drag-node']
+          default: ['drag-canvas', 'zoom-canvas', 'drag-node', 'lasso-select']
+        },
+        layout: {
+          type: 'force',
+          preventOverlap: true,
+          linkDistance: d => {
+            if (d.source.id === 'node0') {
+              return 300;
+            }
+            return 60;
+          },
+          nodeStrength: d => {
+            if (d.isLeaf) {
+              return -50;
+            }
+            return -10;
+          },
+          edgeStrength: d => {
+            if (d.source.id === 'node1' || d.source.id === 'node2' || d.source.id === 'node3') {
+              return 0.7;
+            }
+            return 0.1;
+          },
         },
       });
-      graph.data(data);
+      graph.data({
+        nodes,
+        edges: data.edges.map(function (edge, i) {
+          edge['id'] = 'edge' + i;
+          return Object.assign({}, edge);
+        }),
+      });
       graph.render();
 
-      let members = graph.getNodes().filter(node => node.getModel().group === 2);
-      let nonMembers = graph.getNodes().filter(node => node.getModel().group === 1);
+      let centerNodes = graph.getNodes().filter(node => !node.getModel().isLeaf);
 
-      const hull = graph.addHull({
-        id: 'hull1',
-        mode: 'convex',
-        members: nonMembers,
-      })
-      const hull2 = graph.addHull({
-        id: 'hull2',
-        members,
-        nonMembers,
-        padding: 10,
-        style: {
-          fill: 'pink',
-          stroke: 'red',
-        },
-        autoUpdate: true
-      })
-
-      graph.on('canvas:click', ev => {
-        const item = graph.addItem('node', {
-          x: ev.x,
-          y: ev.y,
-          id: Math.random(),
-          group: 1
+      graph.on('afterlayout', () => {
+        graph.addHull({
+          id: 'centerNode-hull',
+          type: 'bubble',
+          members: centerNodes,
+          padding: 10
         })
-        nonMembers.push(item)
-        hull.addMember(item)
-        hull2.addNonMember(item)
-      })
-      graph.on('canvas:contextmenu', ev => {
-        ev.preventDefault()
-        ev.stopPropagation();
-        const item = graph.addItem('node', {
-          x: ev.x,
-          y: ev.y,
-          id: Math.random(),
-          group: 2
+
+        graph.addHull({
+          id: 'centerNode-hull',
+          members: [graph.findById('node6'), graph.findById('node7')],
+          padding: 10,
+          style: {
+            fill: 'lightgreen',
+            stroke: 'green',
+          }
         })
-        console.log(hull2.contain(item))
-        members.push(item);
-        hull.addNonMember(item)
-        hull2.addMember(item)
-        console.log(hull2.contain(item))
+
+        graph.addHull({
+          id: 'centerNode-hull',
+          members: [graph.findById('node8'), graph.findById('node9'), graph.findById('node10'), graph.findById('node11'), graph.findById('node12')],
+          padding: 10,
+          style: {
+            fill: 'lightgreen',
+            stroke: 'green',
+          }
+        })
       })
 
-      graph.on('dblclick', () => {
-        hull2.destroy()
-      })
     }
   })
 

--- a/stories/Hull/component/interactiveHull.tsx
+++ b/stories/Hull/component/interactiveHull.tsx
@@ -151,13 +151,13 @@ const HullDemo = () => {
       graph.data(data);
       graph.render();
 
-      const hull = graph.addHull({
+      const hull1 = graph.createHull({
         id: 'hull1',
         type: 'smooth-convex',
         padding: 15,
         members: graph.getNodes().filter(node => node.getModel().group === 1),
       })
-      const hull2 = graph.addHull({
+      const hull2 = graph.createHull({
         id: 'hull2',
         members: graph.getNodes().filter(node => node.getModel().group === 2),
         nonMembers: graph.getNodes().filter(node => node.getModel().group === 1),
@@ -180,6 +180,28 @@ const HullDemo = () => {
           group: 2
         })
         hull2.addMember(item)
+      })
+
+      graph.on('afterupdateitem', e => {
+        if (hull1.members.indexOf(e.item) > -1 || hull1.nonMembers.indexOf(e.item) > -1) {
+          hull1.updateData(hull1.members)
+        }
+      })
+
+      graph.on('node:dragend', e => {
+        const item = e.item;
+        const memberIdx = hull2.members.indexOf(item)
+        if (memberIdx > -1) {
+          // 如果移出原hull范围，则去掉
+          if (!hull2.contain(item)) {
+            hull2.removeMember(item)
+          }
+          else {
+            hull2.updateData(hull2.members)
+          }
+        } else {
+          if (hull2.contain(item)) hull2.addMember(item)
+        }
       })
     }
   })

--- a/stories/Hull/component/interactiveHull.tsx
+++ b/stories/Hull/component/interactiveHull.tsx
@@ -1,0 +1,190 @@
+import React, { useEffect } from 'react';
+import { Graph } from '../../../src';
+
+let graph = null;
+const data = {
+  nodes: [
+    {
+      id: '1',
+      label: '公司1',
+      group: 1
+    },
+    {
+      id: '2',
+      label: '公司2',
+      group: 1
+    },
+    {
+      id: '3',
+      label: '公司3',
+      group: 1
+    },
+    {
+      id: '4',
+      label: '公司4',
+      group: 1
+    },
+    {
+      id: '5',
+      label: '公司5',
+      group: 2
+    },
+    {
+      id: '6',
+      label: '公司6',
+      group: 2
+    },
+    {
+      id: '7',
+      label: '公司7',
+      group: 2
+    },
+    {
+      id: '8',
+      label: '公司8',
+      group: 2
+    },
+    {
+      id: '9',
+      label: '公司9',
+      group: 2
+    },
+  ],
+  edges: [
+    {
+      source: '1',
+      target: '1',
+      type: 'loop'
+    },
+    {
+      source: '2',
+      target: '2',
+      type: 'loop'
+    },
+    {
+      source: '1',
+      target: '2',
+      data: {
+        type: 'A',
+        amount: '100,000 元',
+        date: '2019-08-03',
+      },
+    },
+    {
+      source: '1',
+      target: '3',
+      data: {
+        type: 'B',
+        amount: '100,000 元',
+        date: '2019-08-03',
+      },
+    },
+    {
+      source: '2',
+      target: '5',
+      data: {
+        type: 'C',
+        amount: '100,000 元',
+        date: '2019-08-03',
+      },
+    },
+    {
+      source: '5',
+      target: '6',
+      data: {
+        type: 'B',
+        amount: '100,000 元',
+        date: '2019-08-03',
+      },
+    },
+    {
+      source: '3',
+      target: '4',
+      data: {
+        type: 'C',
+        amount: '100,000 元',
+        date: '2019-08-03',
+      },
+    },
+    {
+      source: '4',
+      target: '7',
+      data: {
+        type: 'B',
+        amount: '100,000 元',
+        date: '2019-08-03',
+      },
+    },
+    {
+      source: '1',
+      target: '8',
+      data: {
+        type: 'B',
+        amount: '100,000 元',
+        date: '2019-08-03',
+      },
+    },
+    {
+      source: '1',
+      target: '9',
+      data: {
+        type: 'C',
+        amount: '100,000 元',
+        date: '2019-08-03',
+      },
+    },
+  ],
+};
+
+const HullDemo = () => {
+  const container = React.useRef();
+  useEffect(() => {
+    if (!graph) {
+      graph = new Graph({
+        container: container.current as string | HTMLElement,
+        width: 500,
+        height: 500,
+        modes: {
+          default: ['drag-canvas', 'zoom-canvas', 'drag-node']
+        },
+      });
+      graph.data(data);
+      graph.render();
+
+      const hull = graph.addHull({
+        id: 'hull1',
+        type: 'smooth-convex',
+        padding: 15,
+        members: graph.getNodes().filter(node => node.getModel().group === 1),
+      })
+      const hull2 = graph.addHull({
+        id: 'hull2',
+        members: graph.getNodes().filter(node => node.getModel().group === 2),
+        nonMembers: graph.getNodes().filter(node => node.getModel().group === 1),
+        padding: 15,
+        type: 'bubble',
+        style: {
+          fill: 'pink',
+          stroke: 'red',
+        },
+        update: 'drag'
+      })
+
+      graph.on('canvas:contextmenu', ev => {
+        ev.preventDefault()
+        ev.stopPropagation();
+        const item = graph.addItem('node', {
+          x: ev.x,
+          y: ev.y,
+          id: Math.random(),
+          group: 2
+        })
+        hull2.addMember(item)
+      })
+    }
+  })
+
+  return <div ref={container}></div>;
+}
+
+export default HullDemo

--- a/stories/Hull/hull.stories.tsx
+++ b/stories/Hull/hull.stories.tsx
@@ -1,0 +1,14 @@
+import { storiesOf } from '@storybook/react';
+import React from 'react';
+import Hull from './component/hull';
+// import InteractiveHull from './component/interactiveHull';
+
+export default { title: 'Hull' };
+
+storiesOf('Hull', module)
+  .add('Hull', () => (
+    <Hull />
+  ))
+  // .add('Interactive hull', () => (
+  //   <InteractiveHull />
+  // ))

--- a/stories/Hull/hull.stories.tsx
+++ b/stories/Hull/hull.stories.tsx
@@ -1,7 +1,7 @@
 import { storiesOf } from '@storybook/react';
 import React from 'react';
 import Hull from './component/hull';
-// import InteractiveHull from './component/interactiveHull';
+import InteractiveHull from './component/interactiveHull';
 
 export default { title: 'Hull' };
 
@@ -9,6 +9,6 @@ storiesOf('Hull', module)
   .add('Hull', () => (
     <Hull />
   ))
-  // .add('Interactive hull', () => (
-  //   <InteractiveHull />
-  // ))
+  .add('Interactive hull', () => (
+    <InteractiveHull />
+  ))

--- a/tests/unit/graph/graph-hull-spec.ts
+++ b/tests/unit/graph/graph-hull-spec.ts
@@ -154,14 +154,14 @@ describe('graph hull', () => {
   const nonMembers = graph.getNodes().filter(node => node.getModel().group === 1);
 
   it('add a convex hull', () => {
-    graph.addHull({
+    graph.createHull({
       id: 'hull1',
       members,
-      mode: 'convex'
+      type: 'round-convex'
     })
   })
   it('add a bubble hull', () => {
-    graph.addHull({
+    graph.createHull({
       id: 'hull2',
       nonMembers: members,
       members: nonMembers,

--- a/tests/unit/graph/graph-hull-spec.ts
+++ b/tests/unit/graph/graph-hull-spec.ts
@@ -1,0 +1,185 @@
+import { Graph } from '../../../src';
+
+const div = document.createElement('div');
+div.id = 'hull-spec';
+document.body.appendChild(div);
+
+const data = {
+  nodes: [
+    {
+      id: '1',
+      label: '公司1',
+      group: 1
+    },
+    {
+      id: '2',
+      label: '公司2',
+      group: 1
+    },
+    {
+      id: '3',
+      label: '公司3',
+      group: 1
+    },
+    {
+      id: '4',
+      label: '公司4',
+      group: 1
+    },
+    {
+      id: '5',
+      label: '公司5',
+      group: 2
+    },
+    {
+      id: '6',
+      label: '公司6',
+      group: 2
+    },
+    {
+      id: '7',
+      label: '公司7',
+      group: 2
+    },
+    {
+      id: '8',
+      label: '公司8',
+      group: 2
+    },
+    {
+      id: '9',
+      label: '公司9',
+      group: 2
+    },
+  ],
+  edges: [
+    {
+      source: '1',
+      target: '1',
+      type: 'loop'
+    },
+    {
+      source: '2',
+      target: '2',
+      type: 'loop'
+    },
+    {
+      source: '1',
+      target: '2',
+      data: {
+        type: 'A',
+        amount: '100,000 元',
+        date: '2019-08-03',
+      },
+    },
+    {
+      source: '1',
+      target: '3',
+      data: {
+        type: 'B',
+        amount: '100,000 元',
+        date: '2019-08-03',
+      },
+    },
+    {
+      source: '2',
+      target: '5',
+      data: {
+        type: 'C',
+        amount: '100,000 元',
+        date: '2019-08-03',
+      },
+    },
+    {
+      source: '5',
+      target: '6',
+      data: {
+        type: 'B',
+        amount: '100,000 元',
+        date: '2019-08-03',
+      },
+    },
+    {
+      source: '3',
+      target: '4',
+      data: {
+        type: 'C',
+        amount: '100,000 元',
+        date: '2019-08-03',
+      },
+    },
+    {
+      source: '4',
+      target: '7',
+      data: {
+        type: 'B',
+        amount: '100,000 元',
+        date: '2019-08-03',
+      },
+    },
+    {
+      source: '1',
+      target: '8',
+      data: {
+        type: 'B',
+        amount: '100,000 元',
+        date: '2019-08-03',
+      },
+    },
+    {
+      source: '1',
+      target: '9',
+      data: {
+        type: 'C',
+        amount: '100,000 元',
+        date: '2019-08-03',
+      },
+    },
+  ],
+};
+
+describe('graph hull', () => {
+  const graph = new Graph({
+    container: div,
+    width: 500,
+    height: 500,
+    modes: {
+      default: ['drag-node', 'zoom-canvas', 'drag-canvas'],
+    },
+  });
+
+  graph.data(data)
+  graph.render()
+  const members = graph.getNodes().filter(node => node.getModel().group === 2);
+  const nonMembers = graph.getNodes().filter(node => node.getModel().group === 1);
+
+  it('add a convex hull', () => {
+    graph.addHull({
+      id: 'hull1',
+      members,
+      mode: 'convex'
+    })
+  })
+  it('add a bubble hull', () => {
+    graph.addHull({
+      id: 'hull2',
+      nonMembers: members,
+      members: nonMembers,
+      padding: 10,
+      style: {
+        fill: 'pink',
+        stroke: 'red',
+      },
+    })
+    const hulls = Object.values(graph.getHulls())
+    expect(hulls.length).toEqual(2)
+  })
+  it('remove hull', () => {
+    let hullShapes = graph.get('hullGroup').get('children')
+    expect(hullShapes.length).toEqual(2)
+
+    graph.removeHull('hull2')
+    hullShapes = graph.get('hullGroup').get('children')
+    expect(hullShapes.length).toEqual(1)
+  })
+})


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->
增加hull功能（graph.addHull(cfg: HullCfg)）：根据传入的节点数组，添加包裹轮廓。 
支持的配置项如下：
```
HullCfg {
  id: string,
  members?: Item[] | string[], // 节点实例或节点 Id 数组
  nonMembers?: Item[] | string[], 
  type?: string, // 'round-convex' /'smooth-convex' / 'bubble'
  name?: string,
  padding?: number,
  style?: {
    fill?: string,
    stroke?: string,
    opacity?: number
  },
  update?: string, // 'auto' / 'drag' / 'none' : 自动更新/ 拖拽调整member / 不更新
  bubbleCfg?: BubblesetCfg
}
```

Hull的形状支持`round-convex` / `smooth-convex` / `bubble` 三种类型，默认为`round-convex`类型。`round-convex`为圆角凸包轮廓，`smooth-convex` 为平滑曲线凸包轮廓，这两种凸包轮廓不可绕开nonMembers；`bubble` 为自由凹包轮廓，可以绕开nonMembers。
下图中，蓝色为 `bubble` 类型轮廓， 绿色为`round-convex`类型轮廓。
![rounded-hull](https://user-images.githubusercontent.com/16997933/89892962-1ba80000-dc0a-11ea-8f90-e6070dfb3004.gif)

hull实例可用的方法：
```
  /**
   * 更新数据
   */
public updateData(members: Item[] | string[], nonMembers: string[] | Item[])

  /**
   * 更新样式
   */
 public updateStyle(cfg: HullCfg["style"]) 

  /**
   * 判断是否在hull内部
   * @param item 
   */
  public contain(item: Item | string): boolean 

  /**
   * 增加hull的成员，同时如果该成员原先在nonMembers中，则从nonMembers中去掉
   * @param item 节点实例
   * @return boolean 添加成功返回 true，否则返回 false
   */
  public addMember(item: Item | string): boolean 

 /**
   * 增加hull需要排除的节点，同时如果该成员原先在members中，则从members中去掉
   * @param item 节点实例
   * @return boolean 添加成功返回 true，否则返回 false
   */
  public addNonMember(item: Item | string): boolean 

 /**
  * 移除hull中的成员
  * @param node 节点实例
  * @return boolean 移除成功返回 true，否则返回 false
  */
  public removeMember(item: Item | string): boolean 

  /**
  * @param node 节点实例
  * @return boolean 移除成功返回 true，否则返回 false
  */
  public removeNonMember(item: Item | string): boolean
```
调用hull的方法，可配合监听节点更新来实现hull的动态更新，下图中红色hull配合drag事件，实现节点拖进拖出；蓝色hull随节点位置更新轮廓，始终包裹节点。
![bubble-hull](https://user-images.githubusercontent.com/16997933/89893207-835e4b00-dc0a-11ea-97b3-dafe44423fa5.gif)
```
// 蓝色 hull 随节点更新而更新 
graph.on('afterupdateitem', e => {
    if (hull1.members.indexOf(e.item) > -1 || hull1.nonMembers.indexOf(e.item) > -1) {
          hull1.updateData(hull1.members)
    }
})

// 红色hull：检测节点拖动结束后是否在hull内，若在则添加成为内部成员，否则移除成员
graph.on('node:dragend', e => {
    const item = e.item;
    const memberIdx = hull2.members.indexOf(item)
    if (memberIdx > -1) {
       if (!hull2.contain(item)) {// 如果移出原hull范围，则去掉
         hull2.removeMember(item)
       } else {
          hull2.updateData(hull2.members)
       }
    } else { 
       // 如果原先不在原范围内，被拖入hull中，则添加member
       if (hull2.contain(item)) hull2.addMember(item)
   }
})
```

