### PR TITLE
feat: add zoom animation

### DIFF
--- a/packages/core/src/graph/graph.ts
+++ b/packages/core/src/graph/graph.ts
@@ -32,7 +32,7 @@ import {
   IPoint,
   FitViewRules,
 } from '../types';
-import { move } from '../util/math';
+import { lerp, move } from '../util/math';
 import { dataValidation, singleDataValidation } from '../util/validation';
 import Global from '../global';
 import { ItemController, ModeController, StateController, ViewController } from './controller';
@@ -601,7 +601,7 @@ export default abstract class AbstractGraph extends EventEmitter implements IAbs
     }
 
     const viewController: ViewController = this.get('viewController');
-  
+
     if (rules) {
       viewController.fitViewByRules(rules);
     } else {
@@ -666,9 +666,11 @@ export default abstract class AbstractGraph extends EventEmitter implements IAbs
    * 伸缩窗口
    * @param ratio 伸缩比例
    * @param center 以center的x, y坐标为中心缩放
+   * @param {boolean} animate 是否带有动画地移动
+   * @param {GraphAnimateConfig} animateCfg 若带有动画，动画的配置项
    * @return {boolean} 缩放是否成功
    */
-  public zoom(ratio: number, center?: Point): boolean {
+  public zoom(ratio: number, center?: Point, animate?: boolean, animateCfg?: GraphAnimateConfig): boolean {
     const group: IGroup = this.get('group');
     let matrix = clone(group.getMatrix());
     const minZoom: number = this.get('minZoom');
@@ -693,9 +695,55 @@ export default abstract class AbstractGraph extends EventEmitter implements IAbs
     }
     // matrix = [2, 0, 0, 0, 2, 0, -125, -125, 1];
 
-    group.setMatrix(matrix);
-    this.emit('viewportchange', { action: 'zoom', matrix });
-    this.autoPaint();
+    if (animate) {
+      // Clone the original matrix to perform the animation
+      let aniMatrix = clone(group.getMatrix());
+      if (!aniMatrix) {
+        aniMatrix = [1, 0, 0, 0, 1, 0, 0, 0, 1];
+      }
+      const initialRatio = aniMatrix[0];
+      const targetRatio = initialRatio * ratio;
+
+      let animateConfig: GraphAnimateConfig;
+      if (!animateCfg) {
+        animateConfig = {
+          duration: 500,
+          callback: () => {
+            this.emit('viewportchange', { action: 'zoom', matrix: aniMatrix });
+          }
+        };
+      } else if (animateCfg.callback) {
+        // This is to prevent modifying the original animateCfg.callback
+        const { callback } = animateCfg;
+        animateConfig = clone(animateCfg);
+        animateConfig.callback = () => {
+          this.emit('viewportchange', { action: 'zoom', matrix: aniMatrix });
+          callback();
+        }
+      } else {
+        animateConfig = animateCfg;
+      }
+
+      group.animate((ratio: number) => {
+        if (ratio === 1) {
+          // Reuse the first transformation
+          aniMatrix = matrix;
+        } else {
+          const scale = lerp(initialRatio, targetRatio, ratio) / aniMatrix[0];
+          if (center) {
+            aniMatrix = transform(aniMatrix, [['t', -center.x, -center.y], ['s', scale, scale], ['t', center.x, center.y]]);
+          } else {
+            aniMatrix = transform(aniMatrix, [['s', scale, scale]]);
+          }
+        }
+        return { matrix: aniMatrix };
+      }, animateConfig);
+    } else {
+      group.setMatrix(matrix);
+      this.emit('viewportchange', { action: 'zoom', matrix });
+      this.autoPaint();
+    }
+
     return true;
   }
 

--- a/packages/core/src/util/math.ts
+++ b/packages/core/src/util/math.ts
@@ -821,3 +821,16 @@ export const pointLineDistance = (line, point) => {
   // @ts-ignore
   return Math.abs(vec2.dot(a, u));
 };
+
+
+/**
+ * Linearly interpolate between start and end, where alpha is the percent distance along the line.
+ * alpha = 0 will be start, and alpha = 1 will be end.
+ * @param {Number} start
+ * @param {Number} end
+ * @param {Number} alpha interpolation factor, typically in the closed interval [0, 1]
+ * @returns
+ */
+export const lerp = (start: number, end: number, alpha: number): number => {
+  return start + (end - start) * alpha;
+}


### PR DESCRIPTION
##### Checklist

- [x] `npm test` passes
- [x] commit message follows commit guidelines

##### Description of change
This adds an option to perform an animated zoom.
The only "issue" I see with this implementation is that the zoom function will return true/false before the animation conclusion, but it seems this is a common issue with several other functions

Close https://github.com/antvis/G6/issues/3233
