### PR TITLE
feat: fitItems function

### DIFF
--- a/packages/core/src/graph/controller/view.ts
+++ b/packages/core/src/graph/controller/view.ts
@@ -45,7 +45,8 @@ export default class ViewController {
     graph.translate(viewCenter.x - groupCenter.x, viewCenter.y - groupCenter.y, animate, animateCfg);
   }
 
-  private animatedFitView(group: IGroup, startMatrix: number[], animateCfg: GraphAnimateConfig, bbox: BBox, viewCenter: Point, groupCenter: Point, ratio: number): void {
+  private animatedFitView(group: IGroup, startMatrix: number[], animateCfg: GraphAnimateConfig, bbox: BBox, viewCenter: Point, groupCenter: Point,
+    ratio: number, zoomToFit: boolean): void {
     const { graph } = this;
     animateCfg = animateCfg ? animateCfg : { duration: 500, easing: 'easeCubic' };
 
@@ -56,6 +57,20 @@ export default class ViewController {
     const vx = bbox.x + viewCenter.x - groupCenter.x - bbox.minX;
     const vy = bbox.y + viewCenter.y - groupCenter.y - bbox.minY;
     const translatedMatrix = transform(matrix, [['t', vx, vy]]);
+
+    if (!zoomToFit) {
+      // If zooming is not needed just animate the current translated matrix and return
+      const animationConfig = getAnimateCfgWithCallback({
+        animateCfg,
+        callback: () => {
+          graph.emit('viewportchange', { action: 'translate', matrix: translatedMatrix });
+        }
+      });
+      group.animate((ratio: number) => {
+        return { matrix: lerpArray(startMatrix, translatedMatrix, ratio) };
+      }, animationConfig);
+      return;
+    }
 
     // Zoom
     const minZoom: number = graph.get('minZoom');
@@ -116,7 +131,7 @@ export default class ViewController {
     }
 
     if (animate) {
-      this.animatedFitView(group, startMatrix, animateCfg, bbox, viewCenter, groupCenter, ratio);
+      this.animatedFitView(group, startMatrix, animateCfg, bbox, viewCenter, groupCenter, ratio, true);
     } else {
       graph.translate(viewCenter.x - groupCenter.x, viewCenter.y - groupCenter.y);
 
@@ -168,7 +183,7 @@ export default class ViewController {
     }
 
     if (animate) {
-      this.animatedFitView(group, startMatrix, animateCfg, bbox, viewCenter, groupCenter, ratio);
+      this.animatedFitView(group, startMatrix, animateCfg, bbox, viewCenter, groupCenter, ratio, true);
     } else {
       const initZoomRatio = graph.getZoom();
       let endZoom = initZoomRatio * ratio;
@@ -181,73 +196,6 @@ export default class ViewController {
       graph.translate(viewCenter.x - groupCenter.x, viewCenter.y - groupCenter.y);
 
       graph.zoomTo(endZoom, viewCenter);
-    }
-  }
-
-  public fitItems(items: Item[], animate?: boolean, animateCfg?: GraphAnimateConfig): void {
-    if (!items.length) {
-      this.fitView(animate, animateCfg);
-      return;
-    }
-
-    const { graph } = this;
-    const padding = this.getFormatPadding();
-    const width: number = graph.get('width');
-    const height: number = graph.get('height');
-    const group: IGroup = graph.get('group');
-    const startMatrix = group.getMatrix() || [1, 0, 0, 0, 1, 0, 0, 0, 1];
-    group.resetMatrix();
-
-    let bbox: BBox = {
-      x: 0, y: 0,
-      minX: Number.MAX_SAFE_INTEGER, minY: Number.MAX_SAFE_INTEGER,
-      maxX: Number.MIN_SAFE_INTEGER, maxY: Number.MIN_SAFE_INTEGER,
-      width: 0, height: 0
-    };
-    for (const item of items) {
-      const itemBBox = item.getBBox();
-      if (itemBBox.minX < bbox.minX) {
-        bbox.minX = itemBBox.minX;
-      }
-      if (itemBBox.minY < bbox.minY) {
-        bbox.minY = itemBBox.minY;
-      }
-      if (itemBBox.maxX > bbox.maxX) {
-        bbox.maxX = itemBBox.maxX;
-      }
-      if (itemBBox.maxY > bbox.maxY) {
-        bbox.maxY = itemBBox.maxY;
-      }
-    }
-    bbox.x = bbox.minX;
-    bbox.y = bbox.minY;
-    bbox.width = bbox.maxX - bbox.minX;
-    bbox.height = bbox.maxY - bbox.minY;
-
-    if (bbox.width === 0 || bbox.height === 0) return;
-    const viewCenter = this.getViewCenter();
-
-    const groupCenter: Point = {
-      x: bbox.x + bbox.width / 2,
-      y: bbox.y + bbox.height / 2,
-    };
-
-    // Compute ratio
-    const w = (width - padding[1] - padding[3]) / bbox.width;
-    const h = (height - padding[0] - padding[2]) / bbox.height;
-    let ratio = w;
-    if (w > h) {
-      ratio = h;
-    }
-
-    if (animate) {
-      this.animatedFitView(group, startMatrix, animateCfg, bbox, viewCenter, groupCenter, ratio);
-    } else {
-      graph.translate(viewCenter.x - groupCenter.x, viewCenter.y - groupCenter.y);
-
-      if (!graph.zoom(ratio, viewCenter)) {
-        console.warn('zoom failed, ratio out of range, ratio: %f', ratio);
-      }
     }
   }
 
@@ -373,6 +321,72 @@ export default class ViewController {
       }
       // 用实际位置而不是model中的x,y,防止由于拖拽等的交互导致model的x,y并不是当前的x,y
       this.focusPoint({ x, y }, animate, animateCfg);
+    }
+  }
+
+  public focusItems(items: Item[], zoomToFit: boolean, animate?: boolean, animateCfg?: GraphAnimateConfig): void {
+    if (!items.length) {
+      return;
+    }
+
+    const { graph } = this;
+    const padding = this.getFormatPadding();
+    const width: number = graph.get('width');
+    const height: number = graph.get('height');
+    const group: IGroup = graph.get('group');
+    const startMatrix = group.getMatrix() || [1, 0, 0, 0, 1, 0, 0, 0, 1];
+    group.resetMatrix();
+
+    let bbox: BBox = {
+      x: 0, y: 0,
+      minX: Number.MAX_SAFE_INTEGER, minY: Number.MAX_SAFE_INTEGER,
+      maxX: Number.MIN_SAFE_INTEGER, maxY: Number.MIN_SAFE_INTEGER,
+      width: 0, height: 0
+    };
+    for (const item of items) {
+      const itemBBox = item.getBBox();
+      if (itemBBox.minX < bbox.minX) {
+        bbox.minX = itemBBox.minX;
+      }
+      if (itemBBox.minY < bbox.minY) {
+        bbox.minY = itemBBox.minY;
+      }
+      if (itemBBox.maxX > bbox.maxX) {
+        bbox.maxX = itemBBox.maxX;
+      }
+      if (itemBBox.maxY > bbox.maxY) {
+        bbox.maxY = itemBBox.maxY;
+      }
+    }
+    bbox.x = bbox.minX;
+    bbox.y = bbox.minY;
+    bbox.width = bbox.maxX - bbox.minX;
+    bbox.height = bbox.maxY - bbox.minY;
+
+    if (bbox.width === 0 || bbox.height === 0) return;
+    const viewCenter = this.getViewCenter();
+
+    const groupCenter: Point = {
+      x: bbox.x + bbox.width / 2,
+      y: bbox.y + bbox.height / 2,
+    };
+
+    // Compute ratio
+    const w = (width - padding[1] - padding[3]) / bbox.width;
+    const h = (height - padding[0] - padding[2]) / bbox.height;
+    let ratio = w;
+    if (w > h) {
+      ratio = h;
+    }
+
+    if (animate) {
+      this.animatedFitView(group, startMatrix, animateCfg, bbox, viewCenter, groupCenter, ratio, zoomToFit);
+    } else {
+      graph.translate(viewCenter.x - groupCenter.x, viewCenter.y - groupCenter.y);
+
+      if (zoomToFit && !graph.zoom(ratio, viewCenter)) {
+        console.warn('zoom failed, ratio out of range, ratio: %f', ratio);
+      }
     }
   }
 

--- a/packages/core/src/graph/controller/view.ts
+++ b/packages/core/src/graph/controller/view.ts
@@ -201,7 +201,7 @@ export default class ViewController {
     let bbox: BBox = {
       x: 0, y: 0,
       minX: Number.MAX_SAFE_INTEGER, minY: Number.MAX_SAFE_INTEGER,
-      maxX: 0, maxY: 0,
+      maxX: Number.MIN_SAFE_INTEGER, maxY: Number.MIN_SAFE_INTEGER,
       width: 0, height: 0
     };
     for (const item of items) {

--- a/packages/core/src/graph/controller/view.ts
+++ b/packages/core/src/graph/controller/view.ts
@@ -66,7 +66,7 @@ export default class ViewController {
       realRatio = minZoom;
       console.warn('fitview failed, ratio out of range, ratio: %f', ratio, 'graph minzoom has been used instead');
     } else if (maxZoom && ratio > maxZoom) {
-      realRatio = minZoom;
+      realRatio = maxZoom;
       console.warn('fitview failed, ratio out of range, ratio: %f', ratio, 'graph maxzoom has been used instead');
     }
     let zoomedMatrix = transform(translatedMatrix, [
@@ -181,6 +181,73 @@ export default class ViewController {
       graph.translate(viewCenter.x - groupCenter.x, viewCenter.y - groupCenter.y);
 
       graph.zoomTo(endZoom, viewCenter);
+    }
+  }
+
+  public fitItems(items: Item[], animate?: boolean, animateCfg?: GraphAnimateConfig): void {
+    if (!items.length) {
+      this.fitView(animate, animateCfg);
+      return;
+    }
+
+    const { graph } = this;
+    const padding = this.getFormatPadding();
+    const width: number = graph.get('width');
+    const height: number = graph.get('height');
+    const group: IGroup = graph.get('group');
+    const startMatrix = group.getMatrix() || [1, 0, 0, 0, 1, 0, 0, 0, 1];
+    group.resetMatrix();
+
+    let bbox: BBox = {
+      x: 0, y: 0,
+      minX: Number.MAX_SAFE_INTEGER, minY: Number.MAX_SAFE_INTEGER,
+      maxX: 0, maxY: 0,
+      width: 0, height: 0
+    };
+    for (const item of items) {
+      const itemBBox = item.getBBox();
+      if (itemBBox.minX < bbox.minX) {
+        bbox.minX = itemBBox.minX;
+      }
+      if (itemBBox.minY < bbox.minY) {
+        bbox.minY = itemBBox.minY;
+      }
+      if (itemBBox.maxX > bbox.maxX) {
+        bbox.maxX = itemBBox.maxX;
+      }
+      if (itemBBox.maxY > bbox.maxY) {
+        bbox.maxY = itemBBox.maxY;
+      }
+    }
+    bbox.x = bbox.minX;
+    bbox.y = bbox.minY;
+    bbox.width = bbox.maxX - bbox.minX;
+    bbox.height = bbox.maxY - bbox.minY;
+
+    if (bbox.width === 0 || bbox.height === 0) return;
+    const viewCenter = this.getViewCenter();
+
+    const groupCenter: Point = {
+      x: bbox.x + bbox.width / 2,
+      y: bbox.y + bbox.height / 2,
+    };
+
+    // Compute ratio
+    const w = (width - padding[1] - padding[3]) / bbox.width;
+    const h = (height - padding[0] - padding[2]) / bbox.height;
+    let ratio = w;
+    if (w > h) {
+      ratio = h;
+    }
+
+    if (animate) {
+      this.animatedFitView(group, startMatrix, animateCfg, bbox, viewCenter, groupCenter, ratio);
+    } else {
+      graph.translate(viewCenter.x - groupCenter.x, viewCenter.y - groupCenter.y);
+
+      if (!graph.zoom(ratio, viewCenter)) {
+        console.warn('zoom failed, ratio out of range, ratio: %f', ratio);
+      }
     }
   }
 

--- a/packages/core/src/graph/graph.ts
+++ b/packages/core/src/graph/graph.ts
@@ -642,22 +642,6 @@ export default abstract class AbstractGraph extends EventEmitter implements IAbs
   }
 
   /**
-   * Fits the passed items into the view
-   * @param {Item[]} items Items you want to fit into the view
-   * @param {Padding} padding padding around the items
-   * @param {boolean} animate Wheter to animate the transition
-   * @param {GraphAnimateConfig} animateCfg Animation configuration
-   */
-  public fitItems(items: Item[], padding?: Padding, animate?: boolean, animateCfg?: GraphAnimateConfig): void {
-    if (padding) {
-      this.set('fitViewPadding', padding);
-    }
-
-    const viewController: ViewController = this.get('viewController');
-    viewController.fitItems(items, animate, animateCfg);
-  }
-
-  /**
    * 调整视口适应视图，不缩放，仅将图 bbox 中心对齐到画布中心
    * @param {boolean} animate 是否带有动画地移动
    * @param {GraphAnimateConfig} animateCfg 若带有动画，动画的配置项
@@ -814,6 +798,18 @@ export default abstract class AbstractGraph extends EventEmitter implements IAbs
     viewController.focus(item, isAnimate, curAniamteCfg);
 
     this.autoPaint();
+  }
+
+  /**
+   * Focus on the passed items
+   * @param {Item[]} items Items you want to focus on
+   * @param {boolean} zoomToFit Wether to zoom on the passed items
+   * @param {boolean} animate Wether to animate the transition
+   * @param {GraphAnimateConfig} animateCfg Animation configuration
+   */
+  public focusItems(items: Item[], zoomToFit?: boolean, animate?: boolean, animateCfg?: GraphAnimateConfig): void {
+    const viewController: ViewController = this.get('viewController');
+    viewController.focusItems(items, zoomToFit, animate, animateCfg);
   }
 
   /**

--- a/packages/core/src/graph/graph.ts
+++ b/packages/core/src/graph/graph.ts
@@ -642,6 +642,22 @@ export default abstract class AbstractGraph extends EventEmitter implements IAbs
   }
 
   /**
+   * Fits the passed items into the view
+   * @param {Item[]} items Items you want to fit into the view
+   * @param {Padding} padding padding around the items
+   * @param {boolean} animate Wheter to animate the transition
+   * @param {GraphAnimateConfig} animateCfg Animation configuration
+   */
+  public fitItems(items: Item[], padding?: Padding, animate?: boolean, animateCfg?: GraphAnimateConfig): void {
+    if (padding) {
+      this.set('fitViewPadding', padding);
+    }
+
+    const viewController: ViewController = this.get('viewController');
+    viewController.fitItems(items, animate, animateCfg);
+  }
+
+  /**
    * 调整视口适应视图，不缩放，仅将图 bbox 中心对齐到画布中心
    * @param {boolean} animate 是否带有动画地移动
    * @param {GraphAnimateConfig} animateCfg 若带有动画，动画的配置项

--- a/packages/core/src/interface/graph.ts
+++ b/packages/core/src/interface/graph.ts
@@ -181,6 +181,15 @@ export interface IAbstractGraph extends EventEmitter {
   fitView: (padding?: Padding, rules?: FitViewRules, animate?: boolean, animateCfg?: GraphAnimateConfig) => void;
 
   /**
+   * Fits the passed items into the view. If no items are passed it will fit the whole graph
+   * @param {Item[]} items Items you want to fit into the view
+   * @param {Padding} padding padding around the items
+   * @param {boolean} animate Wheter to animate the transition
+   * @param {GraphAnimateConfig} animateCfg Animation configuration
+   */
+  fitItems: (items: Item[], padding?: Padding, animate?: boolean, animateCfg?: GraphAnimateConfig) => void;
+
+  /**
    * 调整视口适应视图，不缩放，仅将图 bbox 中心对齐到画布中心
    * @param {boolean} animate 是否带有动画地移动
    * @param {GraphAnimateConfig} animateCfg 若带有动画，动画的配置项

--- a/packages/core/src/interface/graph.ts
+++ b/packages/core/src/interface/graph.ts
@@ -172,6 +172,15 @@ export interface IAbstractGraph extends EventEmitter {
   focusItem: (item: Item | string, animate?: boolean, animateCfg?: GraphAnimateConfig) => void;
 
   /**
+   * Fits the passed items into the view. If no items are passed it will fit the whole graph
+   * @param {Item[]} items Items you want to fit into the view
+   * @param {boolean} zoomToFit Wether to zoom on the passed items
+   * @param {boolean} animate Wheter to animate the transition
+   * @param {GraphAnimateConfig} animateCfg Animation configuration
+   */
+  focusItems: (items: Item[], zoomToFit?: boolean, animate?: boolean, animateCfg?: GraphAnimateConfig) => void;
+
+  /**
    * 调整视口适应视图
    * @param {Padding} padding 四周围边距
    * @param {FitViewRules} rules fitView的规则
@@ -179,15 +188,6 @@ export interface IAbstractGraph extends EventEmitter {
    * @param {GraphAnimateConfig} animateCfg 若带有动画，动画的配置项
    */
   fitView: (padding?: Padding, rules?: FitViewRules, animate?: boolean, animateCfg?: GraphAnimateConfig) => void;
-
-  /**
-   * Fits the passed items into the view. If no items are passed it will fit the whole graph
-   * @param {Item[]} items Items you want to fit into the view
-   * @param {Padding} padding padding around the items
-   * @param {boolean} animate Wheter to animate the transition
-   * @param {GraphAnimateConfig} animateCfg Animation configuration
-   */
-  fitItems: (items: Item[], padding?: Padding, animate?: boolean, animateCfg?: GraphAnimateConfig) => void;
 
   /**
    * 调整视口适应视图，不缩放，仅将图 bbox 中心对齐到画布中心

--- a/packages/core/tests/unit/graph/controller/view-spec.ts
+++ b/packages/core/tests/unit/graph/controller/view-spec.ts
@@ -57,71 +57,6 @@ describe('view', () => {
     expect(numberEqual(bbox.width, 320, 1)).toBe(true);
     expect(numberEqual(bbox.height, 480, 1)).toBe(true);
   });
-  it('fit items', () => {
-    const data = {
-      nodes: [
-        {
-          id: 'node-1',
-          x: 100,
-          y: 100,
-          size: [150, 100],
-          type: 'simple-rect',
-          color: '#333',
-          style: {
-            fill: '#666',
-          },
-        },
-        {
-          id: 'node-2',
-          x: 200,
-          y: 200,
-          size: [150, 100],
-          type: 'simple-rect',
-          color: '#333',
-          style: {
-            fill: '#666',
-          },
-        }
-      ],
-    };
-    graph.data(data);
-    graph.render();
-
-    const canvas: AbstractCanvas = graph.get('canvas');
-
-    let bbox = canvas.getCanvasBBox();
-
-    expect(numberEqual(bbox.x, 10, 1)).toBe(true);
-    expect(numberEqual(bbox.y, 57, 1)).toBe(true);
-    expect(numberEqual(bbox.maxX, 490, 1)).toBe(true);
-    expect(numberEqual(bbox.maxY, 442, 1)).toBe(true);
-    expect(numberEqual(bbox.width, 480, 1)).toBe(true);
-    expect(numberEqual(bbox.height, 384, 1)).toBe(true);
-
-    const node1 = graph.findById('node-1');
-    graph.fitItems([node1]);
-
-    bbox = graph.get('canvas').getCanvasBBox();
-
-    expect(numberEqual(bbox.x, 10, 1)).toBe(true);
-    expect(numberEqual(bbox.y, 89, 1)).toBe(true);
-    expect(numberEqual(bbox.maxX, 807, 1)).toBe(true);
-    expect(numberEqual(bbox.maxY, 728, 1)).toBe(true);
-    expect(numberEqual(bbox.width, 797, 1)).toBe(true);
-    expect(numberEqual(bbox.height, 638, 1)).toBe(true);
-
-    const node2 = graph.findById('node-2');
-    graph.fitItems([node1, node2]);
-
-    bbox = graph.get('canvas').getCanvasBBox();
-
-    expect(numberEqual(bbox.x, 10, 1)).toBe(true);
-    expect(numberEqual(bbox.y, 57, 1)).toBe(true);
-    expect(numberEqual(bbox.maxX, 490, 1)).toBe(true);
-    expect(numberEqual(bbox.maxY, 442, 1)).toBe(true);
-    expect(numberEqual(bbox.width, 480, 1)).toBe(true);
-    expect(numberEqual(bbox.height, 384, 1)).toBe(true);
-  });
   it('modify padding', () => {
     const data = {
       nodes: [
@@ -175,6 +110,71 @@ describe('view', () => {
 
     expect(centerPoint.x - 50 < 0.1).toBe(true);
     expect(centerPoint.y - 50 < 0.1).toBe(true);
+  });
+  it('focus items', () => {
+    const data = {
+      nodes: [
+        {
+          id: 'node-1',
+          x: 100,
+          y: 100,
+          size: [150, 100],
+          type: 'simple-rect',
+          color: '#333',
+          style: {
+            fill: '#666',
+          },
+        },
+        {
+          id: 'node-2',
+          x: 200,
+          y: 200,
+          size: [150, 100],
+          type: 'simple-rect',
+          color: '#333',
+          style: {
+            fill: '#666',
+          },
+        }
+      ],
+    };
+    graph.data(data);
+    graph.render();
+
+    const canvas: AbstractCanvas = graph.get('canvas');
+
+    let bbox = canvas.getCanvasBBox();
+
+    expect(numberEqual(bbox.x, 50, 1)).toBe(true);
+    expect(numberEqual(bbox.y, 89, 1)).toBe(true);
+    expect(numberEqual(bbox.maxX, 450, 1)).toBe(true);
+    expect(numberEqual(bbox.maxY, 410, 1)).toBe(true);
+    expect(numberEqual(bbox.width, 400, 1)).toBe(true);
+    expect(numberEqual(bbox.height, 320, 1)).toBe(true);
+
+    const node1 = graph.findById('node-1');
+    graph.focusItems([node1], true);
+
+    bbox = graph.get('canvas').getCanvasBBox();
+
+    expect(numberEqual(bbox.x, 50, 1)).toBe(true);
+    expect(numberEqual(bbox.y, 116, 1)).toBe(true);
+    expect(numberEqual(bbox.maxX, 714, 1)).toBe(true);
+    expect(numberEqual(bbox.maxY, 648, 1)).toBe(true);
+    expect(numberEqual(bbox.width, 664, 1)).toBe(true);
+    expect(numberEqual(bbox.height, 532, 1)).toBe(true);
+
+    const node2 = graph.findById('node-2');
+    graph.focusItems([node1, node2], true);
+
+    bbox = graph.get('canvas').getCanvasBBox();
+
+    expect(numberEqual(bbox.x, 50, 1)).toBe(true);
+    expect(numberEqual(bbox.y, 89, 1)).toBe(true);
+    expect(numberEqual(bbox.maxX, 450, 1)).toBe(true);
+    expect(numberEqual(bbox.maxY, 410, 1)).toBe(true);
+    expect(numberEqual(bbox.width, 400, 1)).toBe(true);
+    expect(numberEqual(bbox.height, 320, 1)).toBe(true);
   });
   it('focus edge', () => {
     const data = {

--- a/packages/core/tests/unit/graph/controller/view-spec.ts
+++ b/packages/core/tests/unit/graph/controller/view-spec.ts
@@ -57,6 +57,71 @@ describe('view', () => {
     expect(numberEqual(bbox.width, 320, 1)).toBe(true);
     expect(numberEqual(bbox.height, 480, 1)).toBe(true);
   });
+  it('fit items', () => {
+    const data = {
+      nodes: [
+        {
+          id: 'node-1',
+          x: 100,
+          y: 100,
+          size: [150, 100],
+          type: 'simple-rect',
+          color: '#333',
+          style: {
+            fill: '#666',
+          },
+        },
+        {
+          id: 'node-2',
+          x: 200,
+          y: 200,
+          size: [150, 100],
+          type: 'simple-rect',
+          color: '#333',
+          style: {
+            fill: '#666',
+          },
+        }
+      ],
+    };
+    graph.data(data);
+    graph.render();
+
+    const canvas: AbstractCanvas = graph.get('canvas');
+
+    let bbox = canvas.getCanvasBBox();
+
+    expect(numberEqual(bbox.x, 10, 1)).toBe(true);
+    expect(numberEqual(bbox.y, 57, 1)).toBe(true);
+    expect(numberEqual(bbox.maxX, 490, 1)).toBe(true);
+    expect(numberEqual(bbox.maxY, 442, 1)).toBe(true);
+    expect(numberEqual(bbox.width, 480, 1)).toBe(true);
+    expect(numberEqual(bbox.height, 384, 1)).toBe(true);
+
+    const node1 = graph.findById('node-1');
+    graph.fitItems([node1]);
+
+    bbox = graph.get('canvas').getCanvasBBox();
+
+    expect(numberEqual(bbox.x, 10, 1)).toBe(true);
+    expect(numberEqual(bbox.y, 89, 1)).toBe(true);
+    expect(numberEqual(bbox.maxX, 807, 1)).toBe(true);
+    expect(numberEqual(bbox.maxY, 728, 1)).toBe(true);
+    expect(numberEqual(bbox.width, 797, 1)).toBe(true);
+    expect(numberEqual(bbox.height, 638, 1)).toBe(true);
+
+    const node2 = graph.findById('node-2');
+    graph.fitItems([node1, node2]);
+
+    bbox = graph.get('canvas').getCanvasBBox();
+
+    expect(numberEqual(bbox.x, 10, 1)).toBe(true);
+    expect(numberEqual(bbox.y, 57, 1)).toBe(true);
+    expect(numberEqual(bbox.maxX, 490, 1)).toBe(true);
+    expect(numberEqual(bbox.maxY, 442, 1)).toBe(true);
+    expect(numberEqual(bbox.width, 480, 1)).toBe(true);
+    expect(numberEqual(bbox.height, 384, 1)).toBe(true);
+  });
   it('modify padding', () => {
     const data = {
       nodes: [
@@ -113,8 +178,8 @@ describe('view', () => {
   });
   it('focus edge', () => {
     const data = {
-      nodes: [{id: '1', x: 10, y: 10}, {id: '2', x: 25, y: 40}, {id: '3', x: -50, y: 80}],
-      edges: [{source: '1', target: '2'}, {source: '1', target: '3'}]
+      nodes: [{ id: '1', x: 10, y: 10 }, { id: '2', x: 25, y: 40 }, { id: '3', x: -50, y: 80 }],
+      edges: [{ source: '1', target: '2' }, { source: '1', target: '3' }]
     }
     const g = new Graph({
       container: div,
@@ -122,7 +187,7 @@ describe('view', () => {
       height: 500,
     })
     g.read(data);
-    g.get('canvas').get('el').style.backgroundColor='#ccc';
+    g.get('canvas').get('el').style.backgroundColor = '#ccc';
     g.zoom(2, { x: 10, y: 10 });
     g.focusItem(g.getEdges()[0]);
     let centerPoint = g.getPointByCanvas(250, 250);


### PR DESCRIPTION
##### Checklist

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change

This PR implements the `fitItems` function. This allows to fit a subset of the graph, eg: fit only the selected items.
This is useful with big graphs, where you want to have a closer look at a bunch of nodes.

In this example I'm using the `fitItems` function on the selected nodes via a keyboard shortcut:

`animate` false

https://user-images.githubusercontent.com/2861371/182404337-01167ecc-acfc-4ec2-98ce-c9af4da3b1e7.mp4

`animate` true

https://user-images.githubusercontent.com/2861371/182404386-77fbaccb-3fdb-4167-9bc6-ff2735257def.mp4



