### PR TITLE
fix: only regenerate id when id is undefined

### DIFF
--- a/packages/core/src/item/item.ts
+++ b/packages/core/src/item/item.ts
@@ -96,7 +96,7 @@ export default class ItemBase implements IItemBase {
 
     const itemType = this.get('type');
 
-    if (!id) {
+    if (typeof id === 'undefined') {
       id = uniqueId(itemType);
       this.get('model').id = id;
     }

--- a/packages/core/src/item/item.ts
+++ b/packages/core/src/item/item.ts
@@ -98,9 +98,11 @@ export default class ItemBase implements IItemBase {
 
     if (typeof id === 'undefined') {
       id = uniqueId(itemType);
-      this.get('model').id = id;
+    } else if (typeof id !== 'string') {
+      id = String(id);
     }
 
+    this.get('model').id = id;
     this.set('id', id);
     const { group } = cfg;
     if (group) {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] commit message follows commit guidelines

##### Description of change

`uniqueId` should be used only when `id` is undefined.

Then case `id === 0` can be user configurable, instead of be changed with item-typed uniqueId:
![image](https://user-images.githubusercontent.com/8591672/167398511-7c04323e-3ed1-4302-8967-b51455f3f01a.png)


<!-- Provide a description of the change below this comment. -->
