### PR TITLE
fix: Fix combos to inherit animation setting from graph

### DIFF
--- a/packages/core/src/graph/controller/item.ts
+++ b/packages/core/src/graph/controller/item.ts
@@ -171,7 +171,7 @@ export default class ItemController {
       item = new Combo({
         model,
         styles,
-        animate: false,
+        animate: graph.get('animate'),
         bbox: model.collapsed ? getComboBBox([], graph) : comboBBox,
         group: comboGroup,
       });


### PR DESCRIPTION
### Checklist

- [x] `npm test` passes
- [x] commit message follows commit guidelines

### Description of change

This PR fixes the animate property initialization for new combos, which should be inherited from the graph rather than just set to false.

### Example screencasts

Suppose I created a graph with `animate: true`. Then I try to make a combo to group some nodes:

Before the fix

https://user-images.githubusercontent.com/16387428/195822382-3a5f42b8-bb32-4275-902f-8fb683789060.mp4


After the fix

https://user-images.githubusercontent.com/16387428/195824011-34dbc32b-f3e8-41ea-9c12-11897f10eb3d.mp4
