### PR TITLE
fix: Swapped allowed events behavior in drag-canvas.

### DIFF
--- a/packages/pc/src/behavior/drag-canvas.ts
+++ b/packages/pc/src/behavior/drag-canvas.ts
@@ -6,7 +6,7 @@ const { cloneEvent, isNaN } = Util;
 
 const { abs } = Math;
 const DRAG_OFFSET = 10;
-const ALLOW_EVENTS = ['shift', 'ctrl', 'alt', 'control'];
+const PREVENT_EVENTS = ['shift', 'ctrl', 'alt', 'control'];
 
 export default {
   getDefaultCfg(): object {
@@ -266,10 +266,10 @@ export default {
     if (!code) {
       return;
     }
-    if (ALLOW_EVENTS.indexOf(code.toLowerCase()) > -1) {
-      self.keydown = false;
-    } else {
+    if (PREVENT_EVENTS.indexOf(code.toLowerCase()) > -1) {
       self.keydown = true;
+    } else {
+      self.keydown = false;
     }
   },
   onKeyUp() {

--- a/packages/pc/src/behavior/drag-canvas.ts
+++ b/packages/pc/src/behavior/drag-canvas.ts
@@ -267,9 +267,9 @@ export default {
       return;
     }
     if (ALLOW_EVENTS.indexOf(code.toLowerCase()) > -1) {
-      self.keydown = true;
-    } else {
       self.keydown = false;
+    } else {
+      self.keydown = true;
     }
   },
   onKeyUp() {


### PR DESCRIPTION
Allows events listed in `ALLOW_EVENTS` to pass instead of blocking them.