### PR TITLE
fix: remove redundant comments in demos

### DIFF
--- a/packages/site/examples/case/australiaFire/demo/index.js
+++ b/packages/site/examples/case/australiaFire/demo/index.js
@@ -1,9 +1,6 @@
 import G6 from '@antv/g6';
 import insertCss from 'insert-css';
 
-// 我们用 insert-css 演示引入自定义样式
-// 推荐将样式添加到自己的样式文件中
-// 若拷贝官方代码，别忘了 npm install insert-css
 insertCss(`
   #legendContainer{
     position: absolute;

--- a/packages/site/examples/case/edgeBundling/demo/index.js
+++ b/packages/site/examples/case/edgeBundling/demo/index.js
@@ -6,9 +6,6 @@ import insertCss from 'insert-css';
  * by 十吾
  */
 
-// 我们用 insert-css 演示引入自定义样式
-// 推荐将样式添加到自己的样式文件中
-// 若拷贝官方代码，别忘了 npm install insert-css
 insertCss(`
   .g6-tooltip {
     border: 1px solid #e2e2e2;

--- a/packages/site/examples/case/largeGraph/demo/index.js
+++ b/packages/site/examples/case/largeGraph/demo/index.js
@@ -2,9 +2,6 @@ import G6 from '@antv/g6';
 import insertCss from 'insert-css';
 import AntVUtil from '@antv/util';
 
-// 我们用 insert-css 演示引入自定义样式
-// 推荐将样式添加到自己的样式文件中
-// 若拷贝官方代码，别忘了 npm install insert-css
 insertCss(`
   .g6-component-contextmenu {
     position: absolute;

--- a/packages/site/examples/net/dagreFlow/demo/basicDagre.js
+++ b/packages/site/examples/net/dagreFlow/demo/basicDagre.js
@@ -1,9 +1,6 @@
 import G6 from '@antv/g6';
 import insertCss from 'insert-css';
 
-// 我们用 insert-css 演示引入自定义样式
-// 推荐将样式添加到自己的样式文件中
-// 若拷贝官方代码，别忘了 npm install insert-css
 insertCss(`
   .g6-tooltip {
     border-radius: 6px;

--- a/packages/site/examples/tool/contextMenu/demo/contextMenu.js
+++ b/packages/site/examples/tool/contextMenu/demo/contextMenu.js
@@ -2,9 +2,7 @@ import G6 from '@antv/g6';
 import insertCss from 'insert-css';
 
 // define the CSS with the id of your menu
-// 我们用 insert-css 演示引入自定义样式
-// 推荐将样式添加到自己的样式文件中
-// 若拷贝官方代码，别忘了 npm install insert-css
+
 insertCss(`
   #contextMenu {
     position: absolute;

--- a/packages/site/examples/tool/toolbar/demo/self-toolbar.js
+++ b/packages/site/examples/tool/toolbar/demo/self-toolbar.js
@@ -1,9 +1,6 @@
 import G6 from '@antv/g6';
 import insertCss from 'insert-css';
 
-// 我们用 insert-css 演示引入自定义样式
-// 推荐将样式添加到自己的样式文件中
-// 若拷贝官方代码，别忘了 npm install insert-css
 insertCss(`
   .g6-toolbar-ul {
     position: absolute;

--- a/packages/site/examples/tool/toolbar/demo/toolbar.js
+++ b/packages/site/examples/tool/toolbar/demo/toolbar.js
@@ -1,9 +1,6 @@
 import G6 from '@antv/g6';
 import insertCss from 'insert-css';
 
-// 我们用 insert-css 演示引入自定义样式
-// 推荐将样式添加到自己的样式文件中
-// 若拷贝官方代码，别忘了 npm install insert-css
 insertCss(`
   .g6-component-toolbar li {
     list-style-type: none !important;

--- a/packages/site/examples/tool/tooltip/demo/tooltip.js
+++ b/packages/site/examples/tool/tooltip/demo/tooltip.js
@@ -1,12 +1,6 @@
 import G6 from '@antv/g6';
 import insertCss from 'insert-css';
 
-// 我们用 insert-css 演示引入自定义样式
-// 推荐将样式添加到自己的样式文件中
-// 若拷贝官方代码，别忘了 npm install insert-css
-// 我们用 insert-css 演示引入自定义样式
-// 推荐将样式添加到自己的样式文件中
-// 若拷贝官方代码，别忘了 npm install insert-css
 insertCss(`
   .g6-component-tooltip {
     background-color: rgba(255, 255, 255, 0.8);

--- a/packages/site/examples/tool/tooltip/demo/tooltipLocalCustom.js
+++ b/packages/site/examples/tool/tooltip/demo/tooltipLocalCustom.js
@@ -1,9 +1,6 @@
 import G6 from '@antv/g6';
 import insertCss from 'insert-css';
 
-// 我们用 insert-css 演示引入自定义样式
-// 推荐将样式添加到自己的样式文件中
-// 若拷贝官方代码，别忘了 npm install insert-css
 insertCss(`
   .g6-tooltip {
     border: 1px solid #e2e2e2;

--- a/packages/site/examples/tool/tooltip/demo/tooltipPlugin.js
+++ b/packages/site/examples/tool/tooltip/demo/tooltipPlugin.js
@@ -1,12 +1,6 @@
 import G6 from '@antv/g6';
 import insertCss from 'insert-css';
 
-// 我们用 insert-css 演示引入自定义样式
-// 推荐将样式添加到自己的样式文件中
-// 若拷贝官方代码，别忘了 npm install insert-css
-// 我们用 insert-css 演示引入自定义样式
-// 推荐将样式添加到自己的样式文件中
-// 若拷贝官方代码，别忘了 npm install insert-css
 insertCss(`
   .g6-component-tooltip {
     background-color: rgba(255, 255, 255, 0.8);

--- a/packages/site/examples/tool/tooltip/demo/tooltipPluginLocal.js
+++ b/packages/site/examples/tool/tooltip/demo/tooltipPluginLocal.js
@@ -1,12 +1,6 @@
 import G6 from '@antv/g6';
 import insertCss from 'insert-css';
 
-// 我们用 insert-css 演示引入自定义样式
-// 推荐将样式添加到自己的样式文件中
-// 若拷贝官方代码，别忘了 npm install insert-css
-// 我们用 insert-css 演示引入自定义样式
-// 推荐将样式添加到自己的样式文件中
-// 若拷贝官方代码，别忘了 npm install insert-css
 insertCss(`
   .g6-component-tooltip {
     background-color: rgba(255, 255, 255, 0.8);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] commit message follows commit guidelines

##### Description of change

Delete the redundant comments for insertCss in demos.

These comments would be added automatically.
Check: 
- https://github.com/antvis/gatsby-theme-antv/blob/bcaa24f24310e8c97ffb89cf494d78b9db5b25e0/%40antv/gatsby-theme-antv/site/components/MdPlayground.tsx#L65
- https://github.com/antvis/gatsby-theme-antv/blob/bcaa24f24310e8c97ffb89cf494d78b9db5b25e0/%40antv/gatsby-theme-antv/site/components/PlayGround.tsx#L117

Since you also added them manually, these comments would be added twice.
Check: https://g6.antv.vision/en/examples/case/largeGraph#index

<img width="1565" alt="case" src="https://user-images.githubusercontent.com/6898060/105474036-c7d13500-5cd8-11eb-8ba2-8a6c3b338e58.png">


<!-- Provide a description of the change below this comment. -->
