### PR TITLE
Feature/force in a box

### DIFF
--- a/src/layout/force/force-in-a-box.ts
+++ b/src/layout/force/force-in-a-box.ts
@@ -51,12 +51,10 @@ export default function forceInABox() {
       return;
     }
 
-    if (nodes && nodes.length > 0) {
-      if (groupBy(nodes[0]) === undefined) {
-        throw Error(
-          "Couldnt find the grouping attribute for the nodes. Make sure to set it up with forceInABox.groupBy('clusterAttr') before calling .links()",
-        );
-      }
+    if (groupBy(nodes[0]) === undefined) {
+      throw Error(
+        "Couldnt find the grouping attribute for the nodes. Make sure to set it up with forceInABox.groupBy('clusterAttr') before calling .links()",
+      );
     }
 
     // checkLinksAsObjects();

--- a/src/layout/force/force-in-a-box.ts
+++ b/src/layout/force/force-in-a-box.ts
@@ -1,0 +1,326 @@
+import * as d3Force from 'd3-force';
+
+// https://github.com/john-guerra/forceInABox/blob/master/src/forceInABox.js
+export default function forceInABox() {
+  function constant(_: any): () => any {
+    return () => _;
+  }
+
+  var nodes = [],
+    nodesMap = {},
+    links = [], //needed for the force version
+    centerX = 100,
+    centerY = 100,
+    forceNodeSize: (() => number) | ((d: any) => number) = constant(1), // The expected node size used for computing the cluster node
+    forceCharge: (() => number) | ((d: any) => number) = constant(-1),
+    forceLinkDistance: (() => number) | ((d: any) => number) = constant(100),
+    forceLinkStrength: (() => number) | ((d: any) => number) = constant(0.1),
+    foci = { none: { x: 0, y: 0 } },
+    templateNodes = [],
+    offset = [0, 0],
+    templateForce,
+    groupBy = function groupBy(d) {
+      return d.cluster;
+    },
+    template = 'force',
+    enableGrouping = true,
+    strength = 0.1;
+
+  function force(alpha) {
+    if (!enableGrouping) {
+      return force;
+    }
+    templateForce.tick();
+    getFocisFromTemplate();
+
+    for (var i = 0, n = nodes.length, node, k = alpha * strength; i < n; ++i) {
+      node = nodes[i];
+      node.vx += (foci[groupBy(node)].x - node.x) * k;
+      node.vy += (foci[groupBy(node)].y - node.y) * k;
+    }
+  }
+
+  function initialize() {
+    if (!nodes) return;
+    initializeWithForce();
+  }
+
+  function initializeWithForce() {
+    var net;
+
+    if (!nodes || !nodes.length) {
+      return;
+    }
+
+    if (nodes && nodes.length > 0) {
+      if (groupBy(nodes[0]) === undefined) {
+        throw Error(
+          "Couldnt find the grouping attribute for the nodes. Make sure to set it up with forceInABox.groupBy('clusterAttr') before calling .links()",
+        );
+      }
+    }
+
+    // checkLinksAsObjects();
+
+    net = getGroupsGraph();
+    templateForce = d3Force
+      .forceSimulation(net.nodes)
+      .force('x', d3Force.forceX(centerX).strength(0.1))
+      .force('y', d3Force.forceY(centerY).strength(0.1))
+      .force(
+        'collide',
+        d3Force
+          .forceCollide(function (d: { r: any }) {
+            return d.r;
+          })
+          .iterations(4),
+      )
+      .force('charge', d3Force.forceManyBody().strength(forceCharge))
+      .force(
+        'links',
+        d3Force
+          .forceLink(net.nodes.length ? net.links : [])
+          .distance(forceLinkDistance)
+          .strength(forceLinkStrength),
+      );
+
+    templateNodes = templateForce.nodes();
+
+    getFocisFromTemplate();
+  }
+
+  function checkLinksAsObjects() {
+    // Check if links come in the format of indexes instead of objects
+    var linkCount = 0;
+    if (nodes.length === 0) return;
+
+    links.forEach(function (link) {
+      var source, target;
+      if (!nodes) return;
+      source = link.source;
+      target = link.target;
+      if (typeof link.source !== 'object') source = nodes[link.source];
+      if (typeof link.target !== 'object') target = nodes[link.target];
+      if (source === undefined || target === undefined) {
+        // console.error(link);
+        throw Error('Error setting links, couldnt find nodes for a link (see it on the console)');
+      }
+      link.source = source;
+      link.target = target;
+      link.index = linkCount++;
+    });
+  }
+
+  function getGroupsGraph() {
+    let gnodes = [],
+      glinks = [],
+      dNodes = {},
+      clustersList = [],
+      // c,
+      // i,
+      // cc,
+      clustersCounts = {},
+      clustersLinks = [];
+
+    clustersCounts = computeClustersNodeCounts(nodes);
+    clustersLinks = computeClustersLinkCounts(links);
+
+    clustersList = Object.keys(clustersCounts);
+    for (let i = 0; i < clustersList.length; i += 1) {
+      const key = clustersList[i];
+      const val = clustersCounts[key];
+      gnodes.push({
+        id: key,
+        size: val.count,
+        r: Math.sqrt(val.sumforceNodeSize / Math.PI),
+      }); // Uses approx meta-node size
+      dNodes[key] = i;
+    }
+
+    clustersLinks.forEach(function (l) {
+      var source = dNodes[l.source],
+        target = dNodes[l.target];
+      if (source !== undefined && target !== undefined) {
+        glinks.push({
+          source: source,
+          target: target,
+          count: l.count,
+        });
+      }
+    });
+
+    return { nodes: gnodes, links: glinks };
+  }
+
+  function computeClustersNodeCounts(nodes) {
+    const clustersCounts = {};
+
+    nodes.forEach(function (d) {
+      const key = groupBy(d);
+      if (!clustersCounts[key]) {
+        clustersCounts[key] = { count: 0, sumforceNodeSize: 0 };
+      }
+    });
+    nodes.forEach(function (d: any) {
+      const key = groupBy(d);
+      const nodeSize = forceNodeSize(d);
+      const tmpCount = clustersCounts[key];
+      tmpCount.count = tmpCount.count + 1;
+      tmpCount.sumforceNodeSize = tmpCount.sumforceNodeSize + Math.PI * (nodeSize * nodeSize) * 1.3;
+      clustersCounts[key] = tmpCount;
+    });
+
+    return clustersCounts;
+  }
+
+  //Returns
+  function computeClustersLinkCounts(links) {
+    const dClusterLinks = {};
+    const clusterLinks = [];
+    links.forEach(function (l) {
+      const key = getLinkKey(l);
+      let count = 0;
+      if (dClusterLinks[key] !== undefined) {
+        count = dClusterLinks[key];
+      }
+      count += 1;
+      dClusterLinks[key] = count;
+    });
+
+    const entries = Object.entries(dClusterLinks);
+
+    entries.forEach(([key, count]) => {
+      const source = key.split('~')[0];
+      const target = key.split('~')[1];
+      if (source !== undefined && target !== undefined) {
+        clusterLinks.push({
+          source: source,
+          target: target,
+          count: count,
+        });
+      }
+    });
+
+    return clusterLinks;
+  }
+
+  function getFocisFromTemplate() {
+    //compute foci
+    foci.none = { x: 0, y: 0 };
+    templateNodes.forEach(function (d) {
+      foci[d.id] = {
+        x: d.x - offset[0],
+        y: d.y - offset[1],
+      };
+    });
+    return foci;
+  }
+
+  function getLinkKey(l) {
+    const sourceID = groupBy(nodesMap[l.source]);
+    const targetID = groupBy(nodesMap[l.target]);
+
+    return sourceID <= targetID ? sourceID + '~' + targetID : targetID + '~' + sourceID;
+  }
+
+  function genNodesMap(nodes) {
+    nodes.forEach((node) => {
+      nodesMap[node.id] = node;
+    });
+  }
+
+  force.initialize = function (_) {
+    nodes = _;
+    initialize();
+  };
+
+  force.template = function (x) {
+    if (!arguments.length) return template;
+    template = x;
+    initialize();
+    return force;
+  };
+
+  force.groupBy = function (x) {
+    if (!arguments.length) return groupBy;
+    if (typeof x === 'string') {
+      groupBy = function (d) {
+        return d[x];
+      };
+      return force;
+    }
+    groupBy = x;
+    return force;
+  };
+
+  force.enableGrouping = function (x) {
+    if (!arguments.length) return enableGrouping;
+    enableGrouping = x;
+    // update();
+    return force;
+  };
+
+  force.strength = function (x) {
+    if (!arguments.length) return strength;
+    strength = x;
+    return force;
+  };
+
+  force.centerX = function (_) {
+    return arguments.length ? ((centerX = _), force) : centerX;
+  };
+
+  force.centerY = function (_) {
+    return arguments.length ? ((centerY = _), force) : centerY;
+  };
+
+  force.nodes = function (_) {
+    arguments.length && genNodesMap(_);
+    return arguments.length ? ((nodes = _), force) : nodes;
+  };
+
+  force.links = function (_) {
+    if (!arguments.length) return links;
+    if (_ === null) links = [];
+    else links = _;
+    initialize();
+    return force;
+  };
+
+  force.forceNodeSize = function (_) {
+    return arguments.length
+      ? ((forceNodeSize = typeof _ === 'function' ? _ : constant(+_)), initialize(), force)
+      : forceNodeSize;
+  };
+
+  // Legacy support
+  force.nodeSize = force.forceNodeSize;
+
+  force.forceCharge = function (_) {
+    return arguments.length
+      ? ((forceCharge = typeof _ === 'function' ? _ : constant(+_)), initialize(), force)
+      : forceCharge;
+  };
+
+  force.forceLinkDistance = function (_) {
+    return arguments.length
+      ? ((forceLinkDistance = typeof _ === 'function' ? _ : constant(+_)), initialize(), force)
+      : forceLinkDistance;
+  };
+
+  force.forceLinkStrength = function (_) {
+    return arguments.length
+      ? ((forceLinkStrength = typeof _ === 'function' ? _ : constant(+_)), initialize(), force)
+      : forceLinkStrength;
+  };
+
+  force.offset = function (_) {
+    return arguments.length
+      ? ((offset = typeof _ === 'function' ? _ : constant(+_)), force)
+      : offset;
+  };
+
+  force.getFocis = getFocisFromTemplate;
+
+  return force;
+}

--- a/src/layout/force/force.ts
+++ b/src/layout/force/force.ts
@@ -90,6 +90,7 @@ export default class ForceLayout<Cfg = any> extends BaseLayout {
   private ticking: boolean | undefined = undefined;
 
   private edgeForce: any;
+
   private clusterForce: any;
 
   public getDefaultCfg() {
@@ -252,12 +253,12 @@ export default class ForceLayout<Cfg = any> extends BaseLayout {
       }
     } else {
       if (reloadData) {
-        simulation.nodes(nodes);
-        self.edgeForce.links(edges);
         if (self.clustering && self.clusterForce) {
           self.clusterForce.nodes(nodes);
           self.clusterForce.links(edges);
         }
+        simulation.nodes(nodes);
+        self.edgeForce.links(edges);
       }
       if (self.preventOverlap) {
         self.overlapProcess(simulation);

--- a/src/layout/index.ts
+++ b/src/layout/index.ts
@@ -9,7 +9,7 @@ import Layout from './layout';
 import Circular from './circular';
 import Concentric from './concentric';
 import Dagre from './dagre';
-import Force from './force';
+import Force from './force/force';
 import G6Force from './g6force';
 import Fruchterman from './fruchterman';
 import Grid from './grid';

--- a/stories/Layout/component/force-clustering-layout.tsx
+++ b/stories/Layout/component/force-clustering-layout.tsx
@@ -1,0 +1,71 @@
+import React, { useEffect } from 'react';
+import G6 from '../../../src';
+import { IGraph } from '../../../src/interface/graph';
+
+let graph: IGraph = null;
+let yearGroup: { [key: string]: number } = {};
+let colorMap = {
+  2012: 'blue',
+  2013: 'yellow',
+  2014: 'red',
+  2015: 'gray',
+  2016: 'black',
+};
+
+const ForceClusteringLayout = () => {
+  const container = React.useRef();
+  useEffect(() => {
+    if (!graph) {
+      const graph = new G6.Graph({
+        container: container.current as string | HTMLElement,
+        width: 1000,
+        height: 1000,
+        layout: {
+          type: 'force',
+          clustering: true,
+          clusterNodeStrength: -10,
+          clusterEdgeDistance: 200,
+          clusterNodeSize: 20,
+          // nodeStrength: -100,
+          clusterFociStrength: 1.2,
+          nodeSpacing: 5,
+          preventOverlap: true,
+        },
+        defaultNode: {
+          size: 15,
+          color: '#5B8FF9',
+          style: {
+            lineWidth: 2,
+            fill: '#C6E5FF',
+          },
+        },
+        defaultEdge: {
+          size: 1,
+          color: '#e2e2e2',
+        },
+        modes: {
+          default: ['drag-canvas'],
+        },
+      });
+
+      fetch(
+        'https://gw.alipayobjects.com/os/basement_prod/7bacd7d1-4119-4ac1-8be3-4c4b9bcbc25f.json',
+      )
+        .then((res) => res.json())
+        .then((data) => {
+          graph.data(data);
+          data.nodes.forEach((i) => {
+            i.cluster = i.year;
+            i.style = Object.assign(i.style || {}, {
+              fill: colorMap[i.year],
+            });
+          });
+          graph.render();
+        });
+    }
+  });
+
+  return <div ref={container}></div>;
+};
+
+export default ForceClusteringLayout;

--- a/stories/Layout/component/force-clustering-layout.tsx
+++ b/stories/Layout/component/force-clustering-layout.tsx
@@ -3,7 +3,6 @@ import G6 from '../../../src';
 import { IGraph } from '../../../src/interface/graph';
 
 let graph: IGraph = null;
-let yearGroup: { [key: string]: number } = {};
 let colorMap = {
   2012: 'blue',
   2013: 'yellow',

--- a/stories/Layout/layout.stories.tsx
+++ b/stories/Layout/layout.stories.tsx
@@ -8,6 +8,7 @@ import AddNodeLayout from './component/addNodeLayout';
 import ChangeData from './component/changeData';
 import ComboForceLayout from './component/combo-force-layout';
 import ForceLayout from './component/force-layout';
+import ForceClusteringLayout from './component/force-clustering-layout';
 import CompactBox from './component/compact-box';
 import AutoLayout from './component/auto-layout';
 
@@ -22,5 +23,6 @@ storiesOf('Layout', module)
   .add('combo force layout', () => <ComboForceLayout />)
   .add('Fruchterman worker layout', () => <FruchtermanWorker />)
   .add('force layout', () => <ForceLayout />)
+  .add('force clustering layout', () => <ForceClusteringLayout />)
   .add('compactbox layout', () => <CompactBox />)
-  .add('auto layout', () => <AutoLayout />)
+  .add('auto layout', () => <AutoLayout />);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change
在原force布局的配置项中，添加了clustering配置开关，以及相关参数配置选项，内部逻辑，大致是，按照节点的cluster属性，进行分组，相同cluster的节点会约束在一个区域内。
与 https://g6.antv.vision/zh/examples/net/forceDirected#forceConstrainedInRect 的差异在于
- demo中主要在onTick回调中调整节点位置，而pr中的是通过force进行约束
- demo中由于onTick是个函数，所以在开启webworker时无效，pr中的支持webworker
<!-- Provide a description of the change below this comment. -->
