### PR TITLE
fix(typings): add sensitivity prop to ModeOption \n\n\n Closes #2433

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -128,6 +128,7 @@ export interface ModeOption {
   updateEdge?: boolean;
   trigger?: string;
   enableDelegate?: boolean;
+  sensitivity?: number;
   maxZoom?: number;
   minZoom?: number;
   enableOptimize?: boolean;

--- a/tests/unit/graph/controller/mode-spec.ts
+++ b/tests/unit/graph/controller/mode-spec.ts
@@ -107,4 +107,24 @@ describe('Mode Controller', () => {
     expect(customd1.type).toBe('bb');
     expect(customd2.type).toBe('bb');
   });
+
+  it('add sensitivity to zoom', () => {
+    const cfg: GraphOptions = {
+      container: 'graph-spec',
+      width: 200,
+      height: 100,
+      modes: {
+        default: [{
+          type: 'zoom-canvas',
+          sensitivity: 2,
+        }],
+      },
+    };
+    const graph: Graph = new Graph(cfg);
+    const modeController = new ModeController(graph);
+    expect(Object.keys(modeController.modes).length).toBe(1);
+    expect(modeController.modes.default[0]).toEqual({ type: 'zoom-canvas', sensitivity: 2});
+    expect(modeController.modes.default.length).toBe(1);
+    expect(modeController.mode).toBe('default');
+  });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change

Added `sensitivity` property to `ModeOption` interface as it was missing, but mentioned in [Official Documentation](https://g6.antv.vision/en/docs/manual/middle/states/defaultBehavior/#zoom-canvas) for `zoom-canvas` built-in behavior.
Also added a test suite, that covers that property.
