### PR TITLE
fix: add missing `inactiveState` field in type `ModeOption`

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -134,6 +134,7 @@ export interface ModeOption {
   optimizeZoom?: number;
   multiple?: boolean;
   activeState?: string;
+  inactiveState?: string;
   comboActiveState?: string;
   selectedState?: string;
   onlyChangeComboSize?: boolean;


### PR DESCRIPTION
ATT
