### PR TITLE
fix: custom node "pieChart" demo

### DIFF
--- a/examples/item/customNode/demo/pieChart.js
+++ b/examples/item/customNode/demo/pieChart.js
@@ -14,12 +14,12 @@ G6.registerNode('pie-node', {
     const radius = cfg.size / 2; // node radius
     const inPercentage = cfg.inDegree / cfg.degree; // the ratio of indegree to outdegree
     const inAngle = inPercentage * Math.PI * 2; // the anble for the indegree fan
-    const inArcEnd = [radius * Math.cos(inAngle), radius * Math.sin(inAngle)]; // the end position for the in-degree fan
-    let isInBigArc = 1,
-      isOutBigArc = 0;
-    if (inAngle > Math.PI) {
-      isInBigArc = 0;
+    const inArcEnd = [radius * Math.cos(inAngle), -radius * Math.sin(inAngle)]; // the end position for the in-degree fan
+    let isInBigArc = 0,
       isOutBigArc = 1;
+    if (inAngle > Math.PI) {
+      isInBigArc = 1;
+      isOutBigArc = 0;
     }
     // fan shape for the in degree
     const fanIn = group.addShape('path', {


### PR DESCRIPTION
large arc flag and the y coordinate of the end position are wrong.

Current rendering:
![image](https://user-images.githubusercontent.com/16070518/98226520-1a7c3a00-1f91-11eb-92ed-95cb477d22a1.png)

Correct rendering:
![image](https://user-images.githubusercontent.com/16070518/98226473-0a645a80-1f91-11eb-8383-aeda2c53c9c6.png)
