### PR TITLE
feat: add detect all cycles for undirected and directed graph

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "site:deploy": "npm run site:build && gh-pages -d public",
     "start": "npm run site:develop",
     "test": "jest",
-    "test-live": "DEBUG_MODE=1 jest --watch  ./tests/unit/plugins/timebar-spec.ts",
+    "test-live": "DEBUG_MODE=1 jest --watch  ./tests/unit/algorithm/detect-cycle-spec",
     "lint-staged:js": "eslint --ext .js,.jsx,.ts,.tsx",
     "watch": "father build -w",
     "cdn": "antv-bin upload -n @antv/g6"

--- a/src/algorithm/connected-component.ts
+++ b/src/algorithm/connected-component.ts
@@ -1,0 +1,108 @@
+import { IGraph } from "../interface/graph";
+import { INode } from '../interface/item';
+
+/**
+ * Generate all connected components for an undirected graph
+ * @param graph
+ */
+export function detectConnectedComponents(nodes: INode[]) {
+  const allComponents = []
+  const visited = {}
+  let count = 0;
+  const nodeStack = []
+
+  const getComponent = (node: INode) => {
+    nodeStack.push(node)
+    visited[node.get('id')] = true
+    const neighbors = node.getNeighbors()
+    for (let i = 0; i < neighbors.length; ++i) {
+      const neighbor = neighbors[i]
+      if (!visited[neighbor.get('id')]) {
+        getComponent(neighbor)
+      }
+    }
+  }
+
+  for (let i = 0; i < nodes.length; i++) {
+    const node = nodes[i]
+    if (!visited[node.get('id')]) {
+      //对于无向图进行dfs遍历，每一次调用后都得到一个连通分量
+      getComponent(node)
+      const component = []
+      while (nodeStack.length > 0) {
+        component.push(nodeStack.pop())
+      }
+      allComponents.push(component)
+    }
+  }
+  return allComponents
+}
+
+/**
+ * Tarjan's Algorithm 复杂度  O(|V|+|E|)
+ * For directed graph only
+ * a directed graph is said to be strongly connected if "every vertex is reachable from every other vertex".
+ * refer: http://en.wikipedia.org/wiki/Tarjan%27s_strongly_connected_components_algorithm
+ * @param graph
+ * @return a list of strongly connected components 
+ */
+export function detectStrongConnectComponents(nodes: INode[]) {
+  const nodeStack = [];
+  const inStack = {}; // 辅助判断是否已经在stack中，减少查找开销
+  const indices = {};
+  const lowLink = {};
+  const allComponents = []
+  let index = 0;
+
+  const getComponent = (node: INode) => {
+    // Set the depth index for v to the smallest unused index
+    indices[node.get('id')] = index
+    lowLink[node.get('id')] = index
+    index += 1
+    nodeStack.push(node)
+    inStack[node.get('id')] = true
+
+    // 考虑每个邻接点
+    const neighbors = node.getNeighbors('target').filter(n => nodes.indexOf(n) > -1)
+    for (let i = 0; i < neighbors.length; i++) {
+      const targetNode = neighbors[i]
+      if (indices[targetNode.get('id')] === undefined) {
+        getComponent(targetNode)
+        // tree edge
+        lowLink[node.get('id')] = Math.min(lowLink[node.get('id')], lowLink[targetNode.get('id')])
+      } else if (inStack[targetNode.get('id')]) {
+        // back edge, target node is in the current SCC
+        lowLink[node.get('id')] = Math.min(lowLink[node.get('id')], indices[targetNode.get('id')])
+      }
+    }
+
+    // If node is a root node, generate an SCC
+    if (lowLink[node.get('id')] === indices[node.get('id')]) {
+      const component = []
+      while (nodeStack.length > 0) {
+        const tmpNode = nodeStack.pop()
+        inStack[tmpNode.get('id')] = false
+        component.push(tmpNode)
+        if (tmpNode === node) break
+      }
+      if (component.length > 0) {
+        allComponents.push(component);
+      }
+    }
+  }
+
+  for (let node of nodes) {
+    if (indices[node.get('id')] === undefined) {
+      getComponent(node)
+    }
+  }
+
+  return allComponents
+}
+
+export default function getConnectedComponents(graph: IGraph, directed?: boolean) {
+  const isDirected = directed === undefined ? graph.get('directed') : directed;
+  const nodes = graph.getNodes()
+  if (isDirected) return detectStrongConnectComponents(nodes)
+  else return detectConnectedComponents(nodes);
+}

