### PR TITLE
Truncate node labels

### DIFF
--- a/packages/core/src/element/node.ts
+++ b/packages/core/src/element/node.ts
@@ -10,6 +10,7 @@ import { formatPadding } from '../util/base';
 import Global from '../global';
 import Shape from './shape';
 import { shapeBase } from './shapeBase';
+import { truncateLabelByLength } from '../util/graphic';
 
 const singleNode: ShapeOptions = {
   itemType: 'node',
@@ -52,8 +53,8 @@ const singleNode: ShapeOptions = {
 
     let text = cfg!.label as string;
 
-    if (labelMaxLength && text.length > labelMaxLength) {
-      text = text.substring(0, labelMaxLength) + '...';
+    if (labelMaxLength) {
+      text = truncateLabelByLength(text, labelMaxLength);
     }
 
     const labelPosition = labelCfg.position || this.labelPosition;

--- a/packages/core/src/element/node.ts
+++ b/packages/core/src/element/node.ts
@@ -48,11 +48,19 @@ const singleNode: ShapeOptions = {
   },
   // 私有方法，不希望扩展的节点复写这个方法
   getLabelStyleByPosition(cfg: NodeConfig, labelCfg: ILabelConfig): LabelStyle {
+    const labelMaxLength = labelCfg.style?.maxLength;
+
+    let text = cfg!.label as string;
+
+    if (labelMaxLength && text.length > labelMaxLength) {
+      text = text.substring(0, labelMaxLength) + '...';
+    }
+
     const labelPosition = labelCfg.position || this.labelPosition;
 
     // 默认的位置（最可能的情形），所以放在最上面
     if (labelPosition === 'center') {
-      return { x: 0, y: 0, text: cfg!.label as string, textBaseline: 'middle', textAlign: 'center' };
+      return { x: 0, y: 0, text, textBaseline: 'middle', textAlign: 'center' };
     }
 
     let { offset } = labelCfg;
@@ -98,7 +106,7 @@ const singleNode: ShapeOptions = {
         };
         break;
     }
-    style.text = cfg.label;
+    style.text = text;
     return style;
   },
   getLabelBgStyleByPosition(

--- a/packages/core/src/element/node.ts
+++ b/packages/core/src/element/node.ts
@@ -49,7 +49,7 @@ const singleNode: ShapeOptions = {
   },
   // 私有方法，不希望扩展的节点复写这个方法
   getLabelStyleByPosition(cfg: NodeConfig, labelCfg: ILabelConfig): LabelStyle {
-    const labelMaxLength = labelCfg.style?.maxLength;
+    const labelMaxLength = labelCfg.maxLength;
 
     let text = cfg!.label as string;
 

--- a/packages/core/src/interface/shape.ts
+++ b/packages/core/src/interface/shape.ts
@@ -8,6 +8,7 @@ export type ILabelConfig = Partial<{
   refY: number;
   autoRotate: boolean;
   style: LabelStyle;
+  maxLength?: number;
 }>;
 
 export type ShapeDefine = string | ((cfg: ModelConfig) => string);

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -553,7 +553,6 @@ export type LabelStyle = Partial<{
   textBaseline: 'top' | 'middle' | 'bottom' | 'hanging' | 'alphabetic' | 'ideographic';
   offset: number;
   fillOpacity: number;
-  maxLength?: number;
   background?: {
     fill?: string;
     stroke?: string;

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -553,6 +553,7 @@ export type LabelStyle = Partial<{
   textBaseline: 'top' | 'middle' | 'bottom' | 'hanging' | 'alphabetic' | 'ideographic';
   offset: number;
   fillOpacity: number;
+  maxLength?: number;
   background?: {
     fill?: string;
     stroke?: string;

--- a/packages/core/src/util/graphic.ts
+++ b/packages/core/src/util/graphic.ts
@@ -376,10 +376,10 @@ export const getTextSize = (text: string, fontSize: number) => {
 };
 
 export const truncateLabelByLength = (text: string, length: number) => {
-  if (text.length > length) {
-    return text.substring(0, length) + '...';
+  if (typeof length !== 'number' || length <= 0 || length >= text.length) {
+    return text;
   }
-  return text;
+  return text.substring(0, length) + '...';
 }
 
 /**

--- a/packages/core/src/util/graphic.ts
+++ b/packages/core/src/util/graphic.ts
@@ -375,6 +375,13 @@ export const getTextSize = (text: string, fontSize: number) => {
   return [width, fontSize];
 };
 
+export const truncateLabelByLength = (text: string, length: number) => {
+  if (text.length > length) {
+    return text.substring(0, length) + '...';
+  }
+  return text;
+}
+
 /**
  * construct the trees from combos data
  * @param array the combos array

--- a/packages/core/tests/unit/shape/node-spec.ts
+++ b/packages/core/tests/unit/shape/node-spec.ts
@@ -247,6 +247,30 @@ describe('shape node test', () => {
       expect(shape.attr('lineWidth')).toBe(1);
     });
 
+    it('max label length', () => {
+      const mockLabel = 'This is a test label';
+      const group = canvas.addGroup();
+      factory.draw(
+        'simple-circle',
+        {
+          size: 20,
+          color: 'blue',
+          label: mockLabel,
+          labelCfg: {
+            style: {
+              maxLength: 5,
+            },
+          },
+        },
+        group,
+      );
+      canvas.draw();
+      const label = group.get('children')[1];
+
+      expect(label.attr('maxLength')).toBe(5);
+      expect(label.attr('text')).toBe(mockLabel.substring(0, 5) + '...');
+    });
+
     it('clear', () => {
       canvas.destroy();
     });

--- a/packages/core/tests/unit/shape/node-spec.ts
+++ b/packages/core/tests/unit/shape/node-spec.ts
@@ -257,9 +257,7 @@ describe('shape node test', () => {
           color: 'blue',
           label: mockLabel,
           labelCfg: {
-            style: {
-              maxLength: 5,
-            },
+            maxLength: 5,
           },
         },
         group,
@@ -267,7 +265,6 @@ describe('shape node test', () => {
       canvas.draw();
       const label = group.get('children')[1];
 
-      expect(label.attr('maxLength')).toBe(5);
       expect(label.attr('text')).toBe(mockLabel.substring(0, 5) + '...');
     });
 

--- a/packages/core/tests/unit/util/graphic-spec.ts
+++ b/packages/core/tests/unit/util/graphic-spec.ts
@@ -91,18 +91,20 @@ describe('graphic unit test', () => {
   });
 
   it('truncateLabelByLength' ,() => {
-    let label = 'This is a test label';
+    const label = 'This is a test label';
     let length = 5;
 
     let result = truncateLabelByLength(label, length);
-
     expect(result).toEqual(label.substring(0, 5) + '...');
 
-    label = 'Test';
-    length = 10;
+    length = 100;
 
     result = truncateLabelByLength(label, length);
-
     expect(result).toEqual(label);
-  })
+
+    length = -1;
+
+    result = truncateLabelByLength(label, length);
+    expect(result).toEqual(label);
+  });
 });

--- a/packages/core/tests/unit/util/graphic-spec.ts
+++ b/packages/core/tests/unit/util/graphic-spec.ts
@@ -1,4 +1,4 @@
-import { traverseTree, traverseTreeUp, getTextSize } from '../../../src/util/graphic';
+import { traverseTree, traverseTreeUp, getTextSize, truncateLabelByLength } from '../../../src/util/graphic';
 
 interface TreeNode {
   id: string;
@@ -89,4 +89,20 @@ describe('graphic unit test', () => {
     result = getTextSize('体验技术', 14);
     expect(result).toEqual([56, 14]);
   });
+
+  it('truncateLabelByLength' ,() => {
+    let label = 'This is a test label';
+    let length = 5;
+
+    let result = truncateLabelByLength(label, length);
+
+    expect(result).toEqual(label.substring(0, 5) + '...');
+
+    label = 'Test';
+    length = 10;
+
+    result = truncateLabelByLength(label, length);
+
+    expect(result).toEqual(label);
+  })
 });


### PR DESCRIPTION
##### Checklist

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change

This PR introduces `truncateLabelByLength` - a utility function which can be used to shorten a label by a specific character length. If the target label is shorter than the specified length, an ellipsis is added. The `maxLength` property of a label's style is what can be used to specify the desired length.
