### PR TITLE
add feature: Layout pipes 

### DIFF
--- a/packages/core/src/graph/controller/layout.ts
+++ b/packages/core/src/graph/controller/layout.ts
@@ -1,5 +1,5 @@
-import { isFunction } from '@antv/util';
-import { isNaN } from '../../util/base';
+import { isFunction, groupBy } from '@antv/util';
+import { isNaN, calculationItemsBBox } from '../../util/base';
 import { GraphData } from '../../types';
 import { IAbstractGraph } from '../../interface/graph';
 
@@ -214,9 +214,9 @@ export default abstract class LayoutController {
 
   // 筛选参与布局的nodes和edges
   protected filterLayoutData(data, cfg) {
-    const { nodes, edges } = data;
+    const { nodes, edges, ...rest } = data;
     if (!nodes) {
-      return false;
+      return data;
     }
 
     let nodesFilter;
@@ -241,7 +241,24 @@ export default abstract class LayoutController {
 
     return {
       nodes: nodes.filter(nodesFilter),
-      edges: edges.filter(edegsFilter)
+      edges: edges.filter(edegsFilter),
+      ...rest
+    }
+  }
+
+  protected getLayoutBBox(nodes) {
+    const { graph } = this;
+    const graphGroupNodes = groupBy(graph.getNodes(), (n: any) => {
+      return n.getModel().layoutOrder;
+    });
+    const layoutNodes = Object.values(graphGroupNodes).map((value) => {
+      return calculationItemsBBox(value as any);
+    });
+
+    const groupNodes = Object.values(groupBy(nodes, 'layoutOrder'));
+    return {
+      groupNodes,
+      layoutNodes
     }
   }
 

--- a/packages/core/src/graph/graph.ts
+++ b/packages/core/src/graph/graph.ts
@@ -2181,37 +2181,24 @@ export default abstract class AbstractGraph extends EventEmitter implements IAbs
    */
   public updateLayout(cfg: any): void {
     const layoutController = this.get('layoutController');
-    let newLayoutType;
 
     if (isString(cfg)) {
-      newLayoutType = cfg;
       cfg = {
-        type: newLayoutType,
+        type: cfg,
       };
-    } else {
-      newLayoutType = cfg.type;
     }
 
     const oriLayoutCfg = this.get('layout');
-    const oriLayoutType = oriLayoutCfg ? oriLayoutCfg.type : undefined;
+    const layoutCfg: any = {};
+    Object.assign(layoutCfg, oriLayoutCfg, cfg);
+    this.set('layout', layoutCfg);
 
-    if (
-      (!newLayoutType || oriLayoutType === newLayoutType) &&
-      (cfg.gpuEnabled === undefined || cfg.gpuEnabled === oriLayoutCfg.gpuEnabled)
-    ) {
+    if (layoutController.isLayoutTypeSame(layoutCfg) && (layoutCfg.gpuEnabled === oriLayoutCfg.gpuEnabled)) {
       // no type or same type, or switch the gpu and cpu, update layout
-      const layoutCfg: any = {};
-      Object.assign(layoutCfg, oriLayoutCfg, cfg);
-      layoutCfg.type = oriLayoutType || 'random';
-
-      this.set('layout', layoutCfg);
-
       layoutController.updateLayoutCfg(layoutCfg);
     } else {
-      if (!newLayoutType) newLayoutType = oriLayoutType;
       // has different type, change layout
-      this.set('layout', cfg);
-      layoutController.changeLayout(newLayoutType);
+      layoutController.changeLayout(layoutCfg);
     }
   }
 
@@ -2795,9 +2782,9 @@ export default abstract class AbstractGraph extends EventEmitter implements IAbs
     const stackData = data
       ? clone(data)
       : {
-          before: {},
-          after: clone(this.save()),
-        };
+        before: {},
+        after: clone(this.save()),
+      };
 
     if (stackType === 'redo') {
       this.redoStack.push({

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -119,9 +119,9 @@ export type LoopConfig = Partial<{
 
 export interface LayoutConfig {
   type?: string;
+  gpuEnabled?: boolean;
   workerEnabled?: boolean;
-  // 只有当 workerEnabled 为 true 时才生效
-  workerScriptURL?: string;
+  onLayoutEnd?: () => void;
   [key: string]: unknown;
 }
 
@@ -183,10 +183,10 @@ export interface States {
 
 export interface StateStyles {
   [key: string]:
-    | ShapeStyle
-    | {
-        [key: string]: ShapeStyle;
-      };
+  | ShapeStyle
+  | {
+    [key: string]: ShapeStyle;
+  };
 }
 
 // model types (node edge group)
@@ -261,7 +261,7 @@ export interface GraphOptions {
     size: number | number[];
     color: string;
   }> &
-    ModelStyle;
+  ModelStyle;
 
   /**
    * 默认状态下边的配置，比如 type, size, color。会被写入的 data 覆盖。
@@ -271,7 +271,7 @@ export interface GraphOptions {
     size: number | number[];
     color: string;
   }> &
-    ModelStyle;
+  ModelStyle;
 
   /**
    * Combo 默认配置
@@ -281,7 +281,7 @@ export interface GraphOptions {
     size: number | number[];
     color: string;
   }> &
-    ModelStyle;
+  ModelStyle;
 
   nodeStateStyles?: StateStyles;
 
@@ -411,10 +411,10 @@ export interface TreeGraphData {
   depth?: number;
   collapsed?: boolean;
   style?:
-    | ShapeStyle
-    | {
-        [key: string]: ShapeStyle;
-      };
+  | ShapeStyle
+  | {
+    [key: string]: ShapeStyle;
+  };
   stateStyles?: StateStyles;
   [key: string]: unknown;
 }

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -121,6 +121,8 @@ export interface LayoutConfig {
   type?: string;
   gpuEnabled?: boolean;
   workerEnabled?: boolean;
+  // 只有当 workerEnabled 为 true 时才生效
+  workerScriptURL?: string;
   onLayoutEnd?: () => void;
   [key: string]: unknown;
 }

--- a/packages/pc/package.json
+++ b/packages/pc/package.json
@@ -47,7 +47,7 @@
     "lint:src": "eslint --ext .ts --format=pretty \"./src\"",
     "prettier": "prettier -c --write \"**/*\"",
     "test": "jest",
-    "test-live": "DEBUG_MODE=1 jest --watch  ./tests/unit/layout/circular-web-worker-spec.ts",
+    "test-live": "DEBUG_MODE=1 jest --watch  ./tests/unit/layout/combo-force-spec.ts",
     "lint-staged:js": "eslint --ext .js,.jsx,.ts,.tsx",
     "watch": "father build -w",
     "cdn": "antv-bin upload -n @antv/g6"

--- a/packages/pc/src/graph/controller/layout.ts
+++ b/packages/pc/src/graph/controller/layout.ts
@@ -263,8 +263,6 @@ export default class LayoutController extends AbstractLayout {
 
         // 更新节点位置
         this.refreshLayout();
-        // 由 graph 传入的，控制 fitView、fitCenter，并触发 afterrender
-        if (success) success();
 
         // 最后再次调整
         if (adjust && layoutCfg.pipes) {
@@ -274,7 +272,6 @@ export default class LayoutController extends AbstractLayout {
 
         // 触发 afterlayout
         graph.emit('afterlayout');
-
       };
     }
 

--- a/packages/pc/src/graph/controller/layout.ts
+++ b/packages/pc/src/graph/controller/layout.ts
@@ -51,13 +51,13 @@ export default class LayoutController extends AbstractLayout {
 
   // private data: GraphData;
 
-  // private layoutMethod: typeof Layout;
+  // private layoutMethods: typeof Layout;
 
   constructor(graph: IGraph) {
     super(graph);
     this.graph = graph;
     this.layoutCfg = graph.get('layout') || {};
-    this.layoutType = this.layoutCfg.type;
+    this.layoutType = this.getLayoutType();
     this.worker = null;
     this.workerData = {};
     this.initLayout();
@@ -105,6 +105,115 @@ export default class LayoutController extends AbstractLayout {
     }
   }
 
+  private execLayoutMethod(layoutCfg, success?: () => void): Promise<void> {
+    return new Promise((reslove, reject) => {
+      const { graph } = this;
+      let layoutType = layoutCfg.type;
+      let isGPU = false;
+
+      // 每个布局方法都需要注册
+      layoutCfg.onLayoutEnd = () => {
+        graph.emit('afterSublayout', { type: layoutType });
+        reslove();
+      }
+
+      // 防止用户直接用 -gpu 结尾指定布局
+      if (layoutType && layoutType.split('-')[1] === 'gpu') {
+        layoutType = layoutType.split('-')[0];
+        layoutCfg.gpuEnabled = true;
+      }
+
+      // 若用户指定开启 gpu，且当前浏览器支持 webgl，且该算法存在 GPU 版本（目前仅支持 fruchterman 和 gForce），使用 gpu 版本的布局
+      if (layoutType && layoutCfg.gpuEnabled) {
+        let enableGPU = true;
+        // 打开下面语句将会导致 webworker 报找不到 window
+        if (!gpuDetector().webgl) {
+          console.warn(`Your browser does not support webGL or GPGPU. The layout will run in CPU.`);
+          enableGPU = false;
+        }
+        if (!this.hasGPUVersion(layoutType)) {
+          console.warn(
+            `The '${layoutType}' layout does not support GPU calculation for now, it will run in CPU.`,
+          );
+          enableGPU = false;
+        }
+        if (enableGPU) {
+          layoutType = `${layoutType}-gpu`;
+          // layoutCfg.canvasEl = this.graph.get('canvas').get('el');
+          isGPU = true;
+        }
+      }
+      this.isGPU = isGPU;
+      const isForce = layoutType === 'force' || layoutType === 'g6force' || layoutType === 'gForce';
+
+      if (isForce) {
+        const { onTick } = layoutCfg;
+        const tick = () => {
+          if (onTick) {
+            onTick();
+          }
+          graph.refreshPositions();
+        };
+        layoutCfg.tick = tick;
+      } else if (layoutType === 'comboForce') {
+        layoutCfg.comboTrees = graph.get('comboTrees');
+      }
+
+      let enableTick = false;
+      let layoutMethod;
+
+      try {
+        layoutMethod = new Layout[layoutType](layoutCfg);
+      } catch (e) {
+        console.warn(`The layout method: '${layoutType}' does not exist! Please specify it first.`);
+        reject();
+      }
+
+      // 是否需要迭代的方式完成布局。这里是来自布局对象的实例属性，是由布局的定义者在布局类定义的。
+      enableTick = layoutMethod.enableTick;
+      if (enableTick) {
+        const { onTick } = layoutCfg;
+        const tick = () => {
+          if (onTick) {
+            onTick();
+          }
+          graph.refreshPositions();
+        };
+        layoutMethod.tick = tick;
+      }
+      const layoutData = this.filterLayoutData(this.data, layoutCfg);
+      layoutMethod.init(layoutData);
+      // 若存在节点没有位置信息，且没有设置 layout，在 initPositions 中 random 给出了所有节点的位置，不需要再次执行 random 布局
+      // 所有节点都有位置信息，且指定了 layout，则执行布局（代表不是第一次进行布局）
+      graph.emit('beforeSublayout', { type: layoutType });
+      layoutMethod.execute();
+      if (layoutMethod.isCustomLayout && layoutCfg.onLayoutEnd) layoutCfg.onLayoutEnd();
+      // 在执行 execute 后立即执行 success，且在 timeBar 中有 throttle，可以防止 timeBar 监听 afterrender 进行 changeData 后 layout，从而死循环
+      // 对于 force 一类布局完成后的 fitView 需要用户自己在 onLayoutEnd 中配置
+      if (success) success();
+      this.layoutMethods.push(layoutMethod);
+    });
+  }
+
+  private updateLayoutMethod(layoutMethod, layoutCfg): Promise<void> {
+    return new Promise((reslove, reject) => {
+      const { graph } = this;
+      const layoutType = layoutCfg?.type;
+
+      // 每个布局方法都需要注册
+      layoutCfg.onLayoutEnd = () => {
+        graph.emit('afterSublayout', { type: layoutType });
+        reslove();
+      }
+
+      const layoutData = this.filterLayoutData(this.data, layoutCfg);
+      layoutMethod.init(layoutData);
+      layoutMethod.updateCfg(layoutCfg);
+      graph.emit('beforeSublayout', { type: layoutType });
+      layoutMethod.execute();
+      if (layoutMethod.isCustomLayout && layoutCfg.onLayoutEnd) layoutCfg.onLayoutEnd();
+    });
+  }
   /**
    * @param {function} success callback
    * @return {boolean} 是否使用web worker布局
@@ -132,48 +241,10 @@ export default class LayoutController extends AbstractLayout {
     );
     this.layoutCfg = layoutCfg;
 
-    const hasLayoutType = !!this.layoutType;
-
-    let { layoutMethod } = this;
-    if (layoutMethod) {
-      layoutMethod.destroy();
-    }
+    this.destoryLayoutMethods();
 
     graph.emit('beforelayout');
-    this.initPositions(layoutCfg.center, nodes);
-    // init hidden ndoes
     this.initPositions(layoutCfg.center, hiddenNodes);
-
-    let layoutType = this.layoutType;
-    let isGPU = false;
-
-    // 防止用户直接用 -gpu 结尾指定布局
-    if (layoutType && layoutType.split('-')[1] === 'gpu') {
-      layoutType = layoutType.split('-')[0];
-      layoutCfg.gpuEnabled = true;
-    }
-
-    // 若用户指定开启 gpu，且当前浏览器支持 webgl，且该算法存在 GPU 版本（目前仅支持 fruchterman 和 gForce），使用 gpu 版本的布局
-    if (layoutType && layoutCfg.gpuEnabled) {
-      let enableGPU = true;
-      // 打开下面语句将会导致 webworker 报找不到 window
-      if (!gpuDetector().webgl) {
-        console.warn(`Your browser does not support webGL or GPGPU. The layout will run in CPU.`);
-        enableGPU = false;
-      }
-      if (!this.hasGPUVersion(layoutType)) {
-        console.warn(
-          `The '${layoutType}' layout does not support GPU calculation for now, it will run in CPU.`,
-        );
-        enableGPU = false;
-      }
-      if (enableGPU) {
-        layoutType = `${layoutType}-gpu`;
-        // layoutCfg.canvasEl = this.graph.get('canvas').get('el');
-        isGPU = true;
-      }
-    }
-    this.isGPU = isGPU;
 
     this.stopWorker();
     if (layoutCfg.workerEnabled && this.layoutWithWorker(this.data, success)) {
@@ -181,14 +252,14 @@ export default class LayoutController extends AbstractLayout {
       return true;
     }
 
-    const isForce = layoutType === 'force' || layoutType === 'g6force' || layoutType === 'gForce';
-
-    // 所有布局挂载 onLayoutEnd, 在布局结束后依次执行：
-    // 执行用户自定义 onLayoutEnd，触发 afterlayout、更新节点位置、fitView/fitCenter、触发 afterrender
+    // 在 onAllLayoutEnd 中执行用户自定义 onLayoutEnd，触发 afterlayout、更新节点位置、fitView/fitCenter、触发 afterrender
     const { onLayoutEnd, layoutEndFormatted } = layoutCfg;
+
     if (!layoutEndFormatted) {
       layoutCfg.layoutEndFormatted = true;
-      layoutCfg.onLayoutEnd = () => {
+      layoutCfg.onLayoutEnd = undefined;
+
+      layoutCfg.onAllLayoutEnd = () => {
         // 执行用户自定义 onLayoutEnd
         if (onLayoutEnd) {
           onLayoutEnd();
@@ -201,59 +272,22 @@ export default class LayoutController extends AbstractLayout {
       };
     }
 
-    if (isForce) {
-      const { onTick } = layoutCfg;
-      const tick = () => {
-        if (onTick) {
-          onTick();
-        }
-        graph.refreshPositions();
-      };
-      layoutCfg.tick = tick;
-    } else if (this.layoutType === 'comboForce') {
-      layoutCfg.comboTrees = graph.get('comboTrees');
+    let start = Promise.resolve();
+    if (layoutCfg.type) {
+      start = start.then(() => this.execLayoutMethod(layoutCfg, success));
+    } else if (layoutCfg.pipes) {
+      for (const cfg of layoutCfg.pipes) {
+        start = start.then(() => this.execLayoutMethod(cfg, success));
+      }
     }
 
-    let enableTick = false;
-    if (layoutType !== undefined) {
-      try {
-        layoutMethod = new Layout[layoutType](layoutCfg);
-      } catch (e) {
-        console.warn(`The layout method: '${layoutType}' does not exist! Please specify it first.`);
-        return false;
-      }
+    // 最后统一在外部调用onAllLayoutEnd
+    start.then(() => {
+      if (layoutCfg.onAllLayoutEnd) layoutCfg.onAllLayoutEnd();
+    }).catch((error) => {
+      console.warn('layout failed', error);
+    });
 
-      // 是否需要迭代的方式完成布局。这里是来自布局对象的实例属性，是由布局的定义者在布局类定义的。
-      enableTick = layoutMethod.enableTick;
-      if (enableTick) {
-        const { onTick } = layoutCfg;
-        const tick = () => {
-          if (onTick) {
-            onTick();
-          }
-          graph.refreshPositions();
-        };
-        layoutMethod.tick = tick;
-      }
-      layoutMethod.init(this.data);
-      // 若存在节点没有位置信息，且没有设置 layout，在 initPositions 中 random 给出了所有节点的位置，不需要再次执行 random 布局
-      // 所有节点都有位置信息，且指定了 layout，则执行布局（代表不是第一次进行布局）
-      if (hasLayoutType) {
-        graph.emit('beginlayout');
-        layoutMethod.execute();
-        if (layoutMethod.isCustomLayout && layoutCfg.onLayoutEnd && !isForce) layoutCfg.onLayoutEnd();
-        // 在执行 execute 后立即执行 success，且在 timeBar 中有 throttle，可以防止 timeBar 监听 afterrender 进行 changeData 后 layout，从而死循环
-        // 对于 force 一类布局完成后的 fitView 需要用户自己在 onLayoutEnd 中配置
-        if (success) success();
-      }
-      this.layoutMethod = layoutMethod;
-    }
-
-    // 若没有配置 layout，也需要更新画布
-    if (!this.layoutMethod && success) {
-      graph.refreshPositions();
-      success();
-    }
     return false;
   }
 
@@ -405,13 +439,23 @@ export default class LayoutController extends AbstractLayout {
     }
   }
 
+  // added in core
+  public hasLayoutPipesChanged(pipes: any[]) {
+    const { layoutType } = this;
+    if (!Array.isArray(layoutType)) {
+      return true;
+    }
+
+    return !pipes?.every((cfg, index) => cfg?.type === layoutType[index]);
+  }
+
   // 更新布局参数
   public updateLayoutCfg(cfg) {
-    const { graph, layoutMethod, layoutType, layoutCfg } = this;
+    const { graph, layoutMethods } = this;
+    const layoutCfg = mix({}, this.layoutCfg, cfg);
+    this.layoutCfg = layoutCfg;
 
-    this.layoutType = cfg.type;
-    if (!layoutMethod || layoutMethod.destroyed) {
-      this.layoutCfg = mix({}, layoutCfg, cfg);
+    if (!layoutMethods?.length) {
       this.layout();
       return;
     }
@@ -423,12 +467,23 @@ export default class LayoutController extends AbstractLayout {
       return;
     }
 
-    layoutMethod.init(this.data);
-    layoutMethod.updateCfg(cfg);
     graph.emit('beforelayout');
-    layoutMethod.execute();
 
-    if (layoutMethod.isCustomLayout && layoutCfg.onLayoutEnd) layoutCfg.onLayoutEnd();
+    let start = Promise.resolve();
+    if (layoutMethods.length === 1) {
+      start = start.then(() => this.updateLayoutMethod(layoutMethods[0], layoutCfg));
+    } else {
+      layoutMethods?.forEach((layoutMethod, index) => {
+        const currentCfg = layoutCfg.pipes[index];
+        start = start.then(() => this.updateLayoutMethod(layoutMethod, currentCfg));
+      });
+    }
+
+    start.then(() => {
+      if (layoutCfg.onAllLayoutEnd) layoutCfg.onAllLayoutEnd();
+    }).catch((error) => {
+      console.warn('layout failed', error);
+    });
   }
 
   public hasGPUVersion(layoutName: string): boolean {
@@ -440,11 +495,7 @@ export default class LayoutController extends AbstractLayout {
   }
 
   public destroy() {
-    const { layoutMethod } = this;
-    if (layoutMethod) {
-      layoutMethod.destroy();
-      layoutMethod.destroyed = true;
-    }
+    this.destoryLayoutMethods();
     const { worker } = this;
     if (worker) {
       worker.terminate();
@@ -455,7 +506,7 @@ export default class LayoutController extends AbstractLayout {
     this.graph.set('layout', undefined);
     this.layoutCfg = undefined;
     this.layoutType = undefined;
-    this.layoutMethod = undefined;
+    this.layoutMethods = undefined;
     this.graph = null;
   }
 }

--- a/packages/pc/src/layout/worker/layout.worker.ts
+++ b/packages/pc/src/layout/worker/layout.worker.ts
@@ -71,11 +71,15 @@ export const LayoutWorker = (
             break;
           }
 
-          const layoutMethod = new LayoutClass(layoutCfg);
+          let layoutMethod;
+          layoutCfg.onLayoutEnd = () => {
+            this.postMessage({ type: LAYOUT_MESSAGE.END, nodes });
+            layoutMethod?.destroy();
+          };
+
+          layoutMethod = new LayoutClass(layoutCfg);
           layoutMethod.init({ nodes, edges });
           layoutMethod.execute();
-          this.postMessage({ type: LAYOUT_MESSAGE.END, nodes });
-          layoutMethod.destroy();
           break;
         }
 

--- a/packages/pc/tests/unit/graph/fitView-spec.ts
+++ b/packages/pc/tests/unit/graph/fitView-spec.ts
@@ -227,6 +227,7 @@ describe('graph', () => {
 
   it('invalid container', () => {
     let layoutEndCount = 0;
+
     globalGraph.on('afterlayout', () => {
       layoutEndCount++;
     });
@@ -244,25 +245,22 @@ describe('graph', () => {
     globalGraph.data(data);
     globalGraph.render();
 
-    expect(layoutEndCount).toBe(1);
     globalGraph.emit('canvas:click', {});
-    expect(layoutEndCount).toBe(2);
+
     globalGraph.emit('node:click', {});
-    expect(layoutEndCount).toBe(3);
 
     globalGraph.updateLayout({
       type: 'concentric',
     });
-    expect(layoutEndCount).toBe(4);
-    const node = globalGraph.getNodes()[0].getModel();
-    expect(node.x).toBe(250);
-    expect(node.y).toBe(210);
 
     globalGraph.updateLayout({
       type: 'comboForce',
     });
-    expect(layoutEndCount).toBe(5);
-    globalGraph.destroy();
+
+    setTimeout(() => {
+      expect(layoutEndCount).toBe(5);
+      globalGraph.destroy();
+    }, 500);
   });
   it('comboForce with afterlayout', () => {
     const graph = new Graph({
@@ -281,7 +279,9 @@ describe('graph', () => {
     graph.data(data);
     graph.render();
 
-    expect(layouted).toBe(true);
-    graph.destroy();
+    setTimeout(() => {
+      expect(layouted).toBe(true);
+      graph.destroy();
+    }, 200);
   });
 });

--- a/packages/pc/tests/unit/graph/svg-spec.ts
+++ b/packages/pc/tests/unit/graph/svg-spec.ts
@@ -1460,10 +1460,13 @@ describe('layouts', () => {
     });
     graph.data(data);
     graph.render();
-    const item = graph.getNodes()[0];
-    expect(item.getModel().x).toBe(250);
-    expect(item.getModel().y).toBe(250);
-    graph.destroy();
+
+    graph.on('afterlayout', () => {
+      const item = graph.getNodes()[0];
+      expect(item.getModel().x).toBe(250);
+      expect(item.getModel().y).toBe(250);
+      graph.destroy();
+    });
   });
   it('with circular layout', () => {
     const graph = new Graph({
@@ -1477,12 +1480,15 @@ describe('layouts', () => {
     });
     graph.data(data);
     graph.render();
-    const item = graph.getNodes()[0];
-    expect(item.getModel().x).not.toBe(null);
-    expect(item.getModel().x).not.toBe(undefined);
-    expect(item.getModel().y).not.toBe(null);
-    expect(item.getModel().y).not.toBe(undefined);
-    graph.destroy();
+
+    graph.on('afterlayout', () => {
+      const item = graph.getNodes()[0];
+      expect(item.getModel().x).not.toBe(null);
+      expect(item.getModel().x).not.toBe(undefined);
+      expect(item.getModel().y).not.toBe(null);
+      expect(item.getModel().y).not.toBe(undefined);
+      graph.destroy();
+    });
   });
   it('with grid layout', () => {
     const graph = new Graph({
@@ -1496,10 +1502,13 @@ describe('layouts', () => {
     });
     graph.data(data);
     graph.render();
-    const item = graph.getNodes()[0];
-    expect(item.getModel().x).toBe(125);
-    expect(item.getModel().y).toBe(83.33333333333333);
-    graph.destroy();
+
+    graph.on('afterlayout', () => {
+      const item = graph.getNodes()[0];
+      expect(item.getModel().x).toBe(125);
+      expect(item.getModel().y).toBe(83.33333333333333);
+      graph.destroy();
+    });
   });
   it('with concentric layout', () => {
     const graph = new Graph({
@@ -1513,10 +1522,13 @@ describe('layouts', () => {
     });
     graph.data(data);
     graph.render();
-    const item = graph.getNodes()[0];
-    expect(item.getModel().x).toBe(250);
-    expect(item.getModel().y).toBe(250);
-    graph.destroy();
+
+    graph.on('afterlayout', () => {
+      const item = graph.getNodes()[0];
+      expect(item.getModel().x).toBe(250);
+      expect(item.getModel().y).toBe(250);
+      graph.destroy();
+    });
   });
   it('with mds layout', () => {
     const graph = new Graph({
@@ -1530,10 +1542,12 @@ describe('layouts', () => {
     });
     graph.data(data);
     graph.render();
-    const item = graph.getNodes()[0];
-    expect(item.getModel().x).toBe(261.9235736012207);
-    expect(item.getModel().y).toBe(249.99999999999997);
-    graph.destroy();
+    graph.on('afterlayout', () => {
+      const item = graph.getNodes()[0];
+      expect(item.getModel().x).toBe(261.9235736012207);
+      expect(item.getModel().y).toBe(249.99999999999997);
+      graph.destroy();
+    });
   });
   it('with dagre layout', () => {
     const graph = new Graph({
@@ -1550,12 +1564,14 @@ describe('layouts', () => {
     });
     graph.data(data);
     graph.render();
-    const item = graph.getNodes()[0];
-    expect(item.getModel().x).not.toBe(null);
-    expect(item.getModel().x).not.toBe(undefined);
-    expect(item.getModel().y).not.toBe(null);
-    expect(item.getModel().y).not.toBe(undefined);
-    graph.destroy();
+    graph.on('afterlayout', () => {
+      const item = graph.getNodes()[0];
+      expect(item.getModel().x).not.toBe(null);
+      expect(item.getModel().x).not.toBe(undefined);
+      expect(item.getModel().y).not.toBe(null);
+      expect(item.getModel().y).not.toBe(undefined);
+      graph.destroy();
+    });
   });
   it('change layout', () => {
     const graph = new Graph({
@@ -1576,8 +1592,11 @@ describe('layouts', () => {
     graph.updateLayout({
       type: 'force',
     });
-    expect(graph.get('layoutController').layoutMethod.type).toBe('force');
-    graph.destroy();
+
+    Promise.resolve().then(() => {
+      expect(graph.get('layoutController').layoutMethods[0].type).toBe('force');
+      graph.destroy();
+    });
   });
   it('subgraph layout', () => {
     const graph = new Graph({
@@ -1979,7 +1998,7 @@ describe('plugins', () => {
       graph.destroy();
 
       done();
-    }, 100);
+    }, 200);
   });
   it('minimap delegate', () => {
     const minimap2 = new G6.Minimap({

--- a/packages/pc/tests/unit/layout/circular-spec.ts
+++ b/packages/pc/tests/unit/layout/circular-spec.ts
@@ -19,14 +19,16 @@ describe('circular layout', () => {
     });
     graph.data(data);
     graph.render();
-    const width = graph.get('width');
-    const height = graph.get('height');
-    const radius = height > width ? width / 2 : height / 2;
-    expect(mathEqual(data.nodes[0].x, 250 + radius)).toEqual(true);
-    expect(mathEqual(data.nodes[0].y, 250)).toEqual(true);
-    expect(data.nodes[0].y === 250);
+    graph.on('afterlayout', () => {
+      const width = graph.get('width');
+      const height = graph.get('height');
+      const radius = height > width ? width / 2 : height / 2;
+      expect(mathEqual(data.nodes[0].x, 250 + radius)).toEqual(true);
+      expect(mathEqual(data.nodes[0].y, 250)).toEqual(true);
+      expect(data.nodes[0].y === 250);
 
-    graph.destroy();
+      graph.destroy();
+    });
   });
 
   it('fixed radius, start angle, end angle', () => {
@@ -45,10 +47,12 @@ describe('circular layout', () => {
     });
     graph.data(data);
     graph.render();
-    const pos = (200 * Math.sqrt(2)) / 2;
-    expect(mathEqual(data.nodes[0].x, 250 + pos)).toEqual(true);
-    expect(mathEqual(data.nodes[0].y, 250 + pos)).toEqual(true);
-    graph.destroy();
+    graph.on('afterlayout', () => {
+      const pos = (200 * Math.sqrt(2)) / 2;
+      expect(mathEqual(data.nodes[0].x, 250 + pos)).toEqual(true);
+      expect(mathEqual(data.nodes[0].y, 250 + pos)).toEqual(true);
+      graph.destroy();
+    });
   });
 
   it('circular with no node', () => {
@@ -88,10 +92,12 @@ describe('circular layout', () => {
       ],
     });
     graph.render();
-    const nodeModel = graph.getNodes()[0].getModel();
-    expect(nodeModel.x).toEqual(center[0]);
-    expect(nodeModel.y).toEqual(center[1]);
-    graph.destroy();
+    graph.on('afterlayout', () => {
+      const nodeModel = graph.getNodes()[0].getModel();
+      expect(nodeModel.x).toEqual(center[0]);
+      expect(nodeModel.y).toEqual(center[1]);
+      graph.destroy();
+    });
   });
 
   it('circular with no radius but startRadius and endRadius', () => {
@@ -111,14 +117,16 @@ describe('circular layout', () => {
     });
     graph.data(data);
     graph.render();
-    const nodeModelFirst = graph.getNodes()[0].getModel();
-    expect(nodeModelFirst.x).toEqual(center[0] + startRadius);
-    expect(nodeModelFirst.y).toEqual(center[1]);
-    const nodeNumber = graph.getNodes().length;
-    const nodeModelLast = graph.getNodes()[nodeNumber - 1].getModel();
-    expect(mathEqual(nodeModelLast.x, 248)).toEqual(true);
-    expect(mathEqual(nodeModelLast.y, 180)).toEqual(true);
-    graph.destroy();
+    graph.on('afterlayout', () => {
+      const nodeModelFirst = graph.getNodes()[0].getModel();
+      expect(nodeModelFirst.x).toEqual(center[0] + startRadius);
+      expect(nodeModelFirst.y).toEqual(center[1]);
+      const nodeNumber = graph.getNodes().length;
+      const nodeModelLast = graph.getNodes()[nodeNumber - 1].getModel();
+      expect(mathEqual(nodeModelLast.x, 248)).toEqual(true);
+      expect(mathEqual(nodeModelLast.y, 180)).toEqual(true);
+      graph.destroy();
+    });
   });
 
   it('circular with no radius and startRadius but endRadius', () => {
@@ -136,10 +144,12 @@ describe('circular layout', () => {
     });
     graph.data(data);
     graph.render();
-    const nodeModelFirst = graph.getNodes()[0].getModel();
-    expect(nodeModelFirst.x).toEqual(center[0] + endRadius);
-    expect(nodeModelFirst.y).toEqual(center[1]);
-    graph.destroy();
+    graph.on('afterlayout', () => {
+      const nodeModelFirst = graph.getNodes()[0].getModel();
+      expect(nodeModelFirst.x).toEqual(center[0] + endRadius);
+      expect(nodeModelFirst.y).toEqual(center[1]);
+      graph.destroy();
+    });
   });
 
   it('circular with no radius and endRadius but startRadius', () => {
@@ -179,21 +189,23 @@ describe('circular layout', () => {
     });
     graph.data(data);
     graph.render();
-    const node0 = graph.findById('Uruguay').getModel();
-    const node1 = graph.findById('Saudi Arabia').getModel();
-    const dist1 =
-      (node0.x - node1.x) * (node0.x - node1.x) + (node0.y - node1.y) * (node0.y - node1.y);
+    graph.on('afterlayout', () => {
+      const node0 = graph.findById('Uruguay').getModel();
+      const node1 = graph.findById('Saudi Arabia').getModel();
+      const dist1 =
+        (node0.x - node1.x) * (node0.x - node1.x) + (node0.y - node1.y) * (node0.y - node1.y);
 
-    const node2 = graph.findById('Switzerland').getModel();
-    const dist2 =
-      (node2.x - node1.x) * (node2.x - node1.x) + (node2.y - node1.y) * (node2.y - node1.y);
-    expect(mathEqual(dist1, dist2)).toEqual(true);
+      const node2 = graph.findById('Switzerland').getModel();
+      const dist2 =
+        (node2.x - node1.x) * (node2.x - node1.x) + (node2.y - node1.y) * (node2.y - node1.y);
+      expect(mathEqual(dist1, dist2)).toEqual(true);
 
-    const node3 = graph.findById('Sweden').getModel();
-    const dist3 =
-      (node2.x - node3.x) * (node2.x - node3.x) + (node2.y - node3.y) * (node2.y - node3.y);
-    expect(mathEqual(dist3, dist2)).toEqual(true);
-    graph.destroy();
+      const node3 = graph.findById('Sweden').getModel();
+      const dist3 =
+        (node2.x - node3.x) * (node2.x - node3.x) + (node2.y - node3.y) * (node2.y - node3.y);
+      expect(mathEqual(dist3, dist2)).toEqual(true);
+      graph.destroy();
+    });
   });
 
   it('circular with topology-directed ordering', () => {
@@ -213,21 +225,23 @@ describe('circular layout', () => {
     });
     graph.data(data);
     graph.render();
-    const node0 = graph.findById('Uruguay').getModel();
-    const node1 = graph.findById('Tunisia').getModel();
-    const dist1 =
-      (node0.x - node1.x) * (node0.x - node1.x) + (node0.y - node1.y) * (node0.y - node1.y);
+    graph.on('afterlayout', () => {
+      const node0 = graph.findById('Uruguay').getModel();
+      const node1 = graph.findById('Tunisia').getModel();
+      const dist1 =
+        (node0.x - node1.x) * (node0.x - node1.x) + (node0.y - node1.y) * (node0.y - node1.y);
 
-    const node2 = graph.findById('Switzerland').getModel();
-    const dist2 =
-      (node2.x - node1.x) * (node2.x - node1.x) + (node2.y - node1.y) * (node2.y - node1.y);
-    expect(mathEqual(dist1, dist2)).toEqual(true);
+      const node2 = graph.findById('Switzerland').getModel();
+      const dist2 =
+        (node2.x - node1.x) * (node2.x - node1.x) + (node2.y - node1.y) * (node2.y - node1.y);
+      expect(mathEqual(dist1, dist2)).toEqual(true);
 
-    const node3 = graph.findById('Sweden').getModel();
-    const dist3 =
-      (node2.x - node3.x) * (node2.x - node3.x) + (node2.y - node3.y) * (node2.y - node3.y);
-    expect(mathEqual(dist3, dist2)).toEqual(true);
-    graph.destroy();
+      const node3 = graph.findById('Sweden').getModel();
+      const dist3 =
+        (node2.x - node3.x) * (node2.x - node3.x) + (node2.y - node3.y) * (node2.y - node3.y);
+      expect(mathEqual(dist3, dist2)).toEqual(true);
+      graph.destroy();
+    });
   });
 
   it('circular with degree ordering, counterclockwise', () => {
@@ -247,21 +261,23 @@ describe('circular layout', () => {
     });
     graph.data(data);
     graph.render();
-    const node0 = graph.findById('England').getModel();
-    const node1 = graph.findById('Croatia').getModel();
-    const dist1 =
-      (node0.x - node1.x) * (node0.x - node1.x) + (node0.y - node1.y) * (node0.y - node1.y);
+    graph.on('afterlayout', () => {
+      const node0 = graph.findById('England').getModel();
+      const node1 = graph.findById('Croatia').getModel();
+      const dist1 =
+        (node0.x - node1.x) * (node0.x - node1.x) + (node0.y - node1.y) * (node0.y - node1.y);
 
-    const node2 = graph.findById('Belgium').getModel();
-    const dist2 =
-      (node2.x - node1.x) * (node2.x - node1.x) + (node2.y - node1.y) * (node2.y - node1.y);
-    expect(mathEqual(dist1, dist2)).toEqual(true);
+      const node2 = graph.findById('Belgium').getModel();
+      const dist2 =
+        (node2.x - node1.x) * (node2.x - node1.x) + (node2.y - node1.y) * (node2.y - node1.y);
+      expect(mathEqual(dist1, dist2)).toEqual(true);
 
-    const node3 = graph.findById('Uruguay').getModel();
-    const dist3 =
-      (node2.x - node3.x) * (node2.x - node3.x) + (node2.y - node3.y) * (node2.y - node3.y);
-    expect(mathEqual(dist3, dist2)).toEqual(true);
-    graph.destroy();
+      const node3 = graph.findById('Uruguay').getModel();
+      const dist3 =
+        (node2.x - node3.x) * (node2.x - node3.x) + (node2.y - node3.y) * (node2.y - node3.y);
+      expect(mathEqual(dist3, dist2)).toEqual(true);
+      graph.destroy();
+    });
   });
 
   it('circular layout', () => {

--- a/packages/pc/tests/unit/layout/circular-web-worker-spec.ts
+++ b/packages/pc/tests/unit/layout/circular-web-worker-spec.ts
@@ -22,6 +22,8 @@ describe('circular layout(web worker)', () => {
       defaultNode: { size: 10 },
     });
     graph.data(data);
+    graph.render();
+
     graph.on('afterlayout', () => {
       const width = graph.get('width');
       const height = graph.get('height');
@@ -33,7 +35,6 @@ describe('circular layout(web worker)', () => {
       graph.destroy();
       done();
     });
-    graph.render();
   });
 
   it('circular(web worker) counterclockwise, and fixed radius, start angle, end angle', done => {
@@ -53,6 +54,8 @@ describe('circular layout(web worker)', () => {
       defaultNode: { size: 10 },
     });
     graph.data(data);
+    graph.render();
+
     graph.on('afterlayout', () => {
       const pos = (200 * Math.sqrt(2)) / 2;
       expect(mathEqual(data.nodes[0].x, 250 + pos)).toEqual(true);
@@ -60,6 +63,5 @@ describe('circular layout(web worker)', () => {
       graph.destroy();
       done();
     });
-    graph.render();
   });
 });

--- a/packages/pc/tests/unit/layout/combo-force-spec.ts
+++ b/packages/pc/tests/unit/layout/combo-force-spec.ts
@@ -43,7 +43,6 @@ describe('no node and one node', () => {
       height: 500,
     });
     graph.on('afterlayout', () => {
-      console.log('after lkayout');
       expect(testData.nodes[0].x).toBe(250);
       expect(testData.nodes[0].y).toBe(250);
       done();
@@ -121,6 +120,7 @@ describe('combo force layout', () => {
       height: 500,
       defaultNode: { size: nodeSize },
     });
+
     graph.on('afterlayout', () => {
       const node0 = data.nodes[0];
       const node1 = data.nodes[1];
@@ -182,8 +182,11 @@ describe('combo force layout', () => {
     });
     graph.data(data);
     graph.render();
-    const forceLayout = graph.get('layoutController').layoutMethod;
-    forceLayout.execute(); // re execute when it is ticking
+
+    Promise.resolve().then(() => {
+      const forceLayout = graph.get('layoutController').layoutMethods[0];
+      forceLayout.execute(); // re execute when it is ticking
+    });
 
     setTimeout(() => {
       const node0 = data.nodes[0];
@@ -224,10 +227,14 @@ describe('undefined configurations and update layout', () => {
     });
     graph.data(data);
     graph.render();
-    const forceLayout = graph.get('layoutController').layoutMethod;
-    expect(isFunction(forceLayout.linkDistance)).toEqual(true);
-    expect(forceLayout.linkDistance()).toEqual(10);
-    expect(forceLayout.preventOverlap).toEqual(false);
+
+    let forceLayout;
+    Promise.resolve().then(() => {
+      forceLayout = graph.get('layoutController').layoutMethods[0];
+      expect(isFunction(forceLayout.linkDistance)).toEqual(true);
+      expect(forceLayout.linkDistance()).toEqual(10);
+      expect(forceLayout.preventOverlap).toEqual(false);
+    });
 
     setTimeout(() => {
       graph.hideItem(graph.getCombos()[0]);
@@ -239,10 +246,13 @@ describe('undefined configurations and update layout', () => {
         nodeSize: 10,
         comboPadding: null,
       });
-      expect(isFunction(forceLayout.linkDistance)).toEqual(true);
-      expect(forceLayout.linkDistance()).toEqual(100);
-      expect(forceLayout.preventOverlap).toEqual(true);
-      done();
+
+      Promise.resolve().then(() => {
+        expect(isFunction(forceLayout.linkDistance)).toEqual(true);
+        expect(forceLayout.linkDistance()).toEqual(100);
+        expect(forceLayout.preventOverlap).toEqual(true);
+        done();
+      });
     }, 300);
   });
 });

--- a/packages/pc/tests/unit/layout/concentric-spec.ts
+++ b/packages/pc/tests/unit/layout/concentric-spec.ts
@@ -24,12 +24,14 @@ describe('concentric layout', () => {
     data.nodes[2].label = data.nodes[2].id;
     graph.data(data);
     graph.render();
-    const node = data.nodes[2];
-    const width = graph.get('width');
-    const height = graph.get('height');
-    expect(mathEqual(node.x, width / 2)).toEqual(true);
-    expect(mathEqual(node.y, height / 2)).toEqual(true);
-    graph.destroy();
+    graph.on('afterlayout', () => {
+      const node = data.nodes[2];
+      const width = graph.get('width');
+      const height = graph.get('height');
+      expect(mathEqual(node.x, width / 2)).toEqual(true);
+      expect(mathEqual(node.y, height / 2)).toEqual(true);
+      graph.destroy();
+    });
   });
 
   it('concentric with no node', () => {
@@ -69,10 +71,12 @@ describe('concentric layout', () => {
       ],
     });
     graph.render();
-    const nodeModel = graph.getNodes()[0].getModel();
-    expect(nodeModel.x).toEqual(center[0]);
-    expect(nodeModel.y).toEqual(center[1]);
-    graph.destroy();
+    graph.on('afterlayout', () => {
+      const nodeModel = graph.getNodes()[0].getModel();
+      expect(nodeModel.x).toEqual(center[0]);
+      expect(nodeModel.y).toEqual(center[1]);
+      graph.destroy();
+    });
   });
 
   it('concentric with array nodeSize', () => {
@@ -132,9 +136,11 @@ describe('concentric layout', () => {
     });
     graph.data(data);
     graph.render();
-    const layout = graph.get('layoutController').layoutMethod;
-    expect(!isString(layout.sortBy)).toEqual(false);
-    graph.destroy();
+    graph.on('afterlayout', () => {
+      const layout = graph.get('layoutController').layoutMethods[0];
+      expect(!isString(layout.sortBy)).toEqual(false);
+      graph.destroy();
+    });
   });
 
   it('concentric preventOverlap', () => {
@@ -149,12 +155,14 @@ describe('concentric layout', () => {
     });
     graph.data(data);
     graph.render();
-    const node = data.nodes[2];
-    const width = graph.get('width');
-    const height = graph.get('height');
-    expect(mathEqual(node.x, width / 2)).toEqual(true);
-    expect(mathEqual(node.y, height / 2)).not.toEqual(true);
-    graph.destroy();
+    graph.on('afterlayout', () => {
+      const node = data.nodes[2];
+      const width = graph.get('width');
+      const height = graph.get('height');
+      expect(mathEqual(node.x, width / 2)).toEqual(true);
+      expect(mathEqual(node.y, height / 2)).not.toEqual(true);
+      graph.destroy();
+    });
   });
 
   it('concentric equidistant', () => {
@@ -169,12 +177,14 @@ describe('concentric layout', () => {
     });
     graph.data(data);
     graph.render();
-    const node = data.nodes[2];
-    const width = graph.get('width');
-    const height = graph.get('height');
-    expect(mathEqual(node.x, width / 2)).toEqual(true);
-    expect(mathEqual(node.y, height / 2)).toEqual(true);
-    graph.destroy();
+    graph.on('afterlayout', () => {
+      const node = data.nodes[2];
+      const width = graph.get('width');
+      const height = graph.get('height');
+      expect(mathEqual(node.x, width / 2)).toEqual(true);
+      expect(mathEqual(node.y, height / 2)).toEqual(true);
+      graph.destroy();
+    });
   });
 
   it('instantiate layout', () => {

--- a/packages/pc/tests/unit/layout/dagre-spec.ts
+++ b/packages/pc/tests/unit/layout/dagre-spec.ts
@@ -535,16 +535,18 @@ describe('dagre layout', () => {
     graph.data(data);
     graph.render();
 
-    const endNode = data.nodes[0];
-    const startNode = data.nodes[1];
-    const edge = data.edges[0];
-    expect(mathEqual(startNode.x, 165)).toEqual(true);
-    expect(mathEqual(startNode.y, 70)).toEqual(true);
-    expect(mathEqual(endNode.x, 70)).toEqual(true);
-    expect(mathEqual(endNode.y, 260)).toEqual(true);
-    expect(mathEqual(edge.controlPoints[0].x, 70)).toEqual(true);
-    expect(mathEqual(edge.controlPoints[0].y, 165)).toEqual(true);
-    graph.destroy();
+    graph.on('afterlayout', () => {
+      const endNode = data.nodes[0];
+      const startNode = data.nodes[1];
+      const edge = data.edges[0];
+      expect(mathEqual(startNode.x, 165)).toEqual(true);
+      expect(mathEqual(startNode.y, 70)).toEqual(true);
+      expect(mathEqual(endNode.x, 70)).toEqual(true);
+      expect(mathEqual(endNode.y, 260)).toEqual(true);
+      expect(mathEqual(edge.controlPoints[0].x, 70)).toEqual(true);
+      expect(mathEqual(edge.controlPoints[0].y, 165)).toEqual(true);
+      graph.destroy();
+    });
   });
   it('dagre with number nodeSize and sepFunc', () => {
     data.edges.forEach((edgeItem) => {
@@ -577,14 +579,16 @@ describe('dagre layout', () => {
     graph.data(data);
     graph.render();
 
-    const node = data.nodes[0];
-    const edge = data.edges[0];
+    graph.on('afterlayout', () => {
+      const node = data.nodes[0];
+      const edge = data.edges[0];
 
-    expect(mathEqual(node.x, 185)).toEqual(true);
-    expect(mathEqual(node.y, 25)).toEqual(true);
-    expect(edge.controlPoints).toBe(undefined);
-    // console.log(graph);
-    // graph.destroy();
+      expect(mathEqual(node.x, 185)).toEqual(true);
+      expect(mathEqual(node.y, 25)).toEqual(true);
+      expect(edge.controlPoints).toBe(undefined);
+      // console.log(graph);
+      // graph.destroy();
+    });
   });
   it('dagre with array nodeSize', () => {
     data.edges.forEach((edgeItem) => {
@@ -617,13 +621,15 @@ describe('dagre layout', () => {
     graph.data(data);
     graph.render();
 
-    const node = data.nodes[0];
-    const edge = data.edges[0];
+    graph.on('afterlayout', () => {
+      const node = data.nodes[0];
+      const edge = data.edges[0];
 
-    expect(mathEqual(node.x, 60)).toEqual(true);
-    expect(mathEqual(node.y, 215)).toEqual(true);
-    expect(edge.controlPoints).toEqual(undefined);
-    graph.destroy();
+      expect(mathEqual(node.x, 60)).toEqual(true);
+      expect(mathEqual(node.y, 215)).toEqual(true);
+      expect(edge.controlPoints).toEqual(undefined);
+      graph.destroy();
+    });
   });
 
   it('dagre with number size in node data, controlpoints', () => {
@@ -659,15 +665,17 @@ describe('dagre layout', () => {
     graph.data(data);
     graph.render();
 
-    const node = data.nodes[0];
-    const edge = data.edges[0];
+    graph.on('afterlayout', () => {
+      const node = data.nodes[0];
+      const edge = data.edges[0];
 
-    expect(mathEqual(node.x, 197.5)).toEqual(true);
-    expect(mathEqual(node.y, 60)).toEqual(true);
-    expect(edge.controlPoints).not.toEqual(undefined);
-    expect(mathEqual(edge.controlPoints[0].x, 125)).toEqual(true);
-    expect(mathEqual(edge.controlPoints[0].y, 60)).toEqual(true);
-    graph.destroy();
+      expect(mathEqual(node.x, 197.5)).toEqual(true);
+      expect(mathEqual(node.y, 60)).toEqual(true);
+      expect(edge.controlPoints).not.toEqual(undefined);
+      expect(mathEqual(edge.controlPoints[0].x, 125)).toEqual(true);
+      expect(mathEqual(edge.controlPoints[0].y, 60)).toEqual(true);
+      graph.destroy();
+    });
   });
   it('dagre with array size in node data', () => {
     data.edges.forEach((edgeItem) => {
@@ -694,13 +702,15 @@ describe('dagre layout', () => {
     graph.data(data);
     graph.render();
 
-    const node = data.nodes[0];
-    const edge = data.edges[0];
+    graph.on('afterlayout', () => {
+      const node = data.nodes[0];
+      const edge = data.edges[0];
 
-    expect(mathEqual(node.x, 350)).toEqual(true);
-    expect(mathEqual(node.y, 85)).toEqual(true);
-    expect(edge.controlPoints).toEqual(undefined);
+      expect(mathEqual(node.x, 350)).toEqual(true);
+      expect(mathEqual(node.y, 85)).toEqual(true);
+      expect(edge.controlPoints).toEqual(undefined);
 
-    graph.destroy();
+      graph.destroy();
+    });
   });
 });

--- a/packages/pc/tests/unit/layout/dagre-spec.ts
+++ b/packages/pc/tests/unit/layout/dagre-spec.ts
@@ -322,18 +322,20 @@ describe('dagre layout with combo', () => {
     graph.data(data2);
     graph.render();
 
-    console.log(graph.findById('1').getModel());
-    console.log(graph.findById('1-2').getModel());
-    console.log(graph.findById('1-1-1').getModel());
+    graph.on('afterlayout', () => {
+      console.log(graph.findById('1').getModel());
+      console.log(graph.findById('1-2').getModel());
+      console.log(graph.findById('1-1-1').getModel());
 
-    expect(graph.findById('1').getModel().x).toBe(195);
-    expect(graph.findById('1').getModel().y).toBe(21.5);
-    expect(graph.findById('1-2').getModel().x).toBe(45);
-    expect(graph.findById('1-2').getModel().y).toBe(64.5);
-    expect(graph.findById('1-1-1').getModel().x).toBe(370);
-    expect(graph.findById('1-1-1').getModel().y).toBe(108);
+      expect(graph.findById('1').getModel().x).toBe(195);
+      expect(graph.findById('1').getModel().y).toBe(21.5);
+      expect(graph.findById('1-2').getModel().x).toBe(45);
+      expect(graph.findById('1-2').getModel().y).toBe(64.5);
+      expect(graph.findById('1-1-1').getModel().x).toBe(370);
+      expect(graph.findById('1-1-1').getModel().y).toBe(108);
 
-    graph.destroy();
+      graph.destroy();
+    })
   });
 
   it('layout with nested combos', () => {
@@ -492,21 +494,23 @@ describe('dagre layout with combo', () => {
     graph.data(data3);
     graph.render();
 
-    console.log(graph.findById('5').getModel());
-    console.log(graph.findById('7').getModel());
-    console.log(graph.findById('8').getModel());
-    console.log(graph.findById('9').getModel());
+    graph.on('afterlayout', () => {
+      console.log(graph.findById('5').getModel());
+      console.log(graph.findById('7').getModel());
+      console.log(graph.findById('8').getModel());
+      console.log(graph.findById('9').getModel());
 
-    expect(graph.findById('5').getModel().x).toBe(527.5);
-    expect(graph.findById('5').getModel().y).toBe(260);
-    expect(graph.findById('7').getModel().x).toBe(282.5);
-    expect(graph.findById('7').getModel().y).toBe(260);
-    expect(graph.findById('8').getModel().x).toBe(352.5);
-    expect(graph.findById('8').getModel().y).toBe(260);
-    expect(graph.findById('9').getModel().x).toBe(192.5);
-    expect(graph.findById('9').getModel().y).toBe(260);
+      expect(graph.findById('5').getModel().x).toBe(527.5);
+      expect(graph.findById('5').getModel().y).toBe(260);
+      expect(graph.findById('7').getModel().x).toBe(282.5);
+      expect(graph.findById('7').getModel().y).toBe(260);
+      expect(graph.findById('8').getModel().x).toBe(352.5);
+      expect(graph.findById('8').getModel().y).toBe(260);
+      expect(graph.findById('9').getModel().x).toBe(192.5);
+      expect(graph.findById('9').getModel().y).toBe(260);
 
-    graph.destroy();
+      graph.destroy();
+    })
   });
 });
 

--- a/packages/pc/tests/unit/layout/destroy-layout-spec.ts
+++ b/packages/pc/tests/unit/layout/destroy-layout-spec.ts
@@ -56,45 +56,50 @@ describe('destroy circular layout', () => {
     graph.data(data);
     graph.render();
 
-    expect(mathEqual(graph.getNodes()[0].getModel().x, 500)).toEqual(true);
-    expect(mathEqual(graph.getNodes()[0].getModel().y, 250)).toEqual(true);
-    expect(mathEqual(graph.getNodes()[1].getModel().x, 0)).toEqual(true);
-    expect(mathEqual(graph.getNodes()[1].getModel().y, 250)).toEqual(true);
+    graph.on('afterlayout', () => {
+      expect(mathEqual(graph.getNodes()[0].getModel().x, 500)).toEqual(true);
+      expect(mathEqual(graph.getNodes()[0].getModel().y, 250)).toEqual(true);
+      expect(mathEqual(graph.getNodes()[1].getModel().x, 0)).toEqual(true);
+      expect(mathEqual(graph.getNodes()[1].getModel().y, 250)).toEqual(true);
 
-    graph.destroyLayout();
-    graph.changeData(data2);
+      graph.destroyLayout();
+      graph.changeData(data2);
 
-    // destroy circular layout 之后，将会使用初始化布局，若节点无坐标信息则自动计算网格状分布
-    expect(mathEqual(graph.getNodes()[0].getModel().x, 100)).toEqual(true);
-    expect(mathEqual(graph.getNodes()[0].getModel().y, 100)).toEqual(true);
-    expect(mathEqual(graph.getNodes()[1].getModel().x, 462.5)).toEqual(true);
-    expect(mathEqual(graph.getNodes()[1].getModel().y, 37.5)).toEqual(true);
-    expect(mathEqual(graph.getNodes()[2].getModel().x, 37.5)).toEqual(true);
-    expect(mathEqual(graph.getNodes()[2].getModel().y, 462.5)).toEqual(true);
-    expect(mathEqual(graph.getNodes()[3].getModel().x, 150)).toEqual(true);
-    expect(mathEqual(graph.getNodes()[3].getModel().y, 250)).toEqual(true);
+      // destroy circular layout 之后，将会使用初始化布局，若节点无坐标信息则自动计算网格状分布
+      expect(mathEqual(graph.getNodes()[0].getModel().x, 100)).toEqual(true);
+      expect(mathEqual(graph.getNodes()[0].getModel().y, 100)).toEqual(true);
+      expect(mathEqual(graph.getNodes()[1].getModel().x, 462.5)).toEqual(true);
+      expect(mathEqual(graph.getNodes()[1].getModel().y, 37.5)).toEqual(true);
+      expect(mathEqual(graph.getNodes()[2].getModel().x, 37.5)).toEqual(true);
+      expect(mathEqual(graph.getNodes()[2].getModel().y, 462.5)).toEqual(true);
+      expect(mathEqual(graph.getNodes()[3].getModel().x, 150)).toEqual(true);
+      expect(mathEqual(graph.getNodes()[3].getModel().y, 250)).toEqual(true);
 
-    // update layout 后，根据新的布局计算
-    graph.updateLayout({
-      type: 'dagre',
+      // update layout 后，根据新的布局计算
+      graph.updateLayout({
+        type: 'dagre',
+      });
+      graph.fitView();
+
+      graph.on('afterlayout', () => {
+        expect(mathEqual(graph.getNodes()[0].getModel().x, 165)).toEqual(true);
+        expect(mathEqual(graph.getNodes()[0].getModel().y, 70)).toEqual(true);
+        expect(mathEqual(graph.getNodes()[1].getModel().x, 70)).toEqual(true);
+        expect(mathEqual(graph.getNodes()[1].getModel().y, 260)).toEqual(true);
+        expect(mathEqual(graph.getNodes()[2].getModel().x, 70)).toEqual(true);
+        expect(mathEqual(graph.getNodes()[2].getModel().y, 450)).toEqual(true);
+        expect(mathEqual(graph.getNodes()[3].getModel().x, 260)).toEqual(true);
+        expect(mathEqual(graph.getNodes()[3].getModel().y, 260)).toEqual(true);
+
+        // 不销毁布局 changeData，使用现有布局计算
+        graph.changeData(data);
+        expect(mathEqual(graph.getNodes()[0].getModel().x, 70)).toEqual(true);
+        expect(mathEqual(graph.getNodes()[0].getModel().y, 70)).toEqual(true);
+        expect(mathEqual(graph.getNodes()[1].getModel().x, 70)).toEqual(true);
+        expect(mathEqual(graph.getNodes()[1].getModel().y, 260)).toEqual(true);
+
+        graph.destroy();
+      })
     });
-    graph.fitView();
-    expect(mathEqual(graph.getNodes()[0].getModel().x, 165)).toEqual(true);
-    expect(mathEqual(graph.getNodes()[0].getModel().y, 70)).toEqual(true);
-    expect(mathEqual(graph.getNodes()[1].getModel().x, 70)).toEqual(true);
-    expect(mathEqual(graph.getNodes()[1].getModel().y, 260)).toEqual(true);
-    expect(mathEqual(graph.getNodes()[2].getModel().x, 70)).toEqual(true);
-    expect(mathEqual(graph.getNodes()[2].getModel().y, 450)).toEqual(true);
-    expect(mathEqual(graph.getNodes()[3].getModel().x, 260)).toEqual(true);
-    expect(mathEqual(graph.getNodes()[3].getModel().y, 260)).toEqual(true);
-
-    // 不销毁布局 changeData，使用现有布局计算
-    graph.changeData(data);
-    expect(mathEqual(graph.getNodes()[0].getModel().x, 70)).toEqual(true);
-    expect(mathEqual(graph.getNodes()[0].getModel().y, 70)).toEqual(true);
-    expect(mathEqual(graph.getNodes()[1].getModel().x, 70)).toEqual(true);
-    expect(mathEqual(graph.getNodes()[1].getModel().y, 260)).toEqual(true);
-
-    graph.destroy();
   });
 });

--- a/packages/pc/tests/unit/layout/force-spec.ts
+++ b/packages/pc/tests/unit/layout/force-spec.ts
@@ -382,8 +382,12 @@ describe('force layout', () => {
     });
     graph.data(data);
     graph.render();
-    const forceLayout = graph.get('layoutController').layoutMethod;
-    forceLayout.execute(); // re execute when it is ticking
+
+    let forceLayout;
+    Promise.resolve().then(() => {
+      forceLayout = graph.get('layoutController').layoutMethods[0];
+      forceLayout.execute(); // re execute when it is ticking
+    });
 
     setTimeout(() => {
       const node0 = data.nodes[0];
@@ -408,9 +412,13 @@ describe('update and simulation', () => {
     });
     graph.data(data);
     graph.render();
-    const forceLayout = graph.get('layoutController').layoutMethod;
-    expect(forceLayout.linkDistance).toEqual(50); // default value
-    expect(forceLayout.preventOverlap).toEqual(false);
+
+    let forceLayout;
+    Promise.resolve().then(() => {
+      forceLayout = graph.get('layoutController').layoutMethods[0];
+      expect(forceLayout.linkDistance).toEqual(50); // default value
+      expect(forceLayout.preventOverlap).toEqual(false);
+    });
 
     setTimeout(() => {
       graph.updateLayout({
@@ -418,11 +426,14 @@ describe('update and simulation', () => {
         preventOverlap: true,
         alphaDecay: 0.8,
       });
-      expect(forceLayout.linkDistance).toEqual(100);
-      expect(forceLayout.preventOverlap).toEqual(true);
-      const simulation = forceLayout.forceSimulation;
-      simulation.stop();
-      done();
+
+      Promise.resolve().then(() => {
+        expect(forceLayout.linkDistance).toEqual(100);
+        expect(forceLayout.preventOverlap).toEqual(true);
+        const simulation = forceLayout.forceSimulation;
+        simulation.stop();
+        done();
+      });
     }, 300);
   });
   it('assign simualtion', (done) => {

--- a/packages/pc/tests/unit/layout/fruchterman-spec.ts
+++ b/packages/pc/tests/unit/layout/fruchterman-spec.ts
@@ -89,10 +89,12 @@ describe('fruchterman', () => {
       ],
     });
     graph.render();
-    const nodeModel = graph.getNodes()[0].getModel();
-    expect(nodeModel.x).toEqual(250);
-    expect(nodeModel.y).toEqual(250);
-    graph.destroy();
+    graph.on('afterlayout', () => {
+      const nodeModel = graph.getNodes()[0].getModel();
+      expect(nodeModel.x).toEqual(250);
+      expect(nodeModel.y).toEqual(250);
+      graph.destroy();
+    });
   });
   it('fruchterman layout with clustering and no clusterGravity', () => {
     const colors = ['#f00', '#0f0', '#00f', '#ff0'];
@@ -160,11 +162,13 @@ describe('fruchterman', () => {
     };
     graph.data(tmpData);
     graph.render();
-    const node0 = tmpData.nodes[0];
-    const node1 = tmpData.nodes[1];
-    expect(node0.x).not.toEqual(node1.x);
-    expect(node0.y).not.toEqual(node1.y);
-    graph.destroy();
+    graph.on('afterlayout', () => {
+      const node0 = tmpData.nodes[0];
+      const node1 = tmpData.nodes[1];
+      expect(node0.x).not.toEqual(node1.x);
+      expect(node0.y).not.toEqual(node1.y);
+      graph.destroy();
+    });
   });
   it('update fructherman layout configurations', () => {
     const graph = new G6.Graph({

--- a/packages/pc/tests/unit/layout/gpu-spec.ts
+++ b/packages/pc/tests/unit/layout/gpu-spec.ts
@@ -27,9 +27,13 @@ describe('gpu layout', () => {
     expect(graph.getNodes()[0].getModel().y).not.toEqual(undefined);
     expect(graph.getNodes()[1].getModel().x).not.toEqual(undefined);
     expect(graph.getNodes()[1].getModel().y).not.toEqual(undefined);
-    const layoutController = graph.get('layoutController');
-    expect(layoutController.layoutMethod.getType()).toEqual('fruchterman-gpu');
-    graph.destroy();
+
+    Promise.resolve().then(() => {
+      const layoutController = graph.get('layoutController');
+      expect(layoutController.layoutMethods[0].getType()).toEqual('fruchterman-gpu');
+      graph.destroy();
+    });
+
   });
   it('gforce gpu', () => {
     const graph = new G6.Graph({
@@ -51,8 +55,11 @@ describe('gpu layout', () => {
     expect(graph.getNodes()[0].getModel().y).not.toEqual(undefined);
     expect(graph.getNodes()[1].getModel().x).not.toEqual(undefined);
     expect(graph.getNodes()[1].getModel().y).not.toEqual(undefined);
-    const layoutController = graph.get('layoutController');
-    expect(layoutController.layoutMethod.getType()).toEqual('gForce-gpu');
-    graph.destroy();
+
+    Promise.resolve().then(() => {
+      const layoutController = graph.get('layoutController');
+      expect(layoutController.layoutMethods[0].getType()).toEqual('gForce-gpu');
+      graph.destroy();
+    });
   });
 });

--- a/packages/pc/tests/unit/layout/grid-spec.ts
+++ b/packages/pc/tests/unit/layout/grid-spec.ts
@@ -39,8 +39,10 @@ describe('grid layout', () => {
     });
     graph.data(data);
     graph.render();
-    expect(graph.getNodes()[0].getModel().x != null).toEqual(true);
-    graph.destroy();
+    graph.on('afterlayout', () => {
+      expect(graph.getNodes()[0].getModel().x != null).toEqual(true);
+      graph.destroy();
+    });
   });
 
   it('grid layout with no node', () => {
@@ -76,10 +78,12 @@ describe('grid layout', () => {
       ],
     });
     graph.render();
-    const nodeModel = graph.getNodes()[0].getModel();
-    expect(nodeModel.x).toEqual(0);
-    expect(nodeModel.y).toEqual(0);
-    graph.destroy();
+    graph.on('afterlayout', () => {
+      const nodeModel = graph.getNodes()[0].getModel();
+      expect(nodeModel.x).toEqual(0);
+      expect(nodeModel.y).toEqual(0);
+      graph.destroy();
+    });
   });
 
   it('grid layout with fixed columns', () => {
@@ -99,15 +103,17 @@ describe('grid layout', () => {
     });
     graph.data(data);
     graph.render();
-    expect(
-      graph.getNodes()[0].getModel().x != null && graph.getNodes()[0].getModel().y != null,
-    ).toEqual(true);
-    expect(
-      graph.getNodes()[2].getModel().x != null && graph.getNodes()[2].getModel().y != null,
-    ).toEqual(true);
-    expect(graph.getNodes()[0].getModel().x === graph.getNodes()[2].getModel().x).toEqual(true);
-    expect(graph.getNodes()[0].getModel().y > graph.getNodes()[2].getModel().y).toEqual(true);
-    graph.destroy();
+    graph.on('afterlayout', () => {
+      expect(
+        graph.getNodes()[0].getModel().x != null && graph.getNodes()[0].getModel().y != null,
+      ).toEqual(true);
+      expect(
+        graph.getNodes()[2].getModel().x != null && graph.getNodes()[2].getModel().y != null,
+      ).toEqual(true);
+      expect(graph.getNodes()[0].getModel().x === graph.getNodes()[2].getModel().x).toEqual(true);
+      expect(graph.getNodes()[0].getModel().y > graph.getNodes()[2].getModel().y).toEqual(true);
+      graph.destroy();
+    });
   });
 
   it('grid layout with fixed rows', () => {
@@ -127,15 +133,17 @@ describe('grid layout', () => {
     });
     graph.data(data);
     graph.render();
-    expect(
-      graph.getNodes()[3].getModel().x != null && graph.getNodes()[3].getModel().y != null,
-    ).toEqual(true);
-    expect(
-      graph.getNodes()[7].getModel().x != null && graph.getNodes()[7].getModel().y != null,
-    ).toEqual(true);
-    expect(graph.getNodes()[3].getModel().x === graph.getNodes()[7].getModel().x).toEqual(true);
-    expect(graph.getNodes()[3].getModel().y > graph.getNodes()[7].getModel().y).toEqual(true);
-    graph.destroy();
+    graph.on('afterlayout', () => {
+      expect(
+        graph.getNodes()[3].getModel().x != null && graph.getNodes()[3].getModel().y != null,
+      ).toEqual(true);
+      expect(
+        graph.getNodes()[7].getModel().x != null && graph.getNodes()[7].getModel().y != null,
+      ).toEqual(true);
+      expect(graph.getNodes()[3].getModel().x === graph.getNodes()[7].getModel().x).toEqual(true);
+      expect(graph.getNodes()[3].getModel().y > graph.getNodes()[7].getModel().y).toEqual(true);
+      graph.destroy();
+    });
   });
 
   it('grid layout with fixed cols and rows, rows*cols>nodes, situation 1', () => {
@@ -156,9 +164,11 @@ describe('grid layout', () => {
     });
     graph.data(data);
     graph.render();
-    expect(graph.getNodes()[2].getModel().x === graph.getNodes()[7].getModel().x).toEqual(true);
-    expect(graph.getNodes()[2].getModel().y > graph.getNodes()[7].getModel().y).toEqual(true);
-    graph.destroy();
+    graph.on('afterlayout', () => {
+      expect(graph.getNodes()[2].getModel().x === graph.getNodes()[7].getModel().x).toEqual(true);
+      expect(graph.getNodes()[2].getModel().y > graph.getNodes()[7].getModel().y).toEqual(true);
+      graph.destroy();
+    });
   });
 
   it('grid layout with fixed cols and rows, rows*cols>nodes, situation 2', () => {
@@ -179,9 +189,11 @@ describe('grid layout', () => {
     });
     graph.data(data);
     graph.render();
-    expect(graph.getNodes()[3].getModel().x === graph.getNodes()[7].getModel().x).toEqual(true);
-    expect(graph.getNodes()[3].getModel().y > graph.getNodes()[7].getModel().y).toEqual(true);
-    graph.destroy();
+    graph.on('afterlayout', () => {
+      expect(graph.getNodes()[3].getModel().x === graph.getNodes()[7].getModel().x).toEqual(true);
+      expect(graph.getNodes()[3].getModel().y > graph.getNodes()[7].getModel().y).toEqual(true);
+      graph.destroy();
+    });
   });
 
   it('grid layout with fixed cols and rows, rows*cols<nodes, situation 1', () => {
@@ -202,11 +214,13 @@ describe('grid layout', () => {
     });
     graph.data(data);
     graph.render();
-    expect(graph.getNodes()[3].getModel().x === graph.getNodes()[7].getModel().x).toEqual(true);
-    expect(graph.getNodes()[3].getModel().y > graph.getNodes()[7].getModel().y).toEqual(true);
-    expect(graph.getNodes()[5].getModel().x === graph.getNodes()[7].getModel().x).toEqual(true);
-    expect(graph.getNodes()[5].getModel().y > graph.getNodes()[7].getModel().y).toEqual(true);
-    graph.destroy();
+    graph.on('afterlayout', () => {
+      expect(graph.getNodes()[3].getModel().x === graph.getNodes()[7].getModel().x).toEqual(true);
+      expect(graph.getNodes()[3].getModel().y > graph.getNodes()[7].getModel().y).toEqual(true);
+      expect(graph.getNodes()[5].getModel().x === graph.getNodes()[7].getModel().x).toEqual(true);
+      expect(graph.getNodes()[5].getModel().y > graph.getNodes()[7].getModel().y).toEqual(true);
+      graph.destroy();
+    });
   });
 
   it('grid layout with fixed cols and rows, rows*cols<nodes, situation 2', () => {
@@ -227,9 +241,11 @@ describe('grid layout', () => {
     });
     graph.data(data);
     graph.render();
-    expect(graph.getNodes()[3].getModel().x === graph.getNodes()[7].getModel().x).toEqual(true);
-    expect(graph.getNodes()[3].getModel().y > graph.getNodes()[7].getModel().y).toEqual(true);
-    graph.destroy();
+    graph.on('afterlayout', () => {
+      expect(graph.getNodes()[3].getModel().x === graph.getNodes()[7].getModel().x).toEqual(true);
+      expect(graph.getNodes()[3].getModel().y > graph.getNodes()[7].getModel().y).toEqual(true);
+      graph.destroy();
+    });
   });
 
   it('grid layout with condense', () => {
@@ -248,9 +264,11 @@ describe('grid layout', () => {
     });
     graph.data(data);
     graph.render();
-    expect(graph.getNodes()[1].getModel().x === graph.getNodes()[6].getModel().x).toEqual(true);
-    expect(graph.getNodes()[1].getModel().y < graph.getNodes()[6].getModel().y).toEqual(true);
-    graph.destroy();
+    graph.on('afterlayout', () => {
+      expect(graph.getNodes()[1].getModel().x === graph.getNodes()[6].getModel().x).toEqual(true);
+      expect(graph.getNodes()[1].getModel().y < graph.getNodes()[6].getModel().y).toEqual(true);
+      graph.destroy();
+    });
   });
 
   it('grid layout with preventOverlap', () => {
@@ -345,11 +363,13 @@ describe('grid layout', () => {
     });
     graph.data(data);
     graph.render();
-    expect(graph.getNodes()[0].getModel().x === graph.getNodes()[3].getModel().x).toEqual(true);
-    expect(graph.getNodes()[0].getModel().y < graph.getNodes()[3].getModel().y).toEqual(true);
-    expect(graph.getNodes()[3].getModel().x === graph.getNodes()[6].getModel().x).toEqual(true);
-    expect(graph.getNodes()[3].getModel().y < graph.getNodes()[6].getModel().y).toEqual(true);
-    graph.destroy();
+    graph.on('afterlayout', () => {
+      expect(graph.getNodes()[0].getModel().x === graph.getNodes()[3].getModel().x).toEqual(true);
+      expect(graph.getNodes()[0].getModel().y < graph.getNodes()[3].getModel().y).toEqual(true);
+      expect(graph.getNodes()[3].getModel().x === graph.getNodes()[6].getModel().x).toEqual(true);
+      expect(graph.getNodes()[3].getModel().y < graph.getNodes()[6].getModel().y).toEqual(true);
+      graph.destroy();
+    });
   });
   it('grid layout with position function, col undefined', () => {
     const graph = new G6.Graph({
@@ -367,11 +387,13 @@ describe('grid layout', () => {
     });
     graph.data(data);
     graph.render();
-    expect(graph.getNodes()[1].getModel().x === graph.getNodes()[3].getModel().x).toEqual(true);
-    expect(graph.getNodes()[1].getModel().y < graph.getNodes()[3].getModel().y).toEqual(true);
-    expect(graph.getNodes()[3].getModel().x === graph.getNodes()[6].getModel().x).toEqual(true);
-    expect(graph.getNodes()[3].getModel().y < graph.getNodes()[6].getModel().y).toEqual(true);
-    graph.destroy();
+    graph.on('afterlayout', () => {
+      expect(graph.getNodes()[1].getModel().x === graph.getNodes()[3].getModel().x).toEqual(true);
+      expect(graph.getNodes()[1].getModel().y < graph.getNodes()[3].getModel().y).toEqual(true);
+      expect(graph.getNodes()[3].getModel().x === graph.getNodes()[6].getModel().x).toEqual(true);
+      expect(graph.getNodes()[3].getModel().y < graph.getNodes()[6].getModel().y).toEqual(true);
+      graph.destroy();
+    });
   });
   it('grid layout with position function, row undefined', () => {
     const graph = new G6.Graph({
@@ -389,10 +411,12 @@ describe('grid layout', () => {
     });
     graph.data(data);
     graph.render();
-    expect(graph.getNodes()[3].getModel().x === graph.getNodes()[6].getModel().x).toEqual(true);
-    expect(graph.getNodes()[3].getModel().y < graph.getNodes()[6].getModel().y).toEqual(true);
-    expect(graph.getNodes()[6].getModel().x === graph.getNodes()[0].getModel().x).toEqual(true);
-    expect(graph.getNodes()[6].getModel().y < graph.getNodes()[0].getModel().y).toEqual(true);
-    graph.destroy();
+    graph.on('afterlayout', () => {
+      expect(graph.getNodes()[3].getModel().x === graph.getNodes()[6].getModel().x).toEqual(true);
+      expect(graph.getNodes()[3].getModel().y < graph.getNodes()[6].getModel().y).toEqual(true);
+      expect(graph.getNodes()[6].getModel().x === graph.getNodes()[0].getModel().x).toEqual(true);
+      expect(graph.getNodes()[6].getModel().y < graph.getNodes()[0].getModel().y).toEqual(true);
+      graph.destroy();
+    });
   });
 });

--- a/packages/pc/tests/unit/layout/layout-mechanism-spec.ts
+++ b/packages/pc/tests/unit/layout/layout-mechanism-spec.ts
@@ -52,11 +52,13 @@ describe('layout mechanism', () => {
     });
     graph.data(data);
     graph.render();
-    expect(graph.getNodes()[0].getModel().x).toEqual(0);
-    expect(graph.getNodes()[0].getModel().y).toEqual(0);
-    expect(graph.getNodes()[1].getModel().x).toEqual(10);
-    expect(graph.getNodes()[1].getModel().y).toEqual(5);
-    graph.destroy();
+    graph.on('afterlayout', () => {
+      expect(graph.getNodes()[0].getModel().x).toEqual(0);
+      expect(graph.getNodes()[0].getModel().y).toEqual(0);
+      expect(graph.getNodes()[1].getModel().x).toEqual(10);
+      expect(graph.getNodes()[1].getModel().y).toEqual(5);
+      graph.destroy();
+    });
   });
   it('register layout and use it independently', () => {
     G6.registerLayout('custom2', {

--- a/packages/pc/tests/unit/layout/mds-spec.ts
+++ b/packages/pc/tests/unit/layout/mds-spec.ts
@@ -76,10 +76,12 @@ describe('mds', () => {
       ],
     });
     graph.render();
-    const nodeModel = graph.getNodes()[0].getModel();
-    expect(nodeModel.x).toEqual(250);
-    expect(nodeModel.y).toEqual(250);
-    graph.destroy();
+    graph.on('afterlayout', () => {
+      const nodeModel = graph.getNodes()[0].getModel();
+      expect(nodeModel.x).toEqual(250);
+      expect(nodeModel.y).toEqual(250);
+      graph.destroy();
+    });
   });
   it('mds layout with unconnected graph', () => {
     const graph = new G6.Graph({

--- a/packages/pc/tests/unit/layout/pipes-spec.ts
+++ b/packages/pc/tests/unit/layout/pipes-spec.ts
@@ -1,0 +1,122 @@
+import G6 from '../../../src';
+import { mathEqual } from './util';
+
+const data = {
+  nodes: [
+    { id: '0', name: '0' },
+    { id: '1', name: '1' },
+    { id: '2', name: '2' },
+    { id: '3', name: '3' },
+    { id: '4', name: '4' },
+    { id: '5', name: '5' },
+    { id: '6', name: '6' },
+    { id: '7', name: '7' },
+  ],
+  edges: [
+    { source: '0', target: '1' },
+    { source: '1', target: '2' },
+    { source: '2', target: '3' },
+    { source: '3', target: '4' },
+    { source: '5', target: '6' },
+    { source: '6', target: '7' },
+  ],
+};
+
+const div = document.createElement('div');
+div.id = 'pipes-layout';
+document.body.appendChild(div);
+
+describe('pipes layout', () => {
+  it('pipe circular and grid layout with default configs', () => {
+    const graph = new G6.Graph({
+      container: div,
+      layout: {
+        pipes: [
+          {
+            type: 'circular',
+            nodesFilter: (node) => node.id <= 4
+          },
+          {
+            type: 'grid',
+            nodesFilter: (node) => node.id > 4
+          }],
+      },
+      defaultNode: {
+        size: [10, 10],
+      },
+      width: 500,
+      height: 500,
+    });
+    graph.data(data);
+    graph.render();
+
+    graph.on('afterlayout', () => {
+      expect(graph.getNodes()[0].getModel().x != null).toEqual(true);
+      // graph.destroy();
+    });
+  });
+
+  it('pipe circular and grid layout with center configs', () => {
+    const graph = new G6.Graph({
+      container: div,
+      layout: {
+        pipes: [
+          {
+            type: 'circular',
+            center: [300, 300],
+            nodesFilter: (node) => node.id <= 4
+          },
+          {
+            type: 'grid',
+            nodesFilter: (node) => node.id > 4
+          }],
+      },
+      defaultNode: {
+        size: [10, 10],
+      },
+      width: 500,
+      height: 500,
+    });
+    graph.data(data);
+    graph.render();
+
+    graph.on('afterlayout', () => {
+      const firstNode = graph.getNodes()[0].getModel();
+      expect(mathEqual(firstNode.x, 450)).toEqual(true);
+      expect(mathEqual(firstNode.y, 300)).toEqual(true);
+      // graph.destroy();
+    });
+  });
+
+  it('pipe circular and grid layout with adjust configs', () => {
+    const graph = new G6.Graph({
+      container: div,
+      layout: {
+        pipes: [
+          {
+            type: 'circular',
+            nodesFilter: (node) => node.id <= 4
+          },
+          {
+            type: 'grid',
+            nodesFilter: (node) => node.id > 4
+          }],
+        adjust: 'force'
+      },
+      defaultNode: {
+        size: [10, 10],
+      },
+      width: 500,
+      height: 500,
+    });
+    graph.data(data);
+    graph.render();
+
+    graph.on('afterlayout', () => {
+      const firstNode = graph.getNodes()[0].getModel();
+      expect(mathEqual(firstNode.x, 450)).toEqual(true);
+      expect(mathEqual(firstNode.y, 300)).toEqual(true);
+      // graph.destroy();
+    });
+  });
+});

--- a/packages/pc/tests/unit/layout/preset-spec.ts
+++ b/packages/pc/tests/unit/layout/preset-spec.ts
@@ -156,11 +156,13 @@ describe('preset layout', () => {
     });
     graph.data(data);
     graph.render();
-    expect(graph.getNodes()[0].getModel().x).not.toEqual(100);
-    expect(graph.getNodes()[0].getModel().y).not.toEqual(30);
-    expect(graph.getNodes()[1].getModel().x).not.toEqual(150);
-    expect(graph.getNodes()[1].getModel().y).not.toEqual(80);
-    graph.destroy();
+    graph.on('afterlayout', () => {
+      expect(graph.getNodes()[0].getModel().x).not.toEqual(100);
+      expect(graph.getNodes()[0].getModel().y).not.toEqual(30);
+      expect(graph.getNodes()[1].getModel().x).not.toEqual(150);
+      expect(graph.getNodes()[1].getModel().y).not.toEqual(80);
+      graph.destroy();
+    });
   });
   it('update layout from undefined layout to force layout', () => {
     const graph = new G6.Graph({

--- a/packages/pc/tests/unit/layout/radial-spec.ts
+++ b/packages/pc/tests/unit/layout/radial-spec.ts
@@ -42,11 +42,13 @@ describe('radial', () => {
     });
     graph.data(data);
     graph.render();
-    const center = [graph.get('width') / 2, graph.get('height') / 2];
-    const focusNode = graph.getNodes()[0].getModel();
-    expect(numberEqual(focusNode.x, center[0])).toEqual(true);
-    expect(numberEqual(focusNode.y, center[1])).toEqual(true);
-    graph.destroy();
+    graph.on('afterlayout', () => {
+      const center = [graph.get('width') / 2, graph.get('height') / 2];
+      const focusNode = graph.getNodes()[0].getModel();
+      expect(numberEqual(focusNode.x, center[0])).toEqual(true);
+      expect(numberEqual(focusNode.y, center[1])).toEqual(true);
+      graph.destroy();
+    });
   });
   it('new graph with radial layout, with configurations', () => {
     const unitRadius = 100;
@@ -71,34 +73,35 @@ describe('radial', () => {
     });
     graph.data(data);
     graph.render();
+    graph.on('afterlayout', () => {
+      const oneStepNode = data.nodes[0];
+      const DistFnToOneStepNode =
+        (oneStepNode.x - focusNode.x) * (oneStepNode.x - focusNode.x) +
+        (oneStepNode.y - focusNode.y) * (oneStepNode.y - focusNode.y);
+      const twoStepNode = data.nodes[2];
+      const DistFnToTwoStepNode =
+        (twoStepNode.x - focusNode.x) * (twoStepNode.x - focusNode.x) +
+        (twoStepNode.y - focusNode.y) * (twoStepNode.y - focusNode.y);
+      const descreteNode = data.nodes[5];
+      const DistFnToDescreteNode =
+        (descreteNode.x - focusNode.x) * (descreteNode.x - focusNode.x) +
+        (descreteNode.y - focusNode.y) * (descreteNode.y - focusNode.y);
+      const descreteComNode1 = data.nodes[3];
+      const DistFnToDescreteComNode1 =
+        (descreteComNode1.x - focusNode.x) * (descreteComNode1.x - focusNode.x) +
+        (descreteComNode1.y - focusNode.y) * (descreteComNode1.y - focusNode.y);
+      const descreteComNode2 = data.nodes[4];
+      const DistFnToDescreteComNode2 =
+        (descreteComNode2.x - focusNode.x) * (descreteComNode2.x - focusNode.x) +
+        (descreteComNode2.y - focusNode.y) * (descreteComNode2.y - focusNode.y);
+      expect(numberEqual(DistFnToOneStepNode, unitRadius * unitRadius)).toEqual(true);
+      expect(numberEqual(DistFnToTwoStepNode, 4 * unitRadius * unitRadius)).toEqual(true);
+      expect(numberEqual(DistFnToDescreteNode, 9 * unitRadius * unitRadius)).toEqual(true);
+      expect(numberEqual(DistFnToDescreteComNode1, 9 * unitRadius * unitRadius)).toEqual(true);
+      expect(numberEqual(DistFnToDescreteComNode2, 16 * unitRadius * unitRadius)).toEqual(true);
 
-    const oneStepNode = data.nodes[0];
-    const DistFnToOneStepNode =
-      (oneStepNode.x - focusNode.x) * (oneStepNode.x - focusNode.x) +
-      (oneStepNode.y - focusNode.y) * (oneStepNode.y - focusNode.y);
-    const twoStepNode = data.nodes[2];
-    const DistFnToTwoStepNode =
-      (twoStepNode.x - focusNode.x) * (twoStepNode.x - focusNode.x) +
-      (twoStepNode.y - focusNode.y) * (twoStepNode.y - focusNode.y);
-    const descreteNode = data.nodes[5];
-    const DistFnToDescreteNode =
-      (descreteNode.x - focusNode.x) * (descreteNode.x - focusNode.x) +
-      (descreteNode.y - focusNode.y) * (descreteNode.y - focusNode.y);
-    const descreteComNode1 = data.nodes[3];
-    const DistFnToDescreteComNode1 =
-      (descreteComNode1.x - focusNode.x) * (descreteComNode1.x - focusNode.x) +
-      (descreteComNode1.y - focusNode.y) * (descreteComNode1.y - focusNode.y);
-    const descreteComNode2 = data.nodes[4];
-    const DistFnToDescreteComNode2 =
-      (descreteComNode2.x - focusNode.x) * (descreteComNode2.x - focusNode.x) +
-      (descreteComNode2.y - focusNode.y) * (descreteComNode2.y - focusNode.y);
-    expect(numberEqual(DistFnToOneStepNode, unitRadius * unitRadius)).toEqual(true);
-    expect(numberEqual(DistFnToTwoStepNode, 4 * unitRadius * unitRadius)).toEqual(true);
-    expect(numberEqual(DistFnToDescreteNode, 9 * unitRadius * unitRadius)).toEqual(true);
-    expect(numberEqual(DistFnToDescreteComNode1, 9 * unitRadius * unitRadius)).toEqual(true);
-    expect(numberEqual(DistFnToDescreteComNode2, 16 * unitRadius * unitRadius)).toEqual(true);
-
-    graph.destroy();
+      graph.destroy();
+    });
   });
 
   it('radial layout with no node', () => {
@@ -162,34 +165,36 @@ describe('radial', () => {
     graph.data(data);
     graph.render();
 
-    const descreteCom1Node1 = data.nodes[0];
-    const DistFnToDescreteCom1Node1 =
-      (descreteCom1Node1.x - focusNode.x) * (descreteCom1Node1.x - focusNode.x) +
-      (descreteCom1Node1.y - focusNode.y) * (descreteCom1Node1.y - focusNode.y);
-    const descreteCom1Node2 = data.nodes[1];
-    const DistFnToDescreteCom1Node2 =
-      (descreteCom1Node2.x - focusNode.x) * (descreteCom1Node2.x - focusNode.x) +
-      (descreteCom1Node2.y - focusNode.y) * (descreteCom1Node2.y - focusNode.y);
-    const descreteCom2Node1 = data.nodes[3];
-    const DistFnToDescreteCom2Node1 =
-      (descreteCom2Node1.x - focusNode.x) * (descreteCom2Node1.x - focusNode.x) +
-      (descreteCom2Node1.y - focusNode.y) * (descreteCom2Node1.y - focusNode.y);
-    const descreteCom2Node2 = data.nodes[4];
-    const DistFnToDescreteCom2Node2 =
-      (descreteCom2Node2.x - focusNode.x) * (descreteCom2Node2.x - focusNode.x) +
-      (descreteCom2Node2.y - focusNode.y) * (descreteCom2Node2.y - focusNode.y);
-    expect(numberEqual(DistFnToDescreteCom1Node1, unitRadius * unitRadius)).toEqual(true);
-    expect(numberEqual(DistFnToDescreteCom1Node2, 4 * unitRadius * unitRadius)).toEqual(true);
-    expect(numberEqual(DistFnToDescreteCom2Node1, unitRadius * unitRadius)).toEqual(true);
-    expect(numberEqual(DistFnToDescreteCom2Node2, 4 * unitRadius * unitRadius)).toEqual(true);
+    graph.on('afterlayout', () => {
+      const descreteCom1Node1 = data.nodes[0];
+      const DistFnToDescreteCom1Node1 =
+        (descreteCom1Node1.x - focusNode.x) * (descreteCom1Node1.x - focusNode.x) +
+        (descreteCom1Node1.y - focusNode.y) * (descreteCom1Node1.y - focusNode.y);
+      const descreteCom1Node2 = data.nodes[1];
+      const DistFnToDescreteCom1Node2 =
+        (descreteCom1Node2.x - focusNode.x) * (descreteCom1Node2.x - focusNode.x) +
+        (descreteCom1Node2.y - focusNode.y) * (descreteCom1Node2.y - focusNode.y);
+      const descreteCom2Node1 = data.nodes[3];
+      const DistFnToDescreteCom2Node1 =
+        (descreteCom2Node1.x - focusNode.x) * (descreteCom2Node1.x - focusNode.x) +
+        (descreteCom2Node1.y - focusNode.y) * (descreteCom2Node1.y - focusNode.y);
+      const descreteCom2Node2 = data.nodes[4];
+      const DistFnToDescreteCom2Node2 =
+        (descreteCom2Node2.x - focusNode.x) * (descreteCom2Node2.x - focusNode.x) +
+        (descreteCom2Node2.y - focusNode.y) * (descreteCom2Node2.y - focusNode.y);
+      expect(numberEqual(DistFnToDescreteCom1Node1, unitRadius * unitRadius)).toEqual(true);
+      expect(numberEqual(DistFnToDescreteCom1Node2, 4 * unitRadius * unitRadius)).toEqual(true);
+      expect(numberEqual(DistFnToDescreteCom2Node1, unitRadius * unitRadius)).toEqual(true);
+      expect(numberEqual(DistFnToDescreteCom2Node2, 4 * unitRadius * unitRadius)).toEqual(true);
 
-    // non overlap
-    const overlapDist1 =
-      (descreteCom1Node1.x - descreteCom2Node1.x) * (descreteCom1Node1.x - descreteCom2Node1.x) +
-      (descreteCom1Node1.y - descreteCom2Node1.y) * (descreteCom1Node1.y - descreteCom2Node1.y);
-    expect(overlapDist1 > nodeSize * nodeSize).toEqual(true);
+      // non overlap
+      const overlapDist1 =
+        (descreteCom1Node1.x - descreteCom2Node1.x) * (descreteCom1Node1.x - descreteCom2Node1.x) +
+        (descreteCom1Node1.y - descreteCom2Node1.y) * (descreteCom1Node1.y - descreteCom2Node1.y);
+      expect(overlapDist1 > nodeSize * nodeSize).toEqual(true);
 
-    graph.destroy();
+      graph.destroy();
+    });
   });
 
   it('focus on descrete node, prevent overlapping with number nodeSpacing', () => {
@@ -424,16 +429,17 @@ describe('radial', () => {
     });
     graph.data(data);
     graph.render();
-
-    const node1 = data.nodes[1];
-    const node2 = data.nodes[2];
-    const node4 = data.nodes[4];
-    const overlapDist1 =
-      (node1.x - node2.x) * (node1.x - node2.x) + (node1.y - node2.y) * (node1.y - node2.y);
-    const overlapDist2 =
-      (node1.x - node4.x) * (node1.x - node4.x) + (node1.y - node4.y) * (node1.y - node4.y);
-    expect(overlapDist1 < overlapDist2).toEqual(true);
-    graph.destroy();
+    graph.on('afterlayout', () => {
+      const node1 = data.nodes[1];
+      const node2 = data.nodes[2];
+      const node4 = data.nodes[4];
+      const overlapDist1 =
+        (node1.x - node2.x) * (node1.x - node2.x) + (node1.y - node2.y) * (node1.y - node2.y);
+      const overlapDist2 =
+        (node1.x - node4.x) * (node1.x - node4.x) + (node1.y - node4.y) * (node1.y - node4.y);
+      expect(overlapDist1 < overlapDist2).toEqual(true);
+      graph.destroy();
+    });
   });
 
   it('sort by sortProperty', () => {
@@ -461,16 +467,17 @@ describe('radial', () => {
     });
     graph.data(data);
     graph.render();
-
-    const node1 = data.nodes[1];
-    const node2 = data.nodes[2];
-    const node4 = data.nodes[4];
-    const overlapDist1 =
-      (node1.x - node2.x) * (node1.x - node2.x) + (node1.y - node2.y) * (node1.y - node2.y);
-    const overlapDist2 =
-      (node2.x - node4.x) * (node2.x - node4.x) + (node2.y - node4.y) * (node2.y - node4.y);
-    expect(overlapDist1 > overlapDist2).toEqual(true);
-    graph.destroy();
+    graph.on('afterlayout', () => {
+      const node1 = data.nodes[1];
+      const node2 = data.nodes[2];
+      const node4 = data.nodes[4];
+      const overlapDist1 =
+        (node1.x - node2.x) * (node1.x - node2.x) + (node1.y - node2.y) * (node1.y - node2.y);
+      const overlapDist2 =
+        (node2.x - node4.x) * (node2.x - node4.x) + (node2.y - node4.y) * (node2.y - node4.y);
+      expect(overlapDist1 > overlapDist2).toEqual(true);
+      graph.destroy();
+    });
   });
 });
 
@@ -496,30 +503,31 @@ describe('radial layout', () => {
     });
     graph.data(data);
     graph.render();
+    graph.on('afterlayout', () => {
+      const focusNode = graph.findById(focusNodeId).getModel();
+      const descreteNode = data.nodes[5];
+      const DistFnToDescreteNode =
+        (descreteNode.x - focusNode.x) * (descreteNode.x - focusNode.x) +
+        (descreteNode.y - focusNode.y) * (descreteNode.y - focusNode.y);
+      const descreteComNode1 = data.nodes[0];
+      const DistFnToDescreteComNode1 =
+        (descreteComNode1.x - focusNode.x) * (descreteComNode1.x - focusNode.x) +
+        (descreteComNode1.y - focusNode.y) * (descreteComNode1.y - focusNode.y);
+      const descreteComNode2 = data.nodes[1];
+      const DistFnToDescreteComNode2 =
+        (descreteComNode2.x - focusNode.x) * (descreteComNode2.x - focusNode.x) +
+        (descreteComNode2.y - focusNode.y) * (descreteComNode2.y - focusNode.y);
+      const descreteComNode3 = data.nodes[2];
+      const DistFnToDescreteComNode3 =
+        (descreteComNode3.x - focusNode.x) * (descreteComNode3.x - focusNode.x) +
+        (descreteComNode3.y - focusNode.y) * (descreteComNode3.y - focusNode.y);
+      expect(numberEqual(DistFnToDescreteNode, 4 * unitRadius * unitRadius)).toEqual(true);
+      expect(numberEqual(DistFnToDescreteComNode1, 4 * unitRadius * unitRadius)).toEqual(true);
+      expect(numberEqual(DistFnToDescreteComNode2, 9 * unitRadius * unitRadius)).toEqual(true);
+      expect(numberEqual(DistFnToDescreteComNode3, 9 * unitRadius * unitRadius)).toEqual(true);
 
-    const focusNode = graph.findById(focusNodeId).getModel();
-    const descreteNode = data.nodes[5];
-    const DistFnToDescreteNode =
-      (descreteNode.x - focusNode.x) * (descreteNode.x - focusNode.x) +
-      (descreteNode.y - focusNode.y) * (descreteNode.y - focusNode.y);
-    const descreteComNode1 = data.nodes[0];
-    const DistFnToDescreteComNode1 =
-      (descreteComNode1.x - focusNode.x) * (descreteComNode1.x - focusNode.x) +
-      (descreteComNode1.y - focusNode.y) * (descreteComNode1.y - focusNode.y);
-    const descreteComNode2 = data.nodes[1];
-    const DistFnToDescreteComNode2 =
-      (descreteComNode2.x - focusNode.x) * (descreteComNode2.x - focusNode.x) +
-      (descreteComNode2.y - focusNode.y) * (descreteComNode2.y - focusNode.y);
-    const descreteComNode3 = data.nodes[2];
-    const DistFnToDescreteComNode3 =
-      (descreteComNode3.x - focusNode.x) * (descreteComNode3.x - focusNode.x) +
-      (descreteComNode3.y - focusNode.y) * (descreteComNode3.y - focusNode.y);
-    expect(numberEqual(DistFnToDescreteNode, 4 * unitRadius * unitRadius)).toEqual(true);
-    expect(numberEqual(DistFnToDescreteComNode1, 4 * unitRadius * unitRadius)).toEqual(true);
-    expect(numberEqual(DistFnToDescreteComNode2, 9 * unitRadius * unitRadius)).toEqual(true);
-    expect(numberEqual(DistFnToDescreteComNode3, 9 * unitRadius * unitRadius)).toEqual(true);
-
-    graph.destroy();
+      graph.destroy();
+    });
   });
 
   it('focus node does not exist', () => {
@@ -540,10 +548,11 @@ describe('radial layout', () => {
     });
     graph.data(data);
     graph.render();
-
-    const radialLayout = graph.get('layoutController').layoutMethod;
-    expect(radialLayout.focusNode.id).toEqual('0');
-    graph.destroy();
+    graph.on('afterlayout', () => {
+      const radialLayout = graph.get('layoutController').layoutMethod[0];
+      expect(radialLayout.focusNode.id).toEqual('0');
+      graph.destroy();
+    });
   });
 
   it('focus node undefined', () => {
@@ -563,10 +572,11 @@ describe('radial layout', () => {
     });
     graph.data(data);
     graph.render();
-
-    const radialLayout = graph.get('layoutController').layoutMethod;
-    expect(radialLayout.focusNode.id).toEqual('0');
-    graph.destroy();
+    graph.on('afterlayout', () => {
+      const radialLayout = graph.get('layoutController').layoutMethod[0];
+      expect(radialLayout.focusNode.id).toEqual('0');
+      graph.destroy();
+    });
   });
 
   it('instantiate layout', () => {

--- a/packages/pc/tests/unit/layout/radial-spec.ts
+++ b/packages/pc/tests/unit/layout/radial-spec.ts
@@ -137,10 +137,12 @@ describe('radial', () => {
       ],
     });
     graph.render();
-    const nodeModel = graph.getNodes()[0].getModel();
-    expect(nodeModel.x).toEqual(250);
-    expect(nodeModel.y).toEqual(250);
-    graph.destroy();
+    graph.on('afterlayout', () => {
+      const nodeModel = graph.getNodes()[0].getModel();
+      expect(nodeModel.x).toEqual(250);
+      expect(nodeModel.y).toEqual(250);
+      graph.destroy();
+    });
   });
 
   it('focus on descrete node, prevent overlapping', () => {

--- a/packages/pc/tests/unit/layout/random-spec.ts
+++ b/packages/pc/tests/unit/layout/random-spec.ts
@@ -26,11 +26,14 @@ describe('random', () => {
     });
     graph.data(data);
     graph.render();
-    expect(graph.getNodes()[0].getModel().x).not.toEqual(undefined);
-    expect(graph.getNodes()[0].getModel().y).not.toEqual(undefined);
-    expect(graph.getNodes()[1].getModel().x).not.toEqual(undefined);
-    expect(graph.getNodes()[1].getModel().y).not.toEqual(undefined);
-    graph.destroy();
+
+    graph.on('afterlayout', () => {
+      expect(graph.getNodes()[0].getModel().x).not.toEqual(undefined);
+      expect(graph.getNodes()[0].getModel().y).not.toEqual(undefined);
+      expect(graph.getNodes()[1].getModel().x).not.toEqual(undefined);
+      expect(graph.getNodes()[1].getModel().y).not.toEqual(undefined);
+      graph.destroy();
+    });
   });
   it('new graph with random layout', () => {
     const graph = new G6.Graph({

--- a/packages/pc/tests/unit/state/state-update-spec.ts
+++ b/packages/pc/tests/unit/state/state-update-spec.ts
@@ -197,31 +197,34 @@ describe('force layout', () => {
 
     graph.data(data);
     graph.render();
-    const edge = graph.getEdges()[0];
 
-    graph.emit('edge:mouseenter', { item: edge });
-    const keyShape = edge.getKeyShape();
-    const text = edge.getContainer().find((e) => e.get('name') === 'text-shape');
-    expect(keyShape.attr('stroke')).toBe('rgb(95, 149, 255)');
-    expect(text.attr('x')).not.toBe(200);
+    graph.on('afterlayout', () => {
+      const edge = graph.getEdges()[0];
 
-    graph.emit('edge:mouseleave', { item: edge });
-    expect(keyShape.attr('stroke')).toBe('#f00');
-    expect(text.attr('x')).not.toBe(200);
+      graph.emit('edge:mouseenter', { item: edge });
+      const keyShape = edge.getKeyShape();
+      const text = edge.getContainer().find((e) => e.get('name') === 'text-shape');
+      expect(keyShape.attr('stroke')).toBe('rgb(95, 149, 255)');
+      expect(text.attr('x')).not.toBe(200);
 
-    graph.emit('edge:mouseenter', { item: edge });
-    graph.emit('edge:click', { item: edge });
-    expect(keyShape.attr('stroke')).toBe('rgb(95, 149, 255)');
-    expect(text.attr('x')).not.toBe(200);
-    expect(keyShape.attr('lineWidth')).toBe(2);
+      graph.emit('edge:mouseleave', { item: edge });
+      expect(keyShape.attr('stroke')).toBe('#f00');
+      expect(text.attr('x')).not.toBe(200);
 
-    graph.emit('edge:mouseleave', { item: edge });
-    graph.emit('canvas:click', {});
-    expect(keyShape.attr('lineWidth')).toBe(1);
-    expect(text.attr('x')).not.toBe(200);
-    expect(keyShape.attr('stroke')).toBe('#f00');
+      graph.emit('edge:mouseenter', { item: edge });
+      graph.emit('edge:click', { item: edge });
+      expect(keyShape.attr('stroke')).toBe('rgb(95, 149, 255)');
+      expect(text.attr('x')).not.toBe(200);
+      expect(keyShape.attr('lineWidth')).toBe(2);
 
-    graph.destroy();
+      graph.emit('edge:mouseleave', { item: edge });
+      graph.emit('canvas:click', {});
+      expect(keyShape.attr('lineWidth')).toBe(1);
+      expect(text.attr('x')).not.toBe(200);
+      expect(keyShape.attr('stroke')).toBe('#f00');
+
+      graph.destroy();
+    });
   });
 
   it('acitvate-relations wrong label position', () => {

--- a/packages/plugin/tests/unit/minimap-spec.ts
+++ b/packages/plugin/tests/unit/minimap-spec.ts
@@ -560,8 +560,8 @@ describe('minimap', () => {
         expect(matrix[4]).toEqual(2);
         graph.destroy();
         done();
-      }, 100);
-    }, 100);
+      }, 300);
+    }, 300);
   });
   it('invalid dom event', () => {
     const minimap = new Minimap({ size: [200, 200] });

--- a/packages/site/docs/api/treeMethods.en.md
+++ b/packages/site/docs/api/treeMethods.en.md
@@ -144,9 +144,9 @@ const layout = {
 treeGraph.changeLayout(layout);
 ```
 
-### refreshLayout(fitView)
+### layout(fitView)
 
-Refresh the layout. Usually, it is called after changing data.
+Refresh the layout. Usually, it is called after changing data. The `refreshLayout` is discarded by v4.x, call `layout` instead.
 
 **Parameters**
 
@@ -157,7 +157,7 @@ Refresh the layout. Usually, it is called after changing data.
 **Usage**
 
 ```javascript
-treeGraph.refreshLayout(true);
+treeGraph.layout(true);
 ```
 
 ## Search

--- a/packages/site/docs/api/treeMethods.zh.md
+++ b/packages/site/docs/api/treeMethods.zh.md
@@ -141,9 +141,9 @@ const layout = {
 treeGraph.changeLayout(layout);
 ```
 
-### refreshLayout(fitView)
+### layout(fitView)
 
-数据变更后，重新布局，刷新视图，并更新到画布。
+数据变更后，重新布局，刷新视图，并更新到画布。v4.x 废弃了 `refreshLayout`，请使用 `layout` 替代。
 
 **参数**
 
@@ -154,7 +154,7 @@ treeGraph.changeLayout(layout);
 **用法**
 
 ```javascript
-treeGraph.refreshLayout(true);
+treeGraph.layout(true);
 ```
 
 ## 查找

--- a/packages/site/examples/case/simpleCase/demo/mindmap.js
+++ b/packages/site/examples/case/simpleCase/demo/mindmap.js
@@ -304,14 +304,14 @@ G6.registerBehavior('dice-mindmap', {
             },
           ]),
         });
-        evt.currentTarget.refreshLayout(false);
+        evt.currentTarget.layout(false);
         break;
       case 'delete':
         const parent = evt.item.get('parent');
         evt.currentTarget.updateItem(parent, {
           children: (parent.get('model').children || []).filter((e) => e.id !== model.id),
         });
-        evt.currentTarget.refreshLayout(false);
+        evt.currentTarget.layout(false);
         break;
       case 'edit':
         break;
@@ -356,7 +356,7 @@ G6.registerBehavior('dice-mindmap', {
         graph.updateItem(item, {
           label: input.value,
         });
-        graph.refreshLayout(false);
+        graph.layout(false);
         graph.off('wheelZoom', clickEvt);
         destroyEl();
       }

--- a/packages/site/examples/interaction/treeBehavior/demo/meta.json
+++ b/packages/site/examples/interaction/treeBehavior/demo/meta.json
@@ -31,8 +31,8 @@
     {
       "filename": "loadTreeData.js",
       "title": {
-        "zh": "使用 refreshLayout",
-        "en": "Using refreshLayout"
+        "zh": "使用 addChild",
+        "en": "Using addChild"
       },
       "screenshot": "https://gw.alipayobjects.com/mdn/rms_f8c6a0/afts/img/A*wc1-QaqOPsgAAAAAAAAAAABkARQnAQ"
     }

--- a/packages/site/examples/interaction/treeBehavior/index.en.md
+++ b/packages/site/examples/interaction/treeBehavior/index.en.md
@@ -12,8 +12,8 @@ Move a subtree to a new parent by dragging the root node of the subtree. Drag th
 
 Click the nodes on the tree graph to onload multiple data. The following demos show two ways to load data:
 
-- `graph.refreshLayout`;
-- `graph.changeData`.
+- `graph.changeData`;
+- `graph.addChild`;
 
 ## Collapse the Sibling Nodes
 

--- a/packages/site/examples/interaction/treeBehavior/index.zh.md
+++ b/packages/site/examples/interaction/treeBehavior/index.zh.md
@@ -13,8 +13,8 @@ order: 1
 
 共演示了两种动态添加数据的方式：
 
-- 使用 `graph.refreshLayout` ；
-- 使用 `graph.changeData`。
+- 使用 `graph.changeData`；
+- 使用 `graph.addChild`。
 
 ## 合并同类兄弟节点
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change

issues:
https://github.com/antvis/G6/issues/1462

changes:
1. 增加了layout-pipes的功能。
2. 所以的layout都改成了异步，用onLayoutEnd回调。

update:
对外接口没有break change, 但是layout过程全部变成异步, 因此不能在graph.render后直接断言或者拿到布局好的数据。

samples:
保存之前的layout方式：
```
layout: { type: 'random', workerEnabled: true}
```
新增的方式，去除外侧的type，使用layout的pipes。
```
layout: {pipes: [{type: 'random', nodeFilter: ..., edgeFilter:...}], workerEnabled: true}
```

