### PR TITLE
refactor: 将 toolbar plugin 的默认操作函数抽离

### DIFF
--- a/packages/plugin/src/toolBar/index.ts
+++ b/packages/plugin/src/toolBar/index.ts
@@ -447,14 +447,12 @@ export default class ToolBar extends Base {
       case 'undo':
         this.undo();
         break;
-      case 'zoomOut': {
+      case 'zoomOut':
         this.zoomOut();
         break;
-      }
-      case 'zoomIn': {
+      case 'zoomIn':
         this.zoomIn();
         break;
-      }
       case 'realZoom':
         this.realZoom();
         break;

--- a/packages/plugin/src/toolBar/index.ts
+++ b/packages/plugin/src/toolBar/index.ts
@@ -74,7 +74,7 @@ const getEventPath = (evt: MouseEvent) => {
 };
 
 export default class ToolBar extends Base {
-  constructor(config?: ToolBarConfig) {
+  constructor (config?: ToolBarConfig) {
     super(config);
   }
   public getDefaultCfgs(): ToolBarConfig {
@@ -161,7 +161,7 @@ export default class ToolBar extends Base {
       if (handleClick) {
         handleClick(code, graph);
       } else {
-        this.handleDefaultOperator(code, graph);
+        this.handleDefaultOperator(code);
       }
     });
 
@@ -393,12 +393,53 @@ export default class ToolBar extends Base {
   }
 
   /**
+   * zoomOut 操作
+   */
+  public zoomOut() {
+    const graph: IGraph = this.get('graph');
+    const currentZoom = graph.getZoom();
+    const ratioOut = 1 / (1 - DELTA * this.get('zoomSensitivity'));
+    const maxZoom = this.get('maxZoom') || graph.get('maxZoom');
+    if (ratioOut * currentZoom > maxZoom) {
+      return;
+    }
+    graph.zoomTo(currentZoom * ratioOut);
+  }
+  /**
+   * zoomIn 操作
+   */
+  public zoomIn() {
+    const graph: IGraph = this.get('graph');
+    const currentZoom = graph.getZoom();
+    const ratioIn = 1 - DELTA * this.get('zoomSensitivity');
+    const minZoom = this.get('minZoom') || graph.get('minZoom');
+    if (ratioIn * currentZoom < minZoom) {
+      return;
+    }
+    graph.zoomTo(currentZoom * ratioIn);
+  }
+  /**
+   * realZoom 操作
+   */
+  public realZoom() {
+    const graph: IGraph = this.get('graph');
+    graph.zoomTo(1);
+  }
+
+  /**
+   * autoZoom 操作
+   */
+  public autoZoom() {
+    const graph: IGraph = this.get('graph');
+    graph.fitView([20, 20]);
+  }
+
+  /**
    * 根据 Toolbar 上不同类型对图进行操作
    * @param code 操作类型编码
    * @param graph Graph 实例
    */
-  private handleDefaultOperator(code: string, graph: IGraph) {
-    const currentZoom = graph.getZoom();
+  public handleDefaultOperator(code: string) {
     switch (code) {
       case 'redo':
         this.redo();
@@ -407,28 +448,18 @@ export default class ToolBar extends Base {
         this.undo();
         break;
       case 'zoomOut': {
-        const ratioOut = 1 / (1 - DELTA * this.get('zoomSensitivity'));
-        const maxZoom = this.get('maxZoom') || graph.get('maxZoom');
-        if (ratioOut * currentZoom > maxZoom) {
-          return;
-        }
-        graph.zoomTo(currentZoom * ratioOut);
+        this.zoomOut();
         break;
       }
       case 'zoomIn': {
-        const ratioIn = 1 - DELTA * this.get('zoomSensitivity');
-        const minZoom = this.get('minZoom') || graph.get('minZoom');
-        if (ratioIn * currentZoom < minZoom) {
-          return;
-        }
-        graph.zoomTo(currentZoom * ratioIn);
+        this.zoomIn();
         break;
       }
       case 'realZoom':
-        graph.zoomTo(1);
+        this.realZoom();
         break;
       case 'autoZoom':
-        graph.fitView([20, 20]);
+        this.autoZoom();
         break;
       default:
     }

--- a/packages/site/docs/api/Plugins.en.md
+++ b/packages/site/docs/api/Plugins.en.md
@@ -354,7 +354,12 @@ const toolbar = new G6.ToolBar({
         y: 150
       })
     } else if (code === 'undo') {
+      // redefine undo operator
       toolbar.undo()
+      toolbar.autoZoom()
+    } else {
+      // Other operations remain default
+      toolbar.handleDefaultOperator(code)
     }
   }
 });

--- a/packages/site/docs/api/Plugins.zh.md
+++ b/packages/site/docs/api/Plugins.zh.md
@@ -359,7 +359,12 @@ const toolbar = new G6.ToolBar({
         y: 150
       })
     } else if (code === 'undo') {
+      // 自定义 undo
       toolbar.undo()
+      toolbar.autoZoom()
+    } else {
+      // 其他操作保持默认不变
+      toolbar.handleDefaultOperator(code)
     }
   }
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes

##### Description of change

<!-- Provide a description of the change below this comment. -->

1. 将 toolbar 的默认操作抽离成函数，更加原子化，这样以便于用户初始化是配置 handleClick 时可以使用
2. 将 handleDefaultOperator 由 private 改为 public，这样用户如果只是想修改一个事件的默认行为，直接根据 code 判断，不修改的直接调用这个方法即可，目前需要用户全盘更改，非常麻烦
3. 更新使用文档

这是我在工作中实际的一个例子，现在的版本只能这么做，且在ts中会报lint 错误

```js
export const toolbar = new G6.ToolBar({
  position: { x: 400, y: 20 },
  handleClick: function(code, graph) {
    if(['redo', 'undo'].includes(code)) {
      toolbar[code]()
      // 这在 g6 是一个私有函数，不能直接调用
      toolbar.handleDefaultOperator?.('autoZoom', graph);
      return
    }
    toolbar.handleDefaultOperator?.(code, graph)
  },
});
```
![image](https://user-images.githubusercontent.com/15937065/172161184-f671ecb2-f004-4756-aa5e-7ea819c1765a.png)

这个变更后能力可原子化调用，上面的例子可以改为：
```js
export const toolbar = new G6.ToolBar({
  position: { x: 400, y: 20 },
  handleClick: function(code, graph) {
    if(['redo', 'undo'].includes(code)) {
      toolbar[code]()
      // 这在 g6 是一个私有函数，不能直接调用
      toolbar.autoZoom()
      return
    }
    toolbar.handleDefaultOperator?.(code)
  },
});
```

