### PR TITLE
fix: drag new node without initial position

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "site:deploy": "npm run site:build && gh-pages -d public",
     "start": "npm run site:develop",
     "test": "jest",
-    "test-live": "DEBUG_MODE=1 jest --watch  ./tests/unit/graph/tree-graph-spec.ts",
+    "test-live": "DEBUG_MODE=1 jest --watch  ./tests/unit/behavior/drag-node-spec.ts",
     "lint-staged:js": "eslint --ext .js,.jsx,.ts,.tsx",
     "watch": "father build -w",
     "cdn": "antv-bin upload -n @antv/g6"

--- a/src/behavior/drag-node.ts
+++ b/src/behavior/drag-node.ts
@@ -185,7 +185,7 @@ export default {
         })
       }
     }
-    
+
     // 拖动结束后，入栈
     if (graph.get('enabledStack')) {
       graph.pushStack('update', clone(graph.save()))
@@ -250,8 +250,8 @@ export default {
     const nodeId: string = item.get('id');
     if (!this.point[nodeId]) {
       this.point[nodeId] = {
-        x: model.x,
-        y: model.y,
+        x: model.x || 0,
+        y: model.y || 0,
       };
     }
 

--- a/src/graph/controller/item.ts
+++ b/src/graph/controller/item.ts
@@ -120,6 +120,9 @@ export default class ItemController {
         group: parent.addGroup(),
       });
     } else if (type === NODE) {
+      model.x = model.x || 0;
+      model.y = model.y || 0;
+
       item = new Node({
         model,
         styles,

--- a/tests/unit/behavior/drag-node-spec.ts
+++ b/tests/unit/behavior/drag-node-spec.ts
@@ -510,6 +510,43 @@ describe('drag-node', () => {
     expect(matrix[7]).toEqual(50);
     graph.destroy();
   });
+  it('drag new added node without config position', () => {
+    const graph = new Graph({
+      container: div,
+      width: 500,
+      height: 500,
+      modes: {
+        default: [
+          {
+            type: 'drag-node',
+            delegateStyle: {
+              fillOpacity: 0.8,
+            },
+          },
+        ],
+      },
+      defaultNode: {
+        type: 'rect',
+        size: [114, 54],
+        style: {
+          radius: 4,
+        },
+      },
+    });
+    graph.render()
+    const node = graph.addItem('node', {
+      id: 'node1',
+    })
+
+    graph.emit('node:dragstart', { x: 0, y: 0, item: node });
+    graph.emit('node:drag', { x: 120, y: 120, item: node });
+    graph.emit('node:dragend', { x: 120, y: 120, item: node });
+    const matrix = node.get('group').getMatrix();
+    expect(matrix[0]).toEqual(1);
+    expect(matrix[6]).toEqual(120);
+    expect(matrix[7]).toEqual(120);
+    graph.destroy()
+  })
   it('drag node not update edge', () => {
     const graph = new Graph({
       container: div,


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->
fix #1787 

- 调用addItem新增节点时，若没有指定x,y怎默认为0
- drag节点时，若model.x, model.y未定义则默认为0