### PR TITLE
Implement layout controller

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     ]
   },
   "dependencies": {
+    "@antv/graphlib": "^2.0.0-alpha.0",
     "eslint": "^7.11.0",
     "eslint-config-prettier": "^6.7.0",
     "eslint-plugin-import": "^2.22.1",
@@ -65,8 +66,7 @@
     "tslint-config-airbnb": "^5.11.2",
     "tslint-config-prettier": "^1.18.0",
     "tslint-eslint-rules": "^5.4.0",
-    "typescript": "^4.6.3",
-    "@antv/graphlib": "^2.0.0-alpha.0"
+    "typescript": "^4.6.3"
   },
   "devDependencies": {
     "@types/react": "^16.9.35",

--- a/packages/g6/package.json
+++ b/packages/g6/package.json
@@ -61,6 +61,7 @@
     "@antv/g": "^5.15.7",
     "@antv/g-canvas": "^1.9.28",
     "@antv/g-svg": "^1.8.36",
+    "@antv/g-webgl": "^1.7.44",
     "@antv/graphlib": "^2.0.0",
     "@antv/layout": "^1.0.0-alpha.15",
     "@antv/layout-gpu": "^1.0.0-alpha.3",

--- a/packages/g6/package.json
+++ b/packages/g6/package.json
@@ -61,7 +61,9 @@
     "@antv/g": "^5.15.7",
     "@antv/g-canvas": "^1.9.28",
     "@antv/g-svg": "^1.8.36",
-    "@antv/graphlib": "^2.0.0-alpha.0",
+    "@antv/graphlib": "^2.0.0",
+    "@antv/layout": "^1.0.0-alpha.15",
+    "@antv/layout-gpu": "^1.0.0-alpha.3",
     "@antv/util": "~2.0.5",
     "typedoc-plugin-markdown": "^3.14.0"
   },

--- a/packages/g6/package.json
+++ b/packages/g6/package.json
@@ -63,7 +63,7 @@
     "@antv/g-svg": "^1.8.36",
     "@antv/g-webgl": "^1.7.44",
     "@antv/graphlib": "^2.0.0",
-    "@antv/layout": "^1.0.0-alpha.15",
+    "@antv/layout": "^1.0.0-alpha.17",
     "@antv/layout-gpu": "^1.0.0-alpha.3",
     "@antv/util": "~2.0.5",
     "typedoc-plugin-markdown": "^3.14.0"

--- a/packages/g6/package.json
+++ b/packages/g6/package.json
@@ -43,7 +43,7 @@
     "lint:src": "eslint --ext .ts --format=pretty \"./src\"",
     "prettier": "prettier -c --write \"**/*\"",
     "test": "jest",
-    "test-live": "DEBUG_MODE=1 jest --watch  ./tests/unit/data-spec.ts",
+    "test-live": "DEBUG_MODE=1 jest --watch  ./tests/unit/item-spec.ts",
     "lint-staged:js": "eslint --ext .js,.jsx,.ts,.tsx",
     "watch": "father build -w"
   },

--- a/packages/g6/src/item/edge.ts
+++ b/packages/g6/src/item/edge.ts
@@ -1,11 +1,11 @@
-import { Group } from "@antv/g";
-import { ID } from "@antv/graphlib";
-import { EdgeDisplayModel, EdgeModel } from "../types";
-import { EdgeModelData } from "../types/edge";
-import { DisplayMapper, ITEM_TYPE } from "../types/item";
-import { updateShapes } from "../util/shape";
-import Item from "./item";
-import Node from "./node";
+import { Group } from '@antv/g';
+import { ID } from '@antv/graphlib';
+import { EdgeDisplayModel, EdgeModel } from '../types';
+import { EdgeModelData } from '../types/edge';
+import { DisplayMapper, ITEM_TYPE } from '../types/item';
+import { updateShapes } from '../util/shape';
+import Item from './item';
+import Node from './node';
 
 interface IProps {
   model: EdgeModel;
@@ -34,28 +34,29 @@ export default class Edge extends Item {
     this.targetItem = targetItem;
     this.draw();
   }
-  public draw(diffData?: { oldData: EdgeModelData, newData: EdgeModelData }, shapesToChange?: { [shapeId: string]: boolean }) {
+  public draw(diffData?: { oldData: EdgeModelData; newData: EdgeModelData }) {
     // get the end points
     const sourceBBox = this.sourceItem.getKeyBBox();
     const targetBBox = this.targetItem.getKeyBBox();
     const sourcePoint = {
       x: sourceBBox.center[0],
-      y: sourceBBox.center[1]
-    }
+      y: sourceBBox.center[1],
+    };
     const targetPoint = {
       x: targetBBox.center[0],
-      y: targetBBox.center[1]
-    }
-    let changeShapes = shapesToChange || {};
-    if (!shapesToChange) {
-      Object.keys(this.shapeMap).forEach(id => changeShapes[id] = true);
-    }
-    const shapeMap = this.renderExt.draw(this.displayModel, sourcePoint, targetPoint, this.shapeMap, changeShapes);
+      y: targetBBox.center[1],
+    };
+    const shapeMap = this.renderExt.draw(
+      this.displayModel,
+      sourcePoint,
+      targetPoint,
+      this.shapeMap,
+    );
 
     // add shapes to group, and update shapeMap
     this.shapeMap = updateShapes(this.shapeMap, shapeMap, this.group);
 
-    super.draw(diffData, shapesToChange);
+    super.draw(diffData);
   }
 
   /**

--- a/packages/g6/src/item/edge.ts
+++ b/packages/g6/src/item/edge.ts
@@ -56,6 +56,9 @@ export default class Edge extends Item {
     // add shapes to group, and update shapeMap
     this.shapeMap = updateShapes(this.shapeMap, shapeMap, this.group);
 
+    const { labelShape } = this.shapeMap;
+    labelShape?.toFront();
+
     super.draw(diffData);
   }
 

--- a/packages/g6/src/item/node.ts
+++ b/packages/g6/src/item/node.ts
@@ -16,25 +16,18 @@ export default class Node extends Item {
     super(props);
     this.draw();
   }
-  public draw(
-    diffData?: { oldData: NodeModelData; newData: NodeModelData },
-    shapesToChange?: { [shapeId: string]: boolean },
-  ) {
+  public draw(diffData?: { oldData: NodeModelData; newData: NodeModelData }) {
     const { group, displayModel, renderExt, shapeMap: prevShapeMap } = this;
     const { data } = displayModel;
     const { x = 0, y = 0 } = data;
     group.style.x = x;
     group.style.y = y;
-    let changeShapes = shapesToChange || {};
-    if (!shapesToChange) {
-      Object.keys(prevShapeMap).forEach((id) => (changeShapes[id] = true));
-    }
-    const shapeMap = renderExt.draw(displayModel, this.shapeMap, diffData, changeShapes);
+    const shapeMap = renderExt.draw(displayModel, this.shapeMap, diffData);
 
     // add shapes to group, and update shapeMap
     this.shapeMap = updateShapes(prevShapeMap, shapeMap, group);
 
-    super.draw(diffData, shapesToChange);
+    super.draw(diffData);
   }
 
   public update(

--- a/packages/g6/src/item/node.ts
+++ b/packages/g6/src/item/node.ts
@@ -1,10 +1,9 @@
 import { Group } from '@antv/g';
-import { clone } from '@antv/util';
 import { NodeModel } from '../types';
-import { DisplayMapper } from "../types/item";
+import { DisplayMapper } from '../types/item';
 import { NodeModelData } from '../types/node';
 import { updateShapes, getGroupSucceedMap } from '../util/shape';
-import Item, { RESERVED_SHAPE_IDS } from "./item";
+import Item from './item';
 
 interface IProps {
   model: NodeModel;
@@ -17,7 +16,10 @@ export default class Node extends Item {
     super(props);
     this.draw();
   }
-  public draw(diffData?: { oldData: NodeModelData, newData: NodeModelData }, shapesToChange?: { [shapeId: string]: boolean }) {
+  public draw(
+    diffData?: { oldData: NodeModelData; newData: NodeModelData },
+    shapesToChange?: { [shapeId: string]: boolean },
+  ) {
     const { group, displayModel, renderExt, shapeMap: prevShapeMap } = this;
     const { data } = displayModel;
     const { x = 0, y = 0 } = data;
@@ -25,18 +27,22 @@ export default class Node extends Item {
     group.style.y = y;
     let changeShapes = shapesToChange || {};
     if (!shapesToChange) {
-      Object.keys(prevShapeMap).forEach(id => changeShapes[id] = true);
+      Object.keys(prevShapeMap).forEach((id) => (changeShapes[id] = true));
     }
     const shapeMap = renderExt.draw(displayModel, this.shapeMap, diffData, changeShapes);
 
     // add shapes to group, and update shapeMap
     this.shapeMap = updateShapes(prevShapeMap, shapeMap, group);
 
-    super.draw(diffData, shapesToChange);;
+    super.draw(diffData, shapesToChange);
   }
 
-  public update(model: NodeModel, diffData: { oldData: NodeModelData, newData: NodeModelData }, dataChangedFields?: string[]) {
-    super.update(model, diffData, dataChangedFields);
+  public update(
+    model: NodeModel,
+    diffData: { oldData: NodeModelData; newData: NodeModelData },
+    isReplace?: boolean,
+  ) {
+    super.update(model, diffData, isReplace);
     const { data } = this.displayModel;
     const { x = 0, y = 0 } = data;
     this.group.style.x = x;
@@ -45,6 +51,6 @@ export default class Node extends Item {
 
   public getKeyBBox() {
     const { keyShape } = this.shapeMap;
-    return keyShape?.getRenderBounds() || { center: [0, 0, 0] }
+    return keyShape?.getRenderBounds() || { center: [0, 0, 0] };
   }
 }

--- a/packages/g6/src/item/node.ts
+++ b/packages/g6/src/item/node.ts
@@ -2,7 +2,7 @@ import { Group } from '@antv/g';
 import { NodeModel } from '../types';
 import { DisplayMapper } from '../types/item';
 import { NodeModelData } from '../types/node';
-import { updateShapes, getGroupSucceedMap } from '../util/shape';
+import { updateShapes } from '../util/shape';
 import Item from './item';
 
 interface IProps {

--- a/packages/g6/src/item/node.ts
+++ b/packages/g6/src/item/node.ts
@@ -27,6 +27,8 @@ export default class Node extends Item {
     // add shapes to group, and update shapeMap
     this.shapeMap = updateShapes(prevShapeMap, shapeMap, group);
 
+    this.shapeMap.labelShape?.toFront();
+
     super.draw(diffData);
   }
 

--- a/packages/g6/src/runtime/controller/data.ts
+++ b/packages/g6/src/runtime/controller/data.ts
@@ -1,13 +1,13 @@
 import { Graph as GraphLib, ID } from '@antv/graphlib';
-import { GraphData, IGraph, ComboModel, ComboUserModel } from '../../types';
-import { registery } from '../../stdlib';
-import { getExtension } from '../../util/extension';
-import { clone, isArray, isNumber, isString, isFunction, isObject } from '@antv/util';
-import { NodeModel, NodeModelData, NodeUserModel, NodeUserModelData } from '../../types/node';
-import { EdgeModel, EdgeModelData, EdgeUserModel, EdgeUserModelData } from '../../types/edge';
-import { DataChangeType, GraphCore } from '../../types/data';
-import { ITEM_TYPE } from '../../types/item';
+import { clone, isArray, isFunction, isNumber, isObject, isString } from '@antv/util';
+import { registry } from '../../stdlib';
+import { ComboModel, ComboUserModel, GraphData, IGraph } from '../../types';
 import { ComboUserModelData } from '../../types/combo';
+import { DataChangeType, GraphCore } from '../../types/data';
+import { EdgeModel, EdgeModelData, EdgeUserModel, EdgeUserModelData } from '../../types/edge';
+import { ITEM_TYPE } from '../../types/item';
+import { NodeModel, NodeModelData, NodeUserModel, NodeUserModelData } from '../../types/node';
+import { getExtension } from '../../util/extension';
 
 /**
  * Manages the data transform extensions;
@@ -85,7 +85,7 @@ export class DataController {
     return transform
       .map((config) => ({
         config,
-        func: getExtension(config, registery.useLib, 'transform'),
+        func: getExtension(config, registry.useLib, 'transform'),
       }))
       .filter((ext) => !!ext.func);
   }

--- a/packages/g6/src/runtime/controller/interaction.ts
+++ b/packages/g6/src/runtime/controller/interaction.ts
@@ -1,7 +1,7 @@
-import { IGraph } from "../../types";
-import { registery } from '../../stdlib';
-import { getExtension } from "../../util/extension";
-import { isObject } from "@antv/util";
+import { isObject } from '@antv/util';
+import { registry } from '../../stdlib';
+import { IGraph } from '../../types';
+import { getExtension } from '../../util/extension';
 
 /**
  * Manages the interaction extensions and graph modes;
@@ -29,14 +29,16 @@ export class InteractionController {
 
   /**
    * Get the extensions from useLib, stdLib is a sub set of useLib.
-   * @returns 
+   * @returns
    */
   private getExtensions() {
     const { modes = {} } = this.graph.getSpecification();
     const modeBehaviors = {};
-    Object.keys(modes).forEach(mode => {
-      modeBehaviors[mode] = modes[mode].map(config => getExtension(config, registery.useLib, 'behavior')).filter(behavior => !!behavior);
-    })
+    Object.keys(modes).forEach((mode) => {
+      modeBehaviors[mode] = modes[mode]
+        .map((config) => getExtension(config, registry.useLib, 'behavior'))
+        .filter((behavior) => !!behavior);
+    });
     return modeBehaviors;
   }
 
@@ -50,27 +52,39 @@ export class InteractionController {
     // ...
   }
 
-
   /**
    * Listener of graph's behaviorchange hook. Update, add, or remove behaviors from modes.
    * @param param contains action, modes, and behaviors
    */
