### PR TITLE
fix: createCombo didn't update the "comboTrees" correctly

### DIFF
--- a/packages/core/src/graph/graph.ts
+++ b/packages/core/src/graph/graph.ts
@@ -1775,13 +1775,13 @@ export default abstract class AbstractGraph extends EventEmitter implements IAbs
 
     // step 2: Pull children out of their parents
     let comboTrees = this.get('comboTrees');
-    const isChildById = new Set(children);
+    const childrenIdsSet = new Set(children);
     const pulledComboTreesById = new Map();
 
     if (comboTrees) {
       comboTrees.forEach(ctree => {
         traverseTreeUp<ComboTree>(ctree, (treeNode, parentTreeNode, index) => {
-          if (isChildById.has(treeNode.id)) {
+          if (childrenIdsSet.has(treeNode.id)) {
             if (parentTreeNode) {
               const parentItem = this.findById(parentTreeNode.id) as ICombo;
               const item = this.findById(treeNode.id) as INode | ICombo;
@@ -1804,7 +1804,7 @@ export default abstract class AbstractGraph extends EventEmitter implements IAbs
           return true;
         });
       });
-      comboTrees = comboTrees.filter(ctree => !isChildById.has(ctree.id));
+      comboTrees = comboTrees.filter(ctree => !childrenIdsSet.has(ctree.id));
 
       this.set('comboTrees', comboTrees);
     }

--- a/packages/core/src/graph/graph.ts
+++ b/packages/core/src/graph/graph.ts
@@ -1775,8 +1775,8 @@ export default abstract class AbstractGraph extends EventEmitter implements IAbs
 
     // step 2: Pull children out of their parents
     let comboTrees = this.get('comboTrees');
-    const childrenIdsSet = new Set(children);
-    const pulledComboTreesById = new Map();
+    const childrenIdsSet = new Set<string>(children);
+    const pulledComboTreesById = new Map<string, ComboTree>();
 
     if (comboTrees) {
       comboTrees.forEach(ctree => {

--- a/packages/core/src/graph/graph.ts
+++ b/packages/core/src/graph/graph.ts
@@ -1752,6 +1752,8 @@ export default abstract class AbstractGraph extends EventEmitter implements IAbs
    * @param children 添加到 Combo 中的元素，包括节点和 combo
    */
   public createCombo(combo: string | ComboConfig, children: string[]): void {
+    const itemController: ItemController = this.get('itemController');
+
     this.set('comboSorted', false);
     // step 1: 创建新的 Combo
     let comboId = '';
@@ -1771,14 +1773,52 @@ export default abstract class AbstractGraph extends EventEmitter implements IAbs
       comboConfig = combo;
     }
 
-    // step2: 更新 children，根据类型添加 comboId 或 parentId
+    // step 2: Pull children out of their parents
+    let comboTrees = this.get('comboTrees');
+    const isChildById = new Set(children);
+    const pulledComboTreesById = new Map();
+
+    if (comboTrees) {
+      comboTrees.forEach(ctree => {
+        traverseTreeUp<ComboTree>(ctree, (treeNode, parentTreeNode, index) => {
+          if (isChildById.has(treeNode.id)) {
+            if (parentTreeNode) {
+              const parentItem = this.findById(parentTreeNode.id) as ICombo;
+              const item = this.findById(treeNode.id) as INode | ICombo;
+
+              // Removing current item from the tree during the traversal is ok because children traversal is done
+              // in an *inverse order* - indices of the next-traversed items are not disturbed by the removal.
+              parentTreeNode.children.splice(index, 1);
+              parentItem.removeChild(item);
+
+              // We have to update the parent node geometry since nodes were removed from them, _while they are still visible_
+              // (combos may be moved inside the new combo and become hidden)
+              itemController.updateCombo(parentItem, parentTreeNode.children);
+            }
+
+            if (treeNode.itemType === 'combo') {
+              pulledComboTreesById.set(treeNode.id, treeNode);
+            }
+          }
+
+          return true;
+        });
+      });
+      comboTrees = (comboTrees || []).filter(ctree => !isChildById.has(ctree.id));
+
+      this.set('comboTrees', comboTrees);
+    }
+
+    // step 3: 更新 children，根据类型添加 comboId 或 parentId
     const trees: ComboTree[] = children.map(elementId => {
       const item = this.findById(elementId);
       const model = item.getModel();
 
       let type = '';
       if (item.getType) type = item.getType();
-      const cItem: ComboTree = {
+
+      // Combos will be just moved around, so their children can be preserved
+      const cItem: ComboTree = pulledComboTreesById.get(elementId) || {
         id: item.getID(),
         itemType: type as 'node' | 'combo',
       };
@@ -1796,23 +1836,25 @@ export default abstract class AbstractGraph extends EventEmitter implements IAbs
 
     comboConfig.children = trees;
 
-    // step 3: 添加 Combo，addItem 时会将子将元素添加到 Combo 中
+    // step 4: 添加 Combo，addItem 时会将子将元素添加到 Combo 中
     this.addItem('combo', comboConfig, false);
     this.set('comboSorted', false);
 
-    // step4: 更新 comboTrees 结构
-    const comboTrees = this.get('comboTrees');
-    (comboTrees || []).forEach(ctree => {
-      traverseTreeUp<ComboTree>(ctree, child => {
-        if (child.id === comboId) {
-          child.itemType = 'combo';
-          child.children = trees as ComboTree[];
-          return false;
-        }
-        return true;
-      });
-    });
+    // step 5: 更新 comboTrees 结构
     if (comboTrees) {
+      comboTrees.forEach(ctree => {
+        traverseTree<ComboTree>(ctree, (treeNode) => {
+          // Set the children to the newly created combo
+          if (treeNode.id === comboId) {
+            treeNode.itemType = 'combo';
+            treeNode.children = trees as ComboTree[];
+            return false;
+          }
+
+          return true;
+        });
+      });
+
       this.sortCombos();
     }
   }

--- a/packages/core/src/graph/graph.ts
+++ b/packages/core/src/graph/graph.ts
@@ -1804,7 +1804,7 @@ export default abstract class AbstractGraph extends EventEmitter implements IAbs
           return true;
         });
       });
-      comboTrees = (comboTrees || []).filter(ctree => !isChildById.has(ctree.id));
+      comboTrees = comboTrees.filter(ctree => !isChildById.has(ctree.id));
 
       this.set('comboTrees', comboTrees);
     }

--- a/packages/core/src/util/graphic.ts
+++ b/packages/core/src/util/graphic.ts
@@ -344,14 +344,19 @@ export const getLabelPosition = (
  * depth first traverse, from root to leaves, children in inverse order
  *  if the fn returns false, terminate the traverse
  */
-const traverse = <T extends { children?: T[] }>(data: T, fn: (param: T) => boolean) => {
-  if (fn(data) === false) {
+const traverse = <T extends { children?: T[] }>(
+  data: T,
+  parent: T | null,
+  index: number,
+  fn: (data: T, parent: T | null, index: number) => boolean
+) => {
+  if (fn(data, parent, index) === false) {
     return false;
   }
 
   if (data && data.children) {
     for (let i = data.children.length - 1; i >= 0; i--) {
-      if (!traverse(data.children[i], fn)) return false;
+      if (!traverse(data.children[i], data, i, fn)) return false;
     }
   }
   return true;
@@ -361,14 +366,19 @@ const traverse = <T extends { children?: T[] }>(data: T, fn: (param: T) => boole
  * depth first traverse, from leaves to root, children in inverse order
  *  if the fn returns false, terminate the traverse
  */
-const traverseUp = <T extends { children?: T[] }>(data: T, fn: (param: T) => boolean) => {
+const traverseUp = <T extends { children?: T[] }>(
+  data: T,
+  parent: T | null,
+  index: number,
+  fn: (data: T, parent: T | null, index: number) => boolean
+) => {
   if (data && data.children) {
     for (let i = data.children.length - 1; i >= 0; i--) {
-      if (!traverseUp(data.children[i], fn)) return;
+      if (!traverseUp(data.children[i], data, i, fn)) return;
     }
   }
 
-  if (fn(data) === false) {
+  if (fn(data, parent, index) === false) {
     return false;
   }
   return true;
@@ -378,11 +388,14 @@ const traverseUp = <T extends { children?: T[] }>(data: T, fn: (param: T) => boo
  * depth first traverse, from root to leaves, children in inverse order
  *  if the fn returns false, terminate the traverse
  */
-export const traverseTree = <T extends { children?: T[] }>(data: T, fn: (param: T) => boolean) => {
+export const traverseTree = <T extends { children?: T[] }>(
+  data: T,
+  fn: (data: T, parent: T | null, index: number) => boolean
+) => {
   if (typeof fn !== 'function') {
     return;
   }
-  traverse(data, fn);
+  traverse(data, null, -1, fn);
 };
 
 /**
@@ -391,12 +404,12 @@ export const traverseTree = <T extends { children?: T[] }>(data: T, fn: (param: 
  */
 export const traverseTreeUp = <T extends { children?: T[] }>(
   data: T,
-  fn: (param: T) => boolean,
+  fn: (data: T, parent: T | null, index: number) => boolean,
 ) => {
   if (typeof fn !== 'function') {
     return;
   }
-  traverseUp(data, fn);
+  traverseUp(data, null, -1, fn);
 };
 
 /**
@@ -525,7 +538,7 @@ export const plainCombosToTrees = (array: ComboConfig[], nodes?: NodeConfig[]) =
   let maxDepth = 0;
   result.forEach((tree: ComboTree) => {
     tree.depth = maxDepth + 10;
-    traverse<ComboTree>(tree, (child) => {
+    traverseTree<ComboTree>(tree, (child) => {
       let parent;
       const itemType = addedMap[child.id].itemType;
       if (itemType === 'node') {

--- a/packages/core/tests/unit/state/image-state-spec.ts
+++ b/packages/core/tests/unit/state/image-state-spec.ts
@@ -25,7 +25,7 @@ describe('graph node states', () => {
           position: 'bottom',
           style: {  fill: '#e80a0a', fontSize: 10,}
         },
-      }
+      },
       nodeStateStyles: {
         hover: {
           img: 'https://gw.alipayobjects.com/zos/bmw-prod/5d015065-8505-4e7a-baec-976f81e3c41d.svg',

--- a/packages/site/docs/api/Util.en.md
+++ b/packages/site/docs/api/Util.en.md
@@ -60,7 +60,15 @@ Traverse the tree data depth-first from top (the root) to bottom (the leaves).
 | Name | Type     | Required | Description                                    |
 | ---- | -------- | -------- | ---------------------------------------------- |
 | data | TreeData | true     | The tree data to be traversed                  |
-| fn   | function | true     | The callback function called when visit a node |
+| fn   | function | true     | The callback function called when visit a node. Returning `false` from the callback function will stop traversal. |
+
+Callback parameters
+
+| Name     | Type     | Description                                            |
+| -------- | -------- | ------------------------------------------------------ |
+| node     | T        | Tree node being currently visited                      |
+| parent   | T | null | Parent of the current tree node                        |
+| index    | number   | Index of current tree node among the parent's children |
 
 #### Usage
 
@@ -104,7 +112,15 @@ Traverse the tree data depth-first from bottom (the leaves) to top (the root).
 | Name | Type     | Required | Description                                    |
 | ---- | -------- | -------- | ---------------------------------------------- |
 | data | TreeData | true     | The tree data to be traversed                  |
-| fn   | function | true     | The callback function called when visit a node |
+| fn   | function | true     | The callback function called when visit a node. Returning `false` from the callback function will stop traversal. |
+
+Callback parameters
+
+| Name     | Type     | Description                                            |
+| -------- | -------- | ------------------------------------------------------ |
+| node     | T        | Tree node being currently visited                      |
+| parent   | T | null | Parent of the current tree node                        |
+| index    | number   | Index of current tree node among the parent's children |
 
 #### Usage
 


### PR DESCRIPTION
### Checklist

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

### Description of change

This PR fixes the update of the `comboTrees` structure involved in a `createCombo()` call. In particular:
- Combos moved inside the newly create combo were not removed from the `comboTrees`, which means they ended up duplicated (in the original place and under the new combo)
- Combos moved inside the new combo had no children

### Example screencasts

Before the fix:

https://user-images.githubusercontent.com/16387428/195824784-cdfda271-ad60-495a-9562-591f2331d5c9.mp4


After the fix:

https://user-images.githubusercontent.com/16387428/195824847-fdb3fece-6b69-4db3-ba08-f5005a7b4732.mp4

