### PR TITLE
fix: react node typings inaccuracy

### DIFF
--- a/packages/react-node/README.md
+++ b/packages/react-node/README.md
@@ -31,7 +31,7 @@ const ReactNode = ({ cfg = {} }) => {
             cursor: 'move',
             stroke: cfg.color,
           }}
-          draggable="true"
+          draggable
         >
           <Text
             style={{

--- a/packages/react-node/docs/index.en-US.md
+++ b/packages/react-node/docs/index.en-US.md
@@ -29,7 +29,7 @@ const ReactNode = ({ cfg = {} }) => {
             cursor: 'move',
             stroke: cfg.color,
           }}
-          draggable="true"
+          draggable
         >
           <Text
             style={{
@@ -114,7 +114,7 @@ const ReactNode = ({ cfg = {} }) => {
             cursor: 'move',
             stroke: cfg.color,
           }}
-          draggable="true"
+          draggable
         >
           <Text
             style={{

--- a/packages/react-node/docs/index.md
+++ b/packages/react-node/docs/index.md
@@ -30,7 +30,7 @@ const ReactNode = ({ cfg = {} }) => {
             stroke: cfg.color,
             justyfyContent: 'center',
           }}
-          draggable="true"
+          draggable
         >
           <Text
             style={{
@@ -113,7 +113,7 @@ const ReactNode = ({ cfg = {} }) => {
             stroke: cfg.color,
             justyfyContent: 'center',
           }}
-          draggable="true"
+          draggable
         >
           <Text
             style={{

--- a/packages/react-node/docs/index.md
+++ b/packages/react-node/docs/index.md
@@ -28,7 +28,7 @@ const ReactNode = ({ cfg = {} }) => {
             radius: [6, 6, 0, 0],
             cursor: 'move',
             stroke: cfg.color,
-            justyfyContent: 'center',
+            justifyContent: 'center',
           }}
           draggable
         >
@@ -111,7 +111,7 @@ const ReactNode = ({ cfg = {} }) => {
             radius: [6, 6, 0, 0],
             cursor: 'move',
             stroke: cfg.color,
-            justyfyContent: 'center',
+            justifyContent: 'center',
           }}
           draggable
         >

--- a/packages/react-node/src/API/rect.en-US.md
+++ b/packages/react-node/src/API/rect.en-US.md
@@ -20,7 +20,7 @@ const ReactNode = ({ cfg = {} }) => {
             cursor: 'move',
             stroke: cfg.color,
           }}
-          draggable="true"
+          draggable
         />
 
         <Rect

--- a/packages/react-node/src/API/rect.md
+++ b/packages/react-node/src/API/rect.md
@@ -20,7 +20,7 @@ const ReactNode = ({ cfg = {} }) => {
             cursor: 'move',
             stroke: cfg.color,
           }}
-          draggable="true"
+          draggable
         />
 
         <Rect

--- a/packages/react-node/src/ReactNode/Group.tsx
+++ b/packages/react-node/src/ReactNode/Group.tsx
@@ -38,6 +38,11 @@ interface GroupProps {
    * @description.zh-CN 动画设置
    */
   animation?: Partial<AnimationConfig>;
+  /**
+   * @description.en-US Nodes wrapped within the component
+   * @description.zh-CN 组件内包装的节点
+   */
+  children?: React.ReactNode;
 }
 
 export type CommonProps = GroupProps & EventAttrs;

--- a/packages/react-node/src/ReactNode/Shape/Rect.tsx
+++ b/packages/react-node/src/ReactNode/Shape/Rect.tsx
@@ -24,7 +24,7 @@ interface RectProps extends CommonProps {
   /**
    * @description.en-US style of shape
    */
-  style: RectStyle;
+  style?: RectStyle;
 }
 
 const Rect: React.FC<RectProps> = (props) => {

--- a/packages/react-node/src/ReactNode/Shape/Text.tsx
+++ b/packages/react-node/src/ReactNode/Shape/Text.tsx
@@ -48,7 +48,7 @@ interface TextProps extends CommonProps {
   /**
    * @description.en-US style of shape
    */
-  style: TextStyle;
+  style?: TextStyle;
 }
 
 const Text: React.FC<TextProps> = (props) => {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->

1. `React.FC` (which is used by all the shapes) got [`children` props removed](https://stackoverflow.com/questions/71788254/react-18-typescript-children-fc/71800185#71800185) since `React v18`. Adding `children` in [common](https://github.com/antvis/G6/blob/5a7681c85f891ecb50e458034c1545d3c9bbdbd5/packages/react-node/src/ReactNode/Group.tsx#L5-L43) `Shape` props shouldn't break it for past `React` versions but would add compatibility with the latest.
2. (non-ts) [Examples](https://github.com/antvis/G6/blob/5a7681c85f891ecb50e458034c1545d3c9bbdbd5/packages/react-node/docs/index.md?plain=1#L22) have `Rect` as a container with no `style` property. `Rect` does have non-optional (i.e. required) `style` which means it should've been used with `style` containing at least an empty object like `<Rect style={{}}>...</Rect>`. Since all `RectStyle` properties [are optional](https://github.com/antvis/G6/blob/5a7681c85f891ecb50e458034c1545d3c9bbdbd5/packages/react-node/src/ReactNode/Shape/Rect.tsx#L6-L20) there is no reason to keep `style` non-optional. [Same thing with `Text`](https://github.com/antvis/G6/blob/5a7681c85f891ecb50e458034c1545d3c9bbdbd5/packages/react-node/src/ReactNode/Shape/Text.tsx#L6-L44).
3. (non-ts) [Examples](https://github.com/antvis/G6/blob/5a7681c85f891ecb50e458034c1545d3c9bbdbd5/packages/react-node/docs/index.md?plain=1#L33) have `draggable="true"` which brings a bit of confusion since the `.ts` type for `draggable` [is `boolean`](https://github.com/antvis/G6/blob/5a7681c85f891ecb50e458034c1545d3c9bbdbd5/packages/react-node/src/ReactNode/Group.tsx#L30).
4. `justifyContent` [typo](https://github.com/antvis/G6/blob/5a7681c85f891ecb50e458034c1545d3c9bbdbd5/packages/react-node/docs/index.md?plain=1#L31).

[Codesandbox](https://codesandbox.io/s/quizzical-fermi-2u6kpb?file=/src/ReactNode.tsx) (see type hint errors)