### PR TITLE
feat: resize combos when dragging contained elements

### DIFF
--- a/packages/pc/src/behavior/drag-combo.ts
+++ b/packages/pc/src/behavior/drag-combo.ts
@@ -192,6 +192,10 @@ export default {
       each(this.targets, (item) => {
         this.updateCombo(item, evt);
       });
+      if (this.onlyChangeComboSize) {
+        // 拖动节点结束后，动态改变 Combo 的大小
+        this.graph.updateCombos();
+      }
     }
   },
 

--- a/packages/pc/src/behavior/drag-node.ts
+++ b/packages/pc/src/behavior/drag-node.ts
@@ -250,6 +250,10 @@ export default {
           this.update(target, evt);
         });
     }
+    if (this.onlyChangeComboSize) {
+      // 拖动节点结束后，动态改变 Combo 的大小
+      this.graph.updateCombos();
+    }
   },
   /**
    * 拖动结束，设置拖动元素capture为true，更新元素位置，如果是拖动涉及到 combo，则更新 combo 结构


### PR DESCRIPTION
##### Description of change
This PR improves combo resizing when using the `drag-node` and `drag-combo` behaviors with `onlyChangeComboSize=true`, so that it happens while dragging and not only when dropping the dragged item

Before: 

https://user-images.githubusercontent.com/2861371/215104957-9adc785f-e119-41e7-9f23-969b2df4dd64.mp4

After:


https://user-images.githubusercontent.com/2861371/215105004-0969f44f-4f4e-4491-84a8-a0648b6b43ab.mp4