--- a/src/algorithm/connected-component.ts
+++ b/src/algorithm/connected-component.ts
@@ -8,7 +8,6 @@ import { INode } from '../interface/item';
 export function detectConnectedComponents(nodes: INode[]) {
   const allComponents = []
   const visited = {}
-  let count = 0;
   const nodeStack = []
 
   const getComponent = (node: INode) => {
@@ -66,7 +65,7 @@ export function detectStrongConnectComponents(nodes: INode[]) {
     const neighbors = node.getNeighbors('target').filter(n => nodes.indexOf(n) > -1)
     for (let i = 0; i < neighbors.length; i++) {
       const targetNode = neighbors[i]
-      if (indices[targetNode.get('id')] === undefined) {
+      if (!indices[targetNode.get('id')] && indices[targetNode.get('id')] !== 0) {
         getComponent(targetNode)
         // tree edge
         lowLink[node.get('id')] = Math.min(lowLink[node.get('id')], lowLink[targetNode.get('id')])
@@ -92,7 +91,7 @@ export function detectStrongConnectComponents(nodes: INode[]) {
   }
 
   for (let node of nodes) {
-    if (indices[node.get('id')] === undefined) {
+    if (!indices[node.get('id')] && indices[node.get('id')] !== 0) {
       getComponent(node)
     }
   }

--- a/src/algorithm/detect-cycle.ts
+++ b/src/algorithm/detect-cycle.ts
@@ -2,6 +2,7 @@ import dfs from './dfs'
 import { IAlgorithmCallbacks } from '../types'
 import { IGraph } from '../interface/graph';
 import { INode } from '../interface/item';
+import { detectStrongConnectComponents } from './connected-component'
 
 const detectDirectedCycle = (graph: IGraph) => {
   let cycle: {
@@ -75,6 +76,248 @@ const detectDirectedCycle = (graph: IGraph) => {
   }
 
   return cycle
+}
+
+/**
+ * 检测无向图中的所有Base cycles
+ * Time Complexity: O(N + M), Auxiliary Space: O(N + M)
+ * graph coloring method
+ * refer: https://www.geeksforgeeks.org/print-all-the-cycles-in-an-undirected-graph/
+ * @param graph 
+ * @param directed 
+ * @param node 
+ * @return [{[key: string]: INode}] 返回所有的base cycle
+ */
+export const detectAllUndirectedCycle = (graph: IGraph, mustInclude?: INode) => {
+  const color = {}
+  const allCycles = []
+  const parent = {}
+  const mark = []
+  let cycleIdx = 0 // cycle的编号
+  const nodes = graph.getNodes()
+
+  const getCycle = (curNode: INode, prevNode: INode) => {
+    // already completely visited
+    let curNodeId = curNode.getID()
+    let prevNodeId = prevNode.getID()
+    let cyclePath = new Set()
+    if (color[curNodeId] === 2) return
+
+    // seen but not completely visited: cycle detected
+    if (color[curNodeId] === 1) {
+      cycleIdx += 1
+      let tmpCur = prevNode
+      let tmpCurId = prevNodeId
+      mark[tmpCurId] = cycleIdx
+      cyclePath.add(tmpCur)
+
+      // backtrack
+      while (tmpCurId !== curNodeId) {
+        tmpCur = parent[tmpCurId]
+        tmpCurId = tmpCur.getID()
+        mark[tmpCurId] = cycleIdx
+        cyclePath.add(tmpCur)
+      }
+
+      if (!mustInclude || (mustInclude && cyclePath.has(mustInclude))) {
+        const cyclePathList: INode[] = Array.from(cyclePath) as INode[]
+        const cycle = {}
+        for (let i = 1; i < cyclePathList.length; i += 1) {
+          cycle[cyclePathList[i - 1].getID()] = cyclePathList[i]
+        }
+        if (cyclePathList.length) cycle[cyclePathList[cyclePathList.length - 1].getID()] = cyclePathList[0]
+        allCycles.push(cycle)
+      }
+      return
+    }
+
+    parent[curNodeId] = prevNode
+    color[curNodeId] = 1
+
+    // dfs
+    const neighbors = curNode.getNeighbors()
+    for (let i = 0; i < neighbors.length; i++) {
+      const neighbor = neighbors[i]
+      if (neighbor === prevNode) continue
+
+      // 处理自环情况
+      if (neighbor === curNode) {
+        allCycles.push({ [curNode.getID()]: curNode })
+        continue
+      }
+      getCycle(neighbor, curNode)
+    }
+    color[curNodeId] = 2
+  }
+
+  if (nodes.length) {
+    for (let neighbor of nodes[0].getNeighbors()) {
+      getCycle(neighbor, nodes[0])
+    }
+  }
+  return allCycles
+}
+
+/**
+ * Johnson's algorithm, 时间复杂度 O((V + E)(C + 1))$ and space bounded by O(V + E)
+ * refer: https://www.cs.tufts.edu/comp/150GA/homeworks/hw1/Johnson%2075.PDF
+ * refer: https://networkx.github.io/documentation/stable/_modules/networkx/algorithms/cycles.html#simple_cycles 
+ * @param graph 
+ * @param node 
+ * @return [{[key: string]: INode}] 返回所有的“simple cycles”
+ */
+export const detectAllDirectedCycle = (graph: IGraph, mustInclude?: INode) => {
+  const path = [] // stack of nodes in current path
+  const blocked = new Set()
+  const B = [] // remember portions of the graph that yield no elementary circuit
+  const allCycles = []
+
+  // 辅助函数： unblock all blocked nodes
+  const unblock = (thisNode) => {
+    const stack = [thisNode]
+    while (stack.length > 0) {
+      const node = stack.pop()
+      if (blocked.has(node)) {
+        blocked.delete(node)
+        B[node.get('id')].forEach(node => {
+          stack.push(node)
+        })
+        B[node.get('id')].clear()
+      }
+    }
+  }
+
+  const circuit = (node, start, adjList) => {
+    let closed = false; // whether a path is closed
+    path.push(node)
+    blocked.add(node)
+
+    const neighbors = adjList[node.getID()]
+    for (let i = 0; i < neighbors.length; i += 1) {
+      const neighbor = idx2Node[neighbors[i]]
+      if (neighbor === start) {
+        const cycle = {}
+        for (let i = 1; i < path.length; i += 1) {
+          cycle[path[i - 1].getID()] = path[i]
+        }
+        if (path.length) cycle[path[path.length - 1].getID()] = path[0]
+        allCycles.push(cycle)
+        closed = true
+      } else if (!blocked.has(neighbor)) {
+        if (circuit(neighbor, start, adjList)) {
+          closed = true
+        }
+      }
+    }
+
+    if (closed) {
+      unblock(node)
+    } else {
+      for (let i = 0; i < neighbors.length; i += 1) {
+        const neighbor = idx2Node[neighbors[i]]
+        if (!B[neighbor.get('id')].has(node)) {
+          B[neighbor.get('id')].add(node)
+        }
+      }
+    }
+    path.pop()
+    return closed
+  }
+
+  const nodes = graph.getNodes()
+  const node2Idx = {}
+  const idx2Node = {}
+
+  // Johnson's algorithm 要求给节点赋顺序，这里按节点在数组中的顺序
+  for (let i = 0; i < nodes.length; i += 1) {
+    const node = nodes[i]
+    node2Idx[node.getID()] = i
+    idx2Node[i] = node
+  }
+  // 如果有指定的节点，则包含将指定节点和首位节点交换位置
+  if (mustInclude) {
+    node2Idx[nodes[0].getID()] = node2Idx[mustInclude.getID()]
+    node2Idx[mustInclude.getID()] = 0
+    idx2Node[0] = mustInclude
+    idx2Node[node2Idx[nodes[0].getID()]] = nodes[0]
+  }
+
+
+  // 返回 节点顺序 >= nodeOrder 的强连通分量的adjList
+  const getMinComponentAdj = (components) => {
+    let minCompIdx;
+    let minIdx = Infinity;
+
+    // Find least component and the lowest node
+    for (let i = 0; i < components.length; i += 1) {
+      const comp = components[i];
+      for (let j = 0; j < comp.length; j++) {
+        const nodeIdx = node2Idx[comp[j].getID()]
+        if (nodeIdx < minIdx) {
+          minIdx = nodeIdx
+          minCompIdx = i
+        }
+      }
+    }
+
+    const component = components[minCompIdx]
+    const adjList = []
+    for (let i = 0; i < component.length; i += 1) {
+      const node = component[i]
+      adjList[node.getID()] = []
+      for (let neighbor of node.getNeighbors('target').filter(n => component.indexOf(n) > -1)) {
+        // 对自环情况 (点连向自身) 特殊处理：记录自环，但不加入adjList
+        if (neighbor === node) {
+          allCycles.push({ [node.getID()]: node })
+        } else {
+          adjList[node.getID()].push(node2Idx[neighbor.getID()])
+        }
+      }
+    }
+
+    return {
+      component,
+      adjList,
+      minIdx
+    }
+  }
+
+  let nodeIdx = 0
+  while (nodeIdx < nodes.length) {
+    const subgraphNodes = nodes.filter(n => node2Idx[n.getID()] >= nodeIdx)
+    const sccs = detectStrongConnectComponents(subgraphNodes).filter(component => component.length > 1)
+    if (sccs.length === 0) break
+
+    const scc = getMinComponentAdj(sccs)
+    const { minIdx, adjList, component } = scc
+    if (component.length > 1) {
+      component.forEach(node => {
+        B[node.get('id')] = new Set()
+      })
+      const startNode = idx2Node[minIdx]
+      circuit(startNode, startNode, adjList)
+      if (mustInclude && mustInclude === startNode) return allCycles
+      nodeIdx = minIdx + 1
+    } else {
+      break
+    }
+  }
+  return allCycles
+}
+
+/**
+ * 查找图中所有满足要求的圈
+ * @param graph 
+ * @param directed 是否为有向图
+ * @param node 圈中需要包含的节点，若不指定则返回所有圈
+ * @return [{[key: string]: Node}] 包含所有环的数组，每个环用一个Object表示，其中key为节点id，value为该节点在环中指向的下一个节点
+ */
+export const detectAllCycles = (graph: IGraph, directed?: boolean, node?: INode) => {
+  if (directed === undefined) {
+    directed = graph.get('directed')
+  }
+  if (directed) return detectAllDirectedCycle(graph, node)
+  else return detectAllUndirectedCycle(graph, node)
 }
 
 export default detectDirectedCycle

--- a/src/algorithm/index.ts
+++ b/src/algorithm/index.ts
@@ -4,4 +4,5 @@ export { default as detectDirectedCycle } from './detect-cycle'
 export { default as degree } from './degree'
 export { default as adjMatrix } from './adjacent-matrix'
 export { default as floydWarshall } from './floydWarshall'
-
+export { default as getConnectedComponents } from './connected-component'
+export { detectAllCycles, detectAllDirectedCycle, detectAllUndirectedCycle } from './detect-cycle'

--- a/tests/unit/algorithm/connected-component-spec.ts
+++ b/tests/unit/algorithm/connected-component-spec.ts
@@ -1,0 +1,116 @@
+import G6, { Algorithm } from '../../../src';
+const { getConnectedComponents } = Algorithm
+
+const div = document.createElement('div');
+div.id = 'container';
+document.body.appendChild(div);
+
+const data = {
+  nodes: [
+    {
+      id: 'A'
+    },
+    {
+      id: 'B'
+    },
+    {
+      id: 'C'
+    },
+    {
+      id: 'D'
+    },
+    {
+      id: 'E'
+    },
+    {
+      id: 'F'
+    },
+    {
+      id: 'G'
+    },
+    {
+      id: 'H'
+    },
+  ],
+  edges: [
+    {
+      source: 'A',
+      target: 'B'
+    },
+    {
+      source: 'B',
+      target: 'C'
+    },
+    {
+      source: 'A',
+      target: 'C'
+    },
+    {
+      source: 'D',
+      target: 'A'
+    },
+    {
+      source: 'D',
+      target: 'E'
+    },
+    {
+      source: 'E',
+      target: 'F'
+    },
+    {
+      source: 'F',
+      target: 'D'
+    },
+    {
+      source: 'G',
+      target: 'H'
+    },
+    {
+      source: 'H',
+      target: 'G'
+    }
+  ]
+}
+data.nodes.forEach(d => {
+  d['label'] = d.id
+})
+describe('find connected components', () => {
+  const graph = new G6.Graph({
+    container: 'container',
+    width: 500,
+    height: 400,
+    layout: {
+      type: 'force'
+    },
+    modes: {
+      default: ['zoom-canvas', 'drag-canvas', 'drag-node']
+    },
+    defaultNode: {
+      type: 'node',
+      labelCfg: {
+        style: {
+          fill: '#fff',
+          fontSize: 14,
+        },
+      },
+    },
+    defaultEdge: {
+      style: {
+        endArrow: true,
+      }
+    }
+  })
+
+  graph.data(data)
+  graph.render()
+
+  it('detect strongly connected components in directed graph', () => {
+    let result = getConnectedComponents(graph, true)
+    console.log(result)
+
+    // const nodeF = graph.findById('F')
+    // const nodeD = graph.findById('D')
+    // const nodeE = graph.findById('E')
+    // expect(result).toEqual();
+  });
+});

--- a/tests/unit/algorithm/connected-component-spec.ts
+++ b/tests/unit/algorithm/connected-component-spec.ts
@@ -104,13 +104,40 @@ describe('find connected components', () => {
   graph.data(data)
   graph.render()
 
+  it('detect strongly connected components in undirected graph', () => {
+    let result = getConnectedComponents(graph, false)
+    expect(result.length).toEqual(2);
+    expect(result[0].map(node => node.get('id')).sort()).toEqual(['A', 'B', 'C', 'D', 'E', 'F'])
+    expect(result[1].map(node => node.get('id')).sort()).toEqual(['G', 'H']);
+  });
   it('detect strongly connected components in directed graph', () => {
     let result = getConnectedComponents(graph, true)
-    console.log(result)
-
-    // const nodeF = graph.findById('F')
-    // const nodeD = graph.findById('D')
-    // const nodeE = graph.findById('E')
-    // expect(result).toEqual();
+    expect(result.length).toEqual(5);
+    expect(result[3].map(node => node.get('id')).sort()).toEqual(['D', 'E', 'F']);
+    expect(result[4].map(node => node.get('id')).sort()).toEqual(['G', 'H']);
   });
+  it('test connected components detection performance using large graph', () => {
+    fetch(
+      'https://gw.alipayobjects.com/os/basement_prod/da5a1b47-37d6-44d7-8d10-f3e046dabf82.json',
+    )
+      .then(res => res.json())
+      .then(data => {
+        data.nodes.forEach(node => {
+          node.label = node.olabel;
+          node.degree = 0;
+          data.edges.forEach(edge => {
+            if (edge.source === node.id || edge.target === node.id) {
+              node.degree++;
+            }
+          });
+        });
+        graph.changeData(data);
+        let directedComps = getConnectedComponents(graph, true)
+        let undirectedComps = getConnectedComponents(graph, false)
+        expect(directedComps.length).toEqual(1589);
+        expect(undirectedComps.length).toEqual(396);
+        graph.destroy()
+      });
+  });
+
 });

--- a/tests/unit/algorithm/detect-cycle-spec.ts
+++ b/tests/unit/algorithm/detect-cycle-spec.ts
@@ -1,5 +1,5 @@
 import G6, { Algorithm } from '../../../src';
-const { detectDirectedCycle } = Algorithm
+const { detectDirectedCycle, detectAllCycles } = Algorithm
 
 const div = document.createElement('div');
 div.id = 'container';
@@ -56,20 +56,40 @@ const data = {
     },
   ]
 }
+data.nodes.forEach(d => {
+  d['label'] = d.id
+})
 describe('detectDirectedCycle', () => {
+  const graph = new G6.Graph({
+    container: 'container',
+    width: 500,
+    height: 500,
+    layout: {
+      type: 'force'
+    },
+    defaultNode: {
+      type: 'node',
+      labelCfg: {
+        style: {
+          fill: '#fff',
+          fontSize: 14,
+        },
+      },
+    },
+    defaultEdge: {
+      style: {
+        endArrow: true,
+      }
+    },
+    modes: { 'default': ['drag-node', 'drag-canvas'] }
+  })
+
+  graph.data(data)
+  graph.render()
+
   it('should detect directed cycle', () => {
-    const graph = new G6.Graph({
-      container: 'container',
-      width: 500,
-      height: 500,
-      // layout
-    })
-
-    graph.data(data)
-    graph.render()
-
     let result = detectDirectedCycle(graph)
-    debugger
+    // debugger
     expect(result).toBeNull();
 
     data.edges.push(
@@ -93,4 +113,442 @@ describe('detectDirectedCycle', () => {
       E: nodeD,
     });
   });
+  it('detect all cycles in directed graph', () => {
+    data.edges.push(
+      {
+        source: 'C',
+        target: 'D'
+      }
+    )
+    graph.changeData(data)
+    const result = detectAllCycles(graph, true)
+    // console.log('All cycles in the directed graph: ', result)
+    expect(result.length).toEqual(3)
+
+    const nodeA = graph.findById('A')
+    const nodeB = graph.findById('B')
+    const nodeC = graph.findById('C')
+    const nodeD = graph.findById('D')
+
+    const result2 = detectAllCycles(graph, true, graph.getNodes()[0])
+    expect(result2[0]).toEqual({
+      A: nodeB,
+      B: nodeC,
+      C: nodeD,
+      D: nodeA
+    });
+    expect(result2[1]).toEqual({
+      A: nodeC,
+      C: nodeD,
+      D: nodeA
+    });
+    // console.log(`All cycles include ${graph.getNodes()[2].getID()} in the directed graph: `, result2)
+  })
+  it('detect cycle in undirected graph', () => {
+    const result = detectAllCycles(graph)
+    expect(result.length).toEqual(3)
+    // console.log(`All elemenetary cycles in the undirected graph: `, result)
+
+
+    const nodeA = graph.findById('A')
+    const nodeB = graph.findById('B')
+    const nodeC = graph.findById('C')
+    const result2 = detectAllCycles(graph, false, nodeB)
+    expect(result2.length).toEqual(1)
+    expect(result2[0]).toEqual({
+      A: nodeC,
+      C: nodeB,
+      B: nodeA,
+    })
+    // console.log(`All elemenetary cycles include ${graph.getNodes()[1].getID()} in the undirected graph: `, result2)
+  })
+  it('test a larger graph', () => {
+    const data = {
+      nodes: [
+        {
+          id: '0',
+          label: '0',
+        },
+        {
+          id: '1',
+          label: '1',
+        },
+        {
+          id: '2',
+          label: '2',
+        },
+        {
+          id: '3',
+          label: '3',
+        },
+        {
+          id: '4',
+          label: '4',
+        },
+        {
+          id: '5',
+          label: '5',
+        },
+        {
+          id: '6',
+          label: '6',
+        },
+        {
+          id: '7',
+          label: '7',
+        },
+        {
+          id: '8',
+          label: '8',
+        },
+        {
+          id: '9',
+          label: '9',
+        },
+        {
+          id: '10',
+          label: '10',
+        },
+        {
+          id: '11',
+          label: '11',
+        },
+        {
+          id: '12',
+          label: '12',
+        },
+        {
+          id: '13',
+          label: '13',
+        },
+        {
+          id: '14',
+          label: '14',
+        },
+        {
+          id: '15',
+          label: '15',
+        },
+        {
+          id: '16',
+          label: '16',
+        },
+        {
+          id: '17',
+          label: '17',
+        },
+        {
+          id: '18',
+          label: '18',
+        },
+        {
+          id: '19',
+          label: '19',
+        },
+        {
+          id: '20',
+          label: '20',
+        },
+        {
+          id: '21',
+          label: '21',
+        },
+        {
+          id: '22',
+          label: '22',
+        },
+        {
+          id: '23',
+          label: '23',
+        },
+        {
+          id: '24',
+          label: '24',
+        },
+        {
+          id: '25',
+          label: '25',
+        },
+        {
+          id: '26',
+          label: '26',
+        },
+        {
+          id: '27',
+          label: '27',
+        },
+        {
+          id: '28',
+          label: '28',
+        },
+        {
+          id: '29',
+          label: '29',
+        },
+        {
+          id: '30',
+          label: '30',
+        },
+        {
+          id: '31',
+          label: '31',
+        },
+        {
+          id: '32',
+          label: '32',
+        },
+        {
+          id: '33',
+          label: '33',
+        },
+      ],
+      edges: [
+        {
+          source: '0',
+          target: '1',
+        },
+        {
+          source: '0',
+          target: '2',
+        },
+        {
+          source: '3',
+          target: '0',
+        },
+        {
+          source: '0',
+          target: '4',
+        },
+        {
+          source: '5',
+          target: '0',
+        },
+        {
+          source: '0',
+          target: '7',
+        },
+        {
+          source: '0',
+          target: '8',
+        },
+        {
+          source: '0',
+          target: '9',
+        },
+        {
+          source: '0',
+          target: '10',
+        },
+        {
+          source: '0',
+          target: '11',
+        },
+        {
+          source: '0',
+          target: '13',
+        },
+        {
+          source: '14',
+          target: '0',
+        },
+        {
+          source: '0',
+          target: '15',
+        },
+        {
+          source: '0',
+          target: '16',
+        },
+        {
+          source: '2',
+          target: '3',
+        },
+        {
+          source: '4',
+          target: '5',
+        },
+        {
+          source: '4',
+          target: '6',
+        },
+        {
+          source: '5',
+          target: '6',
+        },
+        {
+          source: '7',
+          target: '13',
+        },
+        {
+          source: '8',
+          target: '14',
+        },
+        {
+          source: '9',
+          target: '10',
+        },
+        {
+          source: '10',
+          target: '22',
+        },
+        {
+          source: '10',
+          target: '14',
+        },
+        {
+          source: '10',
+          target: '12',
+        },
+        {
+          source: '10',
+          target: '24',
+        },
+        {
+          source: '10',
+          target: '21',
+        },
+        {
+          source: '10',
+          target: '20',
+        },
+        {
+          source: '11',
+          target: '24',
+        },
+        {
+          source: '11',
+          target: '22',
+        },
+        {
+          source: '11',
+          target: '14',
+        },
+        {
+          source: '12',
+          target: '13',
+        },
+        {
+          source: '16',
+          target: '17',
+        },
+        {
+          source: '16',
+          target: '18',
+        },
+        {
+          source: '16',
+          target: '21',
+        },
+        {
+          source: '16',
+          target: '22',
+        },
+        {
+          source: '17',
+          target: '18',
+        },
+        {
+          source: '17',
+          target: '20',
+        },
+        {
+          source: '18',
+          target: '19',
+        },
+        {
+          source: '19',
+          target: '20',
+        },
+        {
+          source: '19',
+          target: '33',
+        },
+        {
+          source: '19',
+          target: '22',
+        },
+        {
+          source: '19',
+          target: '23',
+        },
+        {
+          source: '20',
+          target: '21',
+        },
+        {
+          source: '21',
+          target: '22',
+        },
+        {
+          source: '22',
+          target: '24',
+        },
+        {
+          source: '22',
+          target: '25',
+        },
+        {
+          source: '22',
+          target: '26',
+        },
+        {
+          source: '22',
+          target: '23',
+        },
+        {
+          source: '22',
+          target: '28',
+        },
+        {
+          source: '22',
+          target: '30',
+        },
+        {
+          source: '22',
+          target: '31',
+        },
+        {
+          source: '22',
+          target: '32',
+        },
+        {
+          source: '22',
+          target: '33',
+        },
+        {
+          source: '23',
+          target: '28',
+        },
+        {
+          source: '23',
+          target: '27',
+        },
+        {
+          source: '23',
+          target: '29',
+        },
+        {
+          source: '23',
+          target: '30',
+        },
+        {
+          source: '23',
+          target: '31',
+        },
+        {
+          source: '23',
+          target: '33',
+        },
+        {
+          source: '32',
+          target: '33',
+        },
+      ],
+    };
+    graph.changeData(data)
+    const result = detectAllCycles(graph, true, graph.getNodes()[14])
+    const result2 = detectAllCycles(graph)
+    expect(result.length).toEqual(4);
+    expect(result2.length).toEqual(27);
+  })
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->

1. 提供支持寻找图中所有环路的函数 。对有向图来说返回所有**简单环**；对于无向图来说，返回所有**基本环**。可以传入一个节点为参数，则返回包含该节点的所有环。
```
/**
 * 查找图中所有满足要求的圈
 * @param graph 
 * @param directed 是否为有向图
 * @param nodeIds 节点 ID 的数组，若不指定，则返回图中所有的圈
 * @param include 包含或排除指定的节点 
 * @return [{[key: string]: Node}] 包含所有环的数组，每个环用一个Object表示，其中key为节点id，value为该节点在环中指向的下一个节点
 */
detectAllCycles(graph: IGraph, directed?: boolean, node?: INode)
```
使用时从Algorithm下导出 `import { detectAllCycles } = Algorithm`

2. 由于检测有向图所有环基于检测有向图的强连通分量，因此也支持了检测图的连通分量的算法。
`getConnectedComponents(graph: IGraph, directed?: boolean)`