### PR TITLE
fix: donut rendering - isBig must be number for use in path

### DIFF
--- a/packages/element/src/nodes/donut.ts
+++ b/packages/element/src/nodes/donut.ts
@@ -242,7 +242,7 @@ const drawFan = (group: IGroup, fanConfig: FanConfig): {
   // draw a path represents the whole circle, or the percentage is close to 1
   if (drawWhole || percent > 0.999) {
     arcEnd = [arcR, 0.0001]; // [arcR * cos(2 * PI), -arcR * sin(2 * PI)]
-    isBig = true;
+    isBig = 1;
   } else {
     const angle = percent * Math.PI * 2;
     endAngle = beginAngle + angle;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change

This fixes a bug that was introduced in [this PR](https://github.com/antvis/G6/commit/a94c50a7989fb2915fad17bf2f5598a4bd367670#diff-084ec8a46f517a9858a776d184208fe0a59b13d3a65c84f21d10be7c8349c486). The problem is that the `isBig` variable can be a boolean, when it should only be a number, so that it can be correctly included in the fan path. When using the SVG renderer, this can cause invalid SVGs to be generated, which the browser does not render, so the donuts do not appear.
