### PR TITLE
fix: fix path shape will disappear after setItemState

### DIFF
--- a/packages/core/src/util/graphic.ts
+++ b/packages/core/src/util/graphic.ts
@@ -13,7 +13,7 @@ import {
 } from '../types';
 import { applyMatrix } from './math';
 import letterAspectRatio from './letterAspectRatio';
-import { isString, clone, isNumber, isObject } from '@antv/util';
+import { isString, clone, isNumber, isObject, isArray } from '@antv/util';
 import { IAbstractGraph } from '../interface/graph';
 
 const { PI, sin, cos } = Math;
@@ -653,11 +653,11 @@ export const cloneBesidesImg = (obj) => {
   const clonedObj = {};
   Object.keys(obj).forEach(key1 => {
     const obj2 = obj[key1];
-    if (isObject(obj2)) {
+    if (isObject(obj2) && !isArray(obj2)) {
       const clonedObj2 = {};
       Object.keys(obj2).forEach(key2 => {
         const v = obj2[key2];
-        if(key2 === 'img' && !isString(v)) return;
+        if (key2 === 'img' && !isString(v)) return;
         clonedObj2[key2] = clone(v);
       })
       clonedObj[key1] = clonedObj2;


### PR DESCRIPTION
setItemState will change shape.attrs.path  into a object

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->
cloneBesidesImg 在复制类型为 path 的 subShape 的 attrs 时会把 path 改变为对象，导致该 subShape 消失。当 item 有两个或以上的 state 时，且 stateStyles 都包含 subShape 的 style，取消某个 state 会导致该现象出现。