### PR TITLE
dev/add_missing_modeoption_property

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -122,6 +122,7 @@ export interface ModeOption {
   delegateStyle?: object;
   updateEdge?: boolean;
   trigger?: string;
+  relayout?: boolean;
   enableDelegate?: boolean;
   maxZoom?: number;
   minZoom?: number;


### PR DESCRIPTION
because of missing 'relayout' property in index.d.ts, it was not possible to use it in Typescript project