### PR TITLE
fix: ts error.

### DIFF
--- a/src/global.ts
+++ b/src/global.ts
@@ -92,6 +92,7 @@ export default {
     style: {
       stroke: colorSet.edgeMainStroke,
       lineAppendWidth: 4,
+      lineWidth: 1,
     },
     size: 1,
     color: colorSet.edgeMainStroke,


### PR DESCRIPTION
Fixing 'src/shape/edge.ts:66:43 ' and 'src/shape/edges/polyline.ts:25:45', TS2339:Property 'lineWidth' does not exist on type '{ stroke: string; lineAppendWidth: number; }'.

<!-- Provide a description of the change below this comment. -->
![image](https://user-images.githubusercontent.com/16070518/98925517-0eecbe00-2511-11eb-8c5b-43145f38d8ba.png)
