### PR TITLE
fix: position animate considers auto paint

### DIFF
--- a/packages/core/src/graph/graph.ts
+++ b/packages/core/src/graph/graph.ts
@@ -2114,6 +2114,11 @@ export default abstract class AbstractGraph extends EventEmitter implements IAbs
    */
   public positionsAnimate(referComboModel?: boolean): void {
     const self = this;
+
+    if (!self.get('autoPaint')) {
+      return;
+    }
+
     self.emit('beforeanimate');
 
     const animateCfg: GraphAnimateConfig = self.get('animateCfg');


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->

- `positionsAnimate()` updates element positions even when `autoPaint` is `false`. This fix is to ignore animation when it is turned off.
