### PR TITLE
fix ts类型判断错误

### DIFF
--- a/packages/core/src/graph/graph.ts
+++ b/packages/core/src/graph/graph.ts
@@ -3009,7 +3009,7 @@ export default abstract class AbstractGraph extends EventEmitter implements IAbs
   /**
    * 重新定义监听函数，复写参数类型
    */
-  public on<T = IG6GraphEvent>(eventName: G6Event, callback: (e: T) => void, once?: boolean): this {
+  public on<T = IG6GraphEvent>(eventName: G6Event|string, callback: (e: T) => void, once?: boolean): this {
     return super.on(eventName, callback, once);
   }
 


### PR DESCRIPTION
fix 类型“AbstractGraph”中的属性“on”不可分配给基类型“IAbstractGraph”中的同一属性。
  不能将类型“<T = IG6GraphEvent>(eventName: G6Event, callback: (e: T) => void, once?: boolean | undefined) => this”分配给类型“<T = IG6GraphEvent>(eventName: string, callback: (e: T) => void, once?: boolean | undefined) => this”。
    参数“eventName”和“eventName” 的类型不兼容。
      不能将类型“string”分配给类型“G6Event”。

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->
