### PR TITLE
fix(plugin): don't ignore `lib` `es` folder when publishing, also export `js` not `ts`

### DIFF
--- a/packages/plugin/.npmignore
+++ b/packages/plugin/.npmignore
@@ -13,8 +13,6 @@ coverage
 # Dependency directories
 node_modules
 **/node_modules
-**/lib
-**/es
 jspm_packages/
 
 # Optional npm cache directory
@@ -32,10 +30,6 @@ jspm_packages/
 
 # IDE
 .idea
-
-# build
-lib
-build
 
 # lock
 package-lock.json

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.6",
   "description": "G6 Plugin",
   "main": "lib/index.js",
-  "module": "es/index.ts",
+  "module": "es/index.js",
   "scripts": {
     "build": "npm run clean && father build",
     "ci": "npm run build && npm run coverage",


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->

`@antv/plugin` 的 `.npmignore` 里面指定了发布 npm 包时忽略 `lib` 和 `es` 文件夹。我不知道为什么发布后 `lib` 文件夹还在，但是 `es` 文件夹的确没了

但是 `package.json` 里面指定了 `"module": "es/index.ts"`

https://github.com/antvis/G6/blob/d923571707b6c7882f9443fa0744c14b1724831e/packages/plugin/package.json#L6

这就导致一些检查严格的编译工具/脚手架（例如vite）报错

![image](https://user-images.githubusercontent.com/6134068/105819661-6d471a00-5ff3-11eb-970c-bde206479170.png)

另外 package.json 里面永远应该导出 js 文件而不是 ts