-  private onBehaviorChange(self, param: { action: 'update' | 'add' | 'remove', modes: string[], behaviors: (string | { key: string, type: string })[] }) {
+  private onBehaviorChange(
+    self,
+    param: {
+      action: 'update' | 'add' | 'remove';
+      modes: string[];
+      behaviors: (string | { key: string; type: string })[];
+    },
+  ) {
     const { action, modes, behaviors } = param;
-    modes.forEach(mode => {
+    modes.forEach((mode) => {
       switch (action) {
         case 'add':
-          behaviors.forEach(config => self.extensions[mode].push(getExtension(config, registery.useLib, 'behavior')));
+          behaviors.forEach((config) =>
+            self.extensions[mode].push(getExtension(config, registry.useLib, 'behavior')),
+          );
           break;
         case 'remove':
-          behaviors.forEach(key => {
-            self.extensions[mode] = self.extensions[mode].filter(behavior => behavior.getKey() === key)
+          behaviors.forEach((key) => {
+            self.extensions[mode] = self.extensions[mode].filter(
+              (behavior) => behavior.getKey() === key,
+            );
           });
           break;
         case 'update':
-          behaviors.forEach(config => {
+          behaviors.forEach((config) => {
             if (isObject(config) && config.hasOwnProperty('key')) {
-              const behaviorItem = self.extensions[mode].find(behavior => behavior.getKey() === config.key);
+              const behaviorItem = self.extensions[mode].find(
+                (behavior) => behavior.getKey() === config.key,
+              );
               if (behaviorItem) behaviorItem.updateConfig(config);
             }
           });

--- a/packages/g6/src/runtime/controller/item.ts
+++ b/packages/g6/src/runtime/controller/item.ts
@@ -3,7 +3,7 @@ import { GraphChange, ID } from '@antv/graphlib';
 import Combo from '../../item/combo';
 import Edge from '../../item/edge';
 import Node from '../../item/node';
-import { registery } from '../../stdlib';
+import { registry } from '../../stdlib';
 import { ComboModel, IGraph } from '../../types';
 import { ComboDisplayModel, ComboEncode } from '../../types/combo';
 import { GraphCore } from '../../types/data';
@@ -73,13 +73,13 @@ export class ItemController {
     const comboTypes = ['circle-combo', 'rect-combo']; // TODO: WIP
     return {
       node: nodeTypes
-        .map((config) => getExtension(config, registery.useLib, 'node'))
+        .map((config) => getExtension(config, registry.useLib, 'node'))
         .filter(Boolean),
       edge: edgeTypes
-        .map((config) => getExtension(config, registery.useLib, 'edge'))
+        .map((config) => getExtension(config, registry.useLib, 'edge'))
         .filter(Boolean),
       combo: comboTypes
-        .map((config) => getExtension(config, registery.useLib, 'combo'))
+        .map((config) => getExtension(config, registry.useLib, 'combo'))
         .filter(Boolean),
     };
   }

--- a/packages/g6/src/runtime/controller/item.ts
+++ b/packages/g6/src/runtime/controller/item.ts
@@ -68,8 +68,8 @@ export class ItemController {
   private getExtensions() {
     // TODO: user need to config using node/edge/combo types from useLib to spec?
     // const { transform = [] } = this.graph.getSpecification();
-    const nodeTypes = ['circle-node', 'rect-node']; // TODO: WIP
-    const edgeTypes = ['line-edge', 'polyline-edge']; // TODO: WIP
+    const nodeTypes = ['circle-node', 'custom-node']; // TODO: WIP
+    const edgeTypes = ['line-edge', 'custom-edge']; // TODO: WIP
     const comboTypes = ['circle-combo', 'rect-combo']; // TODO: WIP
     return {
       node: nodeTypes
@@ -240,7 +240,8 @@ export class ItemController {
     const { nodeExtensions, nodeGroup } = this;
     models.forEach((node) => {
       // TODO: get mapper from theme controller which is analysed from graph spec
-      const extension = nodeExtensions.find((ext) => ext.type === node.data?.type || 'circle-node');
+      let extension = nodeExtensions.find((ext) => ext.type === node.data?.type);
+      if (!extension) extension = nodeExtensions.find((ext) => ext.type === 'circle-node');
       this.itemMap[node.id] = new Node({
         model: node,
         renderExt: new extension(),
@@ -259,7 +260,8 @@ export class ItemController {
     models.forEach((edge) => {
       const { source, target, id } = edge;
       // TODO: get mapper from theme controller which is analysed from graph spec
-      const extension = edgeExtensions.find((ext) => ext.type === edge.data?.type || 'line-edge');
+      let extension = edgeExtensions.find((ext) => ext.type === edge.data?.type);
+      if (!extension) extension = edgeExtensions.find((ext) => ext.type === 'line-edge');
       const sourceItem = itemMap[source] as Node;
       const targetItem = itemMap[target] as Node;
       if (!sourceItem) {

--- a/packages/g6/src/runtime/controller/item.ts
+++ b/packages/g6/src/runtime/controller/item.ts
@@ -1,16 +1,16 @@
-import { GraphChange, ID } from "@antv/graphlib";
-import { ComboModel, IGraph } from "../../types";
+import { GraphChange, ID } from '@antv/graphlib';
+import { ComboModel, IGraph } from '../../types';
 import { registery } from '../../stdlib';
-import { getExtension } from "../../util/extension";
-import { GraphCore } from "../../types/data";
-import { NodeDisplayModel, NodeEncode, NodeModel, NodeModelData } from "../../types/node";
-import { EdgeDisplayModel, EdgeEncode, EdgeModel, EdgeModelData } from "../../types/edge";
-import Node from "../../item/node";
-import Edge from "../../item/edge";
-import Combo from "../../item/combo";
-import { Group } from "@antv/g";
-import { ITEM_TYPE } from "../../types/item";
-import { ComboDisplayModel, ComboEncode } from "../../types/combo";
+import { getExtension } from '../../util/extension';
+import { GraphCore } from '../../types/data';
+import { NodeDisplayModel, NodeEncode, NodeModel, NodeModelData } from '../../types/node';
+import { EdgeDisplayModel, EdgeEncode, EdgeModel, EdgeModelData } from '../../types/edge';
+import Node from '../../item/node';
+import Edge from '../../item/edge';
+import Combo from '../../item/combo';
+import { Group } from '@antv/g';
+import { ITEM_TYPE } from '../../types/item';
+import { ComboDisplayModel, ComboEncode } from '../../types/combo';
 
 /**
  * Manages and stores the node / edge / combo items.
@@ -68,14 +68,20 @@ export class ItemController {
   private getExtensions() {
     // TODO: user need to config using node/edge/combo types from useLib to spec?
     // const { transform = [] } = this.graph.getSpecification();
-    const nodeTypes = ['circle-node', 'rect-node',]; // TODO: WIP
-    const edgeTypes = ['line-edge', 'polyline-edge',]; // TODO: WIP
-    const comboTypes = ['circle-combo', 'rect-combo',]; // TODO: WIP
+    const nodeTypes = ['circle-node', 'rect-node']; // TODO: WIP
+    const edgeTypes = ['line-edge', 'polyline-edge']; // TODO: WIP
+    const comboTypes = ['circle-combo', 'rect-combo']; // TODO: WIP
     return {
-      node: nodeTypes.map(config => getExtension(config, registery.useLib, 'node')).filter(Boolean),
-      edge: edgeTypes.map(config => getExtension(config, registery.useLib, 'edge')).filter(Boolean),
-      combo: comboTypes.map(config => getExtension(config, registery.useLib, 'combo')).filter(Boolean),
-    }
+      node: nodeTypes
+        .map((config) => getExtension(config, registery.useLib, 'node'))
+        .filter(Boolean),
+      edge: edgeTypes
+        .map((config) => getExtension(config, registery.useLib, 'edge'))
+        .filter(Boolean),
+      combo: comboTypes
+        .map((config) => getExtension(config, registery.useLib, 'combo'))
+        .filter(Boolean),
+    };
   }
 
   /**
@@ -106,20 +112,24 @@ export class ItemController {
 
   /**
    * Listener of runtime's itemchange lifecycle hook.
-   * @param param 
+   * @param param
    */
-  private onChange(param: { type: ITEM_TYPE, changes: GraphChange<NodeModelData, EdgeModelData>[], graphCore: GraphCore }) {
+  private onChange(param: {
+    type: ITEM_TYPE;
+    changes: GraphChange<NodeModelData, EdgeModelData>[];
+    graphCore: GraphCore;
+  }) {
     const { changes, graphCore } = param;
     const groupedChanges = {
-      'NodeRemoved': [],
-      'EdgeRemoved': [],
-      'NodeAdded': [],
-      'EdgeAdded': [],
-      'NodeDataUpdated': [],
-      'EdgeUpdated': [],
-      'EdgeDataUpdated': []
-    }
-    changes.forEach(change => {
+      NodeRemoved: [],
+      EdgeRemoved: [],
+      NodeAdded: [],
+      EdgeAdded: [],
+      NodeDataUpdated: [],
+      EdgeUpdated: [],
+      EdgeDataUpdated: [],
+    };
+    changes.forEach((change) => {
       const { type: changeType } = change;
       groupedChanges[changeType].push(change);
     });
@@ -137,11 +147,11 @@ export class ItemController {
     });
     // === 3. add nodes ===
     if (groupedChanges.NodeAdded.length) {
-      this.renderNodes(groupedChanges.NodeAdded.map(change => change.value));
+      this.renderNodes(groupedChanges.NodeAdded.map((change) => change.value));
     }
     // === 4. add edges ===
     if (groupedChanges.EdgeAdded.length) {
-      this.renderEdges(groupedChanges.EdgeAdded.map(change => change.value));
+      this.renderEdges(groupedChanges.EdgeAdded.map((change) => change.value));
     }
 
     // === 5. update nodes's data ===
@@ -155,23 +165,23 @@ export class ItemController {
           nodeUpdate[id] = {
             isReplace: true, // whether replace the whole data
             oldData: oldValue,
-            newData: newValue
-          }
+            newData: newValue,
+          };
         } else {
           nodeUpdate[id].oldData[propertyName] = oldValue;
           nodeUpdate[id].newData[propertyName] = newValue;
         }
       });
       const edgeToUpdate = {};
-      Object.keys(nodeUpdate).forEach(id => {
+      Object.keys(nodeUpdate).forEach((id) => {
         const { isReplace, newData, oldData } = nodeUpdate[id];
         const item = itemMap[id];
         const innerModel = graphCore.getNode(id);
-        item.update(innerModel, { newData, oldData }, isReplace ? undefined : Object.keys(nodeUpdate[id]));
+        item.update(innerModel, { newData, oldData }, isReplace);
         const relatedEdgeInnerModels = graphCore.getRelatedEdges(id);
-        relatedEdgeInnerModels.forEach(edge => edgeToUpdate[edge.id] = edge);
+        relatedEdgeInnerModels.forEach((edge) => (edgeToUpdate[edge.id] = edge));
       });
-      Object.keys(edgeToUpdate).forEach(edgeId => {
+      Object.keys(edgeToUpdate).forEach((edgeId) => {
         const item = itemMap[edgeId] as Edge;
         item.forceUpdate();
       });
@@ -180,47 +190,46 @@ export class ItemController {
     // === 6. update edges' data ===
     if (groupedChanges.EdgeDataUpdated.length) {
       const edgeUpdate = {};
-      groupedChanges.EdgeDataUpdated.forEach(change => {
+      groupedChanges.EdgeDataUpdated.forEach((change) => {
         const { id, propertyName, newValue, oldValue } = change;
         edgeUpdate[id] = edgeUpdate[id] || { oldData: {}, newData: {} };
         if (!propertyName) {
           edgeUpdate[id] = {
             isReplace: true, // whether replace the whole data
             oldData: oldValue,
-            newData: newValue
-          }
+            newData: newValue,
+          };
         } else {
           edgeUpdate[id].oldData[propertyName] = oldValue;
           edgeUpdate[id].newData[propertyName] = newValue;
         }
       });
 
-      Object.keys(edgeUpdate).forEach(id => {
+      Object.keys(edgeUpdate).forEach((id) => {
         const { isReplace, newData, oldData } = edgeUpdate[id];
         const item = itemMap[id];
         const innerModel = graphCore.getEdge(id);
-        item.update(innerModel, { newData, oldData }, isReplace ? undefined : Object.keys(edgeUpdate[id]));
+        item.update(innerModel, { newData, oldData }, isReplace);
       });
     }
 
     // === 7. update edges' source target ===
     if (groupedChanges.EdgeUpdated.length) {
       const edgeUpdate = {};
-      groupedChanges.EdgeUpdated.forEach(change => {
+      groupedChanges.EdgeUpdated.forEach((change) => {
         // propertyName is 'source' or 'target'
         const { id, propertyName, newValue } = change;
         edgeUpdate[id] = edgeUpdate[id] || {};
         edgeUpdate[id][propertyName] = newValue;
       });
 
-      Object.keys(edgeUpdate).forEach(id => {
+      Object.keys(edgeUpdate).forEach((id) => {
         const { source, target } = edgeUpdate[id];
         const item = itemMap[id] as Edge;
         if (source !== undefined) item.updateEnd('source', this.itemMap[source] as Node);
         if (target !== undefined) item.updateEnd('target', this.itemMap[target] as Node);
       });
     }
-
   }
 
   /**
@@ -229,9 +238,9 @@ export class ItemController {
    */
   private renderNodes(models: NodeModel[]) {
     const { nodeExtensions, nodeGroup } = this;
-    models.forEach(node => {
+    models.forEach((node) => {
       // TODO: get mapper from theme controller which is analysed from graph spec
-      const extension = nodeExtensions.find(ext => ext.type === node.data?.type || 'circle-node')
+      const extension = nodeExtensions.find((ext) => ext.type === node.data?.type || 'circle-node');
       this.itemMap[node.id] = new Node({
         model: node,
         renderExt: new extension(),
@@ -247,17 +256,21 @@ export class ItemController {
    */
   private renderEdges(models: EdgeModel[]) {
     const { edgeExtensions, edgeGroup, itemMap } = this;
-    models.forEach(edge => {
+    models.forEach((edge) => {
       const { source, target, id } = edge;
       // TODO: get mapper from theme controller which is analysed from graph spec
-      const extension = edgeExtensions.find(ext => ext.type === edge.data?.type || 'line-edge');
+      const extension = edgeExtensions.find((ext) => ext.type === edge.data?.type || 'line-edge');
       const sourceItem = itemMap[source] as Node;
       const targetItem = itemMap[target] as Node;
       if (!sourceItem) {
-        console.warn(`The source node ${source} is not exist in the graph for edge ${id}, please add the node first`);
+        console.warn(
+          `The source node ${source} is not exist in the graph for edge ${id}, please add the node first`,
+        );
       }
       if (!targetItem) {
-        console.warn(`The source node ${source} is not exist in the graph for edge ${id}, please add the node first`);
+        console.warn(
+          `The source node ${source} is not exist in the graph for edge ${id}, please add the node first`,
+        );
       }
       itemMap[id] = new Edge({
         model: edge,

--- a/packages/g6/src/runtime/controller/item.ts
+++ b/packages/g6/src/runtime/controller/item.ts
@@ -181,8 +181,8 @@ export class ItemController {
         const relatedEdgeInnerModels = graphCore.getRelatedEdges(id);
         relatedEdgeInnerModels.forEach((edge) => (edgeToUpdate[edge.id] = edge));
       });
-      Object.keys(edgeToUpdate).forEach((edgeId) => {
-        const item = itemMap[edgeId] as Edge;
+      Object.keys(edgeToUpdate).forEach((id) => {
+        const item = itemMap[id] as Edge;
         item.forceUpdate();
       });
     }

--- a/packages/g6/src/runtime/controller/item.ts
+++ b/packages/g6/src/runtime/controller/item.ts
@@ -1,16 +1,16 @@
-import { GraphChange, ID } from '@antv/graphlib';
-import { ComboModel, IGraph } from '../../types';
-import { registery } from '../../stdlib';
-import { getExtension } from '../../util/extension';
-import { GraphCore } from '../../types/data';
-import { NodeDisplayModel, NodeEncode, NodeModel, NodeModelData } from '../../types/node';
-import { EdgeDisplayModel, EdgeEncode, EdgeModel, EdgeModelData } from '../../types/edge';
-import Node from '../../item/node';
-import Edge from '../../item/edge';
-import Combo from '../../item/combo';
 import { Group } from '@antv/g';
-import { ITEM_TYPE } from '../../types/item';
+import { GraphChange, ID } from '@antv/graphlib';
+import Combo from '../../item/combo';
+import Edge from '../../item/edge';
+import Node from '../../item/node';
+import { registery } from '../../stdlib';
+import { ComboModel, IGraph } from '../../types';
 import { ComboDisplayModel, ComboEncode } from '../../types/combo';
+import { GraphCore } from '../../types/data';
+import { EdgeDisplayModel, EdgeEncode, EdgeModel, EdgeModelData } from '../../types/edge';
+import { ITEM_TYPE } from '../../types/item';
+import { NodeDisplayModel, NodeEncode, NodeModel, NodeModelData } from '../../types/node';
+import { getExtension } from '../../util/extension';
 
 /**
  * Manages and stores the node / edge / combo items.

--- a/packages/g6/src/runtime/controller/layout.ts
+++ b/packages/g6/src/runtime/controller/layout.ts
@@ -1,11 +1,11 @@
-import { isLayoutWithIterations, Layout, LayoutMapping, registry, Supervisor } from '@antv/layout';
+import { isLayoutWithIterations, Layout, LayoutMapping, Supervisor } from '@antv/layout';
+import { stdLib } from '../../stdlib';
 import { IGraph } from '../../types';
 import { GraphCore } from '../../types/data';
 import { LayoutOptions } from '../../types/layout';
 
 /**
  * Manages layout extensions and graph layout.
- *
  * It will also emit `afterlayout` & `tick` events on Graph.
  */
 export class LayoutController {
@@ -45,7 +45,7 @@ export class LayoutController {
     };
 
     // Find built-in layout algorithms.
-    const layoutCtor = registry[type];
+    const layoutCtor = stdLib.layouts[type];
     if (!layoutCtor) {
       throw new Error(`Unknown layout algorithm: ${type}`);
     }

--- a/packages/g6/src/runtime/controller/layout.ts
+++ b/packages/g6/src/runtime/controller/layout.ts
@@ -1,16 +1,19 @@
-import { Layout, LayoutMapping, registry, Supervisor } from '@antv/layout';
+import { isLayoutWithIterations, Layout, LayoutMapping, registry, Supervisor } from '@antv/layout';
 import { IGraph } from '../../types';
 import { GraphCore } from '../../types/data';
 import { LayoutOptions } from '../../types/layout';
 
 /**
  * Manages layout extensions and graph layout.
+ *
+ * It will also emit `afterlayout` & `tick` events on Graph.
  */
 export class LayoutController {
   public extensions = {};
   public graph: IGraph;
 
   private currentLayout: Layout<any>;
+  private currentSupervisor: Supervisor;
 
   constructor(graph: IGraph<any>) {
     this.graph = graph;
@@ -25,9 +28,18 @@ export class LayoutController {
   }
 
   private async onLayout(params: { graphCore: GraphCore; options?: LayoutOptions }) {
+    // Stop currentLayout if any.
+    this.stopLayout();
+
     const { graphCore, options } = params;
 
-    const { type, workerEnabled, ...rest } = {
+    const {
+      type,
+      workerEnabled,
+      animated,
+      iterations = 300,
+      ...rest
+    } = {
       ...this.graph.getSpecification().layout,
       ...options,
     };
@@ -40,16 +52,70 @@ export class LayoutController {
 
     // Initialize layout.
     const layout = new layoutCtor(rest);
+    this.currentLayout = layout;
 
     let positions: LayoutMapping;
+
     if (workerEnabled) {
-      const supervisor = new Supervisor(graphCore, layout);
+      /**
+       * Run algorithm in WebWorker, `animated` option will be ignored.
+       */
+      const supervisor = new Supervisor(graphCore, layout, { iterations });
+      this.currentSupervisor = supervisor;
       positions = await supervisor.execute();
     } else {
-      positions = await layout.execute(graphCore);
+      if (isLayoutWithIterations(layout)) {
+        if (animated) {
+          positions = await layout.execute(graphCore, {
+            onTick: (positionsOnTick: LayoutMapping) => {
+              // Display the animated process of layout.
+              this.updateNodesPosition(positionsOnTick);
+              this.graph.emit('tick', positionsOnTick);
+            },
+          });
+        } else {
+          /**
+           * Manually step simulation in a sync way. `onTick` won't get triggered in this case,
+           * there will be no animation either.
+           */
+          layout.execute(graphCore);
+          layout.stop();
+          positions = layout.tick(iterations);
+        }
+
+        /**
+         * `onTick` will get triggered in this case.
+         */
+      } else {
+        positions = await layout.execute(graphCore);
+      }
     }
 
     // Update nodes' positions.
+    this.updateNodesPosition(positions);
+  }
+
+  stopLayout() {
+    if (this.currentLayout && isLayoutWithIterations(this.currentLayout)) {
+      this.currentLayout.stop();
+      this.currentLayout = null;
+    }
+
+    if (this.currentSupervisor) {
+      this.currentSupervisor.stop();
+      this.currentSupervisor = null;
+    }
+  }
+
+  destroy() {
+    this.stopLayout();
+
+    if (this.currentSupervisor) {
+      this.currentSupervisor.kill();
+    }
+  }
+
+  private updateNodesPosition(positions: LayoutMapping) {
     positions.nodes.forEach((node) => {
       this.graph.updateData('node', {
         id: node.id,
@@ -59,9 +125,5 @@ export class LayoutController {
         },
       });
     });
-  }
-
-  stopLayout() {
-    // this.currentLayout.stop();
   }
 }

--- a/packages/g6/src/runtime/controller/layout.ts
+++ b/packages/g6/src/runtime/controller/layout.ts
@@ -1,4 +1,7 @@
-import { IGraph } from "../../types";
+import { Layout, LayoutMapping, registry, Supervisor } from '@antv/layout';
+import { IGraph } from '../../types';
+import { GraphCore } from '../../types/data';
+import { LayoutOptions } from '../../types/layout';
 
 /**
  * Manages layout extensions and graph layout.
@@ -7,8 +10,58 @@ export class LayoutController {
   public extensions = {};
   public graph: IGraph;
 
+  private currentLayout: Layout<any>;
+
   constructor(graph: IGraph<any>) {
     this.graph = graph;
-    // this.tap();
+    this.tap();
+  }
+
+  /**
+   * Subscribe the lifecycle of graph.
+   */
+  private tap() {
+    this.graph.hooks.layout.tap(this.onLayout.bind(this));
+  }
+
+  private async onLayout(params: { graphCore: GraphCore; options?: LayoutOptions }) {
+    const { graphCore, options } = params;
+
+    const { type, workerEnabled, ...rest } = {
+      ...this.graph.getSpecification().layout,
+      ...options,
+    };
+
+    // Find built-in layout algorithms.
+    const layoutCtor = registry[type];
+    if (!layoutCtor) {
+      throw new Error(`Unknown layout algorithm: ${type}`);
+    }
+
+    // Initialize layout.
+    const layout = new layoutCtor(rest);
+
+    let positions: LayoutMapping;
+    if (workerEnabled) {
+      const supervisor = new Supervisor(graphCore, layout);
+      positions = await supervisor.execute();
+    } else {
+      positions = await layout.execute(graphCore);
+    }
+
+    // Update nodes' positions.
+    positions.nodes.forEach((node) => {
+      this.graph.updateData('node', {
+        id: node.id,
+        data: {
+          x: node.data.x,
+          y: node.data.y,
+        },
+      });
+    });
+  }
+
+  stopLayout() {
+    // this.currentLayout.stop();
   }
 }

--- a/packages/g6/src/runtime/graph.ts
+++ b/packages/g6/src/runtime/graph.ts
@@ -143,25 +143,28 @@ export default class Graph<B extends BehaviorRegistry> extends EventEmitter impl
    * @returns
    * @group Data
    */
-  public read(data: GraphData) {
+  public async read(data: GraphData) {
     this.hooks.datachange.emit({ data, type: 'replace' });
-    const emitRender = () => {
+    const emitRender = async () => {
       this.hooks.render.emit({
         graphCore: this.dataController.graphCore,
       });
       this.emit('afterrender');
 
       // TODO: make read async?
-      this.hooks.layout.emitLinearAsync({
+      await this.hooks.layout.emitLinearAsync({
         graphCore: this.dataController.graphCore,
       });
+
+      this.emit('afterlayout');
     };
     if (this.canvasReady) {
-      emitRender();
+      await emitRender();
     } else {
-      Promise.all(
+      await Promise.all(
         [this.backgroundCanvas, this.canvas, this.transientCanvas].map((canvas) => canvas.ready),
-      ).then(emitRender);
+      );
+      await emitRender();
     }
   }
 
@@ -172,17 +175,18 @@ export default class Graph<B extends BehaviorRegistry> extends EventEmitter impl
    * @returns
    * @group Data
    */
-  public changeData(data: GraphData, type: 'replace' | 'mergeReplace' = 'mergeReplace') {
+  public async changeData(data: GraphData, type: 'replace' | 'mergeReplace' = 'mergeReplace') {
     this.hooks.datachange.emit({ data, type });
     this.hooks.render.emit({
       graphCore: this.dataController.graphCore,
     });
     this.emit('afterrender');
 
-    // TODO: make changeData async?
-    this.hooks.layout.emitLinearAsync({
+    await this.hooks.layout.emitLinearAsync({
       graphCore: this.dataController.graphCore,
     });
+
+    this.emit('afterlayout');
   }
 
   /**
@@ -530,6 +534,7 @@ export default class Graph<B extends BehaviorRegistry> extends EventEmitter impl
       graphCore: this.dataController.graphCore,
       options,
     });
+    this.emit('afterlayout');
   }
 
   /**

--- a/packages/g6/src/runtime/graph.ts
+++ b/packages/g6/src/runtime/graph.ts
@@ -2,7 +2,14 @@ import EventEmitter from '@antv/event-emitter';
 import { Canvas } from '@antv/g';
 import { GraphChange, ID } from '@antv/graphlib';
 import { isArray, isNumber, isObject, isString } from '@antv/util';
-import { ComboUserModel, EdgeUserModel, GraphData, IGraph, NodeUserModel, Specification } from '../types';
+import {
+  ComboUserModel,
+  EdgeUserModel,
+  GraphData,
+  IGraph,
+  NodeUserModel,
+  Specification,
+} from '../types';
 import { AnimateCfg } from '../types/animate';
 import { BehaviorObjectOptionsOf, BehaviorOptionsOf, BehaviorRegistry } from '../types/behavior';
 import { ComboModel } from '../types/combo';
@@ -15,7 +22,14 @@ import { LayoutCommonConfig } from '../types/layout';
 import { NodeModel, NodeModelData } from '../types/node';
 import { FitViewRules, GraphAlignment } from '../types/view';
 import { createCanvas } from '../util/canvas';
-import { DataController, InteractionController, ItemController, LayoutController, ThemeController, ExtensionController } from './controller';
+import {
+  DataController,
+  InteractionController,
+  ItemController,
+  LayoutController,
+  ThemeController,
+  ExtensionController,
+} from './controller';
 import Hook from './hooks';
 
 export default class Graph<B extends BehaviorRegistry> extends EventEmitter implements IGraph<B> {
@@ -78,8 +92,8 @@ export default class Graph<B extends BehaviorRegistry> extends EventEmitter impl
     this.canvas = createCanvas(rendererType, container, width, height, pixelRatio);
     this.transientCanvas = createCanvas(rendererType, container, width, height, pixelRatio);
     Promise.all(
-      [this.backgroundCanvas, this.canvas, this.transientCanvas].map(canvas => canvas.ready)
-    ).then(() => this.canvasReady = true);
+      [this.backgroundCanvas, this.canvas, this.transientCanvas].map((canvas) => canvas.ready),
+    ).then(() => (this.canvasReady = true));
   }
 
   /**
@@ -88,14 +102,18 @@ export default class Graph<B extends BehaviorRegistry> extends EventEmitter impl
   private initHooks() {
     this.hooks = {
       init: new Hook<void>({ name: 'init' }),
-      datachange: new Hook<{ data: GraphData, type: 'replace' }>({ name: 'datachange' }),
-      itemchange: new Hook<{ type: ITEM_TYPE, changes: GraphChange<NodeModelData, EdgeModelData>[], graphCore: GraphCore }>({ name: 'itemchange' }),
+      datachange: new Hook<{ data: GraphData; type: 'replace' }>({ name: 'datachange' }),
+      itemchange: new Hook<{
+        type: ITEM_TYPE;
+        changes: GraphChange<NodeModelData, EdgeModelData>[];
+        graphCore: GraphCore;
+      }>({ name: 'itemchange' }),
       render: new Hook<{ graphCore: GraphCore }>({ name: 'render' }),
       modechange: new Hook<{ mode: string }>({ name: 'modechange' }),
       behaviorchange: new Hook<{
-        action: 'update' | 'add' | 'remove',
-        modes: string[],
-        behaviors: BehaviorOptionsOf<{}>[]
+        action: 'update' | 'add' | 'remove';
+        modes: string[];
+        behaviors: BehaviorOptionsOf<{}>[];
       }>({ name: 'behaviorchange' }),
     };
   }
@@ -118,23 +136,23 @@ export default class Graph<B extends BehaviorRegistry> extends EventEmitter impl
   /**
    * Input data and render the graph.
    * If there is old data, diffs and changes it.
-   * @param data 
-   * @returns 
+   * @param data
+   * @returns
    * @group Data
    */
   public read(data: GraphData) {
     this.hooks.datachange.emit({ data, type: 'replace' });
     const emitRender = () => {
       this.hooks.render.emit({
-        graphCore: this.dataController.graphCore
+        graphCore: this.dataController.graphCore,
       });
       this.emit('afterrender');
-    }
+    };
     if (this.canvasReady) {
       emitRender();
     } else {
       Promise.all(
-        [this.backgroundCanvas, this.canvas, this.transientCanvas].map(canvas => canvas.ready)
+        [this.backgroundCanvas, this.canvas, this.transientCanvas].map((canvas) => canvas.ready),
       ).then(emitRender);
     }
   }
@@ -143,20 +161,20 @@ export default class Graph<B extends BehaviorRegistry> extends EventEmitter impl
    * Change graph data.
    * @param data new data
    * @param type the way to change data, 'replace' means discard the old data and use the new one; 'mergeReplace' means merge the common part, remove (old - new), add (new - old)
-   * @returns 
+   * @returns
    * @group Data
-  */
+   */
   public changeData(data: GraphData, type: 'replace' | 'mergeReplace' = 'mergeReplace') {
     this.hooks.datachange.emit({ data, type });
     this.hooks.render.emit({
-      graphCore: this.dataController.graphCore
+      graphCore: this.dataController.graphCore,
     });
     this.emit('afterrender');
   }
 
   /**
    * Clear the graph, means remove all the items on the graph.
-   * @returns 
+   * @returns
    */
   public clear() {
     // TODO
@@ -167,7 +185,7 @@ export default class Graph<B extends BehaviorRegistry> extends EventEmitter impl
    * @param dx x of the relative vector
    * @param dy y of the relative vector
    * @param animateCfg animation configurations
-   * @returns 
+   * @returns
    * @group View
    */
   public move(dx: number, dy: number, animateCfg?: AnimateCfg) {
@@ -180,7 +198,7 @@ export default class Graph<B extends BehaviorRegistry> extends EventEmitter impl
    * @param y position on the canvas to align
    * @param alignment alignment of the graph content
    * @param animateCfg animation configurations
-   * @returns 
+   * @returns
    * @group View
    */
   public moveTo(x: number, y: number, alignment: GraphAlignment, animateCfg?: AnimateCfg) {
@@ -192,7 +210,7 @@ export default class Graph<B extends BehaviorRegistry> extends EventEmitter impl
    * @param ratio relative ratio to zoom
    * @param center zoom center
    * @param animateCfg animation configurations
-   * @returns 
+   * @returns
    * @group View
    */
   public zoom(ratio: number, center?: Point, animateCfg?: AnimateCfg) {
@@ -204,7 +222,7 @@ export default class Graph<B extends BehaviorRegistry> extends EventEmitter impl
    * @param toRatio specified ratio
    * @param center zoom center
    * @param animateCfg animation configurations
-   * @returns 
+   * @returns
    * @group View
    */
   public zoomTo(toRatio: number, center?: Point, animateCfg?: AnimateCfg) {
@@ -216,7 +234,7 @@ export default class Graph<B extends BehaviorRegistry> extends EventEmitter impl
    * @param padding padding while fitting
    * @param rules rules for fitting
    * @param animateCfg animation configurations
-   * @returns 
+   * @returns
    * @group View
    */
   public fitView(padding?: Padding, rules?: FitViewRules, animateCfg?: AnimateCfg) {
@@ -225,7 +243,7 @@ export default class Graph<B extends BehaviorRegistry> extends EventEmitter impl
   /**
    * Fit the graph center to the view center.
    * @param animateCfg animation configurations
-   * @returns 
+   * @returns
    * @group View
    */
   public fitCenter(animateCfg?: AnimateCfg) {
@@ -235,13 +253,12 @@ export default class Graph<B extends BehaviorRegistry> extends EventEmitter impl
    * Move the graph to make the item align the view center.
    * @param item node/edge/combo item or its id
    * @param animateCfg animation configurations
-   * @returns 
+   * @returns
    * @group View
    */
-  public focusItem(ids: ID | (ID)[], animateCfg?: AnimateCfg) {
+  public focusItem(ids: ID | ID[], animateCfg?: AnimateCfg) {
     // TODO
   }
-
 
   // ===== item operations =====
   /**
@@ -261,7 +278,8 @@ export default class Graph<B extends BehaviorRegistry> extends EventEmitter impl
    * @group Data
    */
   public getEdgeData(condition: ID | Function): EdgeModel | undefined {
-    const conds = isString(condition) || isNumber(condition) || isNumber(condition) ? [condition] : condition;
+    const conds =
+      isString(condition) || isNumber(condition) || isNumber(condition) ? [condition] : condition;
     return this.dataController.findData('edge', conds)?.[0] as EdgeModel;
   }
   /**
@@ -306,7 +324,11 @@ export default class Graph<B extends BehaviorRegistry> extends EventEmitter impl
    * @returns items that is the type and has the state
    * @group Item
    */
-  public findIdByState(itemType: ITEM_TYPE, state: string, additionalFilter?: (item: NodeModel | EdgeModel | ComboModel) => boolean): ID[] {
+  public findIdByState(
+    itemType: ITEM_TYPE,
+    state: string,
+    additionalFilter?: (item: NodeModel | EdgeModel | ComboModel) => boolean,
+  ): ID[] {
     // TODO
     return;
   }
@@ -320,30 +342,39 @@ export default class Graph<B extends BehaviorRegistry> extends EventEmitter impl
    */
   public addData(
     itemType: ITEM_TYPE,
-    models: NodeUserModel | EdgeUserModel | ComboUserModel | NodeUserModel[] | EdgeUserModel[] | ComboUserModel[],
-    stack?: boolean
+    models:
+      | NodeUserModel
+      | EdgeUserModel
+      | ComboUserModel
+      | NodeUserModel[]
+      | EdgeUserModel[]
+      | ComboUserModel[],
+    stack?: boolean,
   ): NodeModel | EdgeModel | ComboModel | NodeModel[] | EdgeModel[] | ComboModel[] {
     // data controller and item controller subscribe additem in order
 
     const { graphCore } = this.dataController;
-    graphCore.once('changed', event => {
+    graphCore.once('changed', (event) => {
       this.hooks.itemchange.emit({
         type: itemType,
         changes: graphCore.reduceChanges(event.changes),
-        graphCore
+        graphCore,
       });
-    })
+    });
 
     const modelArr = isArray(models) ? models : [models];
     const data = { nodes: [], edges: [], combos: [] };
     data[`${itemType}s`] = modelArr;
     this.hooks.datachange.emit({
       data,
-      type: 'union'
+      type: 'union',
     });
-    const dataList = this.dataController.findData(itemType, modelArr.map(model => model.id))
+    const dataList = this.dataController.findData(
+      itemType,
+      modelArr.map((model) => model.id),
+    );
     return isArray(models) ? dataList : dataList[0];
-  };
+  }
   /**
    * Remove one or more node/edge/combo data from the graph.
    * @param item the item to be removed
@@ -356,17 +387,17 @@ export default class Graph<B extends BehaviorRegistry> extends EventEmitter impl
     const data = { nodes: [], edges: [], combos: [] };
     const { userGraphCore, graphCore } = this.dataController;
     const getItem = itemType === 'edge' ? userGraphCore.getEdge : userGraphCore.getNode; // TODO: combo
-    data[`${itemType}s`] = idArr.map(id => getItem.bind(userGraphCore)(id));
-    graphCore.once('changed', event => {
+    data[`${itemType}s`] = idArr.map((id) => getItem.bind(userGraphCore)(id));
+    graphCore.once('changed', (event) => {
       this.hooks.itemchange.emit({
         type: itemType,
         changes: event.changes,
-        graphCore
+        graphCore,
       });
     });
     this.hooks.datachange.emit({
       data,
-      type: 'remove'
+      type: 'remove',
     });
   }
   /**
@@ -378,33 +409,44 @@ export default class Graph<B extends BehaviorRegistry> extends EventEmitter impl
    */
   public updateData(
     itemType: ITEM_TYPE,
-    models: Partial<NodeUserModel> | Partial<EdgeUserModel> | Partial<ComboUserModel | Partial<NodeUserModel>[] | Partial<EdgeUserModel>[] | Partial<ComboUserModel>[]>,
-    stack?: boolean
+    models:
+      | Partial<NodeUserModel>
+      | Partial<EdgeUserModel>
+      | Partial<
+          | ComboUserModel
+          | Partial<NodeUserModel>[]
+          | Partial<EdgeUserModel>[]
+          | Partial<ComboUserModel>[]
+        >,
+    stack?: boolean,
   ): NodeModel | EdgeModel | ComboModel | NodeModel[] | EdgeModel[] | ComboModel[] {
     const modelArr = isArray(models) ? models : [models];
     const data = { nodes: [], edges: [], combos: [] };
     data[`${itemType}s`] = modelArr;
 
     const { graphCore } = this.dataController;
-    graphCore.once('changed', event => {
+    graphCore.once('changed', (event) => {
       this.hooks.itemchange.emit({
         type: itemType,
         changes: event.changes,
-        graphCore
+        graphCore,
       });
     });
 
     this.hooks.datachange.emit({
       data,
-      type: 'update'
+      type: 'update',
     });
-    const dataList = this.dataController.findData(itemType, modelArr.map(model => model.id))
+    const dataList = this.dataController.findData(
+      itemType,
+      modelArr.map((model) => model.id),
+    );
     return isArray(models) ? dataList : dataList[0];
   }
   /**
    * Show the item(s).
    * @param item the item to be shown
-   * @returns 
+   * @returns
    * @group Item
    */
   public showItem(ids: ID | ID[]) {
@@ -413,7 +455,7 @@ export default class Graph<B extends BehaviorRegistry> extends EventEmitter impl
   /**
    * Hide the item(s).
    * @param item the item to be hidden
-   * @returns 
+   * @returns
    * @group Item
    */
   public hideItem(ids: ID | ID[]) {
@@ -424,21 +466,20 @@ export default class Graph<B extends BehaviorRegistry> extends EventEmitter impl
    * @param item the item to be set
    * @param state the state name
    * @param value state value
-   * @returns 
+   * @returns
    * @group Item
    */
   public setItemState(ids: ID | ID[], state: string, value: boolean) {
     // TODO
   }
 
-
   // ===== combo operations =====
   /**
-  * Create a new combo with existing child nodes and combos.
-  * @param combo combo ID or Combo model
-  * @param childrenIds id array of children of the new combo
-  * @group Combo
-  */
+   * Create a new combo with existing child nodes and combos.
+   * @param combo combo ID or Combo model
+   * @param childrenIds id array of children of the new combo
+   * @group Combo
+   */
   public createCombo(combo: string | ComboUserModel, childrenIds: string[], stack?: boolean) {
     // TODO
   }
@@ -451,22 +492,21 @@ export default class Graph<B extends BehaviorRegistry> extends EventEmitter impl
     // TODO
   }
   /**
-  * Collapse a combo.
-  * @param comboId combo id or item
-  * @group Combo
-  */
+   * Collapse a combo.
+   * @param comboId combo id or item
+   * @group Combo
+   */
   public collapseCombo(comboId: ID, stack?: boolean) {
     // TODO
   }
   /**
- * Expand a combo.
- * @param combo combo ID 或 combo 实例
- * @group Combo
- */
+   * Expand a combo.
+   * @param combo combo ID 或 combo 实例
+   * @group Combo
+   */
   public expandCombo(comboId: ID, stack?: boolean) {
     // TODO
   }
-
 
   // ===== layout =====
   /**
@@ -477,16 +517,20 @@ export default class Graph<B extends BehaviorRegistry> extends EventEmitter impl
    * @param {boolean} stack push it into stack
    * @group Layout
    */
-  public layout(cfg?: LayoutCommonConfig, align?: GraphAlignment, canvasPoint?: Point, stack?: boolean) {
+  public layout(
+    cfg?: LayoutCommonConfig,
+    align?: GraphAlignment,
+    canvasPoint?: Point,
+    stack?: boolean,
+  ) {
     // TODO: LayoutConfig combination instead of LayoutCommonConfig
     // TODO
   }
 
-
   /**
    * Switch mode.
    * @param mode mode name
-   * @returns 
+   * @returns
    * @group Interaction
    */
   public setMode(mode: string) {
@@ -497,7 +541,7 @@ export default class Graph<B extends BehaviorRegistry> extends EventEmitter impl
    * Add behavior(s) to mode(s).
    * @param behaviors behavior names or configs
    * @param modes mode names
-   * @returns 
+   * @returns
    * @group Interaction
    */
   public addBehaviors(behaviors: BehaviorOptionsOf<B>[], modes: string | string[]) {
@@ -506,10 +550,10 @@ export default class Graph<B extends BehaviorRegistry> extends EventEmitter impl
     this.hooks.behaviorchange.emit({
       action: 'add',
       modes: modesArr,
-      behaviors: behaviorsArr
+      behaviors: behaviorsArr,
     });
     // update the graph specification
-    modesArr.forEach(mode => {
+    modesArr.forEach((mode) => {
       this.specification.modes[mode] = this.specification.modes[mode].concat(behaviorsArr);
     });
   }
@@ -517,7 +561,7 @@ export default class Graph<B extends BehaviorRegistry> extends EventEmitter impl
    * Remove behavior(s) from mode(s).
    * @param behaviors behavior configs with unique key
    * @param modes mode names
-   * @returns 
+   * @returns
    * @group Interaction
    */
   public removeBehaviors(behaviorKeys: string[], modes: string | string[]) {
@@ -525,22 +569,24 @@ export default class Graph<B extends BehaviorRegistry> extends EventEmitter impl
     this.hooks.behaviorchange.emit({
       action: 'remove',
       modes: modesArr,
-      behaviors: behaviorKeys
+      behaviors: behaviorKeys,
     });
     // update the graph specification
-    modesArr.forEach(mode => {
-      behaviorKeys.forEach(key => {
-        const oldBehavior = this.specification.modes[mode].find(behavior => isObject(behavior) && behavior.key === key);
+    modesArr.forEach((mode) => {
+      behaviorKeys.forEach((key) => {
+        const oldBehavior = this.specification.modes[mode].find(
+          (behavior) => isObject(behavior) && behavior.key === key,
+        );
         const indexOfOldBehavior = this.specification.modes[mode].indexOf(oldBehavior);
         this.specification.modes[mode].splice(indexOfOldBehavior, 1);
-      })
+      });
     });
   }
   /**
    * Update a behavior on a mode.
    * @param behavior behavior configs, whose name indicates the behavior to be updated
    * @param mode mode name
-   * @returns 
+   * @returns
    * @group Interaction
    */
   public updateBehavior(behavior: BehaviorObjectOptionsOf<B>, mode?: string) {
@@ -549,7 +595,7 @@ export default class Graph<B extends BehaviorRegistry> extends EventEmitter impl
       modes: [mode],
       behaviors: [behavior],
     });
-    // no need to update specification since the corresponding part is the same object as the behavior's option 
+    // no need to update specification since the corresponding part is the same object as the behavior's option
     // this.specification.modes[mode].forEach((b, i) => {
     //   if (isObject(b) && b.key === behavior.key) {
     //     this.specification.modes[mode][i] = behavior;

--- a/packages/g6/src/runtime/graph.ts
+++ b/packages/g6/src/runtime/graph.ts
@@ -36,6 +36,8 @@ export default class Graph<B extends BehaviorRegistry> extends EventEmitter impl
   public hooks: Hooks;
   // for nodes and edges, which will be separate into groups
   public canvas: Canvas;
+  // the tag to indicate whether the graph instance is destroyed
+  public destroyed: boolean;
   // for background shapes, e.g. grid, pipe indices
   private backgroundCanvas: Canvas;
   // for transient shapes for interactions, e.g. transient node and related edges while draging, delegates
@@ -601,5 +603,26 @@ export default class Graph<B extends BehaviorRegistry> extends EventEmitter impl
     //     this.specification.modes[mode][i] = behavior;
     //   }
     // });
+  }
+
+  /**
+   * Destroy the graph instance and remove the related canvases.
+   * @returns
+   * @group Graph Instance
+   */
+  public destroy() {
+    this.canvas.destroy();
+    this.backgroundCanvas.destroy();
+    this.transientCanvas.destroy();
+
+    // TODO: destroy controllers and off the listeners
+    // this.dataController.destroy();
+    // this.interactionController.destroy();
+    // this.layoutController.destroy();
+    // this.themeController.destroy();
+    // this.itemController.destroy();
+    // this.extensionController.destroy();
+
+    this.destroyed = true;
   }
 }

--- a/packages/g6/src/runtime/hooks.ts
+++ b/packages/g6/src/runtime/hooks.ts
@@ -1,4 +1,4 @@
-import { IHook } from "../types/hook";
+import { IHook } from '../types/hook';
 
 /**
  * A hook class unified the definitions of tap, untap, and emit.
@@ -16,14 +16,14 @@ export default class Hook<T> implements IHook<T> {
   }
   /**
    * Tap a listener to the corresponding lifecycle of this hook.
-   * @param listener 
+   * @param listener
    */
   public tap(listener: (param: T) => void) {
     this.listeners.push(listener);
   }
   /**
    * Remove a listener from the corresponding lifecycle of this hook.
-   * @param listener 
+   * @param listener
    */
   public unTap(listener: (param: T) => void) {
     const idx = this.listeners.indexOf(listener);
@@ -31,28 +31,34 @@ export default class Hook<T> implements IHook<T> {
   }
   /**
    * Emit the corresponding lifecycle to call the listeners
-   * @param param 
+   * @param param
    */
   public emit(param: T) {
-    this.listeners.forEach(listener => listener(param));
+    this.listeners.forEach((listener) => listener(param));
   }
   /**
    * Linearly async emit the corresponding lifecycle to call the listeners
-   * @param param 
+   * @param param
    */
   public async emitLinearAsync(param: T): Promise<void> {
-    return new Promise(async () => {
-      let start = Promise.resolve();
-      this.listeners.forEach(listener => {
-        start = start.then(async () => new Promise(async (resolve, reject) => {
-          try {
-            await listener(param);
-            resolve();
-          } catch (e) {
-            reject();
-          }
-        }));
-      });
-    });
+    for (const listener of this.listeners) {
+      await listener(param);
+    }
+    // return new Promise(async () => {
+    //   let start = Promise.resolve();
+    //   this.listeners.forEach((listener) => {
+    //     start = start.then(
+    //       async () =>
+    //         new Promise(async (resolve, reject) => {
+    //           try {
+    //             await listener(param);
+    //             resolve();
+    //           } catch (e) {
+    //             reject();
+    //           }
+    //         }),
+    //     );
+    //   });
+    // });
   }
 }

--- a/packages/g6/src/stdlib/index.ts
+++ b/packages/g6/src/stdlib/index.ts
@@ -1,27 +1,28 @@
-import { comboFromNode } from "./data/comboFromNode"
-import DragCanvas from "./behavior/drag-canvas";
-import { Lib } from "../types/stdlib";
-import { CircleNode } from "./item/node";
-import { LineEdge } from "./item/edge";
+import { registry as layoutRegistry } from '@antv/layout';
+import { Lib } from '../types/stdlib';
+import DragCanvas from './behavior/drag-canvas';
+import { comboFromNode } from './data/comboFromNode';
+import { LineEdge } from './item/edge';
+import { CircleNode } from './item/node';
 
 const stdLib = {
   transforms: {
-    comboFromNode
+    comboFromNode,
   },
   themes: {},
-  layouts: {}, // from @antv/layout
+  layouts: layoutRegistry,
   behaviors: {
-    'drag-canvas': DragCanvas
+    'drag-canvas': DragCanvas,
   },
   plugins: {},
   nodes: {
-    'circle-node': CircleNode
+    'circle-node': CircleNode,
   },
   edges: {
-    'line-edge': LineEdge
+    'line-edge': LineEdge,
   },
   combos: {},
-}
+};
 
 const useLib: Lib = {
   transforms: {},
@@ -34,6 +35,6 @@ const useLib: Lib = {
   combos: {},
 };
 
-const registery = { useLib };
-export default registery;
-export { stdLib, registery };
+const registry = { useLib };
+export default registry;
+export { stdLib, registry };

--- a/packages/g6/src/stdlib/item/edge/base.ts
+++ b/packages/g6/src/stdlib/item/edge/base.ts
@@ -1,8 +1,14 @@
-import { DisplayObject } from "@antv/g";
-import { NodeDisplayModel } from "../../../types";
-import { Point } from "../../../types/common";
-import { EdgeLabelShapeStyle } from "../../../types/edge";
-import { ShapeStyle } from "../../../types/item";
+import { DisplayObject, Line, Polyline } from '@antv/g';
+import { isNumber } from '_@antv_util@3.3.2@@antv/util';
+import { Point } from '../../../types/common';
+import {
+  EdgeDisplayModel,
+  EdgeLabelShapeStyle,
+  EdgeModelData,
+  EdgeShapeMap,
+} from '../../../types/edge';
+import { ShapeStyle } from '../../../types/item';
+import { upsertShape } from '../../../util/shape';
 
 export abstract class BaseEdge {
   type: string;
@@ -12,21 +18,142 @@ export abstract class BaseEdge {
     iconShape: ShapeStyle;
     otherShapes: {
       [shapeId: string]: ShapeStyle;
-    }
-  }
+    };
+  };
   abstract draw(
-    model: NodeDisplayModel,
+    model: EdgeDisplayModel,
     sourcePoint: Point,
     targetPoint: Point,
     shapeMap: { [shapeId: string]: DisplayObject },
-    shapesToChange?: { [shapeId: string]: boolean }
+    diffData?: { oldData: EdgeModelData; newData: EdgeModelData },
   ): {
-    keyShape: DisplayObject,
-    labelShape?: DisplayObject,
-    iconShape?: DisplayObject,
-    [otherShapeId: string]: DisplayObject
+    keyShape: DisplayObject;
+    labelShape?: DisplayObject;
+    iconShape?: DisplayObject;
+    [otherShapeId: string]: DisplayObject;
   };
-  afterDraw: (model: NodeDisplayModel, shapeMap: { [shapeId: string]: DisplayObject }, shapesChanged?: string[]) => void;
-  // shouldUpdate: (model: NodeDisplayModel, prevModel: NodeDisplayModel) => boolean = () => true;
+  afterDraw: (
+    model: EdgeDisplayModel,
+    shapeMap: { [shapeId: string]: DisplayObject },
+    shapesChanged?: string[],
+  ) => void;
+  // shouldUpdate: (model: EdgeDisplayModel, prevModel: EdgeDisplayModel) => boolean = () => true;
   setState: (name: string, value: boolean, shapeMap: { [shapeId: string]: DisplayObject }) => void;
+
+  public drawLabelShape(
+    model: EdgeDisplayModel,
+    shapeMap: EdgeShapeMap,
+    diffData?: { oldData: EdgeModelData; newData: EdgeModelData },
+  ): {
+    labelShape: DisplayObject;
+    [id: string]: DisplayObject;
+  } {
+    const { keyShape } = shapeMap;
+
+    const shapeStyle = Object.assign({}, this.defaultStyles.labelShape, model.data?.labelShape);
+    const {
+      position,
+      background,
+      offsetX: propsOffsetX,
+      offsetY: propsOffsetY,
+      autoRotate = true,
+      ...otherStyle
+    } = shapeStyle;
+
+    const positionPreset = {
+      textAlign: 'center',
+      offsetX: 0,
+      offsetY: 0,
+      pointRatio: [0.5, 0.501],
+    };
+    if (isNumber(position)) {
+      positionPreset.pointRatio = [position, position + 0.01];
+    }
+    switch (position) {
+      case 'start':
+        positionPreset.pointRatio = [0, 0.01];
+        positionPreset.textAlign = 'left';
+        positionPreset.offsetX = 4;
+        break;
+      case 'end':
+        positionPreset.pointRatio = [0.99, 1];
+        positionPreset.textAlign = 'right';
+        positionPreset.offsetX = -4;
+        break;
+      default: // at middle by default
+        break;
+    }
+
+    const point = (keyShape as Line | Polyline).getPoint(positionPreset.pointRatio[0]);
+    let positionStyle: any = { x: point.x, y: point.y };
+    if (autoRotate) {
+      const pointOffset = (keyShape as Line | Polyline).getPoint(positionPreset.pointRatio[1]);
+      const angle = Math.atan((point.y - pointOffset.y) / (point.x - pointOffset.x)); // TODO: NaN
+      const offsetX = propsOffsetX === undefined ? positionPreset.offsetX : propsOffsetX;
+      const offsetY = propsOffsetY === undefined ? positionPreset.offsetY : propsOffsetY;
+      // the projection is |offsetX| away from point, along the tangent line of the keyShape's path at point
+      const projection = {
+        x: point.x + offsetX * Math.cos(angle),
+        y: point.y + offsetX * Math.sin(angle),
+      };
+      // the position of the text is |offsetY| away from projection, along the vertical line of the tangent line at point
+      positionStyle = {
+        x: projection.x + offsetY * Math.cos(Math.PI - angle),
+        y: projection.y + offsetY * Math.sin(Math.PI - angle),
+        transform: `rotate(${(angle / Math.PI) * 180})`,
+      };
+    }
+    const style = {
+      textBaseline: 'middle',
+      textAlign: positionPreset.textAlign,
+      ...positionStyle,
+      ...otherStyle,
+    };
+
+    const labelShape = upsertShape('text', 'labelShape', style, shapeMap);
+    const shapes = { labelShape };
+    if (background) {
+      // TODO: zeros, how to estimate the bbox before being appended to group
+      const textBBox = labelShape.getGeometryBounds();
+      console.log('textBBoxxxxxx', textBBox);
+      const { padding = [4, 4, 4, 4], ...backgroundStyle } = background;
+      debugger;
+      shapes['labelBgShape'] = upsertShape(
+        'rect',
+        'labelBgShape',
+        {
+          fill: '#fff',
+          radius: 4,
+          ...backgroundStyle,
+          x: textBBox.min[0] - padding[3],
+          y: textBBox.min[1] - padding[0],
+          width: textBBox.max[0] - textBBox.min[0] + padding[1] + padding[3],
+          height: textBBox.max[1] - textBBox.min[1] + padding[0] + padding[2],
+        },
+        shapeMap,
+      );
+    }
+
+    console.log('label', shapes);
+    return shapes;
+  }
+
+  public drawIconShape(
+    model: EdgeDisplayModel,
+    shapeMap: EdgeShapeMap,
+    diffData?: { oldData: EdgeModelData; newData: EdgeModelData },
+  ): DisplayObject {
+    const { iconShape } = model.data || {};
+    const shapeStyle = Object.assign({}, this.defaultStyles.iconShape, model.data?.iconShape);
+    const iconShapeType = shapeStyle.text ? 'text' : 'image';
+    if (iconShapeType === 'image') {
+      const { width, height } = shapeStyle;
+      if (!iconShape.hasOwnProperty('x')) shapeStyle.x = -width / 2;
+      if (!iconShape.hasOwnProperty('y')) shapeStyle.y = -height / 2;
+    } else {
+      shapeStyle.textAlign = 'center';
+      shapeStyle.textBaseline = 'middle';
+    }
+    return upsertShape(iconShapeType, 'iconShape', shapeStyle, shapeMap);
+  }
 }

--- a/packages/g6/src/stdlib/item/edge/line.ts
+++ b/packages/g6/src/stdlib/item/edge/line.ts
@@ -5,7 +5,7 @@ import { BaseEdge } from './base';
 
 export class LineEdge extends BaseEdge {
   public type = 'line-edge';
-  public defaultStyles = {
+  public defaultStyles = Object.assign({}, super.getDefaultStyles(), {
     keyShape: {
       x1: 0,
       y1: 0,
@@ -14,17 +14,8 @@ export class LineEdge extends BaseEdge {
       stroke: '#ccc',
       lineWidth: 1,
     },
-    labelShape: {
-      fontSize: 12,
-      fill: '#000',
-    },
-    iconShape: {
-      img: 'https://gw.alipayobjects.com/mdn/rms_f8c6a0/afts/img/A*wAmHQJbNVdwAAAAAAAAAAABkARQnAQ',
-      width: 15,
-      height: 15,
-    },
     otherShapes: {},
-  };
+  });
   public draw(
     model: EdgeDisplayModel,
     sourcePoint: Point,

--- a/packages/g6/src/stdlib/item/edge/line.ts
+++ b/packages/g6/src/stdlib/item/edge/line.ts
@@ -1,6 +1,7 @@
 import { DisplayObject, Group } from "@antv/g";
 import { NodeDisplayModel } from "../../../types";
 import { Point } from "../../../types/common";
+import { EdgeShapeMap } from "../../../types/edge";
 import { createShape } from "../../../util/shape";
 import { BaseEdge } from "./base";
 
@@ -33,9 +34,10 @@ export class LineEdge extends BaseEdge {
     model: NodeDisplayModel,
     sourcePoint: Point,
     targetPoint: Point,
-    shapeMap: { [shapeId: string]: DisplayObject },
+    shapeMap: EdgeShapeMap,
     shapesToChange?: { [shapeId: string]: boolean }
-  ) {
+  ): EdgeShapeMap {
+    if (!shapesToChange) return shapeMap;
     const { data = {} } = model;
 
     const handleKeyShape = () => {
@@ -62,20 +64,15 @@ export class LineEdge extends BaseEdge {
       const iconShapeStyle = Object.assign({}, this.defaultStyles.iconShape, data.iconShape);
       // addShape('text', labelShapeStyle, `${this.type}-labelShape`, group);
     }
+
     let keyShape;
-    if (shapesToChange) {
-      if (shapesToChange.keyShape) {
-        keyShape = handleKeyShape()
-      }
-      if (shapesToChange.labelShape) {
-        handleLabelShape();
-      }
-      if (shapesToChange.iconShape) {
-        handleIconShape();
-      }
-    } else {
-      keyShape = handleKeyShape();
+    if (shapesToChange.keyShape) {
+      keyShape = handleKeyShape()
+    }
+    if (shapesToChange.labelShape) {
       handleLabelShape();
+    }
+    if (shapesToChange.iconShape) {
       handleIconShape();
     }
 

--- a/packages/g6/src/stdlib/item/node/base.ts
+++ b/packages/g6/src/stdlib/item/node/base.ts
@@ -1,7 +1,8 @@
-import { DisplayObject, Group, IElement } from "@antv/g";
-import { NodeDisplayModel } from "../../../types";
-import { ShapeStyle } from "../../../types/item";
-import { NodeLabelShapeStyle, NodeModelData } from "../../../types/node";
+import { DisplayObject } from '@antv/g';
+import { NodeDisplayModel } from '../../../types';
+import { ShapeStyle } from '../../../types/item';
+import { NodeLabelShapeStyle, NodeModelData, NodeShapeMap } from '../../../types/node';
+import { upsertShape } from '../../../util/shape';
 
 export abstract class BaseNode {
   type: string;
@@ -11,20 +12,110 @@ export abstract class BaseNode {
     iconShape: ShapeStyle;
     otherShapes: {
       [shapeId: string]: ShapeStyle;
-    }
-  }
+    };
+  };
   abstract draw(
     model: NodeDisplayModel,
     shapeMap: { [shapeId: string]: DisplayObject },
-    diffData?: { oldData: NodeModelData, newData: NodeModelData },
-    shapesToChange?: { [shapeId: string]: boolean }
+    diffData?: { oldData: NodeModelData; newData: NodeModelData },
   ): {
-    keyShape: DisplayObject,
-    labelShape?: DisplayObject,
-    iconShape?: DisplayObject,
-    [otherShapeId: string]: DisplayObject
+    keyShape: DisplayObject;
+    labelShape?: DisplayObject;
+    iconShape?: DisplayObject;
+    [otherShapeId: string]: DisplayObject;
   };
-  afterDraw: (model: NodeDisplayModel, shapeMap: { [shapeId: string]: DisplayObject }, shapesChanged?: string[]) => ({ [otherShapeId: string]: DisplayObject });
+  abstract drawKeyShape(
+    model: NodeDisplayModel,
+    shapeMap: NodeShapeMap,
+    diffData?: { oldData: NodeModelData; newData: NodeModelData },
+  ): DisplayObject;
+
+  afterDraw: (
+    model: NodeDisplayModel,
+    shapeMap: { [shapeId: string]: DisplayObject },
+    shapesChanged?: string[],
+  ) => { [otherShapeId: string]: DisplayObject };
   // shouldUpdate: (model: NodeDisplayModel, prevModel: NodeDisplayModel) => boolean = () => true;
   setState: (name: string, value: boolean, shapeMap: { [shapeId: string]: DisplayObject }) => void;
+
+  public drawLabelShape(
+    model: NodeDisplayModel,
+    shapeMap: NodeShapeMap,
+    diffData?: { oldData: NodeModelData; newData: NodeModelData },
+  ): DisplayObject {
+    const { keyShape } = shapeMap;
+    const keyShapeBox = keyShape.getGeometryBounds();
+    const shapeStyle = Object.assign({}, this.defaultStyles.labelShape, model.data?.labelShape);
+    const {
+      position,
+      background,
+      offsetX: propsOffsetX,
+      offsetY: propsOffsetY,
+      ...otherStyle
+    } = shapeStyle;
+    const positionPreset = {
+      x: keyShapeBox.center[0],
+      y: keyShapeBox.max[1],
+      textBaseline: 'top',
+      textAlign: 'center',
+      offsetX: 0,
+      offsetY: 0,
+    };
+    switch (position) {
+      case 'center':
+        positionPreset.y = keyShapeBox.center[1];
+        break;
+      case 'top':
+        positionPreset.y = keyShapeBox.min[1];
+        positionPreset.textBaseline = 'bottom';
+        positionPreset.offsetY = -4;
+        break;
+      case 'left':
+        positionPreset.x = keyShapeBox.min[0];
+        positionPreset.y = keyShapeBox.center[1];
+        positionPreset.textAlign = 'right';
+        positionPreset.textBaseline = 'middle';
+        positionPreset.offsetX = -4;
+        break;
+      case 'right':
+        positionPreset.x = keyShapeBox.max[0];
+        positionPreset.y = keyShapeBox.center[1];
+        positionPreset.textAlign = 'left';
+        positionPreset.textBaseline = 'middle';
+        positionPreset.offsetX = 4;
+        break;
+      default: // at bottom by default
+        positionPreset.offsetY = 4;
+        break;
+    }
+    const offsetX = propsOffsetX === undefined ? positionPreset.offsetX : propsOffsetX;
+    const offsetY = propsOffsetY === undefined ? positionPreset.offsetY : propsOffsetY;
+    positionPreset.x += offsetX;
+    positionPreset.y += offsetY;
+
+    const style = {
+      ...positionPreset,
+      ...otherStyle,
+    };
+    return upsertShape('text', 'labelShape', style, shapeMap);
+  }
+
+  public drawIconShape(
+    model: NodeDisplayModel,
+    shapeMap: NodeShapeMap,
+    diffData?: { oldData: NodeModelData; newData: NodeModelData },
+  ): DisplayObject {
+    const { iconShape } = model.data || {};
+    const shapeStyle = Object.assign({}, this.defaultStyles.iconShape, model.data?.iconShape);
+    const iconShapeType = shapeStyle.text ? 'text' : 'image';
+    if (iconShapeType === 'image') {
+      const { width, height } = shapeStyle;
+      if (!iconShape.hasOwnProperty('x')) shapeStyle.x = -width / 2;
+      if (!iconShape.hasOwnProperty('y')) shapeStyle.y = -height / 2;
+    } else {
+      shapeStyle.textAlign = 'center';
+      shapeStyle.textBaseline = 'middle';
+    }
+    return upsertShape(iconShapeType, 'iconShape', shapeStyle, shapeMap);
+  }
 }

--- a/packages/g6/src/stdlib/item/node/circle.ts
+++ b/packages/g6/src/stdlib/item/node/circle.ts
@@ -7,7 +7,7 @@ import { BaseNode } from './base';
 
 export class CircleNode extends BaseNode {
   public type = 'circle-node';
-  public defaultStyles = {
+  public defaultStyles = Object.assign({}, super.getDefaultStyles(), {
     keyShape: {
       r: 15,
       x: 0,
@@ -15,30 +15,26 @@ export class CircleNode extends BaseNode {
       fill: '#f00',
       lineWidth: 0,
       stroke: '#0f0',
-    } as ShapeStyle,
-    labelShape: {
-      fontSize: 12,
-      fill: '#000',
-      position: 'bottom',
-    } as NodeLabelShapeStyle,
-    iconShape: {
-      img: 'https://gw.alipayobjects.com/mdn/rms_f8c6a0/afts/img/A*wAmHQJbNVdwAAAAAAAAAAABkARQnAQ',
-      width: 12,
-      height: 12,
-    } as ShapeStyle,
-    otherShapes: {},
-  };
+    },
+  });
   public draw(
     model: NodeDisplayModel,
     shapeMap: NodeShapeMap,
     diffData?: { oldData: NodeModelData; newData: NodeModelData },
   ): NodeShapeMap {
     const { data = {} } = model;
-    const shapes: NodeShapeMap = { keyShape: undefined };
+    let shapes: NodeShapeMap = { keyShape: undefined };
 
     shapes.keyShape = this.drawKeyShape(model, shapeMap, diffData);
-    if (data.labelShape) shapes.labelShape = this.drawLabelShape(model, shapeMap, diffData);
-    if (data.iconShape) shapes.iconShape = this.drawIconShape(model, shapeMap, diffData);
+    if (data.labelShape) {
+      shapes = {
+        ...shapes,
+        ...this.drawLabelShape(model, shapeMap, diffData),
+      };
+    }
+    if (data.iconShape) {
+      shapes.iconShape = this.drawIconShape(model, shapeMap, diffData);
+    }
 
     // TODO: other shapes
 

--- a/packages/g6/src/stdlib/item/node/circle.ts
+++ b/packages/g6/src/stdlib/item/node/circle.ts
@@ -1,6 +1,6 @@
 import { Group, DisplayObject } from "@antv/g";
 import { NodeDisplayModel } from "../../../types";
-import { NodeModelData } from "../../../types/node";
+import { NodeModelData, NodeShapeMap } from "../../../types/node";
 import { createShape } from "../../../util/shape";
 import { BaseNode } from "./base";
 
@@ -31,15 +31,11 @@ export class CircleNode extends BaseNode {
   };
   public draw(
     model: NodeDisplayModel,
-    shapeMap: { [shapeId: string]: DisplayObject },
+    shapeMap: NodeShapeMap,
     diffData?: { oldData: NodeModelData, newData: NodeModelData },
     shapesToChange?: { [shapeId: string]: boolean }
-  ): {
-    keyShape: DisplayObject,
-    labelShape?: DisplayObject,
-    iconShape?: DisplayObject,
-    [otherShapeId: string]: DisplayObject
-  } {
+  ): NodeShapeMap {
+    if (!shapesToChange) return shapeMap;
     const { data = {} } = model;
     const handleKeyShape = () => {
       const keyShapeStyle = Object.assign({}, this.defaultStyles.keyShape, data.keyShape);
@@ -60,19 +56,13 @@ export class CircleNode extends BaseNode {
       // addShape('text', labelShapeStyle, `${this.type}-labelShape`, group);
     }
     let keyShape;
-    if (shapesToChange) {
-      if (shapesToChange.keyShape) {
-        keyShape = handleKeyShape();
-      }
-      if (shapesToChange.labelShape) {
-        handleLabelShape();
-      }
-      if (shapesToChange.iconShape) {
-        handleIconShape();
-      }
-    } else {
+    if (shapesToChange.keyShape) {
       keyShape = handleKeyShape();
+    }
+    if (shapesToChange.labelShape) {
       handleLabelShape();
+    }
+    if (shapesToChange.iconShape) {
       handleIconShape();
     }
     // TODO: add label, icon, and other shapes

--- a/packages/g6/src/stdlib/item/node/circle.ts
+++ b/packages/g6/src/stdlib/item/node/circle.ts
@@ -1,8 +1,9 @@
-import { Group, DisplayObject } from "@antv/g";
-import { NodeDisplayModel } from "../../../types";
-import { NodeModelData, NodeShapeMap } from "../../../types/node";
-import { createShape } from "../../../util/shape";
-import { BaseNode } from "./base";
+import { DisplayObject } from '@antv/g';
+import { NodeDisplayModel } from '../../../types';
+import { ShapeStyle } from '../../../types/item';
+import { NodeLabelShapeStyle, NodeModelData, NodeShapeMap } from '../../../types/node';
+import { upsertShape } from '../../../util/shape';
+import { BaseNode } from './base';
 
 export class CircleNode extends BaseNode {
   public type = 'circle-node';
@@ -13,60 +14,43 @@ export class CircleNode extends BaseNode {
       y: 0,
       fill: '#f00',
       lineWidth: 0,
-      stroke: '#0f0'
-    },
+      stroke: '#0f0',
+    } as ShapeStyle,
     labelShape: {
-      x: 0,
-      y: 0,
-      textAlign: 'center',
       fontSize: 12,
-      fill: '#000'
-    },
+      fill: '#000',
+      position: 'bottom',
+    } as NodeLabelShapeStyle,
     iconShape: {
       img: 'https://gw.alipayobjects.com/mdn/rms_f8c6a0/afts/img/A*wAmHQJbNVdwAAAAAAAAAAABkARQnAQ',
-      width: 15,
-      height: 15
-    },
-    otherShapes: {}
+      width: 12,
+      height: 12,
+    } as ShapeStyle,
+    otherShapes: {},
   };
   public draw(
     model: NodeDisplayModel,
     shapeMap: NodeShapeMap,
-    diffData?: { oldData: NodeModelData, newData: NodeModelData },
-    shapesToChange?: { [shapeId: string]: boolean }
+    diffData?: { oldData: NodeModelData; newData: NodeModelData },
   ): NodeShapeMap {
-    if (!shapesToChange) return shapeMap;
     const { data = {} } = model;
-    const handleKeyShape = () => {
-      const keyShapeStyle = Object.assign({}, this.defaultStyles.keyShape, data.keyShape);
-      const keyShape = createShape(
-        'circle',
-        keyShapeStyle,
-        'keyShape',
-        shapeMap
-      );
-      return keyShape;
-    }
-    const handleLabelShape = () => {
-      const labelShapeStyle = Object.assign({}, this.defaultStyles.labelShape, data.labelShape);
-      // addShape('text', labelShapeStyle, `${this.type}-labelShape`, group);
-    }
-    const handleIconShape = () => {
-      const iconShapeStyle = Object.assign({}, this.defaultStyles.iconShape, data.iconShape);
-      // addShape('text', labelShapeStyle, `${this.type}-labelShape`, group);
-    }
-    let keyShape;
-    if (shapesToChange.keyShape) {
-      keyShape = handleKeyShape();
-    }
-    if (shapesToChange.labelShape) {
-      handleLabelShape();
-    }
-    if (shapesToChange.iconShape) {
-      handleIconShape();
-    }
-    // TODO: add label, icon, and other shapes
+    const shapes: NodeShapeMap = { keyShape: undefined };
 
-    return { keyShape, labelShape: undefined, iconShape: undefined, otherShapes: undefined };
+    shapes.keyShape = this.drawKeyShape(model, shapeMap, diffData);
+    if (data.labelShape) shapes.labelShape = this.drawLabelShape(model, shapeMap, diffData);
+    if (data.iconShape) shapes.iconShape = this.drawIconShape(model, shapeMap, diffData);
+
+    // TODO: other shapes
+
+    return shapes;
+  }
+
+  public drawKeyShape(
+    model: NodeDisplayModel,
+    shapeMap: NodeShapeMap,
+    diffData?: { oldData: NodeModelData; newData: NodeModelData },
+  ): DisplayObject {
+    const shapeStyle = Object.assign({}, this.defaultStyles.keyShape, model.data?.keyShape);
+    return upsertShape('circle', 'keyShape', shapeStyle, shapeMap);
   }
 }

--- a/packages/g6/src/types/edge.ts
+++ b/packages/g6/src/types/edge.ts
@@ -1,3 +1,4 @@
+import { DisplayObject } from '@antv/g';
 import { Edge as GEdge, PlainObject } from '@antv/graphlib';
 import { AnimateAttr } from "./animate";
 import { Encode, IItem, LabelBackground, ShapeAttrEncode, ShapesEncode, ShapeStyle } from "./item";
@@ -53,6 +54,13 @@ export interface EdgeShapesEncode extends ShapesEncode {
 }
 export interface EdgeEncode extends EdgeShapesEncode {
   type?: string | Encode<string>;
+}
+
+export interface EdgeShapeMap {
+  keyShape: DisplayObject,
+  labelShape?: DisplayObject,
+  iconShape?: DisplayObject,
+  [otherShapeId: string]: DisplayObject
 }
 
 // TODO

--- a/packages/g6/src/types/graph.ts
+++ b/packages/g6/src/types/graph.ts
@@ -6,10 +6,10 @@ import { AnimateCfg } from './animate';
 import { BehaviorObjectOptionsOf, BehaviorOptionsOf, BehaviorRegistry } from './behavior';
 import { ComboModel, ComboUserModel } from './combo';
 import { Padding, Point } from './common';
-import { DataChangeType, GraphData } from './data';
+import { GraphData } from './data';
 import { EdgeModel, EdgeUserModel } from './edge';
 import { ITEM_TYPE } from './item';
-import { LayoutCommonConfig } from './layout';
+import { LayoutOptions } from './layout';
 import { NodeModel, NodeUserModel } from './node';
 import { Specification } from './spec';
 import { FitViewRules, GraphAlignment } from './view';
@@ -91,7 +91,7 @@ export interface IGraph<B extends BehaviorRegistry = BehaviorRegistry> extends E
    * @returns
    * @group Data
    */
-  changeData: (data: GraphData, type: 'replace' | 'mergeReplace') => void;
+  changeData: (data: GraphData, type?: 'replace' | 'mergeReplace') => void;
   /**
    * Clear the graph, means remove all the items on the graph.
    * @returns
@@ -283,12 +283,8 @@ export interface IGraph<B extends BehaviorRegistry = BehaviorRegistry> extends E
    * @param {boolean} stack push it into stack
    * @group Layout
    */
-  layout: (
-    cfg?: LayoutCommonConfig,
-    align?: GraphAlignment,
-    canvasPoint?: Point,
-    stack?: boolean,
-  ) => void;
+  layout: (options?: LayoutOptions) => Promise<void>;
+  stopLayout: () => void;
 
   // ===== interaction =====
   /**

--- a/packages/g6/src/types/graph.ts
+++ b/packages/g6/src/types/graph.ts
@@ -15,10 +15,17 @@ import { Specification } from './spec';
 import { FitViewRules, GraphAlignment } from './view';
 
 export interface IGraph<B extends BehaviorRegistry = BehaviorRegistry> extends EventEmitter {
-
   hooks: Hooks;
   canvas: Canvas;
+  destroyed: boolean;
 
+  // ===== graph instance ===
+  /**
+   * Destroy the graph instance and remove the related canvases.
+   * @returns
+   * @group Graph Instance
+   */
+  destroy: () => void;
   /**
    * Update the specs(configurations).
    */
@@ -72,8 +79,8 @@ export interface IGraph<B extends BehaviorRegistry = BehaviorRegistry> extends E
   /**
    * Input data and render the graph.
    * If there is old data, diffs and changes it.
-   * @param data 
-   * @returns 
+   * @param data
+   * @returns
    * @group Data
    */
   read: (data: GraphData) => void;
@@ -81,13 +88,13 @@ export interface IGraph<B extends BehaviorRegistry = BehaviorRegistry> extends E
    * Change graph data.
    * @param data new data
    * @param type the way to change data, 'replace' means discard the old data and use the new one; 'mergeReplace' means merge the common part, remove (old - new), add (new - old)
-   * @returns 
+   * @returns
    * @group Data
    */
   changeData: (data: GraphData, type: 'replace' | 'mergeReplace') => void;
   /**
    * Clear the graph, means remove all the items on the graph.
-   * @returns 
+   * @returns
    */
   clear: () => void;
   /**
@@ -98,7 +105,11 @@ export interface IGraph<B extends BehaviorRegistry = BehaviorRegistry> extends E
    * @returns items that is the type and has the state
    * @group Item
    */
-  findIdByState: (itemType: ITEM_TYPE, state: string, additionalFilter?: (model: NodeModel | EdgeModel | ComboModel) => boolean) => ID[];
+  findIdByState: (
+    itemType: ITEM_TYPE,
+    state: string,
+    additionalFilter?: (model: NodeModel | EdgeModel | ComboModel) => boolean,
+  ) => ID[];
   /**
    * Add one or more node/edge/combo data to the graph.
    * @param itemType item type
@@ -107,7 +118,17 @@ export interface IGraph<B extends BehaviorRegistry = BehaviorRegistry> extends E
    * @returns whehter success
    * @group Data
    */
-  addData: (itemType: ITEM_TYPE, model: NodeUserModel | EdgeUserModel | ComboUserModel | NodeUserModel[] | EdgeUserModel[] | ComboUserModel[], stack?: boolean) => NodeModel | EdgeModel | ComboModel | NodeModel[] | EdgeModel[] | ComboModel[];
+  addData: (
+    itemType: ITEM_TYPE,
+    model:
+      | NodeUserModel
+      | EdgeUserModel
+      | ComboUserModel
+      | NodeUserModel[]
+      | EdgeUserModel[]
+      | ComboUserModel[],
+    stack?: boolean,
+  ) => NodeModel | EdgeModel | ComboModel | NodeModel[] | EdgeModel[] | ComboModel[];
   /**
    * Remove one or more node/edge/combo data from the graph.
    * @param item the item to be removed
@@ -123,9 +144,19 @@ export interface IGraph<B extends BehaviorRegistry = BehaviorRegistry> extends E
    * @param {boolean} stack whether push this operation to stack
    * @group Data
    */
-  updateData: (itemType: ITEM_TYPE, model: Partial<NodeUserModel> | Partial<EdgeUserModel> | Partial<ComboUserModel | Partial<NodeUserModel>[] | Partial<EdgeUserModel>[] | Partial<ComboUserModel>[]>, stack?: boolean) => NodeModel | EdgeModel | ComboModel | NodeModel[] | EdgeModel[] | ComboModel[];
-
-
+  updateData: (
+    itemType: ITEM_TYPE,
+    model:
+      | Partial<NodeUserModel>
+      | Partial<EdgeUserModel>
+      | Partial<
+          | ComboUserModel
+          | Partial<NodeUserModel>[]
+          | Partial<EdgeUserModel>[]
+          | Partial<ComboUserModel>[]
+        >,
+    stack?: boolean,
+  ) => NodeModel | EdgeModel | ComboModel | NodeModel[] | EdgeModel[] | ComboModel[];
 
   // ===== view operations =====
 
@@ -134,7 +165,7 @@ export interface IGraph<B extends BehaviorRegistry = BehaviorRegistry> extends E
    * @param dx x of the relative vector
    * @param dy y of the relative vector
    * @param animateCfg animation configurations
-   * @returns 
+   * @returns
    * @group View
    */
   move: (dx: number, dy: number, animateCfg?: AnimateCfg) => void;
@@ -144,7 +175,7 @@ export interface IGraph<B extends BehaviorRegistry = BehaviorRegistry> extends E
    * @param y position on the canvas to align
    * @param alignment alignment of the graph content
    * @param animateCfg animation configurations
-   * @returns 
+   * @returns
    * @group View
    */
   moveTo: (x: number, y: number, alignment: GraphAlignment, animateCfg?: AnimateCfg) => void;
@@ -153,7 +184,7 @@ export interface IGraph<B extends BehaviorRegistry = BehaviorRegistry> extends E
    * @param ratio relative ratio to zoom
    * @param center zoom center
    * @param animateCfg animation configurations
-   * @returns 
+   * @returns
    * @group View
    */
   zoom: (ratio: number, center?: Point, animateCfg?: AnimateCfg) => void;
@@ -162,7 +193,7 @@ export interface IGraph<B extends BehaviorRegistry = BehaviorRegistry> extends E
    * @param toRatio specified ratio
    * @param center zoom center
    * @param animateCfg animation configurations
-   * @returns 
+   * @returns
    * @group View
    */
   zoomTo: (toRatio: number, center?: Point, animateCfg?: AnimateCfg) => void;
@@ -171,14 +202,14 @@ export interface IGraph<B extends BehaviorRegistry = BehaviorRegistry> extends E
    * @param padding padding while fitting
    * @param rules rules for fitting
    * @param animateCfg animation configurations
-   * @returns 
+   * @returns
    * @group View
    */
   fitView: (padding?: Padding, rules?: FitViewRules, animateCfg?: AnimateCfg) => void;
   /**
    * Fit the graph center to the view center.
    * @param animateCfg animation configurations
-   * @returns 
+   * @returns
    * @group View
    */
   fitCenter: (animateCfg?: AnimateCfg) => void;
@@ -186,24 +217,23 @@ export interface IGraph<B extends BehaviorRegistry = BehaviorRegistry> extends E
    * Move the graph to make the item align the view center.
    * @param item node/edge/combo item or its id
    * @param animateCfg animation configurations
-   * @returns 
+   * @returns
    * @group View
    */
   focusItem: (ids: ID | ID[], animateCfg?: AnimateCfg) => void;
-
 
   // ===== item operations =====
   /**
    * Show the item(s).
    * @param ids the item id(s) to be shown
-   * @returns 
+   * @returns
    * @group Data
    */
   showItem: (ids: ID | ID[]) => void;
   /**
    * Hide the item(s).
    * @param ids the item id(s) to be hidden
-   * @returns 
+   * @returns
    * @group Item
    */
   hideItem: (ids: ID | ID[]) => void;
@@ -212,19 +242,18 @@ export interface IGraph<B extends BehaviorRegistry = BehaviorRegistry> extends E
    * @param ids the id(s) for the item(s) to be set
    * @param state the state name
    * @param value state value
-   * @returns 
+   * @returns
    * @group Item
    */
   setItemState: (ids: ID | ID[], state: string, value: boolean) => void;
 
-
   // ===== combo operations =====
   /**
-  * Create a new combo with existing child nodes and combos.
-  * @param combo combo ID or Combo model
-  * @param childrenIds id array of children of the new combo
-  * @group Combo
-  */
+   * Create a new combo with existing child nodes and combos.
+   * @param combo combo ID or Combo model
+   * @param childrenIds id array of children of the new combo
+   * @group Combo
+   */
   createCombo: (combo: string | ComboUserModel, childrenIds: string[], stack?: boolean) => void;
   /**
    * dissolve combo
@@ -232,19 +261,18 @@ export interface IGraph<B extends BehaviorRegistry = BehaviorRegistry> extends E
    */
   uncombo: (comboId: ID, stack?: boolean) => void;
   /**
-  * Collapse a combo.
-  * @param comboId combo id or item
-  * @group Combo
-  */
+   * Collapse a combo.
+   * @param comboId combo id or item
+   * @group Combo
+   */
   collapseCombo: (comboId: ID, stack?: boolean) => void;
   /**
- * Expand a combo.
- * @group Combo
- * @param combo combo ID 或 combo 实例
- * @group Combo
- */
+   * Expand a combo.
+   * @group Combo
+   * @param combo combo ID 或 combo 实例
+   * @group Combo
+   */
   expandCombo: (comboId: ID, stack?: boolean) => void;
-
 
   // ===== layout =====
   /**
@@ -255,14 +283,18 @@ export interface IGraph<B extends BehaviorRegistry = BehaviorRegistry> extends E
    * @param {boolean} stack push it into stack
    * @group Layout
    */
-  layout: (cfg?: LayoutCommonConfig, align?: GraphAlignment, canvasPoint?: Point, stack?: boolean) => void;
-
+  layout: (
+    cfg?: LayoutCommonConfig,
+    align?: GraphAlignment,
+    canvasPoint?: Point,
+    stack?: boolean,
+  ) => void;
 
   // ===== interaction =====
   /**
    * Switch mode.
    * @param mode mode name
-   * @returns 
+   * @returns
    * @group Interaction
    */
   setMode: (mode: string) => void;
@@ -270,14 +302,14 @@ export interface IGraph<B extends BehaviorRegistry = BehaviorRegistry> extends E
    * Add behavior(s) to mode(s).
    * @param behaviors behavior names or configs
    * @param modes mode names
-   * @returns 
+   * @returns
    */
   addBehaviors: (behaviors: BehaviorOptionsOf<B>[], modes: string | string[]) => void;
   /**
    * Remove behavior(s) from mode(s).
    * @param behaviors behavior names or configs
    * @param modes mode names
-   * @returns 
+   * @returns
    * @group Interaction
    */
   removeBehaviors: (behaviorKeys: string[], modes: string | string[]) => void;
@@ -285,7 +317,7 @@ export interface IGraph<B extends BehaviorRegistry = BehaviorRegistry> extends E
    * Update a behavior on a mode.
    * @param behavior behavior configs, whose name indicates the behavior to be updated
    * @param mode mode name
-   * @returns 
+   * @returns
    * @group Interaction
    */
   updateBehavior: (behavior: BehaviorObjectOptionsOf<B>, mode?: string) => void;

--- a/packages/g6/src/types/hook.ts
+++ b/packages/g6/src/types/hook.ts
@@ -1,8 +1,9 @@
-import { DataChangeType, GraphCore, GraphData } from "./data";
-import { NodeModel, NodeModelData, NodeUserModel } from "./node";
-import { EdgeModel, EdgeModelData, EdgeUserModel } from "./edge";
-import { ITEM_TYPE } from "./item";
-import { GraphChange } from "@antv/graphlib";
+import { GraphChange } from '@antv/graphlib';
+import { DataChangeType, GraphCore, GraphData } from './data';
+import { EdgeModelData } from './edge';
+import { ITEM_TYPE } from './item';
+import { LayoutOptions } from './layout';
+import { NodeModelData } from './node';
 
 export interface IHook<T> {
   name: string;
@@ -10,31 +11,32 @@ export interface IHook<T> {
   tap: (listener: (param: T) => void) => void;
   unTap: (listener: (param: T) => void) => void;
   emit: (param: T) => void;
+  emitLinearAsync: (param: T) => Promise<void>;
 }
 
 export interface Hooks {
-  'init': IHook<void>;
+  init: IHook<void>;
   // data
-  'datachange': IHook<{
+  datachange: IHook<{
     type: DataChangeType;
-    data: GraphData
+    data: GraphData;
   }>;
-  'itemchange': IHook<{
+  itemchange: IHook<{
     type: ITEM_TYPE;
     changes: GraphChange<NodeModelData, EdgeModelData>[];
     graphCore: GraphCore;
   }>;
-  'render': IHook<{ graphCore: GraphCore }>; // TODO: define param template
-  // 'layout': IHook<any>; // TODO: define param template
+  render: IHook<{ graphCore: GraphCore }>; // TODO: define param template
+  layout: IHook<{ graphCore: GraphCore; options?: LayoutOptions }>; // TODO: define param template
   // 'updatelayout': IHook<any>; // TODO: define param template
-  'modechange': IHook<{ mode: string }>;
-  'behaviorchange': IHook<{
+  modechange: IHook<{ mode: string }>;
+  behaviorchange: IHook<{
     action: 'update' | 'add' | 'remove';
     modes: string[];
-    behaviors: (string | { type: string, key: string })[];
+    behaviors: (string | { type: string; key: string })[];
   }>;
   // 'viewportchange': IHook<any>; // TODO: define param template
   // 'itemstatechange': IHook<any>; // TODO: define param template
   // 'destroy': IHook<any>; // TODO: define param template
   // TODO: more timecycles here
-};
+}

--- a/packages/g6/src/types/item.ts
+++ b/packages/g6/src/types/item.ts
@@ -13,6 +13,11 @@ import { NodeDisplayModel, NodeEncode, NodeModel, NodeModelData, NodeUserModel }
 export interface ShapeStyle {
   [shapeAttr: string]: unknown;
   animate?: AnimateAttr;
+  x?: number;
+  y?: number;
+  width?: number;
+  height?: number;
+  r?: number;
 }
 
 export interface Encode<T> {

--- a/packages/g6/src/types/item.ts
+++ b/packages/g6/src/types/item.ts
@@ -1,4 +1,4 @@
-import { Group } from "@antv/g";
+import { DisplayObject, Group } from "@antv/g";
 import { ID } from "@antv/graphlib";
 import { AnimateAttr } from "./animate";
 import { ComboDisplayModel, ComboEncode, ComboModel, ComboModelData, ComboUserModel } from "./combo";

--- a/packages/g6/src/types/item.ts
+++ b/packages/g6/src/types/item.ts
@@ -1,9 +1,14 @@
-import { DisplayObject, Group } from "@antv/g";
-import { ID } from "@antv/graphlib";
-import { AnimateAttr } from "./animate";
-import { ComboDisplayModel, ComboEncode, ComboModel, ComboModelData, ComboUserModel } from "./combo";
-import { EdgeDisplayModel, EdgeEncode, EdgeModel, EdgeModelData, EdgeUserModel } from "./edge";
-import { NodeDisplayModel, NodeEncode, NodeModel, NodeModelData, NodeUserModel } from "./node";
+import { ID } from '@antv/graphlib';
+import { AnimateAttr } from './animate';
+import {
+  ComboDisplayModel,
+  ComboEncode,
+  ComboModel,
+  ComboModelData,
+  ComboUserModel,
+} from './combo';
+import { EdgeDisplayModel, EdgeEncode, EdgeModel, EdgeModelData, EdgeUserModel } from './edge';
+import { NodeDisplayModel, NodeEncode, NodeModel, NodeModelData, NodeUserModel } from './node';
 
 export interface ShapeStyle {
   [shapeAttr: string]: unknown;
@@ -11,14 +16,14 @@ export interface ShapeStyle {
 }
 
 export interface Encode<T> {
-  fields: string[],
+  fields: string[];
   formatter: (values: NodeUserModel | EdgeUserModel | ComboUserModel) => T;
 }
 
 export interface ShapeAttrEncode {
   [shapeAttr: string]: unknown | Encode<unknown>;
   animate: AnimateAttr | Encode<AnimateAttr>;
-};
+}
 
 export interface LabelBackground {
   fill?: string;
@@ -26,7 +31,7 @@ export interface LabelBackground {
   lineWidth?: number;
   radius?: number[] | number;
   padding?: number[] | number;
-};
+}
 
 export interface ShapesEncode {
   keyShape?: ShapeAttrEncode;
@@ -35,7 +40,7 @@ export interface ShapesEncode {
     [shapeId: string]: {
       [shapeAtrr: string]: unknown | Encode<unknown>;
       animate: AnimateAttr | Encode<AnimateAttr>;
-    }
+    };
   };
 }
 
@@ -47,7 +52,11 @@ export type ItemModel = NodeModel | EdgeModel | ComboModel;
 
 export type ItemDisplayModel = NodeDisplayModel | EdgeDisplayModel | ComboDisplayModel;
 
-export type DisplayMapper = ((model: ItemModel) => ItemDisplayModel) | NodeEncode | EdgeEncode | ComboEncode;
+export type DisplayMapper =
+  | ((model: ItemModel) => ItemDisplayModel)
+  | NodeEncode
+  | EdgeEncode
+  | ComboEncode;
 
 /**
  * Base item of node / edge / combo.
@@ -79,12 +88,19 @@ export interface IItem {
    * Draws the shapes.
    * @internal
    * */
-  draw: (diffData?: { oldData: ItemModelData, newData: ItemModelData }, shapesToChange?: { [shapeId: string]: boolean }) => void;
+  draw: (
+    diffData?: { oldData: ItemModelData; newData: ItemModelData },
+    shapesToChange?: { [shapeId: string]: boolean },
+  ) => void;
   /**
    * Updates the shapes.
    * @internal
    * */
-  update: (model: ItemModel, diffData: { oldData: ItemModelData, newData: ItemModelData }, dataChangedFields?: string[]) => void;
+  update: (
+    model: ItemModel,
+    diffData: { oldData: ItemModelData; newData: ItemModelData },
+    isUpdate?: boolean,
+  ) => void;
   /** Puts the item to the front in its graphic group. */
   toFront: () => void;
   /** Puts the item to the back in its graphic group. */
@@ -98,11 +114,11 @@ export interface IItem {
   /** Sets a state value to the item. */
   setState: (state: string, value: string | boolean) => void;
   /** Returns the state if it is true/string. Returns false otherwise. */
-  hasState: (state: string) => { name: string, value: boolean | string } | false;
+  hasState: (state: string) => { name: string; value: boolean | string } | false;
   /** Get all the true or string states of the item. */
   getStates: () => {
-    name: string,
-    value: boolean | string
+    name: string;
+    value: boolean | string;
   }[];
   /** Set all the state to false. */
   clearStates: (states?: string[]) => void;

--- a/packages/g6/src/types/layout.ts
+++ b/packages/g6/src/types/layout.ts
@@ -24,6 +24,8 @@ export type LayoutOptions = (
   | ForceAtlas2
 ) & {
   workerEnabled?: boolean;
+  animated?: boolean;
+  iterations?: number;
 };
 
 interface CircularLayout extends CircularLayoutOptions {

--- a/packages/g6/src/types/layout.ts
+++ b/packages/g6/src/types/layout.ts
@@ -1,9 +1,67 @@
+import {
+  CircularLayoutOptions,
+  ConcentricLayoutOptions,
+  D3ForceLayoutOptions,
+  ForceAtlas2LayoutOptions,
+  ForceLayoutOptions,
+  FruchtermanLayoutOptions,
+  GridLayoutOptions,
+  MDSLayoutOptions,
+  RadialLayoutOptions,
+  RandomLayoutOptions,
+} from '@antv/layout';
 
-
-export interface LayoutCommonConfig {
-  type?: string;
-  gpuEnabled?: boolean;
+export type LayoutOptions = (
+  | CircularLayout
+  | RandomLayout
+  | ConcentricLayout
+  | GridLayout
+  | MDSLayout
+  | RadialLayout
+  | FruchtermanLayout
+  | D3ForceLayout
+  | ForceLayout
+  | ForceAtlas2
+) & {
   workerEnabled?: boolean;
-  // Works when workerEnabled is true, config it with a visitable url to avoid visiting online version.
-  workerScriptURL?: string;
+};
+
+interface CircularLayout extends CircularLayoutOptions {
+  type: 'circular';
+}
+
+interface RandomLayout extends RandomLayoutOptions {
+  type: 'random';
+}
+
+interface GridLayout extends GridLayoutOptions {
+  type: 'grid';
+}
+
+interface MDSLayout extends MDSLayoutOptions {
+  type: 'mds';
+}
+
+interface ConcentricLayout extends ConcentricLayoutOptions {
+  type: 'concentric';
+}
+
+interface RadialLayout extends RadialLayoutOptions {
+  type: 'radial';
+}
+
+interface FruchtermanLayout extends FruchtermanLayoutOptions {
+  type: 'fruchterman' | 'fruchtermanGPU';
+}
+
+interface D3ForceLayout extends D3ForceLayoutOptions {
+  type: 'd3force';
+}
+
+interface ForceLayout extends ForceLayoutOptions {
+  type: 'force' | 'gforce';
+}
+
+interface ForceAtlas2 extends ForceAtlas2LayoutOptions {
+  type: 'forceAtlas2';
 }

--- a/packages/g6/src/types/node.ts
+++ b/packages/g6/src/types/node.ts
@@ -1,7 +1,7 @@
 import { DisplayObject } from '@antv/g';
 import { Node as GNode, PlainObject } from '@antv/graphlib';
-import { AnimateAttr } from "./animate";
-import { Encode, IItem, LabelBackground, ShapeAttrEncode, ShapesEncode, ShapeStyle } from "./item";
+import { AnimateAttr } from './animate';
+import { Encode, IItem, LabelBackground, ShapeAttrEncode, ShapesEncode, ShapeStyle } from './item';
 
 export type NodeLabelPosition = 'bottom' | 'center' | 'top' | 'left' | 'right';
 
@@ -23,7 +23,6 @@ export interface NodeLabelShapeStyle extends ShapeStyle {
   background?: LabelBackground;
 }
 
-
 /** Data in display model. */
 export interface NodeDisplayModelData extends NodeModelData {
   keyShape?: ShapeStyle;
@@ -32,7 +31,7 @@ export interface NodeDisplayModelData extends NodeModelData {
   otherShapes?: {
     [shapeId: string]: ShapeStyle;
   };
-  anchorPoints?: AnchorPoint[]
+  anchorPoints?: AnchorPoint[];
 }
 
 /** User input model. */
@@ -52,7 +51,8 @@ export interface AnchorPoint {
   animate: AnimateAttr;
 }
 
-interface NodeLabelShapeAttrEncode extends ShapeAttrEncode { // TODO: extends Text shape attr, import from G
+interface NodeLabelShapeAttrEncode extends ShapeAttrEncode {
+  // TODO: extends Text shape attr, import from G
   position?: NodeLabelPosition | Encode<NodeLabelPosition>;
   offsetX?: number | Encode<number>;
   offsetY?: number | Encode<number>;
@@ -60,20 +60,18 @@ interface NodeLabelShapeAttrEncode extends ShapeAttrEncode { // TODO: extends Te
 }
 export interface NodeShapesEncode extends ShapesEncode {
   labelShape?: NodeLabelShapeAttrEncode;
-  anchorPoints?: AnchorPoint[] | Encode<AnchorPoint[]>
+  anchorPoints?: AnchorPoint[] | Encode<AnchorPoint[]>;
 }
 export interface NodeEncode extends NodeShapesEncode {
   type?: string | Encode<string>;
 }
 
 export interface NodeShapeMap {
-  keyShape: DisplayObject,
-  labelShape?: DisplayObject,
-  iconShape?: DisplayObject,
-  [otherShapeId: string]: DisplayObject
+  keyShape: DisplayObject;
+  labelShape?: DisplayObject;
+  iconShape?: DisplayObject;
+  [otherShapeId: string]: DisplayObject;
 }
 
 // TODO
-export interface INode extends IItem {
-
-}
+export interface INode extends IItem {}

--- a/packages/g6/src/types/node.ts
+++ b/packages/g6/src/types/node.ts
@@ -1,3 +1,4 @@
+import { DisplayObject } from '@antv/g';
 import { Node as GNode, PlainObject } from '@antv/graphlib';
 import { AnimateAttr } from "./animate";
 import { Encode, IItem, LabelBackground, ShapeAttrEncode, ShapesEncode, ShapeStyle } from "./item";
@@ -63,6 +64,13 @@ export interface NodeShapesEncode extends ShapesEncode {
 }
 export interface NodeEncode extends NodeShapesEncode {
   type?: string | Encode<string>;
+}
+
+export interface NodeShapeMap {
+  keyShape: DisplayObject,
+  labelShape?: DisplayObject,
+  iconShape?: DisplayObject,
+  [otherShapeId: string]: DisplayObject
 }
 
 // TODO

--- a/packages/g6/src/types/spec.ts
+++ b/packages/g6/src/types/spec.ts
@@ -59,7 +59,7 @@ export interface Specification<B extends BehaviorRegistry> {
   };
 
   /** layout */
-  layout?: LayoutOptions;
+  layout?: LayoutOptions | LayoutOptions[];
 
   /** interaction */
   modes?: {

--- a/packages/g6/src/types/spec.ts
+++ b/packages/g6/src/types/spec.ts
@@ -1,12 +1,12 @@
-import { AnimateCfg } from "./animate";
-import { Point } from "./common";
-import { FetchDataConfig, GraphData, InlineDataConfig, TransformerFn } from "./data";
-import { EdgeDisplayModel, EdgeEncode, EdgeModel, EdgeShapesEncode } from "./edge";
-import { NodeDisplayModel, NodeEncode, NodeModel, NodeShapesEncode } from "./node";
-import { GraphAlignment } from "./view";
-import { LayoutCommonConfig } from "./layout";
-import { ComboDisplayModel, ComboEncode, ComboModel, ComboShapesEncode } from "./combo";
-import { BehaviorOptionsOf, BehaviorRegistry } from "./behavior";
+import { AnimateCfg } from './animate';
+import { BehaviorOptionsOf, BehaviorRegistry } from './behavior';
+import { ComboDisplayModel, ComboEncode, ComboModel, ComboShapesEncode } from './combo';
+import { Point } from './common';
+import { FetchDataConfig, GraphData, InlineDataConfig, TransformerFn } from './data';
+import { EdgeDisplayModel, EdgeEncode, EdgeModel, EdgeShapesEncode } from './edge';
+import { LayoutOptions } from './layout';
+import { NodeDisplayModel, NodeEncode, NodeModel, NodeShapesEncode } from './node';
+import { GraphAlignment } from './view';
 
 type rendererName = 'canvas' | 'svg' | 'webgl';
 
@@ -15,24 +15,32 @@ export interface Specification<B extends BehaviorRegistry> {
   container: string | HTMLElement;
   width?: number;
   height?: number;
-  renderer?: rendererName | {
-    type: rendererName,
-    pixelRatio: number,
-    headless: boolean,
-  };
+  renderer?:
+    | rendererName
+    | {
+        type: rendererName;
+        pixelRatio: number;
+        headless: boolean;
+      };
   zoom?: number;
-  autoFit?: 'view' | 'center' | {
-    position: Point,
-    alignment: GraphAlignment
-  };
+  autoFit?:
+    | 'view'
+    | 'center'
+    | {
+        position: Point;
+        alignment: GraphAlignment;
+      };
   optimizeThreshold?: number;
 
   /** data */
   data: GraphData | InlineDataConfig | FetchDataConfig; // TODO: more
-  transform?: string[] | {
-    type: string,
-    [param: string]: unknown // TODO: generate by plugins
-  }[] | TransformerFn[];
+  transform?:
+    | string[]
+    | {
+        type: string;
+        [param: string]: unknown; // TODO: generate by plugins
+      }[]
+    | TransformerFn[];
 
   /** item */
   node?: ((data: NodeModel) => NodeDisplayModel) | NodeEncode;
@@ -51,7 +59,7 @@ export interface Specification<B extends BehaviorRegistry> {
   };
 
   /** layout */
-  layout?: LayoutCommonConfig | LayoutCommonConfig[]; // TODO: Config comes from @antv/layout
+  layout?: LayoutOptions;
 
   /** interaction */
   modes?: {
@@ -65,7 +73,7 @@ export interface Specification<B extends BehaviorRegistry> {
 
   /** free plugins */
   plugins?: {
-    name: string,
+    name: string;
     options: any; // TODO: configs from plugins
-  }[]
+  }[];
 }

--- a/packages/g6/src/util/canvas.ts
+++ b/packages/g6/src/util/canvas.ts
@@ -1,18 +1,18 @@
 import { Canvas } from '@antv/g';
 import { Renderer as CanvasRenderer } from '@antv/g-canvas';
 import { Renderer as SVGRenderer } from '@antv/g-svg';
-// import { Renderer as WebGLRenderer } from '@antv/g-webgl';
+import { Renderer as WebGLRenderer } from '@antv/g-webgl';
 import { isString } from '@antv/util';
 
 /**
  * Create a canvas
- * @param { 'canvas' | 'svg' | 'webgl' } rendererType 
- * @param {string | HTMLElement} container 
+ * @param { 'canvas' | 'svg' | 'webgl' } rendererType
+ * @param {string | HTMLElement} container
  * @param {number} width
  * @param {number} height
  * @param {number} pixelRatio optional
  * @param {boolean} customCanvasTag whether create a <canvas /> for multiple canvas under the container
- * @returns 
+ * @returns
  */
 export const createCanvas = (
   rendererType: 'canvas' | 'svg' | 'webgl',
@@ -20,7 +20,7 @@ export const createCanvas = (
   width: number,
   height: number,
   pixelRatio?: number,
-  customCanvasTag: boolean = true
+  customCanvasTag: boolean = true,
 ) => {
   let Renderer;
   switch (rendererType.toLowerCase()) {
@@ -28,8 +28,7 @@ export const createCanvas = (
       Renderer = SVGRenderer;
       break;
     case 'webgl':
-      // Renderer = WebGLRenderer;
-      // TODO
+      Renderer = WebGLRenderer;
       break;
     default:
       Renderer = CanvasRenderer;
@@ -56,6 +55,6 @@ export const createCanvas = (
     width,
     height,
     devicePixelRatio: pixelRatio,
-    renderer: new Renderer()
+    renderer: new Renderer(),
   });
-}
+};

--- a/packages/g6/src/util/extend.ts
+++ b/packages/g6/src/util/extend.ts
@@ -1,6 +1,6 @@
 import { BehaviorRegistry } from '../types/behavior';
 import Graph from '../runtime/graph';
-import registery from '../stdlib';
+import registry from '../stdlib';
 
 /**
  * Extend graph class with custom libs (extendLibrary), and extendLibrary will be merged into useLib.
@@ -20,9 +20,9 @@ export const extend = <B1 extends BehaviorRegistry, B2 extends BehaviorRegistry>
 ): typeof Graph<B1 & B2> => {
   // merged the extendLibrary to useLib for global usage
   Object.keys(extendLibrary).forEach((cat) => {
-    registery.useLib[cat] = Object.assign({}, registery.useLib[cat], extendLibrary[cat] || {});
-    Object.keys(registery.useLib[cat]).forEach((type) => {
-      const extension = registery.useLib[cat][type];
+    registry.useLib[cat] = Object.assign({}, registry.useLib[cat], extendLibrary[cat] || {});
+    Object.keys(registry.useLib[cat]).forEach((type) => {
+      const extension = registry.useLib[cat][type];
       extension.type = type;
     });
   });

--- a/packages/g6/src/util/extend.ts
+++ b/packages/g6/src/util/extend.ts
@@ -1,4 +1,4 @@
-import { BehaviorRegistry } from "../types/behavior";
+import { BehaviorRegistry } from '../types/behavior';
 import Graph from '../runtime/graph';
 import registery from '../stdlib';
 
@@ -13,13 +13,19 @@ import registery from '../stdlib';
 export const extend = <B1 extends BehaviorRegistry, B2 extends BehaviorRegistry>(
   GraphClass: typeof Graph<B2>,
   extendLibrary: {
-    behaviors?: B1,
-  }
+    behaviors?: B1;
+    nodes?: any; // TODO
+    edges?: any; // TODO
+  },
 ): typeof Graph<B1 & B2> => {
   // merged the extendLibrary to useLib for global usage
-  Object.keys(extendLibrary).forEach(cat => {
+  Object.keys(extendLibrary).forEach((cat) => {
     registery.useLib[cat] = Object.assign({}, registery.useLib[cat], extendLibrary[cat] || {});
+    Object.keys(registery.useLib[cat]).forEach((type) => {
+      const extension = registery.useLib[cat][type];
+      extension.type = type;
+    });
   });
   // @ts-expect-error
   return GraphClass;
-}
+};

--- a/packages/g6/src/util/shape.ts
+++ b/packages/g6/src/util/shape.ts
@@ -1,6 +1,8 @@
 import { Circle, DisplayObject, Element, Ellipse, Group, IElement, Line, Polygon, Polyline, Rect } from "@antv/g";
 import { BaseEdge } from "../stdlib/item/edge/base";
 import { BaseNode } from "../stdlib/item/node/base";
+import { EdgeShapeMap } from "../types/edge";
+import { NodeShapeMap } from "../types/node";
 
 const shapeTagMap = {
   'circle': Circle,
@@ -36,4 +38,51 @@ export const getGroupSucceedMap = (group: IElement, map?: { [id: string]: IEleme
     useMap[child.id] = child;
   });
   return useMap;
+}
+
+/**
+ * Update shapes in the intersaction of prevShapeMap and newShapeMap;
+ * Remove shapes in the prevShapeMap - newShapeMap (if removeDiff is true);
+ * Add shapes in the newShapeMap - prevShapeMap;
+ * @param prevShapeMap previous shape map
+ * @param newShapeMap new shape map
+ * @param group container group
+ * @returns merged shape map
+ */
+export const updateShapes = (
+  prevShapeMap: { [id: string]: DisplayObject },
+  newShapeMap: { [id: string]: DisplayObject },
+  group: Group,
+  removeDiff: boolean = true,
+  shouldUpdate: (id: string) => boolean = () => true
+): (NodeShapeMap | EdgeShapeMap) => {
+  const tolalMap = {
+    ...prevShapeMap,
+    ...newShapeMap
+  };
+  const finalShapeMap = {
+    ...prevShapeMap
+  };
+  Object.keys(tolalMap).forEach(id => {
+    const prevShape = prevShapeMap[id];
+    const newShape = newShapeMap[id];
+    if (newShape && !shouldUpdate(id)) return;
+    if (prevShape && newShape) {
+      // update intersaction
+      finalShapeMap[id] = newShape;
+      if (prevShape !== newShape) {
+        prevShape.remove();
+        group.appendChild(newShape);
+      }
+    } else if (!prevShape && newShape) {
+      // add newShapeMap - prevShapeMap
+      finalShapeMap[id] = newShape;
+      group.appendChild(newShape);
+    } else if (prevShape && !newShape && removeDiff) {
+      // remove prevShapeMap - newShapeMap
+      delete finalShapeMap[id];
+      prevShape.remove();
+    }
+  });
+  return finalShapeMap as NodeShapeMap;
 }

--- a/packages/g6/src/util/shape.ts
+++ b/packages/g6/src/util/shape.ts
@@ -11,6 +11,7 @@ import {
   Text,
   Image,
 } from '@antv/g';
+import { isArray, isNumber } from '@antv/util';
 import { EdgeShapeMap } from '../types/edge';
 import { NodeShapeMap } from '../types/node';
 
@@ -47,6 +48,7 @@ export const upsertShape = (
       shape.style[key] = style[key];
     });
   }
+  shapeMap[id] = shape;
   return shape;
 };
 
@@ -91,8 +93,8 @@ export const updateShapes = (
       finalShapeMap[id] = newShape;
       if (prevShape !== newShape) {
         prevShape.remove();
-        group.appendChild(newShape);
       }
+      group.appendChild(newShape);
     } else if (!prevShape && newShape) {
       // add newShapeMap - prevShapeMap
       finalShapeMap[id] = newShape;
@@ -104,4 +106,39 @@ export const updateShapes = (
     }
   });
   return finalShapeMap as NodeShapeMap;
+};
+
+/**
+ * Format the number or array padding to an array with length 4, [padding-top, padding-right, padding-bottom, padding-left].
+ * @param value value to be formatted
+ * @param defaultArr default value
+ * @returns [padding-top, padding-right, padding-bottom, padding-left]
+ */
+export const formatPadding = (value, defaultArr = [4, 4, 4, 4]) => {
+  if (isArray(value)) {
+    switch (value.length) {
+      case 0:
+        return defaultArr;
+      case 1:
+        return [value[0], value[0], value[0], value[0]];
+      case 2:
+        return value.concat(value);
+      default:
+        return value;
+    }
+  }
+  if (isNumber(value)) return [value, value, value, value];
+  return defaultArr;
+};
+
+export const DEFAULT_LABEL_BG_PADDING = [4, 4, 4, 4];
+export const DEFAULT_TEXT_STYLE = {
+  fontSize: 12,
+  fontFamily: 'sans-serif',
+  fontWeight: 'normal',
+  fontVariant: 'normal',
+  fontStyle: 'normal',
+  textBaseline: 'middle',
+  textAlign: 'center',
+  lineWidth: 0,
 };

--- a/packages/g6/tests/datasets/dataset1.ts
+++ b/packages/g6/tests/datasets/dataset1.ts
@@ -1,0 +1,841 @@
+import { GraphData } from '../../src';
+
+const data: GraphData = {
+  nodes: [
+    {
+      id: 'Argentina',
+      data: {
+        name: 'Argentina',
+      },
+    },
+    {
+      id: 'Australia',
+      data: {
+        name: 'Australia',
+      },
+    },
+    {
+      id: 'Belgium',
+      data: {
+        name: 'Belgium',
+      },
+    },
+    {
+      id: 'Brazil',
+      data: {
+        name: 'Brazil',
+      },
+    },
+    {
+      id: 'Colombia',
+      data: {
+        name: 'Colombia',
+      },
+    },
+    {
+      id: 'Costa Rica',
+      data: {
+        name: 'Costa Rica',
+      },
+    },
+    {
+      id: 'Croatia',
+      data: {
+        name: 'Croatia',
+      },
+    },
+    {
+      id: 'Denmark',
+      data: {
+        name: 'Denmark',
+      },
+    },
+    {
+      id: 'Egypt',
+      data: {
+        name: 'Egypt',
+      },
+    },
+    {
+      id: 'England',
+      data: {
+        name: 'England',
+      },
+    },
+    {
+      id: 'France',
+      data: {
+        name: 'France',
+      },
+    },
+    {
+      id: 'Germany',
+      data: {
+        name: 'Germany',
+      },
+    },
+    {
+      id: 'Iceland',
+      data: {
+        name: 'Iceland',
+      },
+    },
+    {
+      id: 'IR Iran',
+      data: {
+        name: 'IR Iran',
+      },
+    },
+    {
+      id: 'Japan',
+      data: {
+        name: 'Japan',
+      },
+    },
+    {
+      id: 'Korea Republic',
+      data: {
+        name: 'Korea Republic',
+      },
+    },
+    {
+      id: 'Mexico',
+      data: {
+        name: 'Mexico',
+      },
+    },
+    {
+      id: 'Morocco',
+      data: {
+        name: 'Morocco',
+      },
+    },
+    {
+      id: 'Nigeria',
+      data: {
+        name: 'Nigeria',
+      },
+    },
+    {
+      id: 'Panama',
+      data: {
+        name: 'Panama',
+      },
+    },
+    {
+      id: 'Peru',
+      data: {
+        name: 'Peru',
+      },
+    },
+    {
+      id: 'Poland',
+      data: {
+        name: 'Poland',
+      },
+    },
+    {
+      id: 'Portugal',
+      data: {
+        name: 'Portugal',
+      },
+    },
+    {
+      id: 'Russia',
+      data: {
+        name: 'Russia',
+      },
+    },
+    {
+      id: 'Saudi Arabia',
+      data: {
+        name: 'Saudi Arabia',
+      },
+    },
+    {
+      id: 'Senegal',
+      data: {
+        name: 'Senegal',
+      },
+    },
+    {
+      id: 'Serbia',
+      data: {
+        name: 'Serbia',
+      },
+    },
+    {
+      id: 'Spain',
+      data: {
+        name: 'Spain',
+      },
+    },
+    {
+      id: 'Sweden',
+      data: {
+        name: 'Sweden',
+      },
+    },
+    {
+      id: 'Switzerland',
+      data: {
+        name: 'Switzerland',
+      },
+    },
+    {
+      id: 'Tunisia',
+      data: {
+        name: 'Tunisia',
+      },
+    },
+    {
+      id: 'Uruguay',
+      data: {
+        name: 'Uruguay',
+      },
+    },
+  ],
+  edges: [
+    {
+      id: '0',
+      target: 'Russia',
+      source: 'Saudi Arabia',
+      data: {
+        target_score: 5,
+        source_score: 0,
+        directed: true,
+      },
+    },
+    {
+      id: '1',
+      target: 'Uruguay',
+      source: 'Egypt',
+      data: {
+        target_score: 1,
+        source_score: 0,
+        directed: true,
+      },
+    },
+    {
+      id: '2',
+      target: 'Russia',
+      source: 'Egypt',
+      data: {
+        target_score: 3,
+        source_score: 1,
+        directed: true,
+      },
+    },
+    {
+      id: '3',
+      target: 'Uruguay',
+      source: 'Saudi Arabia',
+      data: {
+        target_score: 1,
+        source_score: 0,
+        directed: true,
+      },
+    },
+    {
+      id: '4',
+      target: 'Uruguay',
+      source: 'Russia',
+      data: {
+        target_score: 3,
+        source_score: 0,
+        directed: true,
+      },
+    },
+    {
+      id: '5',
+      target: 'Saudi Arabia',
+      source: 'Egypt',
+      data: {
+        target_score: 2,
+        source_score: 1,
+        directed: true,
+      },
+    },
+    {
+      id: '6',
+      target: 'IR Iran',
+      source: 'Morocco',
+      data: {
+        target_score: 1,
+        source_score: 0,
+        directed: true,
+      },
+    },
+    {
+      id: '7',
+      target: 'Portugal',
+      source: 'Spain',
+      data: {
+        target_score: 3,
+        source_score: 3,
+        directed: false,
+      },
+    },
+    {
+      id: '8',
+      target: 'Portugal',
+      source: 'Morocco',
+      data: {
+        target_score: 1,
+        source_score: 0,
+        directed: true,
+      },
+    },
+    {
+      id: '9',
+      target: 'Spain',
+      source: 'IR Iran',
+      data: {
+        target_score: 1,
+        source_score: 0,
+        directed: true,
+      },
+    },
+    {
+      id: '10',
+      target: 'IR Iran',
+      source: 'Portugal',
+      data: {
+        target_score: 1,
+        source_score: 1,
+        directed: false,
+      },
+    },
+    {
+      id: '11',
+      target: 'Spain',
+      source: 'Morocco',
+      data: {
+        target_score: 2,
+        source_score: 2,
+        directed: false,
+      },
+    },
+    {
+      id: '12',
+      target: 'France',
+      source: 'Australia',
+      data: {
+        target_score: 2,
+        source_score: 1,
+        directed: true,
+      },
+    },
+    {
+      id: '13',
+      target: 'Denmark',
+      source: 'Peru',
+      data: {
+        target_score: 1,
+        source_score: 0,
+        directed: true,
+      },
+    },
+    {
+      id: '14',
+      target: 'Denmark',
+      source: 'Australia',
+      data: {
+        target_score: 1,
+        source_score: 1,
+        directed: false,
+      },
+    },
+    {
+      id: '15',
+      target: 'France',
+      source: 'Peru',
+      data: {
+        target_score: 1,
+        source_score: 0,
+        directed: true,
+      },
+    },
+    {
+      id: '16',
+      target: 'Denmark',
+      source: 'France',
+      data: {
+        target_score: 0,
+        source_score: 0,
+        directed: false,
+      },
+    },
+    {
+      id: '17',
+      target: 'Peru',
+      source: 'Australia',
+      data: {
+        target_score: 2,
+        source_score: 0,
+        directed: true,
+      },
+    },
+    {
+      id: '18',
+      target: 'Argentina',
+      source: 'Iceland',
+      data: {
+        target_score: 1,
+        source_score: 1,
+      },
+    },
+    {
+      id: '19',
+      target: 'Croatia',
+      source: 'Nigeria',
+      data: {
+        target_score: 2,
+        source_score: 0,
+        directed: true,
+      },
+    },
+    {
+      id: '20',
+      target: 'Croatia',
+      source: 'Argentina',
+      data: {
+        target_score: 3,
+        source_score: 0,
+        directed: true,
+      },
+    },
+    {
+      id: '21',
+      target: 'Nigeria',
+      source: 'Iceland',
+      data: {
+        target_score: 2,
+        source_score: 0,
+        directed: true,
+      },
+    },
+    {
+      id: '22',
+      target: 'Argentina',
+      source: 'Nigeria',
+      data: {
+        target_score: 2,
+        source_score: 1,
+        directed: true,
+      },
+    },
+    {
+      id: '23',
+      target: 'Croatia',
+      source: 'Iceland',
+      data: {
+        target_score: 2,
+        source_score: 1,
+        directed: true,
+      },
+    },
+    {
+      id: '24',
+      target: 'Serbia',
+      source: 'Costa Rica',
+      data: {
+        target_score: 1,
+        source_score: 0,
+        directed: true,
+      },
+    },
+    {
+      id: '25',
+      target: 'Brazil',
+      source: 'Switzerland',
+      data: {
+        target_score: 1,
+        source_score: 1,
+        directed: false,
+      },
+    },
+    {
+      id: '26',
+      target: 'Brazil',
+      source: 'Costa Rica',
+      data: {
+        target_score: 2,
+        source_score: 0,
+        directed: true,
+      },
+    },
+    {
+      id: '27',
+      target: 'Switzerland',
+      source: 'Serbia',
+      data: {
+        target_score: 2,
+        source_score: 1,
+        directed: true,
+      },
+    },
+    {
+      id: '28',
+      target: 'Brazil',
+      source: 'Serbia',
+      data: {
+        target_score: 2,
+        source_score: 0,
+        directed: true,
+      },
+    },
+    {
+      id: '29',
+      target: 'Switzerland',
+      source: 'Costa Rica',
+      data: {
+        target_score: 2,
+        source_score: 2,
+        directed: false,
+      },
+    },
+    {
+      id: '30',
+      target: 'Mexico',
+      source: 'Germany',
+      data: {
+        target_score: 1,
+        source_score: 0,
+        directed: true,
+      },
+    },
+    {
+      id: '31',
+      target: 'Sweden',
+      source: 'Korea Republic',
+      data: {
+        target_score: 1,
+        source_score: 0,
+        directed: true,
+      },
+    },
+    {
+      id: '32',
+      target: 'Mexico',
+      source: 'Korea Republic',
+      data: {
+        target_score: 1,
+        source_score: 0,
+        directed: true,
+      },
+    },
+    {
+      id: '33',
+      target: 'Germany',
+      source: 'Sweden',
+      data: {
+        target_score: 2,
+        source_score: 1,
+        directed: true,
+      },
+    },
+    {
+      id: '34',
+      target: 'Korea Republic',
+      source: 'Germany',
+      data: {
+        target_score: 2,
+        source_score: 0,
+        directed: true,
+      },
+    },
+    {
+      id: '35',
+      target: 'Sweden',
+      source: 'Mexico',
+      data: {
+        target_score: 3,
+        source_score: 0,
+        directed: true,
+      },
+    },
+    {
+      id: '36',
+      target: 'Belgium',
+      source: 'Panama',
+      data: {
+        target_score: 3,
+        source_score: 0,
+        directed: true,
+      },
+    },
+    {
+      id: '37',
+      target: 'England',
+      source: 'Tunisia',
+      data: {
+        target_score: 2,
+        source_score: 1,
+        directed: true,
+      },
+    },
+    {
+      id: '38',
+      target: 'Belgium',
+      source: 'Tunisia',
+      data: {
+        target_score: 5,
+        source_score: 2,
+        directed: true,
+      },
+    },
+    {
+      id: '39',
+      target: 'England',
+      source: 'Panama',
+      data: {
+        target_score: 6,
+        source_score: 1,
+        directed: true,
+      },
+    },
+    {
+      id: '40',
+      target: 'Belgium',
+      source: 'England',
+      data: {
+        target_score: 1,
+        source_score: 0,
+        directed: true,
+      },
+    },
+    {
+      id: '41',
+      target: 'Tunisia',
+      source: 'Panama',
+      data: {
+        target_score: 2,
+        source_score: 1,
+        directed: true,
+      },
+    },
+    {
+      id: '42',
+      target: 'Japan',
+      source: 'Colombia',
+      data: {
+        target_score: 2,
+        source_score: 1,
+        directed: true,
+      },
+    },
+    {
+      id: '43',
+      target: 'Senegal',
+      source: 'Poland',
+      data: {
+        target_score: 2,
+        source_score: 1,
+        directed: true,
+      },
+    },
+    {
+      id: '44',
+      target: 'Japan',
+      source: 'Senegal',
+      data: {
+        target_score: 2,
+        source_score: 2,
+        directed: false,
+      },
+    },
+    {
+      id: '45',
+      target: 'Colombia',
+      source: 'Poland',
+      data: {
+        target_score: 3,
+        source_score: 0,
+        directed: true,
+      },
+    },
+    {
+      id: '46',
+      target: 'Poland',
+      source: 'Japan',
+      data: {
+        target_score: 1,
+        source_score: 0,
+        directed: true,
+      },
+    },
+    {
+      id: '47',
+      target: 'Colombia',
+      source: 'Senegal',
+      data: {
+        target_score: 1,
+        source_score: 0,
+        directed: true,
+      },
+    },
+    {
+      id: '48',
+      target: 'Uruguay',
+      source: 'Portugal',
+      data: {
+        target_score: 2,
+        source_score: 1,
+        directed: true,
+      },
+    },
+    {
+      id: '49',
+      target: 'France',
+      source: 'Argentina',
+      data: {
+        target_score: 4,
+        source_score: 3,
+        directed: true,
+      },
+    },
+    {
+      id: '50',
+      target: 'Russia',
+      source: 'Spain',
+      data: {
+        target_score: 5,
+        source_score: 4,
+        directed: true,
+      },
+    },
+    {
+      id: '51',
+      target: 'Croatia',
+      source: 'Denmark',
+      data: {
+        target_score: 4,
+        source_score: 3,
+        directed: true,
+      },
+    },
+    {
+      id: '52',
+      target: 'Brazil',
+      source: 'Mexico',
+      data: {
+        target_score: 2,
+        source_score: 0,
+        directed: true,
+      },
+    },
+    {
+      id: '53',
+      target: 'Belgium',
+      source: 'Japan',
+      data: {
+        target_score: 3,
+        source_score: 2,
+        directed: true,
+      },
+    },
+    {
+      id: '54',
+      target: 'Sweden',
+      source: 'Switzerland',
+      data: {
+        target_score: 1,
+        source_score: 0,
+        directed: true,
+      },
+    },
+    {
+      id: '55',
+      target: 'England',
+      source: 'Colombia',
+      data: {
+        target_score: 4,
+        source_score: 3,
+        directed: true,
+      },
+    },
+    {
+      id: '56',
+      target: 'France',
+      source: 'Uruguay',
+      data: {
+        target_score: 2,
+        source_score: 0,
+        directed: true,
+      },
+    },
+    {
+      id: '57',
+      target: 'Belgium',
+      source: 'Brazil',
+      data: {
+        target_score: 2,
+        source_score: 1,
+        directed: true,
+      },
+    },
+    {
+      id: '58',
+      target: 'Croatia',
+      source: 'Russia',
+      data: {
+        target_score: 6,
+        source_score: 5,
+        directed: true,
+      },
+    },
+    {
+      id: '59',
+      target: 'England',
+      source: 'Sweden',
+      data: {
+        target_score: 2,
+        source_score: 0,
+        directed: true,
+      },
+    },
+    {
+      id: '60',
+      target: 'France',
+      source: 'Belgium',
+      data: {
+        target_score: 1,
+        source_score: 0,
+        directed: true,
+      },
+    },
+    {
+      id: '61',
+      target: 'Croatia',
+      source: 'England',
+      data: {
+        target_score: 2,
+        source_score: 1,
+        directed: true,
+      },
+    },
+    {
+      id: '62',
+      target: 'Belgium',
+      source: 'England',
+      data: {
+        target_score: 2,
+        source_score: 0,
+        directed: true,
+      },
+    },
+    {
+      id: '63',
+      target: 'France',
+      source: 'Croatia',
+      data: {
+        target_score: 4,
+        source_score: 2,
+        directed: true,
+      },
+    },
+  ],
+};
+
+export { data };

--- a/packages/g6/tests/unit/data-spec.ts
+++ b/packages/g6/tests/unit/data-spec.ts
@@ -1,9 +1,6 @@
-import { CanvasEvent } from '@antv/g';
-import G6, { GraphData, IGraph } from '../../src/index'
-import { Graph as GraphLib, ID } from "@antv/graphlib";
+import G6, { GraphData, IGraph } from '../../src/index';
 const container = document.createElement('div');
 document.querySelector('body').appendChild(container);
-
 
 const data: GraphData = {
   nodes: [
@@ -14,20 +11,9 @@ const data: GraphData = {
   ],
   edges: [
     { id: 'edge1', source: 'node1', target: 'node2', data: {} },
-    { id: 'edge2', source: 'node1', target: 'node3', data: {} }
-  ]
-}
-
-xdescribe('graphlib', () => {
-  it('xx', () => {
-    const graphLib = new GraphLib<any, any>({
-      ...data,
-      onChanged: event => {
-        console.log('event', event.changes);
-      }
-    })
-  })
-});
+    { id: 'edge2', source: 'node1', target: 'node3', data: {} },
+  ],
+};
 
 describe('data', () => {
   let graph: IGraph<any>;
@@ -55,7 +41,7 @@ describe('data', () => {
       id: 'node1',
       data: {
         x: 350,
-      }
+      },
     };
     graph.updateData('node', node1UpdateUserData);
     const newNode1UserData = {
@@ -63,9 +49,9 @@ describe('data', () => {
       ...node1UpdateUserData,
       data: {
         ...data.nodes[0].data,
-        ...node1UpdateUserData.data
-      }
-    }
+        ...node1UpdateUserData.data,
+      },
+    };
     const node1InnerData = graph.getNodeData('node1');
     expect(JSON.stringify(newNode1UserData)).toBe(JSON.stringify(node1InnerData));
 
@@ -74,34 +60,41 @@ describe('data', () => {
       id: 'edge2',
       data: {
         keyShape: {
-          lineWidth: 8
-        }
-      }
-    }
+          lineWidth: 8,
+        },
+      },
+    };
     graph.updateData('edge', edge2UpdateUserData);
     const newEdge2UserData = {
       ...data.edges[1],
       ...edge2UpdateUserData,
       data: {
         ...data.edges[1].data,
-        ...edge2UpdateUserData.data
-      }
-    }
+        ...edge2UpdateUserData.data,
+      },
+    };
     const edge2InnerData = graph.getEdgeData('edge2');
     expect(JSON.stringify(newEdge2UserData)).toBe(JSON.stringify(edge2InnerData));
-    expect(graph.itemController.itemMap['edge2'].shapeMap['keyShape'].attributes.lineWidth).toBe(edge2UpdateUserData.data.keyShape.lineWidth);
+    expect(graph.itemController.itemMap['edge2'].shapeMap['keyShape'].attributes.lineWidth).toBe(
+      edge2UpdateUserData.data.keyShape.lineWidth,
+    );
 
     // === update edge source  ===
     const edge1UpdateUserData = {
       id: 'edge1',
-      source: 'node3'
-    }
+      source: 'node3',
+    };
     graph.updateData('edge', edge1UpdateUserData);
     const newSourceData = graph.getNodeData('node3');
-    expect(graph.itemController.itemMap['edge1'].shapeMap['keyShape'].attributes.x1).toBe(newSourceData.data.x);
-    expect(graph.itemController.itemMap['edge1'].shapeMap['keyShape'].attributes.y1).toBe(newSourceData.data.y);
-    expect(graph.itemController.itemMap['edge1'].sourceItem).toBe(graph.itemController.itemMap['node3']);
-
+    expect(graph.itemController.itemMap['edge1'].shapeMap['keyShape'].attributes.x1).toBe(
+      newSourceData.data.x,
+    );
+    expect(graph.itemController.itemMap['edge1'].shapeMap['keyShape'].attributes.y1).toBe(
+      newSourceData.data.y,
+    );
+    expect(graph.itemController.itemMap['edge1'].sourceItem).toBe(
+      graph.itemController.itemMap['node3'],
+    );
 
     // === update edge source, target, and data in the same time  ===
     const edge1UpdateUserData2 = {
@@ -110,19 +103,21 @@ describe('data', () => {
       target: 'node4',
       data: {
         keyShape: {
-          stroke: '#f00'
-        }
-      }
-    }
+          stroke: '#f00',
+        },
+      },
+    };
     graph.updateData('edge', edge1UpdateUserData2);
     const sourceData = graph.getNodeData('node1');
     const targetData = graph.getNodeData('node4');
-    const edgeItem = graph.itemController.itemMap['edge1']
+    const edgeItem = graph.itemController.itemMap['edge1'];
     expect(edgeItem.shapeMap['keyShape'].attributes.x1).toBe(sourceData.data.x);
     expect(edgeItem.shapeMap['keyShape'].attributes.y1).toBe(sourceData.data.y);
     expect(edgeItem.shapeMap['keyShape'].attributes.x2).toBe(targetData.data.x);
     expect(edgeItem.shapeMap['keyShape'].attributes.y2).toBe(targetData.data.y);
-    expect(edgeItem.shapeMap['keyShape'].attributes.stroke).toBe(edge1UpdateUserData2.data.keyShape.stroke);
+    expect(edgeItem.shapeMap['keyShape'].attributes.stroke).toBe(
+      edge1UpdateUserData2.data.keyShape.stroke,
+    );
 
     // === update nodes ===
     graph.updateData('node', [
@@ -130,18 +125,18 @@ describe('data', () => {
         id: 'node1',
         data: {
           keyShape: {
-            fill: '#0f0'
-          }
-        }
+            fill: '#0f0',
+          },
+        },
       },
       {
         id: 'node2',
         data: {
           keyShape: {
             lineWidth: 2,
-            stroke: '#0f0'
-          }
-        }
+            stroke: '#0f0',
+          },
+        },
       },
     ]);
     const node1Item = graph.itemController.itemMap['node1'];
@@ -157,17 +152,18 @@ describe('data', () => {
         source: 'node2',
         data: {
           keyShape: {
-            stroke: '#0f0'
-          }
-        }
-      }, {
+            stroke: '#0f0',
+          },
+        },
+      },
+      {
         id: 'edge2',
         data: {
           keyShape: {
-            lineDash: [5, 5]
-          }
-        }
-      }
+            lineDash: [5, 5],
+          },
+        },
+      },
     ]);
     const edge1Item = graph.itemController.itemMap['edge1'];
     const edge2Item = graph.itemController.itemMap['edge2'];
@@ -181,20 +177,20 @@ describe('data', () => {
       data: {
         x: 300,
         y: 100,
-      }
+      },
     });
     graph.addData('node', {
       id: 'node6',
       data: {
         x: 300,
         y: 200,
-      }
+      },
     });
     graph.addData('edge', {
       id: 'edge3',
       source: 'node5',
       target: 'node6',
-      data: {}
+      data: {},
     });
     expect(graph.dataController.graphCore.getAllNodes().length).toBe(6);
     expect(graph.dataController.graphCore.getAllEdges().length).toBe(3);
@@ -206,20 +202,22 @@ describe('data', () => {
         data: {
           x: 100,
           y: 400,
-        }
-      }, {
+        },
+      },
+      {
         id: 'node8',
         data: {
           x: 200,
           y: 400,
-        }
-      }, {
+        },
+      },
+      {
         id: 'node9',
         data: {
           x: 300,
           y: 400,
-        }
-      }
+        },
+      },
     ]);
     expect(graph.dataController.graphCore.getAllNodes().length).toBe(9);
     graph.addData('edge', [
@@ -227,16 +225,16 @@ describe('data', () => {
         id: 'edge4',
         source: 'node7',
         target: 'node8',
-        data: {}
-      }, {
+        data: {},
+      },
+      {
         id: 'edge5',
         source: 'node8',
         target: 'node9',
-        data: {}
-      }
+        data: {},
+      },
     ]);
     expect(graph.dataController.graphCore.getAllEdges().length).toBe(5);
-
   });
   it('removeData', () => {
     // === remove node ===
@@ -254,4 +252,10 @@ describe('data', () => {
     graph.removeData('edge', 'edge1');
     expect(graph.dataController.graphCore.getAllEdges().length).toBe(1);
   });
+  xit('findNodeData', () => {});
+  xit('findEdgeData', () => {});
+
+  xit('changeData with replace', () => {});
+
+  xit('changeData with mergeReplace', () => {});
 });

--- a/packages/g6/tests/unit/data-spec.ts
+++ b/packages/g6/tests/unit/data-spec.ts
@@ -67,36 +67,113 @@ describe('data', () => {
       }
     }
     const node1InnerData = graph.getNodeData('node1');
-    console.log('node1InnerData', node1InnerData)
     expect(JSON.stringify(newNode1UserData)).toBe(JSON.stringify(node1InnerData));
 
-    // // === update edge ===
-    // const edge2UpdateUserData = {
-    //   id: 'edge2',
-    //   source: 'node2',
-    //   data: {
-    //     keyShape: {
-    //       lineWidth: 2
-    //     }
-    //   }
-    // }
-    // graph.updateData('edge', edge2UpdateUserData);
-    // const newEdge2UserData = {
-    //   ...data.edges[1],
-    //   ...edge2UpdateUserData,
-    //   data: {
-    //     ...data.edges[1].data,
-    //     ...edge2UpdateUserData.data
-    //   }
-    // }
-    // const edge2InnerData = graph.getEdgeData('edge2');
-    // expect(JSON.stringify(newEdge2UserData)).toBe(JSON.stringify(edge2InnerData));
+    // === update edge data ===
+    const edge2UpdateUserData = {
+      id: 'edge2',
+      data: {
+        keyShape: {
+          lineWidth: 8
+        }
+      }
+    }
+    graph.updateData('edge', edge2UpdateUserData);
+    const newEdge2UserData = {
+      ...data.edges[1],
+      ...edge2UpdateUserData,
+      data: {
+        ...data.edges[1].data,
+        ...edge2UpdateUserData.data
+      }
+    }
+    const edge2InnerData = graph.getEdgeData('edge2');
+    expect(JSON.stringify(newEdge2UserData)).toBe(JSON.stringify(edge2InnerData));
+    expect(graph.itemController.itemMap['edge2'].shapeMap['keyShape'].attributes.lineWidth).toBe(edge2UpdateUserData.data.keyShape.lineWidth);
 
-    // // === update nodes ===
-    // graph.updateData('node', [
+    // === update edge source  ===
+    const edge1UpdateUserData = {
+      id: 'edge1',
+      source: 'node3'
+    }
+    graph.updateData('edge', edge1UpdateUserData);
+    const newSourceData = graph.getNodeData('node3');
+    expect(graph.itemController.itemMap['edge1'].shapeMap['keyShape'].attributes.x1).toBe(newSourceData.data.x);
+    expect(graph.itemController.itemMap['edge1'].shapeMap['keyShape'].attributes.y1).toBe(newSourceData.data.y);
+    expect(graph.itemController.itemMap['edge1'].sourceItem).toBe(graph.itemController.itemMap['node3']);
 
-    // ])
 
+    // === update edge source, target, and data in the same time  ===
+    const edge1UpdateUserData2 = {
+      id: 'edge1',
+      source: 'node1',
+      target: 'node4',
+      data: {
+        keyShape: {
+          stroke: '#f00'
+        }
+      }
+    }
+    graph.updateData('edge', edge1UpdateUserData2);
+    const sourceData = graph.getNodeData('node1');
+    const targetData = graph.getNodeData('node4');
+    const edgeItem = graph.itemController.itemMap['edge1']
+    expect(edgeItem.shapeMap['keyShape'].attributes.x1).toBe(sourceData.data.x);
+    expect(edgeItem.shapeMap['keyShape'].attributes.y1).toBe(sourceData.data.y);
+    expect(edgeItem.shapeMap['keyShape'].attributes.x2).toBe(targetData.data.x);
+    expect(edgeItem.shapeMap['keyShape'].attributes.y2).toBe(targetData.data.y);
+    expect(edgeItem.shapeMap['keyShape'].attributes.stroke).toBe(edge1UpdateUserData2.data.keyShape.stroke);
+
+    // === update nodes ===
+    graph.updateData('node', [
+      {
+        id: 'node1',
+        data: {
+          keyShape: {
+            fill: '#0f0'
+          }
+        }
+      },
+      {
+        id: 'node2',
+        data: {
+          keyShape: {
+            lineWidth: 2,
+            stroke: '#0f0'
+          }
+        }
+      },
+    ]);
+    const node1Item = graph.itemController.itemMap['node1'];
+    const node2Item = graph.itemController.itemMap['node2'];
+    expect(node1Item.shapeMap['keyShape'].attributes.fill).toBe('#0f0');
+    expect(node2Item.shapeMap['keyShape'].attributes.lineWidth).toBe(2);
+    expect(node2Item.shapeMap['keyShape'].attributes.stroke).toBe('#0f0');
+
+    // === update edges ===
+    graph.updateData('edge', [
+      {
+        id: 'edge1',
+        source: 'node2',
+        data: {
+          keyShape: {
+            stroke: '#0f0'
+          }
+        }
+      }, {
+        id: 'edge2',
+        data: {
+          keyShape: {
+            lineDash: [5, 5]
+          }
+        }
+      }
+    ]);
+    const edge1Item = graph.itemController.itemMap['edge1'];
+    const edge2Item = graph.itemController.itemMap['edge2'];
+    expect(edge1Item.shapeMap['keyShape'].attributes.stroke).toBe('#0f0');
+    expect(edge1Item.sourceItem).toBe(graph.itemController.itemMap['node2']);
+    expect(JSON.stringify(edge2Item.shapeMap['keyShape'].attributes.lineDash)).toBe('[5,5]');
   });
   it('addData', () => {
     graph.addData('node', {
@@ -121,11 +198,60 @@ describe('data', () => {
     });
     expect(graph.dataController.graphCore.getAllNodes().length).toBe(6);
     expect(graph.dataController.graphCore.getAllEdges().length).toBe(3);
+
+    // === add nodes ===
+    graph.addData('node', [
+      {
+        id: 'node7',
+        data: {
+          x: 100,
+          y: 400,
+        }
+      }, {
+        id: 'node8',
+        data: {
+          x: 200,
+          y: 400,
+        }
+      }, {
+        id: 'node9',
+        data: {
+          x: 300,
+          y: 400,
+        }
+      }
+    ]);
+    expect(graph.dataController.graphCore.getAllNodes().length).toBe(9);
+    graph.addData('edge', [
+      {
+        id: 'edge4',
+        source: 'node7',
+        target: 'node8',
+        data: {}
+      }, {
+        id: 'edge5',
+        source: 'node8',
+        target: 'node9',
+        data: {}
+      }
+    ]);
+    expect(graph.dataController.graphCore.getAllEdges().length).toBe(5);
+
   });
-  xit('removeData', () => {
+  it('removeData', () => {
+    // === remove node ===
     // remoev a node, related edges will be removed in the same time
-    graph.removeData('node', ['node5']);
-    expect(graph.dataController.graphCore.getAllNodes().length).toBe(3);
+    graph.removeData('node', 'node5');
+    expect(graph.dataController.graphCore.getAllNodes().length).toBe(8);
+    expect(graph.dataController.graphCore.getAllEdges().length).toBe(4);
+
+    // === remove nodes ===
+    graph.removeData('node', ['node7', 'node8']);
+    expect(graph.dataController.graphCore.getAllNodes().length).toBe(6);
+    expect(graph.dataController.graphCore.getAllEdges().length).toBe(2);
+
+    // === remove edge ===
+    graph.removeData('edge', 'edge1');
     expect(graph.dataController.graphCore.getAllEdges().length).toBe(1);
   });
 });

--- a/packages/g6/tests/unit/data-spec.ts
+++ b/packages/g6/tests/unit/data-spec.ts
@@ -252,10 +252,69 @@ describe('data', () => {
     graph.removeData('edge', 'edge1');
     expect(graph.dataController.graphCore.getAllEdges().length).toBe(1);
   });
-  xit('findNodeData', () => {});
-  xit('findEdgeData', () => {});
+  it('getNodeData', () => {
+    const foundNode = graph.getNodeData('node1');
+    expect(foundNode).toBe(graph.dataController.graphCore.getNode('node1'));
 
-  xit('changeData with replace', () => {});
+    const inexisNode = graph.getNodeData('inexistnode');
+    expect(inexisNode).toBe(undefined);
+  });
+  it('getEdgeData', () => {
+    const foundEdge = graph.getEdgeData('edge2');
+    expect(foundEdge).toBe(graph.dataController.graphCore.getEdge('edge2'));
 
-  xit('changeData with mergeReplace', () => {});
+    const removedEdge = graph.getEdgeData('edge1');
+    expect(removedEdge).toBe(undefined);
+
+    const inexisEdge = graph.getEdgeData('inexistedge');
+    expect(inexisEdge).toBe(undefined);
+  });
+  it('getAllNodesData getAllEdgesDat', () => {
+    expect(graph.getAllNodesData().length).toBe(6);
+    expect(graph.getAllEdgesData().length).toBe(1);
+  });
+
+  it('changeData with replace', () => {
+    const newData = {
+      nodes: [
+        { id: 'node1', data: { x: 100, y: 200 } },
+        { id: 'node2', data: { x: 400, y: 450 } },
+        { id: 'node11', data: { x: 300, y: 200 } },
+        { id: 'node12', data: { x: 300, y: 250 } },
+      ],
+      edges: [
+        { id: 'edge1', source: 'node1', target: 'node2', data: {} },
+        { id: 'edge11', source: 'node1', target: 'node11', data: {} },
+      ],
+    };
+    graph.changeData(newData, 'replace');
+    expect(graph.getNodeData('node2').data.x).toBe(400);
+    expect(graph.getNodeData('node2').data.y).toBe(450);
+    expect(graph.getNodeData('node3')).toBe(undefined);
+    expect(graph.getNodeData('node11')).not.toBe(undefined);
+    expect(graph.getNodeData('node12')).not.toBe(undefined);
+  });
+
+  it('changeData with mergeReplace', () => {
+    const newData = {
+      nodes: [{ id: 'node13', data: { x: 50, y: 50 } }],
+      edges: [{ id: 'edge1', source: 'node13', target: 'node13', data: {} }],
+    };
+    graph.changeData(newData, 'mergeReplace');
+    const allNodes = graph.getAllNodesData();
+    expect(allNodes.length).toBe(1);
+    expect(allNodes[0].id).toBe('node13');
+
+    const allEdges = graph.getAllEdgesData();
+    expect(allEdges.length).toBe(1);
+    expect(allEdges[0].id).toBe('edge1');
+    expect(allEdges[0].source).toBe('node13');
+    expect(allEdges[0].target).toBe('node13');
+
+    graph.destroy();
+    expect(graph.destroyed).toBe(true);
+    // expect(graph.canvas.destroyed).toBe(true);
+    // expect(graph.backgroundCanvas.destroyed).toBe(true);
+    // expect(graph.transientCanvas.destroyed).toBe(true);
+  });
 });

--- a/packages/g6/tests/unit/item-spec.ts
+++ b/packages/g6/tests/unit/item-spec.ts
@@ -1,4 +1,12 @@
-import G6, { GraphData, IGraph } from '../../src/index';
+import { DisplayObject } from '@antv/g';
+import { clone } from '@antv/util';
+import G6, { EdgeDisplayModel, GraphData, IGraph, NodeDisplayModel } from '../../src/index';
+import { LineEdge } from '../../src/stdlib/item/edge';
+import { CircleNode } from '../../src/stdlib/item/node';
+import { BaseNode } from '../../src/stdlib/item/node/base';
+import { NodeModelData, NodeShapeMap } from '../../src/types/node';
+import { extend } from '../../src/util/extend';
+import { upsertShape } from '../../src/util/shape';
 
 const container = document.createElement('div');
 document.querySelector('body').appendChild(container);
@@ -35,6 +43,7 @@ xdescribe('node item', () => {
         labelShape: {
           text: 'node-label',
           position: 'left',
+          background: {},
         },
       },
     });
@@ -42,6 +51,14 @@ xdescribe('node item', () => {
     expect(nodeItem.shapeMap.labelShape).not.toBe(undefined);
     expect(nodeItem.shapeMap.labelShape.attributes.text).toBe('node-label');
     expect(nodeItem.shapeMap.labelShape.attributes.fill).toBe('#000');
+    expect(nodeItem.shapeMap.labelBgShape).not.toBe(undefined);
+    const labelBounds = nodeItem.shapeMap.labelShape.getGeometryBounds();
+    expect(nodeItem.shapeMap.labelBgShape.attributes.x).toBe(
+      labelBounds.min[0] + nodeItem.shapeMap.labelShape.attributes.x - 4,
+    );
+    expect(nodeItem.shapeMap.labelBgShape.attributes.y).toBe(
+      labelBounds.min[1] + nodeItem.shapeMap.labelShape.attributes.y - 4,
+    );
 
     graph.updateData('node', {
       id: 'node1',
@@ -60,6 +77,7 @@ xdescribe('node item', () => {
       },
     });
     expect(nodeItem.shapeMap.labelShape).toBe(undefined);
+    expect(nodeItem.shapeMap.labelBgShape).toBe(undefined);
   });
   it('update node icon', () => {
     graph.updateData('node', {
@@ -70,6 +88,10 @@ xdescribe('node item', () => {
         },
       },
     });
+    const nodeItem = graph.itemController.itemMap['node1'];
+    expect(nodeItem.shapeMap.iconShape).not.toBe(undefined);
+    expect(nodeItem.shapeMap.iconShape.attributes.width).toBe(15);
+    expect(nodeItem.shapeMap.iconShape.nodeName).toBe('image');
 
     graph.updateData('node', {
       id: 'node1',
@@ -81,10 +103,15 @@ xdescribe('node item', () => {
         },
       },
     });
+    expect(nodeItem.shapeMap.iconShape).not.toBe(undefined);
+    expect(nodeItem.shapeMap.iconShape.attributes.text).toBe('A');
+    expect(nodeItem.shapeMap.iconShape.attributes.fontSize).toBe(12);
+    expect(nodeItem.shapeMap.iconShape.nodeName).toBe('text');
+    graph.destroy();
   });
 });
 
-describe('edge item', () => {
+xdescribe('edge item', () => {
   let graph: IGraph<any>;
   it('new graph with two nodes and one edge', (done) => {
     graph = new G6.Graph({
@@ -96,7 +123,7 @@ describe('edge item', () => {
         nodes: [
           {
             id: 'node1',
-            data: { x: 100, y: 100 },
+            data: { x: 100, y: 100, keyShape: { opacity: 0.1 } },
           },
           {
             id: 'node2',
@@ -122,58 +149,489 @@ describe('edge item', () => {
     });
   });
   it('update edge label', () => {
+    const padding = [4, 8, 4, 8];
     graph.updateData('edge', {
       id: 'edge1',
       data: {
         labelShape: {
           text: 'edge-label',
-          position: 'start',
-          // background: {}, // TODO
+          position: 'middle',
+          background: {
+            radius: 10,
+            padding,
+          },
         },
       },
     });
-    const edgeitem = graph.itemController.itemMap['edge1'];
-    expect(edgeitem.shapeMap.labelShape).not.toBe(undefined);
-    expect(edgeitem.shapeMap.labelShape.attributes.text).toBe('edge-label');
-    expect(edgeitem.shapeMap.labelShape.attributes.fill).toBe('#000');
+    const edgeItem = graph.itemController.itemMap['edge1'];
+    expect(edgeItem.shapeMap.labelShape).not.toBe(undefined);
+    expect(edgeItem.shapeMap.labelShape.attributes.text).toBe('edge-label');
+    expect(edgeItem.shapeMap.labelShape.attributes.fill).toBe('#000');
+    expect(edgeItem.shapeMap.labelShape.attributes.transform).toBe('rotate(45)');
+    expect(edgeItem.shapeMap.labelBgShape.attributes.transform).toBe('rotate(45)');
+    let labelBounds = edgeItem.shapeMap.labelShape.getGeometryBounds();
+    expect(edgeItem.shapeMap.labelBgShape.attributes.width).toBe(
+      labelBounds.max[0] - labelBounds.min[0] + padding[1] + padding[3],
+    );
+    expect(edgeItem.shapeMap.labelBgShape.attributes.height).toBe(
+      labelBounds.max[1] - labelBounds.min[1] + padding[0] + padding[2],
+    );
 
-    // graph.updateData('node', {
-    //   id: 'node1',
-    //   data: {
-    //     labelShape: {
-    //       fill: '#00f',
-    //     },
-    //   },
-    // });
-    // expect(nodeItem.shapeMap.labelShape.attributes.fill).toBe('#00f');
+    graph.updateData('edge', {
+      id: 'edge1',
+      data: {
+        labelShape: {
+          fill: '#00f',
+          position: 'start',
+        },
+      },
+    });
+    expect(edgeItem.shapeMap.labelShape.attributes.fill).toBe('#00f');
+    expect(
+      edgeItem.shapeMap.labelShape.attributes.x - edgeItem.shapeMap.labelBgShape.attributes.x,
+    ).toBe(padding[3]);
+    labelBounds = edgeItem.shapeMap.labelShape.getGeometryBounds();
+    const labelWidth = labelBounds.max[0] - labelBounds.min[0];
+    const labelHeight = labelBounds.max[1] - labelBounds.min[1];
+    const labelBgBounds = edgeItem.shapeMap.labelBgShape.getGeometryBounds();
+    const labelBgWidth = labelBgBounds.max[0] - labelBgBounds.min[0];
+    const labelBgHeight = labelBgBounds.max[1] - labelBgBounds.min[1];
+    expect(labelBgWidth - labelWidth).toBe(padding[1] + padding[3]);
+    expect(labelBgHeight - labelHeight).toBe(padding[0] + padding[2]);
 
-    // graph.updateData('node', {
-    //   id: 'node1',
-    //   data: {
-    //     labelShape: undefined,
-    //   },
-    // });
-    // expect(nodeItem.shapeMap.labelShape).toBe(undefined);
+    graph.updateData('edge', {
+      id: 'edge1',
+      data: {
+        labelShape: undefined,
+      },
+    });
+    expect(edgeItem.shapeMap.labelShape).toBe(undefined);
+    expect(edgeItem.shapeMap.labelBgShape).toBe(undefined);
   });
-  // it('update node icon', () => {
-  //   graph.updateData('node', {
-  //     id: 'node1',
-  //     data: {
-  //       iconShape: {
-  //         img: 'https://gw.alipayobjects.com/zos/basement_prod/012bcf4f-423b-4922-8c24-32a89f8c41ce.svg',
-  //       },
-  //     },
-  //   });
+  it('update edge icon', () => {
+    // add image icon to follow the label at path's center
+    graph.updateData('edge', {
+      id: 'edge1',
+      data: {
+        labelShape: {
+          text: 'abcddd',
+          fill: '#f00',
+          position: 'center',
+        },
+        iconShape: {
+          img: 'https://gw.alipayobjects.com/zos/basement_prod/012bcf4f-423b-4922-8c24-32a89f8c41ce.svg',
+          // text: 'A',
+          fill: '#fff',
+        },
+      },
+    });
+    const edgeItem = graph.itemController.itemMap['edge1'];
+    let labelShape = edgeItem.shapeMap['labelShape'];
+    let iconShape = edgeItem.shapeMap['iconShape'];
+    expect(iconShape.attributes.x + iconShape.attributes.width + 4).toBe(
+      labelShape.getGeometryBounds().min[0] + labelShape.attributes.x,
+    );
+    expect(iconShape.attributes.transform).toBe(labelShape.attributes.transform);
+    expect(iconShape.attributes.y + iconShape.attributes.height / 2 - 2).toBe(
+      labelShape.getGeometryBounds().center[1] + labelShape.attributes.y,
+    );
 
-  //   graph.updateData('node', {
-  //     id: 'node1',
-  //     data: {
-  //       iconShape: {
-  //         text: 'A',
-  //         fill: '#fff',
-  //         fontWeight: 500,
-  //       },
-  //     },
-  //   });
-  // });
+    // update icon to be a text
+    graph.updateData('edge', {
+      id: 'edge1',
+      data: {
+        iconShape: {
+          text: 'A',
+          fill: '#fff',
+          fontWeight: 500,
+        },
+      },
+    });
+    labelShape = edgeItem.shapeMap['labelShape'];
+    iconShape = edgeItem.shapeMap['iconShape'];
+    expect(iconShape.attributes.x + iconShape.attributes.width + 4).toBe(
+      labelShape.getGeometryBounds().min[0] + labelShape.attributes.x,
+    );
+    expect(iconShape.attributes.transform).toBe(labelShape.attributes.transform);
+    expect(iconShape.attributes.y + iconShape.attributes.height / 2 - 2).toBe(
+      labelShape.getGeometryBounds().center[1] + labelShape.attributes.y,
+    );
+
+    // move label to the start, and the icon follows
+    graph.updateData('edge', {
+      id: 'edge1',
+      data: {
+        labelShape: {
+          position: 'start',
+        },
+      },
+    });
+    labelShape = edgeItem.shapeMap['labelShape'];
+    iconShape = edgeItem.shapeMap['iconShape'];
+    expect(iconShape.attributes.x + iconShape.attributes.width + 4).toBe(
+      labelShape.getGeometryBounds().min[0] + labelShape.attributes.x,
+    );
+    expect(iconShape.attributes.transform).toBe(labelShape.attributes.transform);
+    expect(iconShape.attributes.y + iconShape.attributes.height / 2 - 2).toBe(
+      labelShape.getGeometryBounds().center[1] + labelShape.attributes.y,
+    );
+    graph.destroy();
+  });
+});
+
+xdescribe('node mapper', () => {
+  const data = {
+    nodes: [
+      {
+        id: 'node1',
+        data: { x: 100, y: 200, buStatus: true, buType: 1 },
+      },
+      {
+        id: 'node2',
+        data: { x: 100, y: 300, buStatus: false, buType: 0 },
+      },
+    ],
+  };
+  const graphConfig = {
+    container,
+    width: 500,
+    height: 500,
+    type: 'graph',
+  };
+  it('function mapper', (done) => {
+    const graph = new G6.Graph({
+      ...graphConfig,
+      node: (innerModel) => {
+        const { x, y, buStatus } = innerModel.data;
+        return {
+          ...innerModel,
+          data: {
+            x,
+            y,
+            keyShape: {
+              fill: buStatus ? '#0f0' : '#f00',
+            },
+          },
+        };
+      },
+    } as any);
+    graph.read(clone(data));
+    graph.on('afterrender', () => {
+      const node1 = graph.itemController.itemMap['node1'];
+      expect(node1.shapeMap.keyShape.attributes.fill).toBe('#0f0');
+      let node2 = graph.itemController.itemMap['node2'];
+      expect(node2.shapeMap.keyShape.attributes.fill).toBe('#f00');
+
+      // update user data
+      graph.updateData('node', {
+        id: 'node2',
+        data: {
+          buStatus: true,
+        },
+      });
+      node2 = graph.itemController.itemMap['node2'];
+      expect(node2.shapeMap.keyShape.attributes.fill).toBe('#0f0');
+
+      graph.destroy();
+      done();
+    });
+  });
+  it('value and encode mapper', (done) => {
+    const graph = new G6.Graph({
+      ...graphConfig,
+      node: {
+        keyShape: {
+          fill: {
+            fields: ['buStatus'],
+            formatter: (innerModel) => (innerModel.data.buStatus ? '#0f0' : '#f00'),
+          },
+          lineWidth: 5,
+          stroke: {
+            fields: ['buStatus', 'buType'],
+            formatter: (innerModel) =>
+              innerModel.data.buStatus || innerModel.data.buType ? '#fff' : '#000',
+          },
+        },
+        labelShape: {},
+      },
+    } as any);
+    graph.read(clone(data));
+    graph.on('afterrender', () => {
+      const node1 = graph.itemController.itemMap['node1'];
+      expect(node1.shapeMap.keyShape.attributes.fill).toBe('#0f0');
+      expect(node1.shapeMap.keyShape.attributes.lineWidth).toBe(5);
+      expect(node1.shapeMap.keyShape.attributes.stroke).toBe('#fff');
+      let node2 = graph.itemController.itemMap['node2'];
+      expect(node2.shapeMap.keyShape.attributes.fill).toBe('#f00');
+      expect(node2.shapeMap.keyShape.attributes.lineWidth).toBe(5);
+      expect(node2.shapeMap.keyShape.attributes.stroke).toBe('#000');
+
+      // update user data
+      graph.updateData('node', {
+        id: 'node2',
+        data: {
+          buStatus: true,
+        },
+      });
+      node2 = graph.itemController.itemMap['node2'];
+      expect(node2.shapeMap.keyShape.attributes.fill).toBe('#0f0');
+      expect(node2.shapeMap.keyShape.attributes.stroke).toBe('#fff');
+
+      graph.destroy();
+      done();
+    });
+  });
+});
+
+xdescribe('edge mapper', () => {
+  const data = {
+    nodes: [
+      {
+        id: 'node1',
+        data: { x: 100, y: 200 },
+      },
+      {
+        id: 'node2',
+        data: { x: 100, y: 300 },
+      },
+      {
+        id: 'node3',
+        data: { x: 200, y: 300 },
+      },
+    ],
+    edges: [
+      {
+        id: 'edge1',
+        source: 'node1',
+        target: 'node2',
+        data: { buStatus: true, buType: 1, buName: 'edge-1' },
+      },
+      {
+        id: 'edge2',
+        source: 'node1',
+        target: 'node3',
+        data: { buStatus: false, buType: 0, buName: 'edge-2' },
+      },
+    ],
+  };
+  const graphConfig = {
+    container,
+    width: 500,
+    height: 500,
+    type: 'graph',
+  };
+  it('function mapper', (done) => {
+    const graph = new G6.Graph({
+      ...graphConfig,
+      edge: (innerModel) => {
+        const { x, y, buStatus } = innerModel.data;
+        return {
+          ...innerModel,
+          data: {
+            x,
+            y,
+            keyShape: {
+              stroke: buStatus ? '#0f0' : '#f00',
+            },
+          },
+        };
+      },
+    } as any);
+    graph.read(clone(data));
+    graph.on('afterrender', () => {
+      const edge1 = graph.itemController.itemMap['edge1'];
+      expect(edge1.shapeMap.keyShape.attributes.stroke).toBe('#0f0');
+      let edge2 = graph.itemController.itemMap['edge2'];
+      expect(edge2.shapeMap.keyShape.attributes.stroke).toBe('#f00');
+
+      // update user data
+      graph.updateData('edge', {
+        id: 'edge2',
+        data: {
+          buStatus: true,
+        },
+      });
+      edge2 = graph.itemController.itemMap['edge2'];
+      expect(edge2.shapeMap.keyShape.attributes.stroke).toBe('#0f0');
+
+      graph.destroy();
+      done();
+    });
+  });
+  it('value and encode mapper', (done) => {
+    const graph = new G6.Graph({
+      ...graphConfig,
+      edge: {
+        keyShape: {
+          stroke: {
+            fields: ['buStatus'],
+            formatter: (innerModel) => (innerModel.data.buStatus ? '#0f0' : '#f00'),
+          },
+          lineWidth: 5,
+          lineDash: {
+            fields: ['buStatus', 'buType'],
+            formatter: (innerModel) =>
+              innerModel.data.buStatus || innerModel.data.buType ? undefined : [5, 5],
+          },
+        },
+        labelShape: {
+          text: {
+            fields: ['buName', 'buType'],
+            formatter: (innerModel) => `${innerModel.data.buName}-${innerModel.data.buType}`,
+          },
+        },
+      },
+    } as any);
+    graph.read(clone(data));
+    graph.on('afterrender', () => {
+      const edge1 = graph.itemController.itemMap['edge1'];
+      expect(edge1.shapeMap.keyShape.attributes.stroke).toBe('#0f0');
+      expect(edge1.shapeMap.keyShape.attributes.lineWidth).toBe(5);
+      expect(edge1.shapeMap.keyShape.attributes.lineDash).toBe('');
+      expect(edge1.shapeMap.labelShape.attributes.text).toBe('edge-1-1');
+      let edge2 = graph.itemController.itemMap['edge2'];
+      expect(edge2.shapeMap.keyShape.attributes.stroke).toBe('#f00');
+      expect(edge2.shapeMap.keyShape.attributes.lineWidth).toBe(5);
+      expect(JSON.stringify(edge2.shapeMap.keyShape.attributes.lineDash)).toBe('[5,5]');
+      expect(edge2.shapeMap.labelShape.attributes.text).toBe('edge-2-0');
+
+      // update user data
+      graph.updateData('edge', {
+        id: 'edge2',
+        data: {
+          buStatus: true,
+          buName: 'newedge2name',
+        },
+      });
+      edge2 = graph.itemController.itemMap['edge2'];
+      expect(edge2.shapeMap.keyShape.attributes.stroke).toBe('#0f0');
+      expect(edge2.shapeMap.keyShape.attributes.lineDash).toBe('');
+      expect(edge2.shapeMap.labelShape.attributes.text).toBe('newedge2name-0');
+
+      graph.destroy();
+      done();
+    });
+  });
+});
+
+describe('register node', () => {
+  it('custom node extends circle', (done) => {
+    class CustomNode extends CircleNode {
+      public drawLabelShape(
+        model: NodeDisplayModel,
+        shapeMap: NodeShapeMap,
+        diffData?: { oldData: NodeModelData; newData: NodeModelData },
+      ) {
+        const extraShape = upsertShape(
+          'circle',
+          'extraShape',
+          {
+            r: 4,
+            fill: '#0f0',
+            x: -20,
+            y: 0,
+          },
+          shapeMap,
+        );
+        const labelShape = upsertShape(
+          'text',
+          'labelShape',
+          {
+            text: 'it-is-custom-node',
+          },
+          shapeMap,
+        );
+        return { labelShape, extraShape };
+      }
+    }
+    class CustomEdge extends LineEdge {
+      public afterDraw(
+        model: EdgeDisplayModel,
+        shapeMap: { [shapeId: string]: DisplayObject<any, any> },
+        shapesChanged?: string[],
+      ): { [otherShapeId: string]: DisplayObject } {
+        const { keyShape } = shapeMap;
+        const point = keyShape.getPoint(0.3);
+        return {
+          buShape: upsertShape(
+            'rect',
+            'buShape',
+            {
+              width: 6,
+              height: 6,
+              x: point.x,
+              y: point.y,
+              fill: '#0f0',
+            },
+            shapeMap,
+          ),
+        };
+      }
+    }
+    const CustomGraph = extend(G6.Graph, {
+      nodes: {
+        'custom-node': CustomNode,
+      },
+      edges: {
+        'custom-edge': CustomEdge,
+      },
+    });
+
+    // TODO: G6.Graph is modified unexpectively
+    const graph = new CustomGraph({
+      container,
+      width: 500,
+      height: 500,
+      type: 'graph',
+      data: {
+        nodes: [
+          {
+            id: 'node1',
+            data: { x: 100, y: 200, labelShape: {}, type: 'custom-node' },
+          },
+          {
+            id: 'node2',
+            data: { x: 100, y: 300, labelShape: {} },
+          },
+          {
+            id: 'node3',
+            data: { x: 200, y: 300 },
+          },
+        ],
+        edges: [
+          {
+            id: 'edge1',
+            source: 'node1',
+            target: 'node2',
+            data: { type: 'custom-edge' },
+          },
+          {
+            id: 'edge2',
+            source: 'node1',
+            target: 'node3',
+            data: {},
+          },
+        ],
+      },
+      node: {
+        type: 'custom-node',
+      },
+    });
+    graph.on('afterrender', () => {
+      const node1 = graph.itemController.itemMap['node1'];
+      expect(node1.shapeMap.extraShape).not.toBe(undefined);
+      const node2 = graph.itemController.itemMap['node2'];
+      expect(node2.shapeMap.extraShape).toBe(undefined);
+
+      const edge1 = graph.itemController.itemMap['edge1'];
+      expect(edge1.shapeMap.buShape).not.toBe(undefined);
+      const edge2 = graph.itemController.itemMap['edge2'];
+      expect(edge2.shapeMap.buShape).toBe(undefined);
+
+      // TODO: other shapes
+      // TODO: node/edge type on spec
+
+      done();
+    });
+  });
 });

--- a/packages/g6/tests/unit/item-spec.ts
+++ b/packages/g6/tests/unit/item-spec.ts
@@ -1,0 +1,179 @@
+import G6, { GraphData, IGraph } from '../../src/index';
+
+const container = document.createElement('div');
+document.querySelector('body').appendChild(container);
+
+xdescribe('node item', () => {
+  let graph: IGraph<any>;
+  it('new graph with one node', (done) => {
+    graph = new G6.Graph({
+      container,
+      width: 500,
+      height: 500,
+      type: 'graph',
+      data: {
+        nodes: [
+          {
+            id: 'node1',
+            data: { x: 100, y: 200 },
+          },
+        ],
+      },
+    });
+
+    graph.on('afterrender', () => {
+      const nodeItem = graph.itemController.itemMap['node1'];
+      expect(nodeItem).not.toBe(undefined);
+      expect(nodeItem.shapeMap.labelShape).toBe(undefined);
+      done();
+    });
+  });
+  it('update node label', () => {
+    graph.updateData('node', {
+      id: 'node1',
+      data: {
+        labelShape: {
+          text: 'node-label',
+          position: 'left',
+        },
+      },
+    });
+    const nodeItem = graph.itemController.itemMap['node1'];
+    expect(nodeItem.shapeMap.labelShape).not.toBe(undefined);
+    expect(nodeItem.shapeMap.labelShape.attributes.text).toBe('node-label');
+    expect(nodeItem.shapeMap.labelShape.attributes.fill).toBe('#000');
+
+    graph.updateData('node', {
+      id: 'node1',
+      data: {
+        labelShape: {
+          fill: '#00f',
+        },
+      },
+    });
+    expect(nodeItem.shapeMap.labelShape.attributes.fill).toBe('#00f');
+
+    graph.updateData('node', {
+      id: 'node1',
+      data: {
+        labelShape: undefined,
+      },
+    });
+    expect(nodeItem.shapeMap.labelShape).toBe(undefined);
+  });
+  it('update node icon', () => {
+    graph.updateData('node', {
+      id: 'node1',
+      data: {
+        iconShape: {
+          img: 'https://gw.alipayobjects.com/zos/basement_prod/012bcf4f-423b-4922-8c24-32a89f8c41ce.svg',
+        },
+      },
+    });
+
+    graph.updateData('node', {
+      id: 'node1',
+      data: {
+        iconShape: {
+          text: 'A',
+          fill: '#fff',
+          fontWeight: 500,
+        },
+      },
+    });
+  });
+});
+
+describe('edge item', () => {
+  let graph: IGraph<any>;
+  it('new graph with two nodes and one edge', (done) => {
+    graph = new G6.Graph({
+      container,
+      width: 500,
+      height: 500,
+      type: 'graph',
+      data: {
+        nodes: [
+          {
+            id: 'node1',
+            data: { x: 100, y: 100 },
+          },
+          {
+            id: 'node2',
+            data: { x: 300, y: 300 },
+          },
+        ],
+        edges: [
+          {
+            id: 'edge1',
+            source: 'node1',
+            target: 'node2',
+            data: {},
+          },
+        ],
+      },
+    });
+
+    graph.on('afterrender', () => {
+      const edgeItem = graph.itemController.itemMap['edge1'];
+      expect(edgeItem).not.toBe(undefined);
+      expect(edgeItem.shapeMap.labelShape).toBe(undefined);
+      done();
+    });
+  });
+  it('update edge label', () => {
+    graph.updateData('edge', {
+      id: 'edge1',
+      data: {
+        labelShape: {
+          text: 'edge-label',
+          position: 'start',
+          // background: {}, // TODO
+        },
+      },
+    });
+    const edgeitem = graph.itemController.itemMap['edge1'];
+    expect(edgeitem.shapeMap.labelShape).not.toBe(undefined);
+    expect(edgeitem.shapeMap.labelShape.attributes.text).toBe('edge-label');
+    expect(edgeitem.shapeMap.labelShape.attributes.fill).toBe('#000');
+
+    // graph.updateData('node', {
+    //   id: 'node1',
+    //   data: {
+    //     labelShape: {
+    //       fill: '#00f',
+    //     },
+    //   },
+    // });
+    // expect(nodeItem.shapeMap.labelShape.attributes.fill).toBe('#00f');
+
+    // graph.updateData('node', {
+    //   id: 'node1',
+    //   data: {
+    //     labelShape: undefined,
+    //   },
+    // });
+    // expect(nodeItem.shapeMap.labelShape).toBe(undefined);
+  });
+  // it('update node icon', () => {
+  //   graph.updateData('node', {
+  //     id: 'node1',
+  //     data: {
+  //       iconShape: {
+  //         img: 'https://gw.alipayobjects.com/zos/basement_prod/012bcf4f-423b-4922-8c24-32a89f8c41ce.svg',
+  //       },
+  //     },
+  //   });
+
+  //   graph.updateData('node', {
+  //     id: 'node1',
+  //     data: {
+  //       iconShape: {
+  //         text: 'A',
+  //         fill: '#fff',
+  //         fontWeight: 500,
+  //       },
+  //     },
+  //   });
+  // });
+});

--- a/packages/g6/tests/unit/layout-spec.ts
+++ b/packages/g6/tests/unit/layout-spec.ts
@@ -1,0 +1,863 @@
+import G6, { GraphData, IGraph } from '../../src/index';
+const container = document.createElement('div');
+document.querySelector('body').appendChild(container);
+
+const data: GraphData = {
+  nodes: [
+    {
+      id: 'Argentina',
+      data: {
+        name: 'Argentina',
+      },
+    },
+    {
+      id: 'Australia',
+      data: {
+        name: 'Australia',
+      },
+    },
+    {
+      id: 'Belgium',
+      data: {
+        name: 'Belgium',
+      },
+    },
+    {
+      id: 'Brazil',
+      data: {
+        name: 'Brazil',
+      },
+    },
+    {
+      id: 'Colombia',
+      data: {
+        name: 'Colombia',
+      },
+    },
+    {
+      id: 'Costa Rica',
+      data: {
+        name: 'Costa Rica',
+      },
+    },
+    {
+      id: 'Croatia',
+      data: {
+        name: 'Croatia',
+      },
+    },
+    {
+      id: 'Denmark',
+      data: {
+        name: 'Denmark',
+      },
+    },
+    {
+      id: 'Egypt',
+      data: {
+        name: 'Egypt',
+      },
+    },
+    {
+      id: 'England',
+      data: {
+        name: 'England',
+      },
+    },
+    {
+      id: 'France',
+      data: {
+        name: 'France',
+      },
+    },
+    {
+      id: 'Germany',
+      data: {
+        name: 'Germany',
+      },
+    },
+    {
+      id: 'Iceland',
+      data: {
+        name: 'Iceland',
+      },
+    },
+    {
+      id: 'IR Iran',
+      data: {
+        name: 'IR Iran',
+      },
+    },
+    {
+      id: 'Japan',
+      data: {
+        name: 'Japan',
+      },
+    },
+    {
+      id: 'Korea Republic',
+      data: {
+        name: 'Korea Republic',
+      },
+    },
+    {
+      id: 'Mexico',
+      data: {
+        name: 'Mexico',
+      },
+    },
+    {
+      id: 'Morocco',
+      data: {
+        name: 'Morocco',
+      },
+    },
+    {
+      id: 'Nigeria',
+      data: {
+        name: 'Nigeria',
+      },
+    },
+    {
+      id: 'Panama',
+      data: {
+        name: 'Panama',
+      },
+    },
+    {
+      id: 'Peru',
+      data: {
+        name: 'Peru',
+      },
+    },
+    {
+      id: 'Poland',
+      data: {
+        name: 'Poland',
+      },
+    },
+    {
+      id: 'Portugal',
+      data: {
+        name: 'Portugal',
+      },
+    },
+    {
+      id: 'Russia',
+      data: {
+        name: 'Russia',
+      },
+    },
+    {
+      id: 'Saudi Arabia',
+      data: {
+        name: 'Saudi Arabia',
+      },
+    },
+    {
+      id: 'Senegal',
+      data: {
+        name: 'Senegal',
+      },
+    },
+    {
+      id: 'Serbia',
+      data: {
+        name: 'Serbia',
+      },
+    },
+    {
+      id: 'Spain',
+      data: {
+        name: 'Spain',
+      },
+    },
+    {
+      id: 'Sweden',
+      data: {
+        name: 'Sweden',
+      },
+    },
+    {
+      id: 'Switzerland',
+      data: {
+        name: 'Switzerland',
+      },
+    },
+    {
+      id: 'Tunisia',
+      data: {
+        name: 'Tunisia',
+      },
+    },
+    {
+      id: 'Uruguay',
+      data: {
+        name: 'Uruguay',
+      },
+    },
+  ],
+  edges: [
+    {
+      id: '0',
+      target: 'Russia',
+      source: 'Saudi Arabia',
+      data: {
+        target_score: 5,
+        source_score: 0,
+        directed: true,
+      },
+    },
+    {
+      id: '1',
+      target: 'Uruguay',
+      source: 'Egypt',
+      data: {
+        target_score: 1,
+        source_score: 0,
+        directed: true,
+      },
+    },
+    {
+      id: '2',
+      target: 'Russia',
+      source: 'Egypt',
+      data: {
+        target_score: 3,
+        source_score: 1,
+        directed: true,
+      },
+    },
+    {
+      id: '3',
+      target: 'Uruguay',
+      source: 'Saudi Arabia',
+      data: {
+        target_score: 1,
+        source_score: 0,
+        directed: true,
+      },
+    },
+    {
+      id: '4',
+      target: 'Uruguay',
+      source: 'Russia',
+      data: {
+        target_score: 3,
+        source_score: 0,
+        directed: true,
+      },
+    },
+    {
+      id: '5',
+      target: 'Saudi Arabia',
+      source: 'Egypt',
+      data: {
+        target_score: 2,
+        source_score: 1,
+        directed: true,
+      },
+    },
+    {
+      id: '6',
+      target: 'IR Iran',
+      source: 'Morocco',
+      data: {
+        target_score: 1,
+        source_score: 0,
+        directed: true,
+      },
+    },
+    {
+      id: '7',
+      target: 'Portugal',
+      source: 'Spain',
+      data: {
+        target_score: 3,
+        source_score: 3,
+        directed: false,
+      },
+    },
+    {
+      id: '8',
+      target: 'Portugal',
+      source: 'Morocco',
+      data: {
+        target_score: 1,
+        source_score: 0,
+        directed: true,
+      },
+    },
+    {
+      id: '9',
+      target: 'Spain',
+      source: 'IR Iran',
+      data: {
+        target_score: 1,
+        source_score: 0,
+        directed: true,
+      },
+    },
+    {
+      id: '10',
+      target: 'IR Iran',
+      source: 'Portugal',
+      data: {
+        target_score: 1,
+        source_score: 1,
+        directed: false,
+      },
+    },
+    {
+      id: '11',
+      target: 'Spain',
+      source: 'Morocco',
+      data: {
+        target_score: 2,
+        source_score: 2,
+        directed: false,
+      },
+    },
+    {
+      id: '12',
+      target: 'France',
+      source: 'Australia',
+      data: {
+        target_score: 2,
+        source_score: 1,
+        directed: true,
+      },
+    },
+    {
+      id: '13',
+      target: 'Denmark',
+      source: 'Peru',
+      data: {
+        target_score: 1,
+        source_score: 0,
+        directed: true,
+      },
+    },
+    {
+      id: '14',
+      target: 'Denmark',
+      source: 'Australia',
+      data: {
+        target_score: 1,
+        source_score: 1,
+        directed: false,
+      },
+    },
+    {
+      id: '15',
+      target: 'France',
+      source: 'Peru',
+      data: {
+        target_score: 1,
+        source_score: 0,
+        directed: true,
+      },
+    },
+    {
+      id: '16',
+      target: 'Denmark',
+      source: 'France',
+      data: {
+        target_score: 0,
+        source_score: 0,
+        directed: false,
+      },
+    },
+    {
+      id: '17',
+      target: 'Peru',
+      source: 'Australia',
+      data: {
+        target_score: 2,
+        source_score: 0,
+        directed: true,
+      },
+    },
+    {
+      id: '18',
+      target: 'Argentina',
+      source: 'Iceland',
+      data: {
+        target_score: 1,
+        source_score: 1,
+      },
+    },
+    {
+      id: '19',
+      target: 'Croatia',
+      source: 'Nigeria',
+      data: {
+        target_score: 2,
+        source_score: 0,
+        directed: true,
+      },
+    },
+    {
+      id: '20',
+      target: 'Croatia',
+      source: 'Argentina',
+      data: {
+        target_score: 3,
+        source_score: 0,
+        directed: true,
+      },
+    },
+    {
+      id: '21',
+      target: 'Nigeria',
+      source: 'Iceland',
+      data: {
+        target_score: 2,
+        source_score: 0,
+        directed: true,
+      },
+    },
+    {
+      id: '22',
+      target: 'Argentina',
+      source: 'Nigeria',
+      data: {
+        target_score: 2,
+        source_score: 1,
+        directed: true,
+      },
+    },
+    {
+      id: '23',
+      target: 'Croatia',
+      source: 'Iceland',
+      data: {
+        target_score: 2,
+        source_score: 1,
+        directed: true,
+      },
+    },
+    {
+      id: '24',
+      target: 'Serbia',
+      source: 'Costa Rica',
+      data: {
+        target_score: 1,
+        source_score: 0,
+        directed: true,
+      },
+    },
+    {
+      id: '25',
+      target: 'Brazil',
+      source: 'Switzerland',
+      data: {
+        target_score: 1,
+        source_score: 1,
+        directed: false,
+      },
+    },
+    {
+      id: '26',
+      target: 'Brazil',
+      source: 'Costa Rica',
+      data: {
+        target_score: 2,
+        source_score: 0,
+        directed: true,
+      },
+    },
+    {
+      id: '27',
+      target: 'Switzerland',
+      source: 'Serbia',
+      data: {
+        target_score: 2,
+        source_score: 1,
+        directed: true,
+      },
+    },
+    {
+      id: '28',
+      target: 'Brazil',
+      source: 'Serbia',
+      data: {
+        target_score: 2,
+        source_score: 0,
+        directed: true,
+      },
+    },
+    {
+      id: '29',
+      target: 'Switzerland',
+      source: 'Costa Rica',
+      data: {
+        target_score: 2,
+        source_score: 2,
+        directed: false,
+      },
+    },
+    {
+      id: '30',
+      target: 'Mexico',
+      source: 'Germany',
+      data: {
+        target_score: 1,
+        source_score: 0,
+        directed: true,
+      },
+    },
+    {
+      id: '31',
+      target: 'Sweden',
+      source: 'Korea Republic',
+      data: {
+        target_score: 1,
+        source_score: 0,
+        directed: true,
+      },
+    },
+    {
+      id: '32',
+      target: 'Mexico',
+      source: 'Korea Republic',
+      data: {
+        target_score: 1,
+        source_score: 0,
+        directed: true,
+      },
+    },
+    {
+      id: '33',
+      target: 'Germany',
+      source: 'Sweden',
+      data: {
+        target_score: 2,
+        source_score: 1,
+        directed: true,
+      },
+    },
+    {
+      id: '34',
+      target: 'Korea Republic',
+      source: 'Germany',
+      data: {
+        target_score: 2,
+        source_score: 0,
+        directed: true,
+      },
+    },
+    {
+      id: '35',
+      target: 'Sweden',
+      source: 'Mexico',
+      data: {
+        target_score: 3,
+        source_score: 0,
+        directed: true,
+      },
+    },
+    {
+      id: '36',
+      target: 'Belgium',
+      source: 'Panama',
+      data: {
+        target_score: 3,
+        source_score: 0,
+        directed: true,
+      },
+    },
+    {
+      id: '37',
+      target: 'England',
+      source: 'Tunisia',
+      data: {
+        target_score: 2,
+        source_score: 1,
+        directed: true,
+      },
+    },
+    {
+      id: '38',
+      target: 'Belgium',
+      source: 'Tunisia',
+      data: {
+        target_score: 5,
+        source_score: 2,
+        directed: true,
+      },
+    },
+    {
+      id: '39',
+      target: 'England',
+      source: 'Panama',
+      data: {
+        target_score: 6,
+        source_score: 1,
+        directed: true,
+      },
+    },
+    {
+      id: '40',
+      target: 'Belgium',
+      source: 'England',
+      data: {
+        target_score: 1,
+        source_score: 0,
+        directed: true,
+      },
+    },
+    {
+      id: '41',
+      target: 'Tunisia',
+      source: 'Panama',
+      data: {
+        target_score: 2,
+        source_score: 1,
+        directed: true,
+      },
+    },
+    {
+      id: '42',
+      target: 'Japan',
+      source: 'Colombia',
+      data: {
+        target_score: 2,
+        source_score: 1,
+        directed: true,
+      },
+    },
+    {
+      id: '43',
+      target: 'Senegal',
+      source: 'Poland',
+      data: {
+        target_score: 2,
+        source_score: 1,
+        directed: true,
+      },
+    },
+    {
+      id: '44',
+      target: 'Japan',
+      source: 'Senegal',
+      data: {
+        target_score: 2,
+        source_score: 2,
+        directed: false,
+      },
+    },
+    {
+      id: '45',
+      target: 'Colombia',
+      source: 'Poland',
+      data: {
+        target_score: 3,
+        source_score: 0,
+        directed: true,
+      },
+    },
+    {
+      id: '46',
+      target: 'Poland',
+      source: 'Japan',
+      data: {
+        target_score: 1,
+        source_score: 0,
+        directed: true,
+      },
+    },
+    {
+      id: '47',
+      target: 'Colombia',
+      source: 'Senegal',
+      data: {
+        target_score: 1,
+        source_score: 0,
+        directed: true,
+      },
+    },
+    {
+      id: '48',
+      target: 'Uruguay',
+      source: 'Portugal',
+      data: {
+        target_score: 2,
+        source_score: 1,
+        directed: true,
+      },
+    },
+    {
+      id: '49',
+      target: 'France',
+      source: 'Argentina',
+      data: {
+        target_score: 4,
+        source_score: 3,
+        directed: true,
+      },
+    },
+    {
+      id: '50',
+      target: 'Russia',
+      source: 'Spain',
+      data: {
+        target_score: 5,
+        source_score: 4,
+        directed: true,
+      },
+    },
+    {
+      id: '51',
+      target: 'Croatia',
+      source: 'Denmark',
+      data: {
+        target_score: 4,
+        source_score: 3,
+        directed: true,
+      },
+    },
+    {
+      id: '52',
+      target: 'Brazil',
+      source: 'Mexico',
+      data: {
+        target_score: 2,
+        source_score: 0,
+        directed: true,
+      },
+    },
+    {
+      id: '53',
+      target: 'Belgium',
+      source: 'Japan',
+      data: {
+        target_score: 3,
+        source_score: 2,
+        directed: true,
+      },
+    },
+    {
+      id: '54',
+      target: 'Sweden',
+      source: 'Switzerland',
+      data: {
+        target_score: 1,
+        source_score: 0,
+        directed: true,
+      },
+    },
+    {
+      id: '55',
+      target: 'England',
+      source: 'Colombia',
+      data: {
+        target_score: 4,
+        source_score: 3,
+        directed: true,
+      },
+    },
+    {
+      id: '56',
+      target: 'France',
+      source: 'Uruguay',
+      data: {
+        target_score: 2,
+        source_score: 0,
+        directed: true,
+      },
+    },
+    {
+      id: '57',
+      target: 'Belgium',
+      source: 'Brazil',
+      data: {
+        target_score: 2,
+        source_score: 1,
+        directed: true,
+      },
+    },
+    {
+      id: '58',
+      target: 'Croatia',
+      source: 'Russia',
+      data: {
+        target_score: 6,
+        source_score: 5,
+        directed: true,
+      },
+    },
+    {
+      id: '59',
+      target: 'England',
+      source: 'Sweden',
+      data: {
+        target_score: 2,
+        source_score: 0,
+        directed: true,
+      },
+    },
+    {
+      id: '60',
+      target: 'France',
+      source: 'Belgium',
+      data: {
+        target_score: 1,
+        source_score: 0,
+        directed: true,
+      },
+    },
+    {
+      id: '61',
+      target: 'Croatia',
+      source: 'England',
+      data: {
+        target_score: 2,
+        source_score: 1,
+        directed: true,
+      },
+    },
+    {
+      id: '62',
+      target: 'Belgium',
+      source: 'England',
+      data: {
+        target_score: 2,
+        source_score: 0,
+        directed: true,
+      },
+    },
+    {
+      id: '63',
+      target: 'France',
+      source: 'Croatia',
+      data: {
+        target_score: 4,
+        source_score: 2,
+        directed: true,
+      },
+    },
+  ],
+};
+
+describe('layout', () => {
+  let graph: IGraph<any>;
+  it('should apply circular layout correctly.', (done) => {
+    graph = new G6.Graph({
+      container,
+      width: 500,
+      height: 500,
+      type: 'graph',
+      data,
+      layout: {
+        type: 'circular',
+        center: [250, 250],
+        radius: 200,
+      },
+    });
+    graph.on('afterrender', () => {
+      // expect(graph.canvas.document.childNodes[0].childNodes.length).toBe(2);
+      done();
+    });
+  });
+});

--- a/packages/g6/tests/unit/layout-spec.ts
+++ b/packages/g6/tests/unit/layout-spec.ts
@@ -1,844 +1,7 @@
-import G6, { GraphData, IGraph } from '../../src/index';
+import G6, { IGraph } from '../../src/index';
+import { data } from '../datasets/dataset1';
 const container = document.createElement('div');
 document.querySelector('body').appendChild(container);
-
-const data: GraphData = {
-  nodes: [
-    {
-      id: 'Argentina',
-      data: {
-        name: 'Argentina',
-      },
-    },
-    {
-      id: 'Australia',
-      data: {
-        name: 'Australia',
-      },
-    },
-    {
-      id: 'Belgium',
-      data: {
-        name: 'Belgium',
-      },
-    },
-    {
-      id: 'Brazil',
-      data: {
-        name: 'Brazil',
-      },
-    },
-    {
-      id: 'Colombia',
-      data: {
-        name: 'Colombia',
-      },
-    },
-    {
-      id: 'Costa Rica',
-      data: {
-        name: 'Costa Rica',
-      },
-    },
-    {
-      id: 'Croatia',
-      data: {
-        name: 'Croatia',
-      },
-    },
-    {
-      id: 'Denmark',
-      data: {
-        name: 'Denmark',
-      },
-    },
-    {
-      id: 'Egypt',
-      data: {
-        name: 'Egypt',
-      },
-    },
-    {
-      id: 'England',
-      data: {
-        name: 'England',
-      },
-    },
-    {
-      id: 'France',
-      data: {
-        name: 'France',
-      },
-    },
-    {
-      id: 'Germany',
-      data: {
-        name: 'Germany',
-      },
-    },
-    {
-      id: 'Iceland',
-      data: {
-        name: 'Iceland',
-      },
-    },
-    {
-      id: 'IR Iran',
-      data: {
-        name: 'IR Iran',
-      },
-    },
-    {
-      id: 'Japan',
-      data: {
-        name: 'Japan',
-      },
-    },
-    {
-      id: 'Korea Republic',
-      data: {
-        name: 'Korea Republic',
-      },
-    },
-    {
-      id: 'Mexico',
-      data: {
-        name: 'Mexico',
-      },
-    },
-    {
-      id: 'Morocco',
-      data: {
-        name: 'Morocco',
-      },
-    },
-    {
-      id: 'Nigeria',
-      data: {
-        name: 'Nigeria',
-      },
-    },
-    {
-      id: 'Panama',
-      data: {
-        name: 'Panama',
-      },
-    },
-    {
-      id: 'Peru',
-      data: {
-        name: 'Peru',
-      },
-    },
-    {
-      id: 'Poland',
-      data: {
-        name: 'Poland',
-      },
-    },
-    {
-      id: 'Portugal',
-      data: {
-        name: 'Portugal',
-      },
-    },
-    {
-      id: 'Russia',
-      data: {
-        name: 'Russia',
-      },
-    },
-    {
-      id: 'Saudi Arabia',
-      data: {
-        name: 'Saudi Arabia',
-      },
-    },
-    {
-      id: 'Senegal',
-      data: {
-        name: 'Senegal',
-      },
-    },
-    {
-      id: 'Serbia',
-      data: {
-        name: 'Serbia',
-      },
-    },
-    {
-      id: 'Spain',
-      data: {
-        name: 'Spain',
-      },
-    },
-    {
-      id: 'Sweden',
-      data: {
-        name: 'Sweden',
-      },
-    },
-    {
-      id: 'Switzerland',
-      data: {
-        name: 'Switzerland',
-      },
-    },
-    {
-      id: 'Tunisia',
-      data: {
-        name: 'Tunisia',
-      },
-    },
-    {
-      id: 'Uruguay',
-      data: {
-        name: 'Uruguay',
-      },
-    },
-  ],
-  edges: [
-    {
-      id: '0',
-      target: 'Russia',
-      source: 'Saudi Arabia',
-      data: {
-        target_score: 5,
-        source_score: 0,
-        directed: true,
-      },
-    },
-    {
-      id: '1',
-      target: 'Uruguay',
-      source: 'Egypt',
-      data: {
-        target_score: 1,
-        source_score: 0,
-        directed: true,
-      },
-    },
-    {
-      id: '2',
-      target: 'Russia',
-      source: 'Egypt',
-      data: {
-        target_score: 3,
-        source_score: 1,
-        directed: true,
-      },
-    },
-    {
-      id: '3',
-      target: 'Uruguay',
-      source: 'Saudi Arabia',
-      data: {
-        target_score: 1,
-        source_score: 0,
-        directed: true,
-      },
-    },
-    {
-      id: '4',
-      target: 'Uruguay',
-      source: 'Russia',
-      data: {
-        target_score: 3,
-        source_score: 0,
-        directed: true,
-      },
-    },
-    {
-      id: '5',
-      target: 'Saudi Arabia',
-      source: 'Egypt',
-      data: {
-        target_score: 2,
-        source_score: 1,
-        directed: true,
-      },
-    },
-    {
-      id: '6',
-      target: 'IR Iran',
-      source: 'Morocco',
-      data: {
-        target_score: 1,
-        source_score: 0,
-        directed: true,
-      },
-    },
-    {
-      id: '7',
-      target: 'Portugal',
-      source: 'Spain',
-      data: {
-        target_score: 3,
-        source_score: 3,
-        directed: false,
-      },
-    },
-    {
-      id: '8',
-      target: 'Portugal',
-      source: 'Morocco',
-      data: {
-        target_score: 1,
-        source_score: 0,
-        directed: true,
-      },
-    },
-    {
-      id: '9',
-      target: 'Spain',
-      source: 'IR Iran',
-      data: {
-        target_score: 1,
-        source_score: 0,
-        directed: true,
-      },
-    },
-    {
-      id: '10',
-      target: 'IR Iran',
-      source: 'Portugal',
-      data: {
-        target_score: 1,
-        source_score: 1,
-        directed: false,
-      },
-    },
-    {
-      id: '11',
-      target: 'Spain',
-      source: 'Morocco',
-      data: {
-        target_score: 2,
-        source_score: 2,
-        directed: false,
-      },
-    },
-    {
-      id: '12',
-      target: 'France',
-      source: 'Australia',
-      data: {
-        target_score: 2,
-        source_score: 1,
-        directed: true,
-      },
-    },
-    {
-      id: '13',
-      target: 'Denmark',
-      source: 'Peru',
-      data: {
-        target_score: 1,
-        source_score: 0,
-        directed: true,
-      },
-    },
-    {
-      id: '14',
-      target: 'Denmark',
-      source: 'Australia',
-      data: {
-        target_score: 1,
-        source_score: 1,
-        directed: false,
-      },
-    },
-    {
-      id: '15',
-      target: 'France',
-      source: 'Peru',
-      data: {
-        target_score: 1,
-        source_score: 0,
-        directed: true,
-      },
-    },
-    {
-      id: '16',
-      target: 'Denmark',
-      source: 'France',
-      data: {
-        target_score: 0,
-        source_score: 0,
-        directed: false,
-      },
-    },
-    {
-      id: '17',
-      target: 'Peru',
-      source: 'Australia',
-      data: {
-        target_score: 2,
-        source_score: 0,
-        directed: true,
-      },
-    },
-    {
-      id: '18',
-      target: 'Argentina',
-      source: 'Iceland',
-      data: {
-        target_score: 1,
-        source_score: 1,
-      },
-    },
-    {
-      id: '19',
-      target: 'Croatia',
-      source: 'Nigeria',
-      data: {
-        target_score: 2,
-        source_score: 0,
-        directed: true,
-      },
-    },
-    {
-      id: '20',
-      target: 'Croatia',
-      source: 'Argentina',
-      data: {
-        target_score: 3,
-        source_score: 0,
-        directed: true,
-      },
-    },
-    {
-      id: '21',
-      target: 'Nigeria',
-      source: 'Iceland',
-      data: {
-        target_score: 2,
-        source_score: 0,
-        directed: true,
-      },
-    },
-    {
-      id: '22',
-      target: 'Argentina',
-      source: 'Nigeria',
-      data: {
-        target_score: 2,
-        source_score: 1,
-        directed: true,
-      },
-    },
-    {
-      id: '23',
-      target: 'Croatia',
-      source: 'Iceland',
-      data: {
-        target_score: 2,
-        source_score: 1,
-        directed: true,
-      },
-    },
-    {
-      id: '24',
-      target: 'Serbia',
-      source: 'Costa Rica',
-      data: {
-        target_score: 1,
-        source_score: 0,
-        directed: true,
-      },
-    },
-    {
-      id: '25',
-      target: 'Brazil',
-      source: 'Switzerland',
-      data: {
-        target_score: 1,
-        source_score: 1,
-        directed: false,
-      },
-    },
-    {
-      id: '26',
-      target: 'Brazil',
-      source: 'Costa Rica',
-      data: {
-        target_score: 2,
-        source_score: 0,
-        directed: true,
-      },
-    },
-    {
-      id: '27',
-      target: 'Switzerland',
-      source: 'Serbia',
-      data: {
-        target_score: 2,
-        source_score: 1,
-        directed: true,
-      },
-    },
-    {
-      id: '28',
-      target: 'Brazil',
-      source: 'Serbia',
-      data: {
-        target_score: 2,
-        source_score: 0,
-        directed: true,
-      },
-    },
-    {
-      id: '29',
-      target: 'Switzerland',
-      source: 'Costa Rica',
-      data: {
-        target_score: 2,
-        source_score: 2,
-        directed: false,
-      },
-    },
-    {
-      id: '30',
-      target: 'Mexico',
-      source: 'Germany',
-      data: {
-        target_score: 1,
-        source_score: 0,
-        directed: true,
-      },
-    },
-    {
-      id: '31',
-      target: 'Sweden',
-      source: 'Korea Republic',
-      data: {
-        target_score: 1,
-        source_score: 0,
-        directed: true,
-      },
-    },
-    {
-      id: '32',
-      target: 'Mexico',
-      source: 'Korea Republic',
-      data: {
-        target_score: 1,
-        source_score: 0,
-        directed: true,
-      },
-    },
-    {
-      id: '33',
-      target: 'Germany',
-      source: 'Sweden',
-      data: {
-        target_score: 2,
-        source_score: 1,
-        directed: true,
-      },
-    },
-    {
-      id: '34',
-      target: 'Korea Republic',
-      source: 'Germany',
-      data: {
-        target_score: 2,
-        source_score: 0,
-        directed: true,
-      },
-    },
-    {
-      id: '35',
-      target: 'Sweden',
-      source: 'Mexico',
-      data: {
-        target_score: 3,
-        source_score: 0,
-        directed: true,
-      },
-    },
-    {
-      id: '36',
-      target: 'Belgium',
-      source: 'Panama',
-      data: {
-        target_score: 3,
-        source_score: 0,
-        directed: true,
-      },
-    },
-    {
-      id: '37',
-      target: 'England',
-      source: 'Tunisia',
-      data: {
-        target_score: 2,
-        source_score: 1,
-        directed: true,
-      },
-    },
-    {
-      id: '38',
-      target: 'Belgium',
-      source: 'Tunisia',
-      data: {
-        target_score: 5,
-        source_score: 2,
-        directed: true,
-      },
-    },
-    {
-      id: '39',
-      target: 'England',
-      source: 'Panama',
-      data: {
-        target_score: 6,
-        source_score: 1,
-        directed: true,
-      },
-    },
-    {
-      id: '40',
-      target: 'Belgium',
-      source: 'England',
-      data: {
-        target_score: 1,
-        source_score: 0,
-        directed: true,
-      },
-    },
-    {
-      id: '41',
-      target: 'Tunisia',
-      source: 'Panama',
-      data: {
-        target_score: 2,
-        source_score: 1,
-        directed: true,
-      },
-    },
-    {
-      id: '42',
-      target: 'Japan',
-      source: 'Colombia',
-      data: {
-        target_score: 2,
-        source_score: 1,
-        directed: true,
-      },
-    },
-    {
-      id: '43',
-      target: 'Senegal',
-      source: 'Poland',
-      data: {
-        target_score: 2,
-        source_score: 1,
-        directed: true,
-      },
-    },
-    {
-      id: '44',
-      target: 'Japan',
-      source: 'Senegal',
-      data: {
-        target_score: 2,
-        source_score: 2,
-        directed: false,
-      },
-    },
-    {
-      id: '45',
-      target: 'Colombia',
-      source: 'Poland',
-      data: {
-        target_score: 3,
-        source_score: 0,
-        directed: true,
-      },
-    },
-    {
-      id: '46',
-      target: 'Poland',
-      source: 'Japan',
-      data: {
-        target_score: 1,
-        source_score: 0,
-        directed: true,
-      },
-    },
-    {
-      id: '47',
-      target: 'Colombia',
-      source: 'Senegal',
-      data: {
-        target_score: 1,
-        source_score: 0,
-        directed: true,
-      },
-    },
-    {
-      id: '48',
-      target: 'Uruguay',
-      source: 'Portugal',
-      data: {
-        target_score: 2,
-        source_score: 1,
-        directed: true,
-      },
-    },
-    {
-      id: '49',
-      target: 'France',
-      source: 'Argentina',
-      data: {
-        target_score: 4,
-        source_score: 3,
-        directed: true,
-      },
-    },
-    {
-      id: '50',
-      target: 'Russia',
-      source: 'Spain',
-      data: {
-        target_score: 5,
-        source_score: 4,
-        directed: true,
-      },
-    },
-    {
-      id: '51',
-      target: 'Croatia',
-      source: 'Denmark',
-      data: {
-        target_score: 4,
-        source_score: 3,
-        directed: true,
-      },
-    },
-    {
-      id: '52',
-      target: 'Brazil',
-      source: 'Mexico',
-      data: {
-        target_score: 2,
-        source_score: 0,
-        directed: true,
-      },
-    },
-    {
-      id: '53',
-      target: 'Belgium',
-      source: 'Japan',
-      data: {
-        target_score: 3,
-        source_score: 2,
-        directed: true,
-      },
-    },
-    {
-      id: '54',
-      target: 'Sweden',
-      source: 'Switzerland',
-      data: {
-        target_score: 1,
-        source_score: 0,
-        directed: true,
-      },
-    },
-    {
-      id: '55',
-      target: 'England',
-      source: 'Colombia',
-      data: {
-        target_score: 4,
-        source_score: 3,
-        directed: true,
-      },
-    },
-    {
-      id: '56',
-      target: 'France',
-      source: 'Uruguay',
-      data: {
-        target_score: 2,
-        source_score: 0,
-        directed: true,
-      },
-    },
-    {
-      id: '57',
-      target: 'Belgium',
-      source: 'Brazil',
-      data: {
-        target_score: 2,
-        source_score: 1,
-        directed: true,
-      },
-    },
-    {
-      id: '58',
-      target: 'Croatia',
-      source: 'Russia',
-      data: {
-        target_score: 6,
-        source_score: 5,
-        directed: true,
-      },
-    },
-    {
-      id: '59',
-      target: 'England',
-      source: 'Sweden',
-      data: {
-        target_score: 2,
-        source_score: 0,
-        directed: true,
-      },
-    },
-    {
-      id: '60',
-      target: 'France',
-      source: 'Belgium',
-      data: {
-        target_score: 1,
-        source_score: 0,
-        directed: true,
-      },
-    },
-    {
-      id: '61',
-      target: 'Croatia',
-      source: 'England',
-      data: {
-        target_score: 2,
-        source_score: 1,
-        directed: true,
-      },
-    },
-    {
-      id: '62',
-      target: 'Belgium',
-      source: 'England',
-      data: {
-        target_score: 2,
-        source_score: 0,
-        directed: true,
-      },
-    },
-    {
-      id: '63',
-      target: 'France',
-      source: 'Croatia',
-      data: {
-        target_score: 4,
-        source_score: 2,
-        directed: true,
-      },
-    },
-  ],
-};
 
 describe('layout', () => {
   let graph: IGraph<any>;
@@ -855,8 +18,205 @@ describe('layout', () => {
         radius: 200,
       },
     });
-    graph.on('afterrender', () => {
-      // expect(graph.canvas.document.childNodes[0].childNodes.length).toBe(2);
+
+    graph.once('afterlayout', () => {
+      const nodesData = graph.getAllNodesData();
+      expect(nodesData[0].data.x).toBe(450);
+      expect(nodesData[0].data.y).toBe(250);
+
+      graph.destroy();
+      done();
+    });
+  });
+
+  it('should trigger re-layout by calling `layout` method manually.', (done) => {
+    graph = new G6.Graph({
+      container,
+      width: 500,
+      height: 500,
+      type: 'graph',
+      data,
+      layout: {
+        type: 'circular',
+        center: [250, 250],
+        radius: 200,
+      },
+    });
+
+    // first-time layout
+    graph.once('afterlayout', () => {
+      const nodesData = graph.getAllNodesData();
+      expect(nodesData[0].data.x).toBe(450);
+      expect(nodesData[0].data.y).toBe(250);
+
+      // re-layout
+      graph.once('afterlayout', () => {
+        const nodesData = graph.getAllNodesData();
+        expect(nodesData[0].data.x).toBe(350);
+        expect(nodesData[0].data.y).toBe(250);
+
+        graph.destroy();
+        done();
+      });
+
+      graph.layout({
+        type: 'circular',
+        center: [250, 250],
+        radius: 100, // change radius here
+      });
+    });
+  });
+
+  it('should trigger re-layout by calling `changeData` method manually.', (done) => {
+    graph = new G6.Graph({
+      container,
+      width: 500,
+      height: 500,
+      type: 'graph',
+      data,
+      layout: {
+        type: 'circular',
+        center: [250, 250],
+        radius: 200,
+      },
+    });
+
+    // first-time layout
+    graph.once('afterlayout', () => {
+      const nodesData = graph.getAllNodesData();
+      expect(nodesData[0].data.x).toBe(450);
+      expect(nodesData[0].data.y).toBe(250);
+
+      // re-layout
+      graph.once('afterlayout', () => {
+        const nodesData = graph.getAllNodesData();
+        expect(nodesData[0].data.x).toBe(250);
+        expect(nodesData[0].data.y).toBe(250);
+
+        graph.destroy();
+        done();
+      });
+
+      // Only one single node.
+      const newData = {
+        nodes: [{ id: 'node13', data: { x: 50, y: 50 } }],
+        edges: [{ id: 'edge1', source: 'node13', target: 'node13', data: {} }],
+      };
+      graph.changeData(newData);
+    });
+  });
+
+  it('should run layout in WebWorker with `workerEnabled`.', (done) => {
+    graph = new G6.Graph({
+      container,
+      width: 500,
+      height: 500,
+      type: 'graph',
+      data,
+      layout: {
+        type: 'circular',
+        workerEnabled: true,
+        center: [250, 250],
+        radius: 200,
+      },
+    });
+
+    graph.once('afterlayout', () => {
+      const nodesData = graph.getAllNodesData();
+      expect(nodesData[0].data.x).toBe(450);
+      expect(nodesData[0].data.y).toBe(250);
+
+      // re-layout
+      graph.once('afterlayout', () => {
+        const nodesData = graph.getAllNodesData();
+        expect(nodesData[0].data.x).toBe(350);
+        expect(nodesData[0].data.y).toBe(250);
+
+        graph.destroy();
+        done();
+      });
+
+      graph.layout({
+        type: 'circular',
+        center: [250, 250],
+        radius: 100, // change radius here
+      });
+    });
+  });
+
+  it('should display the layout process with `animated`.', (done) => {
+    graph = new G6.Graph({
+      container,
+      width: 500,
+      height: 500,
+      type: 'graph',
+      data,
+      layout: {
+        type: 'd3force',
+        animated: true,
+        center: [250, 250],
+        preventOverlap: true,
+        nodeSize: 20,
+      },
+    });
+
+    graph.once('afterlayout', () => {
+      const nodesData = graph.getAllNodesData();
+      expect(nodesData.every((node) => node.data.x > 0 && node.data.y > 0)).toBeTruthy();
+      graph.destroy();
+      done();
+    });
+  });
+
+  it('should stop animated layout process with `stopLayout`.', (done) => {
+    graph = new G6.Graph({
+      container,
+      width: 500,
+      height: 500,
+      type: 'graph',
+      data,
+      layout: {
+        type: 'd3force',
+        animated: true,
+        center: [250, 250],
+        preventOverlap: true,
+        nodeSize: 20,
+      },
+    });
+
+    setTimeout(() => {
+      graph.stopLayout();
+
+      const nodesData = graph.getAllNodesData();
+      expect(nodesData.every((node) => node.data.x > 0 && node.data.y > 0)).toBeTruthy();
+
+      graph.destroy();
+      done();
+    }, 1000);
+  });
+
+  it('should manually steps the simulation with `iterations` and `animated` disabled.', (done) => {
+    graph = new G6.Graph({
+      container,
+      width: 500,
+      height: 500,
+      type: 'graph',
+      data,
+      layout: {
+        type: 'd3force',
+        animated: false,
+        center: [250, 250],
+        preventOverlap: true,
+        nodeSize: 20,
+        iterations: 1000,
+      },
+    });
+
+    graph.once('afterlayout', () => {
+      const nodesData = graph.getAllNodesData();
+      expect(nodesData.every((node) => node.data.x > 0 && node.data.y > 0)).toBeTruthy();
+
+      graph.destroy();
       done();
     });
   });


### PR DESCRIPTION
## Spec 中的布局参数

使用 `type` 指明使用的内置布局（来自`@antv/layout`和`@antv/layout-gpu`），传入其他布局参数（以 Circular 为例）：
```js
layout: {
  type: 'circular',
  center: [200, 200],
  width: 400,
  height: 400,
}
```

其他参数：

* `animated` 对于支持多次迭代的布局，开启后会在每个 tick 中更新节点位置，同时在 Graph 上触发 `tick` 事件
* `iterations` 对于支持多次迭代的布局，当 `animated` 关闭时，可以传入该参数一次性执行指定迭代次数，此时**不会**在 Graph 上触发 `tick` 事件
* `workerEnabled` 开启后使用 `@antv/layout` 提供的 Supervisor 用于 WebWorker 创建、执行算法

创建 Graph 时传入 `layout` 参数立即开始首次布局。

## Graph API

API：

* `layout` 异步方法，用于首次布局之后手动触发
* `stopLayout` 同步方法，用于停止支持多次迭代的布局

在下面的例子中 Graph 创建后自动开始首次布局，通过 `layout` 方法触发二次布局：

```js
graph = new G6.Graph({
  // 省略其他参数
  layout: {
    type: 'circular',
    center: [250, 250],
    radius: 200,
  },
});

// 首次布局完成后触发
graph.once('afterlayout', () => {
  // 重新布局完成后触发
  graph.once('afterlayout', () => {});
  // 重新布局
  graph.layout({
    type: 'circular',
    center: [250, 250],
    radius: 100,
  });
});
```

在 Graph 上调用 `read` / `changeData` / `layout` 均会触发布局，完成后触发 `afterlayout` 事件。由于 `@antv/layout` `@antv/layout-gpu` 提供的都是异步 API，因此 Hook 需要调用 `emitLinearAsync`：

```js
await this.hooks.layout.emitLinearAsync({
  graphCore: this.dataController.graphCore,
  options,
});
```

在 `graph.destroy` 需要调用 `layoutController.destroy`，用于销毁 WebWorker（通过调用 `supervisor.kill()`）。

会触发两种事件：

* `'afterlayout'` 布局计算完成后触发
* `'tick'` 支持多次迭代的布局每个 tick 中触发

## 注册自定义布局

详见测试用例：

```ts
import { Graph } from '@antv/graphlib';
import { Layout, LayoutMapping } from '@antv/layout';
import { stdLib } from '@antv/g6';

// 实现 Layout 接口
class MyCustomLayout implements Layout<{}> {
  async assign(graph: Graph, options?: {}): Promise<void> {
    throw new Error('Method not implemented.');
  }
// G6 里只会调用该方法
  async execute(graph: Graph, options?: {}): Promise<LayoutMapping> {
    const nodes = graph.getAllNodes();
    return {
      nodes: nodes.map((node) => ({
        id: node.id,
        data: {
          x: 0,
          y: 0,
        },
      })),
      edges: [],
    };
  }
  options: {};
  id: 'myCustomLayout';
}

// 在 stdLib 中注册
stdLib.layouts['myCustomLayout'] = MyCustomLayout;
```

但由于目前的 WebWorker 方案是在构建时生成 Worker 代码，因此运行时注册的布局就不支持通过 Supervisor 方式运行了。用户需要自行创建 WebWorker 并处理和主线程的数据传输。

## 测试用例

增加 Circular 测试用例：

<img width="514" alt="截屏2023-02-20 下午8 24 08" src="https://user-images.githubusercontent.com/3608471/220106688-a048c2fe-f3c3-48e4-ad66-8dc33a05bbe5.png">

目前全部测试如下：

<img width="491" alt="截屏2023-02-22 下午4 11 14" src="https://user-images.githubusercontent.com/3608471/220560820-53e9cf79-918e-418b-b8a4-9e054f5eb973.png">

## 其他修改

* `registery` -> `registry`
* 之前 Jest 中使用 `g-webgl` 需要额外配置否则会报错，现已解决：https://github.com/antvis/G/issues/1289