### PR TITLE
fix: jsx node relative positioning error

### DIFF
--- a/examples/item/customNode/demo/jsxNode.js
+++ b/examples/item/customNode/demo/jsxNode.js
@@ -15,25 +15,25 @@ G6.registerNode('rect-jsx',
           height: 20,
           fill: ${cfg.color},
           radius: [6, 6, 0, 0],
-          cursor: 'move'，
+          cursor: 'move',
           stroke: ${cfg.color}
         }} draggable="true">
-          <text style={{ 
-            marginTop: 2, 
-            marginLeft: 75, 
-            textAlign: 'center', 
-            fontWeight: 'bold', 
+          <text style={{
+            marginTop: 2,
+            marginLeft: 75,
+            textAlign: 'center',
+            fontWeight: 'bold',
             fill: '#fff' }}>{{label}}</text>
         </rect>
         <rect style={{
           width: 150,
           height: 55,
           stroke: ${cfg.color},
-          fill: #ffffff,
+          fill: '#ffffff',
           radius: [0, 0, 6, 6],
         }}>
-          <text style={{ marginTop: 5, marginLeft: 3, fill: '#333', marginLeft: 4 }}>描述: {{description}}</text>
-          <text style={{ marginTop: 10, marginLeft: 3, fill: '#333', marginLeft: 4 }}>创建者: {{meta.creatorName}}</text>
+          <text style={{ marginTop: 5, fill: '#333', marginLeft: 4 }}>描述: {{description}}</text>
+          <text style={{ marginTop: 10, fill: '#333', marginLeft: 4 }}>创建者: {{meta.creatorName}}</text>
         </rect>
       </rect>
       <circle style={{

--- a/examples/item/customNode/demo/jsxNodeWithAnimate.js
+++ b/examples/item/customNode/demo/jsxNodeWithAnimate.js
@@ -18,25 +18,25 @@ G6.registerNode('rect-xml', {
           height: 20,
           fill: ${cfg.color},
           radius: [6, 6, 0, 0],
-          cursor: 'move'，
+          cursor: 'move',
           stroke: ${cfg.color}
         }} draggable="true">
-          <text style={{ 
-            marginTop: 2, 
-            marginLeft: 75, 
-            textAlign: 'center', 
-            fontWeight: 'bold', 
+          <text style={{
+            marginTop: 2,
+            marginLeft: 75,
+            textAlign: 'center',
+            fontWeight: 'bold',
             fill: '#fff' }}>{{label}}</text>
         </rect>
         <rect style={{
           width: 150,
           height: 55,
           stroke: ${cfg.color},
-          fill: #ffffff,
+          fill: '#ffffff',
           radius: [0, 0, 6, 6],
         }}>
-          <text style={{ marginTop: 5, marginLeft: 3, fill: '#333', marginLeft: 4 }}>描述: {{description}}</text>
-          <text style={{ marginTop: 10, marginLeft: 3, fill: '#333', marginLeft: 4 }}>创建者: {{meta.creatorName}}</text>
+          <text style={{ marginTop: 5, fill: '#333', marginLeft: 4 }}>描述: {{description}}</text>
+          <text style={{ marginTop: 10, fill: '#333', marginLeft: 4 }}>创建者: {{meta.creatorName}}</text>
         </rect>
       </rect>
       <circle style={{

--- a/src/shape/xml.ts
+++ b/src/shape/xml.ts
@@ -275,7 +275,7 @@ export function getBBox(
     case 'text':
       if (attrs.text) {
         shapeWidth = getTextSize(attrs.text, attrs.fontSize || 12)[0];
-        shapeHeight = 16;
+        shapeHeight = attrs.fontSize ? (attrs.fontSize + 4) : 16;
         bbox.y += shapeHeight;
         bbox.height = shapeHeight;
         bbox.width = shapeWidth;
@@ -328,22 +328,34 @@ export function generateTarget(target: NodeInstructure, lastOffset = { x: 0, y: 
 
   if (target.children?.length) {
     const { attrs = {} } = target;
-    const { marginTop } = attrs;
+    const { marginTop, marginLeft } = attrs;
     const offset = { ...lastOffset };
 
     if (marginTop) {
       offset.y += marginTop;
     }
 
+    const parentTrueOffsetX = lastOffset.x + (marginLeft || 0)
+    offset.x = parentTrueOffsetX
+    let inlineMaxHeight = -1
     for (let index = 0; index < target.children.length; index++) {
       target.children[index].attrs.key = `${attrs.key || 'root'} -${index} `;
       const node = generateTarget(target.children[index], offset);
       if (node.bbox) {
         const { bbox } = node;
         if (node.attrs.next === 'inline') {
+          if (bbox.height > inlineMaxHeight) {
+            inlineMaxHeight = bbox.height
+          }
           offset.x += node.bbox.width;
         } else {
-          offset.y += node.bbox.height;
+          offset.x = parentTrueOffsetX;
+          if (inlineMaxHeight === -1) {
+            offset.y += node.bbox.height;
+          } else {
+            offset.y += inlineMaxHeight > node.bbox.height ? inlineMaxHeight : node.bbox.height;
+          }
+          inlineMaxHeight = -1
         }
         if (bbox.width + bbox.x > defaultBbox.width) {
           defaultBbox.width = bbox.width + bbox.x;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->
fix relative positioning bugs with marginTop，marginLeft，inline

1.修复 父节点存在marginLeft时，子元素定位异常
2.修复节点存在inline属性时，后续无inline元素排版错误
3.修复 水平inline元素中，高度不同时，下一个块级元素纵向偏移计算错误
4.text元素shapeHeight根据fontSize动态计算

Closes #2375  