### PR TITLE
fix: Update Event.zh.md 经调试 初始化布局后没有调用afterlayout 方法 而是调用了afterrender

### DIFF
--- a/docs/api/Event.zh.md
+++ b/docs/api/Event.zh.md
@@ -112,7 +112,7 @@ order: 8
 | beforemodechange | 调用 `setMode` / `addBehaviors` / `removeBehaviors` 方法之前触发 |
 | aftermodechange | 调用 `setMode` / `addBehaviors` / `removeBehaviors` 方法之后触发 |
 | beforelayout | 布局前触发。调用 `render` 时会进行布局，因此 `render` 时会触发。或用户主动调用图的 `layout` 时触发。 |
-| afterlayout | 布局完成后触发。调用 `render` 时会进行布局，因此 `render` 时布局完成后会触发。或用户主动调用图的 `layout` 时布局完成后触发。 |
+| afterrender | 布局完成后触发。调用 `render` 时会进行布局，因此 `render` 时布局完成后会触发。或用户主动调用图的 `layout` 时布局完成后触发。 |
 | afteractivaterelations | 使用了 `'activate-relations'` Behavior 并触发了该行为后，该事件被触发 |
 | nodeselectchange | 使用了 `'brush-select'` , `'click-select'` 或 `'lasso-select'` Behavior 且选中元素发生变化时，该事件被触发 |
 | itemcollapsed | 在 TreeGraph 上使用了 `'collapse-expand'` Behavior 并触发了该行为后，该事件被触发 |
@@ -184,7 +184,7 @@ order: 8
 | ---- | ---- | -------------------- |
 | item | Item | 当前操作的 item 实例 |
 
-#### beforelayout / afterlayout
+#### beforelayout / afterrender
 
 无参数
 


### PR DESCRIPTION
经调试 初始化布局后没有调用afterlayout 方法
```
this.graph.on('beforelayout',function(){
    console.log('beforelayout')
})
this.graph.on('afterlayout',function(){
    console.log('afterlayout')
})
this.graph.on('afterrender',function(){
    console.log('afterrender')
})
```
结果：
afterrender
beforelayout
afterrender
麻烦大家一起check一下

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->
