### PR TITLE
fix: handleMenuClick trigger multiple times

### DIFF
--- a/src/plugins/menu/index.ts
+++ b/src/plugins/menu/index.ts
@@ -118,7 +118,11 @@ export default class Menu extends Base {
 
     const handleMenuClick = this.get('handleMenuClick')
     if (handleMenuClick) {
-      menuDom.addEventListener('click', handleMenuClick);
+      const handleMenuClickWrapper = (evt) => {
+        handleMenuClick(evt.target, e.item)
+      }
+      this.set('handleMenuClickWrapper', handleMenuClickWrapper)
+      menuDom.addEventListener('click', handleMenuClickWrapper);
     }
 
     const graph: Graph = this.get('graph');
@@ -166,9 +170,9 @@ export default class Menu extends Base {
     // 隐藏菜单后需要移除事件监听
     document.body.removeEventListener('click', this.get('handler'));
 
-    const handleMenuClick = this.get('handleMenuClick')
-    if (handleMenuClick) {
-      menuDom.removeEventListener('click', handleMenuClick)
+    const handleMenuClickWrapper = this.get('handleMenuClickWrapper');
+    if (handleMenuClickWrapper) {
+      menuDom.removeEventListener('click', handleMenuClickWrapper);
     }
   }
 
@@ -176,9 +180,9 @@ export default class Menu extends Base {
     const menu = this.get('menu')
     const handler = this.get('handler');
 
-    const handleMenuClick = this.get('handleMenuClick')
-    if (handleMenuClick) {
-      menu.removeEventListener('click', handleMenuClick)
+    const handleMenuClickWrapper = this.get('handleMenuClickWrapper');
+    if (handleMenuClickWrapper) {
+      menu.removeEventListener('click', handleMenuClickWrapper);
     }
 
     if (menu) {


### PR DESCRIPTION
1. handleMenuClick listerner not removed on menu hide

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->
