### PR TITLE
Update index.ts

### DIFF
--- a/examples/case/decisionTree/demo/index.ts
+++ b/examples/case/decisionTree/demo/index.ts
@@ -495,7 +495,7 @@ const initEvent = () => {
         updateCollapseStatus(id, recordIndex, collapsed);
         graph.changeData(getPosition(backUpData));
         await sleep(500);
-        graph.setItemState(item, 'click', false);
+        graph.setItemState(item, 'click', true);
         isAnimating = false;
       } else {
         updateCollapseStatus(id, recordIndex, collapsed, 'collapsed');
@@ -514,7 +514,7 @@ const initEvent = () => {
             graph.remove(childrenItem);
           }
         });
-        graph.setItemState(item, 'click', false);
+        graph.setItemState(item, 'click', true);
         isAnimating = false;
       }
     } else {


### PR DESCRIPTION
demo中 https://g6.antv.vision/zh/examples/case/decisionTree

第一次点击根节点的使得节点全部collapsed的时候, TextShape的text还是‘-’， 但理论上说应该为‘+’。

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->
