### PR TITLE
fix: show menu when triggered by click

### DIFF
--- a/packages/plugin/src/menu/index.ts
+++ b/packages/plugin/src/menu/index.ts
@@ -157,7 +157,13 @@ export default class Menu extends Base {
       visibility: 'visible',
     });
 
+    // 左键单击会触发 body 上监听的 click 事件，导致菜单展示出来后又立即被隐藏了，需要过滤掉
+    let triggeredByFirstClick = this.get('trigger') === 'click';
     const handler = (evt) => {
+      if (triggeredByFirstClick) {
+        triggeredByFirstClick = false;
+        return;
+      }
       self.onMenuHide();
     };
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->
修复左键单击无法弹出菜单的问题