### PR TITLE
fix: 修复G6内置 shortcuts-call behavior 类型错误

### DIFF
--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -318,6 +318,7 @@ export interface ModeOption {
   delegateStyle?: object;
   updateEdge?: boolean;
   trigger?: string;
+  combinedKey?: string;
   enableDelegate?: boolean;
   maxZoom?: number;
   minZoom?: number;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->
按照官网实例使用 shortcuts-call ，发现类型错误
<img width="413" alt="image" src="https://user-images.githubusercontent.com/30526662/167304201-07fc4084-ba6b-4b6f-8dc7-940cf2db0abc.png">
<img width="594" alt="image" src="https://user-images.githubusercontent.com/30526662/167304220-714957f3-ff5d-4653-8c94-71771339e2da.png">

