### PR TITLE
fix: findAllByState should not select hidden nodes

### DIFF
--- a/packages/core/src/graph/graph.ts
+++ b/packages/core/src/graph/graph.ts
@@ -551,7 +551,7 @@ export default abstract class AbstractGraph extends EventEmitter implements IAbs
     if (additionalFilter) {
       return this.findAll(type, item => item.hasState(state) && additionalFilter(item));
     } else {
-      return this.findAll(type, item => item.hasState(state))
+      return this.findAll(type, item => item.hasState(state));
     }
   }
 
@@ -605,7 +605,7 @@ export default abstract class AbstractGraph extends EventEmitter implements IAbs
     }
 
     const viewController: ViewController = this.get('viewController');
-  
+
     if (rules) {
       viewController.fitViewByRules(rules);
     } else {
@@ -2837,9 +2837,9 @@ export default abstract class AbstractGraph extends EventEmitter implements IAbs
     const stackData = data
       ? clone(data)
       : {
-          before: {},
-          after: clone(this.save()),
-        };
+        before: {},
+        after: clone(this.save()),
+      };
 
     if (stackType === 'redo') {
       this.redoStack.push({

--- a/packages/core/src/graph/graph.ts
+++ b/packages/core/src/graph/graph.ts
@@ -547,8 +547,12 @@ export default abstract class AbstractGraph extends EventEmitter implements IAbs
    * @param {string} state 状态
    * @return {object} 元素实例
    */
-  public findAllByState<T extends Item>(type: ITEM_TYPE, state: string): T[] {
-    return this.findAll(type, item => item.hasState(state));
+  public findAllByState<T extends Item>(type: ITEM_TYPE, state: string, additionalFilter?: (item: Item) => boolean): T[] {
+    if (additionalFilter) {
+      return this.findAll(type, item => item.hasState(state) && additionalFilter(item));
+    } else {
+      return this.findAll(type, item => item.hasState(state))
+    }
   }
 
   /**

--- a/packages/core/src/interface/graph.ts
+++ b/packages/core/src/interface/graph.ts
@@ -483,7 +483,7 @@ export interface IAbstractGraph extends EventEmitter {
    * @param {string} state z状态
    * @return {object} 元素实例
    */
-  findAllByState: <T extends Item>(type: ITEM_TYPE, state: string, additionalFilter: (item: Item) => boolean) => T[];
+  findAllByState: <T extends Item>(type: ITEM_TYPE, state: string, additionalFilter?: (item: Item) => boolean) => T[];
 
   /**
    * 更换布局配置项

--- a/packages/core/src/interface/graph.ts
+++ b/packages/core/src/interface/graph.ts
@@ -483,7 +483,7 @@ export interface IAbstractGraph extends EventEmitter {
    * @param {string} state z状态
    * @return {object} 元素实例
    */
-  findAllByState: <T extends Item>(type: ITEM_TYPE, state: string) => T[];
+  findAllByState: <T extends Item>(type: ITEM_TYPE, state: string, additionalFilter: (item: Item) => boolean) => T[];
 
   /**
    * 更换布局配置项

--- a/packages/core/tests/unit/graph/graph-spec.ts
+++ b/packages/core/tests/unit/graph/graph-spec.ts
@@ -529,6 +529,30 @@ describe('graph', () => {
     expect(nodes[0]).toEqual(node2);
   });
 
+  it('findAllByState should not select nodes that are not visible', () => {
+    globalGraph.clear();
+
+    const node1 = globalGraph.addItem('node', {
+      id: 'node1',
+      visible: false
+    });
+
+    const node2 = globalGraph.addItem('node', {
+      id: 'node2'
+    });
+
+    node1.setState('selected', true);
+    node2.setState('selected', true);
+
+    function additionalFilter(item) {
+      return item.isVisible();
+    }
+
+    const selectedNodes = globalGraph.findAllByState('node', 'selected', additionalFilter);
+
+    expect(selectedNodes.length).toEqual(1);
+  })
+
   it('refresh positions', () => {
     const data = { id: 'node4', x: 100, y: 50, size: 50, className: 'test test2' };
     const node = globalGraph.addItem('node', data);

--- a/packages/core/tests/unit/graph/graph-spec.ts
+++ b/packages/core/tests/unit/graph/graph-spec.ts
@@ -551,7 +551,7 @@ describe('graph', () => {
     const selectedNodes = globalGraph.findAllByState('node', 'selected', additionalFilter);
 
     expect(selectedNodes.length).toEqual(1);
-  })
+  });
 
   it('refresh positions', () => {
     const data = { id: 'node4', x: 100, y: 50, size: 50, className: 'test test2' };


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->

This PR introduces `additionalFilter` parameter on `findAllByState`. This allows for extra filtering e.g don't select nodes with `visible: false`.
