### PR TITLE
fix: update combo tree before remove item

### DIFF
--- a/src/algorithm/structs/queue/index.ts
+++ b/src/algorithm/structs/queue/index.ts
@@ -40,7 +40,7 @@ export default class Queue {
     return removeHead ? removeHead.value : null;
   }
 
-  public toString(callback) {
+  public toString(callback?: any) {
     return this.linkedList.toString(callback);
   }
 }

--- a/src/graph/graph.ts
+++ b/src/graph/graph.ts
@@ -948,8 +948,16 @@ export default class Graph extends EventEmitter implements IGraph {
         });
       }
 
+      if (type === 'node') {
+        const model = (nodeItem as INode).getModel()
+        // 如果删除的是节点，且该节点存在于某个 Combo 中，则需要先将 node 从 combo 中移除，否则删除节点后，操作 combo 会出错
+        if (model.comboId) {
+          this.updateComboTree(nodeItem as INode)
+        }
+      }
+
       const itemController: ItemController = this.get('itemController');
-      itemController.removeItem(item);
+      itemController.removeItem(nodeItem);
       if (type === 'combo') {
         const newComboTrees = reconstructTree(this.get('comboTrees'));
         this.set('comboTrees', newComboTrees);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,7 @@
     "lib": ["esnext", "dom"],
     "types": ["jest"]
   },
-  "include": ["src"],
+  "include": ["src", "tests"],
   "typedocOptions": {
     "mode": "modules",
     "out": "docs/api-ts",


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->
1. 删除combo 中的节点之前，先更新 Combo 的结构。