### PR TITLE
Fix: fitView zoom after translate animation

### DIFF
--- a/packages/core/src/graph/graph.ts
+++ b/packages/core/src/graph/graph.ts
@@ -37,7 +37,7 @@ import { lerp, move } from '../util/math';
 import { dataValidation, singleDataValidation } from '../util/validation';
 import Global from '../global';
 import { ItemController, ModeController, StateController, ViewController } from './controller';
-import { plainCombosToTrees, traverseTree, reconstructTree, traverseTreeUp } from '../util/graphic';
+import { getAnimateCfgWithCallback, plainCombosToTrees, traverseTree, reconstructTree, traverseTreeUp } from '../util/graphic';
 import Hull from '../item/hull';
 
 const { transform } = ext;
@@ -557,34 +557,6 @@ export default abstract class AbstractGraph extends EventEmitter implements IAbs
     return this.findAll(type, item => item.hasState(state));
   }
 
-  private getAnimateCfgWithCallback({
-    animateCfg,
-    callback
-  }: {
-    animateCfg: GraphAnimateConfig;
-    callback: () => void;
-  }): GraphAnimateConfig {
-    let animateConfig: GraphAnimateConfig;
-    if (!animateCfg) {
-      animateConfig = {
-        duration: 500,
-        callback
-      };
-    } else {
-      animateConfig = clone(animateCfg);
-      if (animateCfg.callback) {
-        const animateCfgCallback = animateCfg.callback;
-        animateConfig.callback = () => {
-          callback();
-          animateCfgCallback();
-        }
-      } else {
-        animateConfig.callback = callback;
-      }
-    }
-    return animateConfig;
-  }
-
   /**
    * 平移画布
    * @param dx 水平方向位移
@@ -600,7 +572,7 @@ export default abstract class AbstractGraph extends EventEmitter implements IAbs
       matrix = [1, 0, 0, 0, 1, 0, 0, 0, 1];
     }
     if (animate) {
-      const animateConfig = this.getAnimateCfgWithCallback({
+      const animateConfig = getAnimateCfgWithCallback({
         animateCfg,
         callback: () => this.emit('viewportchange', { action: 'translate', matrix: group.getMatrix() })
       });
@@ -760,7 +732,7 @@ export default abstract class AbstractGraph extends EventEmitter implements IAbs
       const initialRatio = aniMatrix[0];
       const targetRatio = initialRatio * ratio;
 
-      const animateConfig = this.getAnimateCfgWithCallback({
+      const animateConfig = getAnimateCfgWithCallback({
         animateCfg,
         callback: () => this.emit('viewportchange', { action: 'zoom', matrix: group.getMatrix() })
       });

--- a/packages/core/src/util/graphic.ts
+++ b/packages/core/src/util/graphic.ts
@@ -10,7 +10,8 @@ import {
   NodeConfig,
   ComboTree,
   ComboConfig,
-  ICombo
+  ICombo,
+  GraphAnimateConfig
 } from '../types';
 import { applyMatrix } from './math';
 import letterAspectRatio from './letterAspectRatio';
@@ -685,4 +686,32 @@ export const cloneBesidesImg = (obj) => {
     }
   });
   return clonedObj;
+}
+
+export const getAnimateCfgWithCallback = ({
+  animateCfg,
+  callback
+}: {
+  animateCfg: GraphAnimateConfig;
+  callback: () => void;
+}): GraphAnimateConfig => {
+  let animateConfig: GraphAnimateConfig;
+  if (!animateCfg) {
+    animateConfig = {
+      duration: 500,
+      callback
+    };
+  } else {
+    animateConfig = clone(animateCfg);
+    if (animateCfg.callback) {
+      const animateCfgCallback = animateCfg.callback;
+      animateConfig.callback = () => {
+        callback();
+        animateCfgCallback();
+      }
+    } else {
+      animateConfig.callback = callback;
+    }
+  }
+  return animateConfig;
 }

--- a/packages/core/tests/unit/graph/controller/view-spec.ts
+++ b/packages/core/tests/unit/graph/controller/view-spec.ts
@@ -113,8 +113,8 @@ describe('view', () => {
   });
   it('focus edge', () => {
     const data = {
-      nodes: [{id: '1', x: 10, y: 10}, {id: '2', x: 25, y: 40}, {id: '3', x: -50, y: 80}],
-      edges: [{source: '1', target: '2'}, {source: '1', target: '3'}]
+      nodes: [{ id: '1', x: 10, y: 10 }, { id: '2', x: 25, y: 40 }, { id: '3', x: -50, y: 80 }],
+      edges: [{ source: '1', target: '2' }, { source: '1', target: '3' }]
     }
     const g = new Graph({
       container: div,
@@ -122,7 +122,7 @@ describe('view', () => {
       height: 500,
     })
     g.read(data);
-    g.get('canvas').get('el').style.backgroundColor='#ccc';
+    g.get('canvas').get('el').style.backgroundColor = '#ccc';
     g.zoom(2, { x: 10, y: 10 });
     g.focusItem(g.getEdges()[0]);
     let centerPoint = g.getPointByCanvas(250, 250);
@@ -185,6 +185,16 @@ describe('fitViewByRules, not out of viewport', () => {
     expect(bboxAfterFitView.width).toEqual(bbox.width);
     expect(bboxAfterFitView.height).toEqual(bbox.height);
   });
+  it('fitViewByRules, not out of viewport, custom rules, animated', async () => {
+    graph.fitView(0, { onlyOutOfViewPort: true }, true, { duration: 10 });
+    await new Promise((r) => setTimeout(r, 50));
+    const bboxAfterFitView = graph.get('canvas').getCanvasBBox();
+    expect(graph.getZoom()).toEqual(1);
+    expect(numberEqual(bboxAfterFitView.x, 100, 1)).toBe(true);
+    expect(numberEqual(bboxAfterFitView.y, 150, 1)).toBe(true);
+    expect(bboxAfterFitView.width).toEqual(bbox.width);
+    expect(bboxAfterFitView.height).toEqual(bbox.height);
+  });
 });
 
 describe('fitViewByRules, out of viewport', () => {
@@ -233,6 +243,16 @@ describe('fitViewByRules, out of viewport', () => {
   });
   it('fitViewByRules, out of viewport, custom rules', () => {
     graph.fitView(0, { onlyOutOfViewPort: true, direction: 'y' });
+    const bbox = graph.get('canvas').getCanvasBBox();
+    expect(numberEqual(graph.getZoom(), 0.28, 0.01)).toBe(true);
+    expect(numberEqual(bbox.x, -18, 1)).toBe(true);
+    expect(numberEqual(bbox.y, 10, 1)).toBe(true);
+    expect(numberEqual(bbox.width, 536, 1)).toBe(true);
+    expect(numberEqual(bbox.height, 480, 1)).toBe(true);
+  });
+  it('fitViewByRules, out of viewport, custom rules, animated', async () => {
+    graph.fitView(0, { onlyOutOfViewPort: true, direction: 'y' }, true, { duration: 10 });
+    await new Promise((r) => setTimeout(r, 50));
     const bbox = graph.get('canvas').getCanvasBBox();
     expect(numberEqual(graph.getZoom(), 0.28, 0.01)).toBe(true);
     expect(numberEqual(bbox.x, -18, 1)).toBe(true);


### PR DESCRIPTION
##### Checklist

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change
This fixes an issue, where the zoom was not doing anything because it was called before the translate animation.

I'll probably work on the following improvements in the future:
- do not reset the matrix at every call
- perform the translate and zoom with a single smooth animation
