### PR TITLE
docs(site): 修复 site 模块在_windows_上本地启动无法设置环境变量的问题，使用通用的 cross-env 包

### DIFF
--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -24,11 +24,14 @@
   "license": "MIT",
   "author": "https://github.com/orgs/antvis/people",
   "scripts": {
-    "site:build": "npm run site:clean && GATSBY=true gatsby build --prefix-paths",
+    "site:build": "npm run site:clean && cross-env GATSBY=true gatsby build --prefix-paths",
     "site:clean": "gatsby clean",
-    "site:develop": "GATSBY=true gatsby develop --open",
+    "site:develop": "cross-env GATSBY=true gatsby develop --open",
     "site:deploy": "npm run site:build && gh-pages -d public",
     "start": "npm run site:develop"
+  },
+  "devDependencies": {
+    "cross-env": "^7.0.3"
   },
   "dependencies": {
     "@ant-design/icons": "^4.0.6",


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change

简而言之，吾辈使用 windows 启动 website 模块的本地服务器时，会因为无法使用 `GATSBY=true` 的方式设置环境变量而失败，所以吾辈使用了跨平台的 cross-env 设置环境变量。

另外，启动之前似乎还需要在根目录运行 `build:all`，但会失败（mobile 模块），但之后可以运行 website 了，如果可能，希望将之添加到项目的构建文档中。
