### PR TITLE
fix: unnecessary mousedown.

### DIFF
--- a/src/behavior/drag-canvas.ts
+++ b/src/behavior/drag-canvas.ts
@@ -76,7 +76,7 @@ export default {
     const self = this as any;
     const event = e.originalEvent as MouseEvent;
 
-    if (event.button !== 0) {
+    if (event && event.button !== 0) {
       return;
     }
     

--- a/src/behavior/drag-canvas.ts
+++ b/src/behavior/drag-canvas.ts
@@ -74,6 +74,12 @@ export default {
   },
   onMouseDown(e: IG6GraphEvent) {
     const self = this as any;
+    const event = e.originalEvent as MouseEvent;
+
+    if (event.button !== 0) {
+      return;
+    }
+    
     if (
       e.name !== G6Event.TOUCHSTART &&
       window &&


### PR DESCRIPTION
Avoid enabling drag when the non-left mouse button is pressed, causing optimization to be enabled.

Right click before fix：
![Before fix](https://user-images.githubusercontent.com/16070518/99022959-90d6f880-259e-11eb-9e99-5f5f0aefafe6.gif)

Right click after fix：
![After fix](https://user-images.githubusercontent.com/16070518/99022954-8fa5cb80-259e-11eb-811a-bebb04433f80.gif)


