### PR TITLE
fix: get fontFamily of the window in global leads to DOM depending wh…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # ChangeLog
 
+#### 3.8.5
+- fix: get fontFamily of the window in global leads to DOM depending when using bigfish;
+
 #### 3.8.4
 - feat: new version of basic styles for light version;
 - feat: shortcuts-call behavior for calling a Graph function by shortcuts;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antv/g6",
-  "version": "3.8.4",
+  "version": "3.8.5",
   "description": "A Graph Visualization Framework in JavaScript",
   "keywords": [
     "antv",

--- a/src/global.ts
+++ b/src/global.ts
@@ -2,13 +2,12 @@ import { getColorsWithSubjectColor } from './util/color';
 
 const subjectColor = 'rgb(95, 149, 255)';
 const backColor = 'rgb(255, 255, 255)';
-const disableColor = 'rgb(150, 150, 150)';
 const textColor = 'rgb(0, 0, 0)';
 
 const colorSet = getColorsWithSubjectColor(subjectColor, backColor);
 
 export default {
-  version: '3.8.4',
+  version: '3.8.5',
   rootContainerClassName: 'root-container',
   nodeContainerClassName: 'node-container',
   edgeContainerClassName: 'edge-container',
@@ -22,7 +21,6 @@ export default {
       fontSize: 12,
       textAlign: 'center',
       textBaseline: 'middle',
-      fontFamily: typeof window !== 'undefined' ? window.getComputedStyle(document.body, null).getPropertyValue("font-family") || 'Arial, sans-serif' : 'Arial, sans-serif',
     },
     offset: 4, // 节点的默认文本不居中时的偏移量
   },
@@ -86,7 +84,6 @@ export default {
       textAlign: 'center',
       textBaseline: 'middle',
       fontSize: 12,
-      fontFamily: typeof window !== 'undefined' ? window.getComputedStyle(document.body, null).getPropertyValue("font-family") || 'Arial, sans-serif' : 'Arial, sans-serif',
     },
   },
   defaultEdge: {

--- a/src/shape/edge.ts
+++ b/src/shape/edge.ts
@@ -341,7 +341,9 @@ const singleEdge: ShapeOptions = {
   },
   drawLabel(cfg: EdgeConfig, group: GGroup): IShape {
     const { labelCfg: defaultLabelCfg } = this.options as ModelConfig;
-    const labelCfg = deepMix({}, defaultLabelCfg, cfg.labelCfg);
+    const labelCfg = deepMix({
+      fontFamily: typeof window !== 'undefined' ? window.getComputedStyle(document.body, null).getPropertyValue("font-family") || 'Arial, sans-serif' : 'Arial, sans-serif',
+    }, defaultLabelCfg, cfg.labelCfg);
     const labelStyle = this.getLabelStyle!(cfg, labelCfg, group);
     const rotate = labelStyle.rotate;
     delete labelStyle.rotate;

--- a/src/shape/shapeBase.ts
+++ b/src/shape/shapeBase.ts
@@ -28,7 +28,19 @@ export const shapeBase: ShapeOptions = {
     return {};
   },
   getOptions(cfg: ModelConfig): ModelConfig {
-    return deepMix({}, this.options, this.getCustomConfig(cfg) || {}, cfg);
+    return deepMix({
+      // 解决局部渲染导致的文字移动残影问题
+      labelCfg: {
+        style: {
+          fontFamily: typeof window !== 'undefined' ? window.getComputedStyle(document.body, null).getPropertyValue("font-family") || 'Arial, sans-serif' : 'Arial, sans-serif',
+        }
+      },
+      descriptionCfg: {
+        style: {
+          fontFamily: typeof window !== 'undefined' ? window.getComputedStyle(document.body, null).getPropertyValue("font-family") || 'Arial, sans-serif' : 'Arial, sans-serif',
+        }
+      }
+    }, this.options, this.getCustomConfig(cfg) || {}, cfg);
   },
   /**
    * 绘制节点/边，包含文本


### PR DESCRIPTION
…en using bigfish

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->
