### PR TITLE
feat: add addItems function

### DIFF
--- a/packages/core/src/graph/graph.ts
+++ b/packages/core/src/graph/graph.ts
@@ -1174,7 +1174,7 @@ export default abstract class AbstractGraph extends EventEmitter implements IAbs
     if (combos && combos.length > 0) {
       this.sortCombos();
     }
-    return true;
+    return item;
   }
 
   /**
@@ -1242,21 +1242,23 @@ export default abstract class AbstractGraph extends EventEmitter implements IAbs
 
     const returnItems: (Item | boolean)[] = [];
 
-    // 1. add anything that is not an edge
-    let edges: { type: ITEM_TYPE; model: ModelConfig }[] = [];
+    // 1. add anything that is not an edge.
+    // Add undefined as a placeholder for the next cycle. This way we return items matching the input order
     for (let i = 0; i < items.length; i++) {
       const item = items[i];
       if (item.type !== 'edge') {
         returnItems.push(this.innerAddItem(item.type, item.model, itemController));
       } else {
-        edges.push(item);
+        returnItems.push(undefined);
       }
     }
 
     // 2. add all the edges
-    for (let i = 0; i < edges.length; i++) {
-      const edge = edges[i];
-      returnItems.push(this.innerAddItem(edge.type, edge.model, itemController));
+    for (let i = 0; i < items.length; i++) {
+      const item = items[i];
+      if (item.type === 'edge') {
+        returnItems[i] = this.innerAddItem(item.type, item.model, itemController);
+      }
     }
 
     this.autoPaint();

--- a/packages/core/src/interface/graph.ts
+++ b/packages/core/src/interface/graph.ts
@@ -211,11 +211,22 @@ export interface IAbstractGraph extends EventEmitter {
    * @param {string} type 元素类型(node | edge)
    * @param {ModelConfig} model 元素数据模型
    * @param {boolean} stack 本次操作是否入栈，默认为 true
-   * @return {Item} 元素实例
+   * @param {boolean} sortCombo 本次操作是否需要更新 combo 层级顺序，内部参数，用户在外部使用 addItem 时始终时需要更新
+   * @return {Item | boolean} 元素实例
    */
-  addItem: (type: ITEM_TYPE, model: ModelConfig, stack?: boolean) => Item;
+  addItem: (type: ITEM_TYPE, model: ModelConfig, stack?: boolean, sortCombo?: boolean) => Item | boolean;
 
