### PR TITLE
feat: enable edge selection in `click-select`

### DIFF
--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -350,6 +350,9 @@ export interface ModeOption {
   relayout?: boolean;
   brushStyle?: object;
   zoomKey?: ZoomKeyType | ZoomKeyType[];
+  selectNode?: boolean;
+  selectEdge?: boolean;
+  selectCombo?: boolean;
   shouldUpdate?: (e: IG6GraphEvent) => boolean;
   shouldBegin?: (e: IG6GraphEvent) => boolean;
   shouldEnd?: (e: IG6GraphEvent) => boolean;

--- a/packages/pc/src/behavior/click-select.ts
+++ b/packages/pc/src/behavior/click-select.ts
@@ -10,6 +10,9 @@ export default {
       multiple: true,
       trigger: DEFAULT_TRIGGER,
       selectedState: 'selected',
+      selectNode: true,
+      selectEdge: false,
+      selectCombo: true,
     };
   },
   getEvents(): { [key in G6Event]?: string } {
@@ -19,19 +22,21 @@ export default {
       self.trigger = DEFAULT_TRIGGER;
       // eslint-disable-next-line no-console
       console.warn(
-        "Behavior brush-select 的 trigger 参数不合法，请输入 'drag'、'shift'、'ctrl' 或 'alt'",
+        "Behavior click-select 的 trigger 参数不合法，请输入 'drag'、'shift'、'ctrl' 或 'alt'",
       );
     }
     if (!self.multiple) {
       return {
         'node:click': 'onClick',
         'combo:click': 'onClick',
+        'edge:click': 'onClick',
         'canvas:click': 'onCanvasClick',
       };
     }
     return {
       'node:click': 'onClick',
       'combo:click': 'onClick',
+      'edge:click': 'onClick',
       'canvas:click': 'onCanvasClick',
       keyup: 'onKeyUp',
       keydown: 'onKeyDown',
@@ -52,12 +57,42 @@ export default {
 
     // allow to select multiple nodes but did not press a key || do not allow the select multiple nodes
     if (!keydown || !multiple) {
-      const selected = graph.findAllByState('node', self.selectedState).concat(graph.findAllByState('combo', self.selectedState));
-      each(selected, (combo) => {
-        if (combo !== item) {
-          graph.setItemState(combo, self.selectedState, false);
+      const selected = graph.findAllByState('node', self.selectedState)
+        .concat(graph.findAllByState('edge', self.selectedState))
+        .concat(graph.findAllByState('combo', self.selectedState));
+      each(selected, (selectedItem) => {
+        if (selectedItem !== item) {
+          graph.setItemState(selectedItem, self.selectedState, false);
         }
       });
+    }
+
+    // check if the item could be selected, given the current cfg
+    const itemSelectable = (() => {
+      switch (type) {
+        case 'node':
+          return self.selectNode;
+        case 'edge':
+          return self.selectEdge;
+        case 'combo':
+          return self.selectCombo;
+        default:
+          return false;
+      }
+    })();
+    if (!itemSelectable) {
+      const selectedNodes = graph.findAllByState('node', self.selectedState);
+      const selectedEdges = graph.findAllByState('edge', self.selectedState);
+      const selectedCombos = graph.findAllByState('combo', self.selectedState);
+      graph.emit('nodeselectchange', {
+        selectedItems: {
+          nodes: selectedNodes,
+          edges: selectedEdges,
+          combos: selectedCombos,
+        },
+        select: false,
+      });
+      return;
     }
 
     if (item.hasState(self.selectedState)) {
@@ -65,11 +100,13 @@ export default {
         graph.setItemState(item, self.selectedState, false);
       }
       const selectedNodes = graph.findAllByState('node', self.selectedState);
+      const selectedEdges = graph.findAllByState('edge', self.selectedState);
       const selectedCombos = graph.findAllByState('combo', self.selectedState);
       graph.emit('nodeselectchange', {
         target: item,
         selectedItems: {
           nodes: selectedNodes,
+          edges: selectedEdges,
           combos: selectedCombos,
         },
         select: false,
@@ -79,11 +116,13 @@ export default {
         graph.setItemState(item, self.selectedState, true);
       }
       const selectedNodes = graph.findAllByState('node', self.selectedState);
+      const selectedEdges = graph.findAllByState('edge', self.selectedState);
       const selectedCombos = graph.findAllByState('combo', self.selectedState);
       graph.emit('nodeselectchange', {
         target: item,
         selectedItems: {
           nodes: selectedNodes,
+          edges: selectedEdges,
           combos: selectedCombos,
         },
         select: true,
@@ -99,6 +138,11 @@ export default {
     const selected = graph.findAllByState('node', this.selectedState);
     each(selected, (node) => {
       graph.setItemState(node, this.selectedState, false);
+    });
+
+    const selectedEdges = graph.findAllByState('edge', this.selectedState);
+    each(selected, (edge) => {
+      graph.setItemState(edge, this.selectedState, false);
     });
 
     const selectedCombos = graph.findAllByState('combo', this.selectedState);

--- a/packages/pc/tests/unit/behavior/select-spec.ts
+++ b/packages/pc/tests/unit/behavior/select-spec.ts
@@ -88,6 +88,120 @@ describe('select-node', () => {
     expect(node2.getStates().length).toEqual(0);
     graph.destroy();
   });
+  it('select & deselect single edge', () => {
+    const graph = new Graph({
+      container: div,
+      width: 500,
+      height: 500,
+      modes: {
+        default: [
+          {
+            type: 'click-select',
+            selectEdge: true,
+          }
+        ],
+      },
+      nodeStateStyles: {
+        selected: {},
+      },
+    });
+    graph.addItem('node', {
+      id: 'node1',
+      color: '#666',
+      x: 50,
+      y: 50,
+      size: 20,
+      style: { lineWidth: 2, fill: '#666' },
+    });
+    graph.addItem('node', {
+      id: 'node2',
+      color: '#666',
+      x: 150,
+      y: 150,
+      size: 20,
+      style: { lineWidth: 2, fill: '#666' },
+    });
+    const edge = graph.addItem('edge', {
+      id: 'edge',
+      source: 'node1',
+      target: 'node2',
+      type: 'line',
+    })
+
+    graph.once('nodeselectchange', (e) => {
+      expect(e.selectedItems.edges.length).toEqual(1);
+    });
+
+    graph.emit('edge:click', { item: edge });
+    expect(edge.getStates().length).toEqual(1);
+    expect(edge.hasState('selected')).toBe(true);
+    graph.emit('edge:click', { item: edge });
+    expect(edge.getStates().length).toEqual(0);
+    graph.destroy();
+  });
+  it('select & deselect multiple nodes and edges', () => {
+    const graph = new Graph({
+      container: div,
+      width: 500,
+      height: 500,
+      modes: {
+        default: [
+          {
+            type: 'click-select',
+            selectEdge: true,
+          }
+        ],
+      },
+      nodeStateStyles: {
+        selected: {},
+      },
+    });
+    const node1 = graph.addItem('node', {
+      id: 'node1',
+      color: '#666',
+      x: 50,
+      y: 50,
+      size: 20,
+      style: { lineWidth: 2, fill: '#666' },
+    });
+    const node2 = graph.addItem('node', {
+      id: 'node2',
+      color: '#666',
+      x: 150,
+      y: 150,
+      size: 20,
+      style: { lineWidth: 2, fill: '#666' },
+    });
+    const edge = graph.addItem('edge', {
+      id: 'edge',
+      source: 'node1',
+      target: 'node2',
+      type: 'line',
+    })
+    graph.emit('node:click', { item: node1 });
+    expect(node1.getStates().length).toEqual(1);
+    expect(node1.getStates()[0]).toEqual('selected');
+    graph.emit('keydown', { key: 'shift' });
+    graph.emit('node:click', { item: node1 });
+    graph.emit('edge:click', { item: edge });
+    expect(node1.getStates().length).toEqual(0);
+    expect(edge.getStates().length).toEqual(1);
+    graph.emit('node:click', { item: node1 });
+    graph.emit('edge:click', { item: edge });
+    expect(node1.hasState('selected')).toBe(true);
+    expect(edge.hasState('selected')).toBe(false);
+    graph.emit('node:click', { item: node2 });
+    expect(node2.getStates().length).toEqual(1);
+    expect(node2.getStates()[0]).toEqual('selected');
+    expect(node1.hasState('selected')).toBe(true);
+    graph.emit('edge:click', { item: edge });
+    graph.emit('keyup', { key: 'shift' });
+    graph.emit('node:click', { item: node1 });
+    expect(node1.getStates().length).toEqual(0);
+    expect(node2.getStates().length).toEqual(0);
+    expect(edge.getStates().length).toEqual(0);
+    graph.destroy();
+  });
   it('shouldUpdate', () => {
     const graph = new Graph({
       container: div,


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->

 对应 issue #3565 

###### 新功能

允许在内置行为 `click-select` 中自定义可选择的对象，目前支持三种：node，edge 和 combo。具体来说，在行为中增加了 3 个可修改的配置项 `selectNode`，`selectEdge` 和 `selectCombo`，且 node 和 combo 默认可选，edge 默认不可选（与原有行为一致）。

此外，`click-select` 行为中返回的 `nodeselectchange` 事件中的 `selectedItems` 一项固定增加了 `edges` 返回项。

对象是否可选的判定时间，在 shouldUpdate 之前进行，在非多选模式下清空已经选择对象的操作之后。

另外，修改了 warning 中的 typo。

###### 新测试

在测试文件 `packages/pc/tests/unit/behavior/select-spec.ts` 中加入 2 个新测试，分别为 “select & deselect single edge” 和 “select & deselect multiple nodes and edges”，测试表现符合预期且通过。

此功能相关的测试均已通过，但 npm test 里面过不了的测试太多，与我无瓜。
