### PR TITLE
fix: type definition error

### DIFF
--- a/packages/pc/src/graph/tree-graph.ts
+++ b/packages/pc/src/graph/tree-graph.ts
@@ -9,6 +9,7 @@ import {
   ShapeStyle,
   TreeGraphData,
   GraphOptions,
+  IPoint,
 } from '@antv/g6-core';
 import { ITreeGraph } from '../interface/graph';
 import Util from '../util';
@@ -273,7 +274,7 @@ export default class TreeGraph extends Graph implements ITreeGraph {
    * 更改并应用树布局算法
    * @param {object} layout 布局算法
    */
-  public updateLayout(layout: any, stack: boolean = true) {
+  public updateLayout(layout: any, _align?: 'center' | 'begin', _canvasPoint?: IPoint, stack?: boolean = true) {
     const self = this;
     if (!layout) {
       // eslint-disable-next-line no-console
@@ -628,7 +629,7 @@ export default class TreeGraph extends Graph implements ITreeGraph {
    * 设置视图初始化数据
    * @param {TreeGraphData} data 初始化数据
    */
-  public data(data?: TreeGraphData): void {
+  public data(data?: GraphData | TreeGraphData): void {
     super.data(data);
     this.set('originData', JSON.parse(JSON.stringify(data)));
   }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->

close #4301 

在 Angular V14 下, 安装G6会报错. 看了下G6源代码, 主要是由于以下关系导致的
```ts
export default class TreeGraph extends Graph implements ITreeGraph { }
export interface ITreeGraph extends IGraph { }
export interface IGraph extends IAbstractGraph {
    data: (data?: GraphData | TreeGraphData) => void;
}
export interface IAbstractGraph extends EventEmitter {
    updateLayout: (cfg: LayoutConfig, align?: 'center' | 'begin', canvasPoint?: IPoint, stack?: boolean) => void;
}
```
在ts版本4.7.2当中会有问题.