### PR TITLE
fix: [tooltip plugin] wrap className in quotes when createDom to support multi classname

### DIFF
--- a/packages/plugin/src/tooltip/index.ts
+++ b/packages/plugin/src/tooltip/index.ts
@@ -93,7 +93,7 @@ export default class Tooltip extends Base {
   public init() {
     const self = this;
     const className = self.get('className') || 'g6-component-tooltip';
-    const tooltip = createDom(`<div class=${className}></div>`);
+    const tooltip = createDom(`<div class='${className}'></div>`);
     let container: HTMLDivElement | null = self.get('container');
     if (!container) {
       container = self.get('graph').get('container');

--- a/packages/site/docs/manual/middle/elements/advanced-style/set-label-bg.en.md
+++ b/packages/site/docs/manual/middle/elements/advanced-style/set-label-bg.en.md
@@ -17,27 +17,31 @@ In G6 3.4.5 version, uses can set the background for nodes or edges through `bac
 const graph = new G6.Graph({
   // ...
   defaultNode: {
-    position: 'left',
-    style: {
-      background: {
-        fill: '#ffffff',
-        stroke: 'green',
-        padding: [3, 2, 3, 2],
-        radius: 2,
-        lineWidth: 3,
+    labelCfg: {
+      position: 'left',
+      style: {
+        background: {
+          fill: '#ffffff',
+          stroke: 'green',
+          padding: [3, 2, 3, 2],
+          radius: 2,
+          lineWidth: 3,
+        },
       },
-    },
+    }
   },
   defaultEdge: {
-    autoRotate: true,
-    style: {
-      background: {
-        fill: '#ffffff',
-        stroke: '#000000',
-        padding: [2, 2, 2, 2],
-        radius: 2,
+    labelCfg: {
+      autoRotate: true,
+      style: {
+        background: {
+          fill: '#ffffff',
+          stroke: '#000000',
+          padding: [2, 2, 2, 2],
+          radius: 2,
+        },
       },
-    },
+    }
   }
 })
 ```

--- a/packages/site/docs/manual/middle/elements/advanced-style/set-label-bg.zh.md
+++ b/packages/site/docs/manual/middle/elements/advanced-style/set-label-bg.zh.md
@@ -17,27 +17,31 @@ order: 0
 const graph = new G6.Graph({
   // ...
   defaultNode: {
-    position: 'left',
-    style: {
-      background: {
-        fill: '#ffffff',
-        stroke: 'green',
-        padding: [3, 2, 3, 2],
-        radius: 2,
-        lineWidth: 3,
+    labelCfg: {
+      position: 'left',
+      style: {
+        background: {
+          fill: '#ffffff',
+          stroke: 'green',
+          padding: [3, 2, 3, 2],
+          radius: 2,
+          lineWidth: 3,
+        },
       },
-    },
+    }
   },
   defaultEdge: {
-    autoRotate: true,
-    style: {
-      background: {
-        fill: '#ffffff',
-        stroke: '#000000',
-        padding: [2, 2, 2, 2],
-        radius: 2,
+    labelCfg: {
+      autoRotate: true,
+      style: {
+        background: {
+          fill: '#ffffff',
+          stroke: '#000000',
+          padding: [2, 2, 2, 2],
+          radius: 2,
+        },
       },
-    },
+    }
   }
 })
 ```

--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@ant-design/icons": "^4.0.6",
     "@antv/chart-node-g6": "^0.0.3",
-    "@antv/g6": "4.3.8",
+    "@antv/g6": "4.6.6",
     "@antv/gatsby-theme-antv": "1.1.15",
     "@antv/util": "^2.0.9",
     "@antv/vis-predict-engine": "^0.1.1",


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->


##### Description of change

<!-- Provide a description of the change below this comment. -->

使 tooltip 插件的 className 配置支持空格分割的多个class，例如：`g6-tooltip tooltip-1`

修改前会生成：`<div class="g6-tooltip" tooltip-1></div>`
