### PR TITLE
fix: allow enabling stack operations at runtime

### DIFF
--- a/packages/core/src/graph/graph.ts
+++ b/packages/core/src/graph/graph.ts
@@ -353,6 +353,10 @@ export default abstract class AbstractGraph extends EventEmitter implements IAbs
     } else {
       this.cfg[key] = val;
     }
+    if (key === 'enabledStack' && val && !this.undoStack && !this.redoStack) {
+      this.undoStack = new Stack(this.cfg.maxStep);
+      this.redoStack = new Stack(this.cfg.maxStep);
+    }
     return this;
   }
 

--- a/packages/core/tests/unit/graph/graph-spec.ts
+++ b/packages/core/tests/unit/graph/graph-spec.ts
@@ -1415,6 +1415,22 @@ describe('redo stack & undo stack', () => {
     expect(graph.getRedoStack()).toBe(undefined);
   });
 
+  it('enable stack operations at runtime', () => {
+    const graph = new Graph({
+      container: 'global-spec',
+      width: 500,
+      height: 500,
+    });
+
+    expect(graph.getUndoStack()).toBe(undefined);
+    expect(graph.getRedoStack()).toBe(undefined);
+
+    graph.set('enabledStack', true);
+
+    expect(graph.getUndoStack()).toBeDefined();
+    expect(graph.getRedoStack()).toBeDefined();
+  });
+
   const graph = new Graph({
     container: 'global-spec',
     width: 500,


### PR DESCRIPTION
##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change

This fix allows enabling the stack operations at runtime, in use cases where the user wants to have control over the undo/redo functionality 