-  add: (type: ITEM_TYPE, model: ModelConfig, stack?: boolean) => Item;
+  add: (type: ITEM_TYPE, model: ModelConfig, stack?: boolean, sortCombo?: boolean) => Item | boolean;
+
+  /**
+   * Adds multiple items with a single operation
+   * @param {{type: ITEM_TYPE, model: ModelConfig}[]} items Items to be added to the graph
+   * @param {AddItemsCfg} opts Additional parameters to control how nodes are added
+   * @param {boolean} animate Enables the animation
+   * @param {GraphAnimateConfig} animateCfg Configures the animation if enabled
+   * @return {(Item | boolean)[]} Instance of the added items
+   */
+  addItems: (items: { type: ITEM_TYPE, model: ModelConfig }[], stack: boolean, sortCombo: boolean) => (Item | boolean)[];
 
   /**
    * 更新元素

--- a/packages/core/tests/unit/graph/graph-spec.ts
+++ b/packages/core/tests/unit/graph/graph-spec.ts
@@ -689,121 +689,197 @@ describe('all node link center', () => {
     expect(edge.get('keyShape').attr('path')).toEqual([['M', 10, 10], ['L', 100, 100]]);
   });
 
-  it('loop', () => {
-    graph.set('linkCenter', false);
-
-    const node = graph.addItem('node', {
+  const loopNode: any = {
+    type: 'node',
+    model: {
       id: 'circleNode',
       x: 150,
       y: 150,
       style: { fill: 'yellow' },
       anchorPoints: [[0, 0], [0, 1]],
-    });
+    }
+  };
 
-    const edge1 = graph.addItem('edge', {
-      id: 'edge',
-      source: 'circleNode',
-      target: 'circleNode',
-      type: 'loop',
-      loopCfg: {
-        position: 'top',
-        dist: 60,
-        clockwise: true,
-      },
-      style: { endArrow: true },
-    });
+  const loopEdges: any = [
+    {
+      type: 'edge',
+      model: {
+        id: 'edge',
+        source: 'circleNode',
+        target: 'circleNode',
+        type: 'loop',
+        loopCfg: {
+          position: 'top',
+          dist: 60,
+          clockwise: true,
+        },
+        style: { endArrow: true },
+      }
+    },
+    {
+      type: 'edge',
+      model: {
+        id: 'edge1',
+        source: 'circleNode',
+        target: 'circleNode',
+        type: 'loop',
+        loopCfg: {
+          position: 'top-left',
+          dist: 60,
+          clockwise: false,
+        },
+        style: { endArrow: true },
+      }
+    },
+    {
+      type: 'edge',
+      model: {
+        id: 'edge2',
+        source: 'circleNode',
+        target: 'circleNode',
+        type: 'loop',
+        loopCfg: {
+          position: 'top-right',
+          dist: 60,
+        },
+        style: { endArrow: true },
+      }
+    },
+    {
+      type: 'edge',
+      model: {
+        id: 'edge4',
+        source: 'circleNode',
+        target: 'circleNode',
+        type: 'loop',
+        loopCfg: {
+          position: 'right',
+          dist: 60,
+          clockwise: true,
+        },
+        style: { endArrow: true },
+      }
+    },
+    {
+      type: 'edge',
+      model: {
+        id: 'edge5',
+        source: 'circleNode',
+        target: 'circleNode',
+        type: 'loop',
+        sourceAnchor: 0,
+        targetAnchor: 1,
+        loopCfg: {
+          position: 'bottom-right',
+          dist: 60,
+          clockwise: true,
+        },
+        style: { endArrow: true },
+      }
+    },
+    {
+      type: 'edge',
+      model: {
+        id: 'edge6',
+        source: 'circleNode',
+        target: 'circleNode',
+        type: 'loop',
+        loopCfg: {
+          position: 'bottom',
+          dist: 60,
+          clockwise: true,
+        },
+        style: { endArrow: true },
+      }
+    },
+    {
+      type: 'edge',
+      model: {
+        id: 'edge7',
+        source: 'circleNode',
+        target: 'circleNode',
+        type: 'loop',
+        loopCfg: {
+          position: 'bottom-left',
+          dist: 60,
+          clockwise: true,
+        },
+        style: { endArrow: true },
+      }
+    },
+    {
+      type: 'edge',
+      model: {
+        id: 'edge8',
+        source: 'circleNode',
+        target: 'circleNode',
+        type: 'loop',
+        loopCfg: {
+          position: 'left',
+          dist: 60,
+          clockwise: true,
+        },
+        style: { endArrow: true },
+      }
+    }
+  ];
 
-    const edge2 = graph.addItem('edge', {
-      id: 'edge1',
-      source: 'circleNode',
-      target: 'circleNode',
-      type: 'loop',
-      loopCfg: {
-        position: 'top-left',
-        dist: 60,
-        clockwise: false,
-      },
-      style: { endArrow: true },
-    });
+  it('loop - addItem', () => {
+    graph.clear();
+    graph.set('linkCenter', false);
 
-    const edge3 = graph.addItem('edge', {
-      id: 'edge2',
-      source: 'circleNode',
-      target: 'circleNode',
-      type: 'loop',
-      loopCfg: {
-        position: 'top-right',
-        dist: 60,
-      },
-      style: { endArrow: true },
-    });
+    const node = graph.addItem(loopNode.type, loopNode.model);
 
-    const edge4 = graph.addItem('edge', {
-      id: 'edge4',
-      source: 'circleNode',
-      target: 'circleNode',
-      type: 'loop',
-      loopCfg: {
-        position: 'right',
-        dist: 60,
-        clockwise: true,
-      },
-      style: { endArrow: true },
-    });
+    const edge1 = graph.addItem(loopEdges[0].type, loopEdges[0].model);
+    const edge2 = graph.addItem(loopEdges[1].type, loopEdges[1].model);
+    const edge3 = graph.addItem(loopEdges[2].type, loopEdges[2].model);
+    const edge4 = graph.addItem(loopEdges[3].type, loopEdges[3].model);
 
-    const edgeWithAnchor = graph.addItem('edge', {
-      id: 'edge5',
-      source: 'circleNode',
-      target: 'circleNode',
-      type: 'loop',
-      sourceAnchor: 0,
-      targetAnchor: 1,
-      loopCfg: {
-        position: 'bottom-right',
-        dist: 60,
-        clockwise: true,
-      },
-      style: { endArrow: true },
-    });
+    const edgeWithAnchor = graph.addItem(loopEdges[4].type, loopEdges[4].model);
 
-    graph.addItem('edge', {
-      id: 'edge6',
-      source: 'circleNode',
-      target: 'circleNode',
-      type: 'loop',
-      loopCfg: {
-        position: 'bottom',
-        dist: 60,
-        clockwise: true,
-      },
-      style: { endArrow: true },
-    });
+    graph.addItem(loopEdges[5].type, loopEdges[5].model);
+    graph.addItem(loopEdges[6].type, loopEdges[6].model);
+    graph.addItem(loopEdges[7].type, loopEdges[7].model);
 
-    graph.addItem('edge', {
-      id: 'edge7',
-      source: 'circleNode',
-      target: 'circleNode',
-      type: 'loop',
-      loopCfg: {
-        position: 'bottom-left',
-        dist: 60,
-        clockwise: true,
-      },
-      style: { endArrow: true },
-    });
+    const edgeShape = edge1.getKeyShape().attr('path');
+    const edge2Shape = edge2.getKeyShape().attr('path');
 
-    graph.addItem('edge', {
-      id: 'edge8',
-      source: 'circleNode',
-      target: 'circleNode',
-      type: 'loop',
-      loopCfg: {
-        position: 'left',
-        dist: 60,
-        clockwise: true,
-      },
-      style: { endArrow: true },
-    });
+    expect(edge2Shape[0][1]).toEqual(edgeShape[0][1]);
+    expect(edge2Shape[0][2]).toEqual(edgeShape[0][2]);
+    expect(edge3.getKeyShape().attr('path')[1][0]).toEqual('C');
+    expect(edge3.getKeyShape().attr('path')[0][1]).toEqual(edgeShape[1][5]);
+    expect(edge4.getKeyShape().attr('path')[0][1]).toEqual(edge3.getKeyShape().attr('path')[1][5]);
+    expect(edge4.getKeyShape().attr('path')[0][2]).toEqual(edge3.getKeyShape().attr('path')[1][6]);
+
+    const pathWithAnchor = edgeWithAnchor.getKeyShape().attr('path');
+    expect(pathWithAnchor[0][1]).toEqual(139.5);
+    expect(pathWithAnchor[0][2]).toEqual(139.5);
+    expect(pathWithAnchor[1][0]).toEqual('C');
+    expect(pathWithAnchor[1][5]).toEqual(139.5);
+    expect(pathWithAnchor[1][6]).toEqual(160.5);
+  });
+
+  it('loop - addItems', () => {
+    graph.clear();
+    graph.set('linkCenter', false);
+
+    const allItems = loopEdges.concat(loopNode);
+
+    const items = graph.addItems(allItems);
+
+    const edge1 = items[0];
+    debugger;
+    console.log('');
+    console.log('edge1');
+    console.log(edge1);
+    console.log('');
+    console.log('items');
+    console.log(items);
+    const edge2 = items[1];
+    const edge3 = items[2];
+    const edge4 = items[3];
+
+    const edgeWithAnchor = items[4];
 
     const edgeShape = edge1.getKeyShape().attr('path');
     const edge2Shape = edge2.getKeyShape().attr('path');
@@ -1545,6 +1621,18 @@ describe('redo stack & undo stack', () => {
     expect(firstStackData.action).toEqual('delete');
     expect(firstStackData.data.before.nodes[0].id).toEqual('node2');
     expect(firstStackData.data.before.nodes[0].itemType).toEqual('node');
+
+    graph.addItems([
+      { type: 'node', model: {} }, { type: 'node', model: {} }
+    ]);
+
+    stackData = graph.getStackData();
+    undoStack = stackData.undoStack;
+    expect(undoStack.length).toBe(7);
+
+    firstStackData = undoStack[0];
+    expect(firstStackData.action).toEqual('addItems');
+    expect(firstStackData.data.after.nodes).toHaveLength(2);
   });
 
   it('clear stack', () => {


### PR DESCRIPTION
##### Checklist

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change
This partially implements what was done in https://github.com/antvis/G6/pull/3519

This adds a function to add multiple items at once. In the following examples I'm usingrandom x/y coordinates for the added nodes:

https://user-images.githubusercontent.com/2861371/158199728-1dad3303-86ef-4deb-b67a-1939e55869f8.mp4


