### PR TITLE
docs(site): 修复节点分组 Combo 和 图形分组 Group 引用链接的错误

### DIFF
--- a/packages/site/docs/manual/middle/elements/combos/defaultCombo.en.md
+++ b/packages/site/docs/manual/middle/elements/combos/defaultCombo.en.md
@@ -3,7 +3,7 @@ title: Overview of Combos
 order: 0
 ---
 
-> Node Combo is a new feature for V3.5. The [node group](/en/docs/manual/middle/discard/nodeGroup) will be deprecated. We recommend to use Combo for node grouping. <a href='/en/examples/item/defaultCombos' target='_blank'>Demo</a>. <br /><img src='https://gw.alipayobjects.com/mdn/rms_f8c6a0/afts/img/A*AngFRpOo4SAAAAAAAAAAAABkARQnAQ' width=600 alt='img'/>
+> Node Combo is a new feature for V3.5. The [node group](/en/docs/manual/middle/elements/shape/graphics-group) will be deprecated. We recommend to use Combo for node grouping. <a href='/en/examples/item/defaultCombos' target='_blank'>Demo</a>. <br /><img src='https://gw.alipayobjects.com/mdn/rms_f8c6a0/afts/img/A*AngFRpOo4SAAAAAAAAAAAABkARQnAQ' width=600 alt='img'/>
 
 The built-in Combos in G6 include circle and rect types. <br /> <img src='https://gw.alipayobjects.com/mdn/rms_f8c6a0/afts/img/A*UwaHSKkwoVUAAAAAAAAAAABkARQnAQ' width='250' alt='img'/>
 

--- a/packages/site/docs/manual/middle/elements/combos/defaultCombo.zh.md
+++ b/packages/site/docs/manual/middle/elements/combos/defaultCombo.zh.md
@@ -3,7 +3,7 @@ title: Combo 总览
 order: 0
 ---
 
-> V3.5 后支持的全新节点分组 Combo 机制。[原节点分组](/zh/docs/manual/middle/discard/nodeGroup)即将废除。
+> V3.5 后支持的全新节点分组 Combo 机制。[原节点分组](/zh/docs/manual/middle/elements/shape/graphics-group)即将废除。
 
 对于熟悉图可视化类库的用户来说，节点分组是非常实用的一个功能。此前，G6 已经存在一个节点分组 Node Group 功能，但它的机制无法支持一些较复杂的功能，例如：带有节点分组的图布局、自定义 Combo、嵌套节点分组的均匀 padding、节点与分组的边、分组与分组的边、空的节点分组等。V3.5 推出了全新的节点分组 Combo 机制，能够支持所有常用功能，参考 <a href='/zh/examples/item/defaultCombos' target='_blank'>Demo</a>。 <br /><img src='https://gw.alipayobjects.com/mdn/rms_f8c6a0/afts/img/A*AngFRpOo4SAAAAAAAAAAAABkARQnAQ' width=600 alt='img'/>
 

--- a/packages/site/docs/manual/middle/elements/methods/elementIndex.en.md
+++ b/packages/site/docs/manual/middle/elements/methods/elementIndex.en.md
@@ -3,7 +3,7 @@ title: The Visual Level of Node and Edge
 order: 4
 ---
 
-The visual levels (zIndex) of nodes and edges are refered to their [Graphics Group](/en/docs/manual/middle/elements/shape/graphics-group) (hereinafter referred to as Shape). (<span style="background-color: rgb(251, 233, 231); color: rgb(139, 53, 56)"><strong>⚠️Attention:</strong></span> The Graphics Group is different from the [Node Combo](/en/docs/manual/middle/discard/nodeGroup), the differences are described in [Graphics Group](/en/docs/manual/middle/elements/shape/graphics-group)).
+The visual levels (zIndex) of nodes and edges are refered to their [Graphics Group](/en/docs/manual/middle/elements/shape/graphics-group) (hereinafter referred to as Shape). (<span style="background-color: rgb(251, 233, 231); color: rgb(139, 53, 56)"><strong>⚠️Attention:</strong></span> The Graphics Group is different from the [Node Combo](/en/docs/manual/middle/elements/combos/defaultCombo), the differences are described in [Graphics Group](/en/docs/manual/middle/elements/shape/graphics-group)).
 
 In [Graphics Group](/en/docs/manual/middle/elements/shape/graphics-group), we stated: All the nodes instances in a Graph is grouped by a Group named `nodeGroup`, all the edges instances are grouped by `edgeGroup`. And the visual level (zIndex) of `nodeGroup` is higher than `edgeGroup`, which means all the nodes will be drawed on the top of all the edges.
 

--- a/packages/site/docs/manual/middle/elements/methods/elementIndex.zh.md
+++ b/packages/site/docs/manual/middle/elements/methods/elementIndex.zh.md
@@ -3,7 +3,7 @@ title: 节点与边的层级
 order: 4
 ---
 
-节点与边在视觉上的层级涉及到了它们相对应的 [图形分组 Group](/zh/docs/manual/middle/elements/shape/graphics-group)。本文提到的所有分组 Group 都为 G6 的图形分组 Group，而非 G6 的  [节点分组 Combo](/zh/docs/manual/middle/discard/nodeGroup)，其区别在 [图形分组 Group](/zh/docs/manual/middle/elements/shape/graphics-group)  中说明。
+节点与边在视觉上的层级涉及到了它们相对应的 [图形分组 Group](/zh/docs/manual/middle/elements/shape/graphics-group)。本文提到的所有分组 Group 都为 G6 的图形分组 Group，而非 G6 的  [节点分组 Combo](/zh/docs/manual/middle/elements/combos/defaultCombo)，其区别在 [图形分组 Group](/zh/docs/manual/middle/elements/shape/graphics-group)  中说明。
 
 在 [图形分组 Group](/zh/docs/manual/middle/elements/shape/graphics-group) 中我们提到：在 G6 中，Graph 的一个实例中的所有节点属于同一个变量名为 `nodeGroup` 的 group，所有的边属于同一个变量名为 `edgeGroup` 的 group。节点 group 在视觉上的层级（zIndex）高于边 group，即所有节点会绘制在所有边的上层。
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change

![image](https://user-images.githubusercontent.com/24560368/128830758-26d31ba0-cccd-42cc-9532-00fdcd3b811a.png)

---

另外，强烈建议添加 cli 检查引用关系，毕竟只针对变动的文件 + worker_threads 性能上也并非无法接受的，总比现在这种只有有人碰到了才能发现问题更好

个人推荐 [remark.js](https://remark.js.org/) 系列工具包，处理 markdown ast 非常方便

