### PR TITLE
支持更多场景下的布局过渡动画

### DIFF
--- a/packages/g6/src/runtime/graph.ts
+++ b/packages/g6/src/runtime/graph.ts
@@ -1,5 +1,5 @@
 import EventEmitter from '@antv/event-emitter';
-import { Canvas } from '@antv/g';
+import { Canvas, runtime } from '@antv/g';
 import { GraphChange, ID } from '@antv/graphlib';
 import { isArray, isNil, isNumber, isObject, isString } from '@antv/util';
 import {
@@ -35,6 +35,11 @@ import {
   ThemeController,
 } from './controller';
 import Hook from './hooks';
+
+/**
+ * Disable CSS parsing for better performance.
+ */
+runtime.enableCSSParsing = false;
 
 export default class Graph<B extends BehaviorRegistry> extends EventEmitter implements IGraph<B> {
   public hooks: Hooks;
@@ -580,7 +585,7 @@ export default class Graph<B extends BehaviorRegistry> extends EventEmitter impl
         // Use `grid` layout as default when x/y of each node is unset.
         (formattedOptions as StandardLayoutOptions).type = 'grid';
       } else {
-        // - 没有配置 layout，只要部分节点数据中有 x y 的时候，直接使用数据中的坐标，没有 x y 的部分就初始化为 0 0
+        // Use user-defined position(x/y default to 0).
         (formattedOptions as ImmediatelyInvokedLayoutOptions).execute = async (graph) => {
           const nodes = graph.getAllNodes();
           return {

--- a/packages/g6/src/types/index.ts
+++ b/packages/g6/src/types/index.ts
@@ -4,3 +4,10 @@ export { NodeUserModel, NodeModel, NodeDisplayModel } from './node';
 export { EdgeUserModel, EdgeModel, EdgeDisplayModel } from './edge';
 export { ComboUserModel, ComboModel, ComboDisplayModel } from './combo';
 export { Specification } from './spec';
+export {
+  StandardLayoutOptions,
+  ImmediatelyInvokedLayoutOptions,
+  LayoutOptions,
+  isImmediatelyInvokedLayoutOptions,
+  isLayoutWorkerized,
+} from './layout';

--- a/packages/g6/src/types/layout.ts
+++ b/packages/g6/src/types/layout.ts
@@ -1,3 +1,4 @@
+import { IAnimationEffectTiming } from '@antv/g';
 import {
   CircularLayoutOptions,
   ConcentricLayoutOptions,
@@ -23,8 +24,25 @@ export type LayoutOptions = (
   | ForceLayout
   | ForceAtlas2
 ) & {
+  /**
+   * Make layout running in WebWorker.
+   */
   workerEnabled?: boolean;
+
+  /**
+   * Make layout animated. For layouts with iterations, transitions will happen between ticks.
+   */
   animated?: boolean;
+
+  /**
+   * Effect timing of animation for layouts without iterations.
+   * @see https://g.antv.antgroup.com/api/animation/waapi#effecttiming
+   */
+  animationEffectTiming?: Partial<IAnimationEffectTiming>;
+
+  /**
+   * Iterations for iteratable layouts such as Force.
+   */
   iterations?: number;
 };
 

--- a/packages/g6/src/types/layout.ts
+++ b/packages/g6/src/types/layout.ts
@@ -7,28 +7,14 @@ import {
   ForceLayoutOptions,
   FruchtermanLayoutOptions,
   GridLayoutOptions,
+  LayoutMapping,
   MDSLayoutOptions,
   RadialLayoutOptions,
   RandomLayoutOptions,
 } from '@antv/layout';
+import { GraphCore } from './data';
 
-export type LayoutOptions = (
-  | CircularLayout
-  | RandomLayout
-  | ConcentricLayout
-  | GridLayout
-  | MDSLayout
-  | RadialLayout
-  | FruchtermanLayout
-  | D3ForceLayout
-  | ForceLayout
-  | ForceAtlas2
-) & {
-  /**
-   * Make layout running in WebWorker.
-   */
-  workerEnabled?: boolean;
-
+type Animatable = {
   /**
    * Make layout animated. For layouts with iterations, transitions will happen between ticks.
    */
@@ -39,12 +25,38 @@ export type LayoutOptions = (
    * @see https://g.antv.antgroup.com/api/animation/waapi#effecttiming
    */
   animationEffectTiming?: Partial<IAnimationEffectTiming>;
-
-  /**
-   * Iterations for iteratable layouts such as Force.
-   */
-  iterations?: number;
 };
+
+export type LayoutOptions =
+  | ({
+      /**
+       * like an IIFE.
+       */
+      execute: (graph: GraphCore, options?: any) => Promise<LayoutMapping>;
+    } & Animatable)
+  | (((
+      | CircularLayout
+      | RandomLayout
+      | ConcentricLayout
+      | GridLayout
+      | MDSLayout
+      | RadialLayout
+      | FruchtermanLayout
+      | D3ForceLayout
+      | ForceLayout
+      | ForceAtlas2
+    ) & {
+      /**
+       * Make layout running in WebWorker.
+       */
+      workerEnabled?: boolean;
+
+      /**
+       * Iterations for iteratable layouts such as Force.
+       */
+      iterations?: number;
+    }) &
+      Animatable);
 
 interface CircularLayout extends CircularLayoutOptions {
   type: 'circular';

--- a/packages/g6/src/types/layout.ts
+++ b/packages/g6/src/types/layout.ts
@@ -27,14 +27,32 @@ type Animatable = {
   animationEffectTiming?: Partial<IAnimationEffectTiming>;
 };
 
-export type LayoutOptions =
-  | ({
-      /**
-       * like an IIFE.
-       */
-      execute: (graph: GraphCore, options?: any) => Promise<LayoutMapping>;
-    } & Animatable)
-  | (((
+type Workerized = {
+  /**
+   * Make layout running in WebWorker.
+   */
+  workerEnabled?: boolean;
+
+  /**
+   * Iterations for iteratable layouts such as Force.
+   */
+  iterations?: number;
+};
+
+export type ImmediatelyInvokedLayoutOptions = {
+  /**
+   * like an IIFE.
+   */
+  execute: (graph: GraphCore, options?: any) => Promise<LayoutMapping>;
+} & Animatable;
+
+type CustomLayout = {
+  type: string;
+  [option: string]: any;
+};
+
+export type StandardLayoutOptions =
+  | (
       | CircularLayout
       | RandomLayout
       | ConcentricLayout
@@ -45,18 +63,37 @@ export type LayoutOptions =
       | D3ForceLayout
       | ForceLayout
       | ForceAtlas2
-    ) & {
-      /**
-       * Make layout running in WebWorker.
-       */
-      workerEnabled?: boolean;
+      | CustomLayout
+    ) &
+      Animatable &
+      Workerized;
 
-      /**
-       * Iterations for iteratable layouts such as Force.
-       */
-      iterations?: number;
-    }) &
-      Animatable);
+export type LayoutOptions = StandardLayoutOptions | ImmediatelyInvokedLayoutOptions;
+
+export function isImmediatelyInvokedLayoutOptions(
+  options: any,
+): options is ImmediatelyInvokedLayoutOptions {
+  return !!options.execute;
+}
+
+export function isLayoutWorkerized(options: StandardLayoutOptions) {
+  return (
+    [
+      'circular',
+      'random',
+      'grid',
+      'mds',
+      'concentric',
+      'radial',
+      'fruchterman',
+      'fruchtermanGPU',
+      'd3force',
+      'force',
+      'gforce',
+      'forceAtlas2',
+    ].indexOf(options.type) > -1
+  );
+}
 
 interface CircularLayout extends CircularLayoutOptions {
   type: 'circular';

--- a/packages/g6/tests/unit/layout-spec.ts
+++ b/packages/g6/tests/unit/layout-spec.ts
@@ -222,6 +222,53 @@ describe('layout', () => {
     }, 500);
   });
 
+  it('should execute an immediately invoked layout with animation.', (done) => {
+    setTimeout(() => {
+      graph = new G6.Graph({
+        container,
+        width: 500,
+        height: 500,
+        type: 'graph',
+        data,
+        layout: {
+          type: 'circular',
+          animated: true,
+          center: [250, 250],
+          radius: 200,
+        },
+      });
+
+      graph.once('afterlayout', async () => {
+        const nodesData = graph.getAllNodesData();
+        expect(nodesData[0].data.x).toBe(450);
+        expect(nodesData[0].data.y).toBe(250);
+
+        await graph.layout({
+          execute: async (graph) => {
+            const nodes = graph.getAllNodes();
+            return {
+              nodes: nodes.map((node) => ({
+                id: node.id,
+                data: {
+                  x: 250,
+                  y: 250,
+                },
+              })),
+              edges: [],
+            };
+          },
+          animated: true,
+          animationEffectTiming: {
+            duration: 1000,
+          },
+        });
+
+        graph.destroy();
+        done();
+      });
+    }, 500);
+  });
+
   it('should stop animated layout process with `stopLayout`.', (done) => {
     graph = new G6.Graph({
       container,

--- a/packages/g6/tests/unit/layout-spec.ts
+++ b/packages/g6/tests/unit/layout-spec.ts
@@ -1,11 +1,146 @@
-import { Graph, Layout, LayoutMapping } from '@antv/layout';
-import G6, { IGraph, stdLib } from '../../src/index';
+import { Layout, LayoutMapping } from '@antv/layout';
+import G6, { stdLib } from '../../src/index';
 import { data } from '../datasets/dataset1';
 const container = document.createElement('div');
-document.querySelector('body').appendChild(container);
+document.querySelector('body')!.appendChild(container);
 
 describe('layout', () => {
-  let graph: IGraph<any>;
+  let graph: any;
+  // it.only('should use `x/y` properties of nodes when layout is unset.', (done) => {
+  //   // - 没有配置 layout，只要部分节点数据中有 x y 的时候，直接使用数据中的坐标，没有 x y 的部分就初始化为 0 0
+  //   // - 没有配置 layout，数据中没有 x y，使用 grid 布局进行初始化
+  //   graph = new G6.Graph({
+  //     container,
+  //     width: 500,
+  //     height: 500,
+  //     type: 'graph',
+  //     data,
+  //   });
+
+  //   graph.once('afterlayout', () => {
+  //     const nodesData = graph.getAllNodesData();
+  //     expect(nodesData[0].data.x).toBe(125);
+  //     expect(nodesData[0].data.y).toBe(75);
+
+  //     expect(nodesData[1].data.x).toBe(225);
+  //     expect(nodesData[1].data.y).toBe(75);
+
+  //     // graph.destroy();
+  //     done();
+  //   });
+  // });
+
+  it('should use grid as default when layout is unset in spec.', (done) => {
+    graph = new G6.Graph({
+      container,
+      width: 500,
+      height: 500,
+      type: 'graph',
+      data,
+    });
+
+    graph.once('afterlayout', () => {
+      const nodesData = graph.getAllNodesData();
+      expect(nodesData[0].data.x).toBe(125);
+      expect(nodesData[0].data.y).toBe(75);
+
+      expect(nodesData[1].data.x).toBe(225);
+      expect(nodesData[1].data.y).toBe(125);
+
+      graph.destroy();
+      done();
+    });
+  });
+
+  it("should use user-defined x/y as node's position when layout is unset in spec.", (done) => {
+    setTimeout(() => {
+      graph = new G6.Graph({
+        container,
+        width: 500,
+        height: 500,
+        type: 'graph',
+        data: {
+          nodes: [
+            {
+              id: 'a',
+              data: {
+                x: 100,
+                y: 100,
+              },
+            },
+            {
+              id: 'b',
+              data: {
+                x: 100,
+              },
+            },
+            {
+              id: 'c',
+              data: {},
+            },
+          ],
+          edges: [],
+        },
+      });
+
+      graph.once('afterlayout', async () => {
+        const nodesData = graph.getAllNodesData();
+        expect(nodesData[0].data.x).toBe(100);
+        expect(nodesData[0].data.y).toBe(100);
+        expect(nodesData[1].data.x).toBe(100);
+        expect(nodesData[1].data.y).toBe(0);
+        expect(nodesData[2].data.x).toBe(0);
+        expect(nodesData[2].data.y).toBe(0);
+
+        // re-layout
+        await graph.layout({
+          execute: async () => {
+            return {
+              nodes: [
+                {
+                  id: 'a',
+                  data: {
+                    x: 200,
+                    y: 200,
+                  },
+                },
+                {
+                  id: 'b',
+                  data: {
+                    x: 100,
+                    y: 100,
+                  },
+                },
+                {
+                  id: 'c',
+                  data: {
+                    x: 250,
+                    y: 250,
+                  },
+                },
+              ],
+              edges: [],
+            };
+          },
+          animated: true,
+          animationEffectTiming: {
+            duration: 1000,
+          },
+        });
+
+        expect(nodesData[0].data.x).toBe(200);
+        expect(nodesData[0].data.y).toBe(200);
+        expect(nodesData[1].data.x).toBe(100);
+        expect(nodesData[1].data.y).toBe(100);
+        expect(nodesData[2].data.x).toBe(250);
+        expect(nodesData[2].data.y).toBe(250);
+
+        graph.destroy();
+        done();
+      });
+    }, 500);
+  });
+
   it('should apply circular layout correctly.', (done) => {
     graph = new G6.Graph({
       container,
@@ -325,10 +460,10 @@ describe('layout', () => {
   it('should allow registering custom layout at runtime.', (done) => {
     // Put all nodes at `[0, 0]`.
     class MyCustomLayout implements Layout<{}> {
-      async assign(graph: Graph, options?: {}): Promise<void> {
+      async assign(graph, options?: {}): Promise<void> {
         throw new Error('Method not implemented.');
       }
-      async execute(graph: Graph, options?: {}): Promise<LayoutMapping> {
+      async execute(graph, options?: {}): Promise<LayoutMapping> {
         const nodes = graph.getAllNodes();
         return {
           nodes: nodes.map((node) => ({
@@ -355,7 +490,6 @@ describe('layout', () => {
       type: 'graph',
       data,
       layout: {
-        // @ts-ignore
         type: 'myCustomLayout',
       },
     });

--- a/packages/g6/tests/unit/layout-spec.ts
+++ b/packages/g6/tests/unit/layout-spec.ts
@@ -145,7 +145,7 @@ describe('layout', () => {
     });
   });
 
-  it('should display the layout process with `animated`.', (done) => {
+  it('should display the process in layout with iterations when `animated` enabled.', (done) => {
     graph = new G6.Graph({
       container,
       width: 500,
@@ -167,6 +167,59 @@ describe('layout', () => {
       graph.destroy();
       done();
     });
+  });
+
+  it('should display the process in layout without iterations when `animated` enabled.', (done) => {
+    setTimeout(() => {
+      graph = new G6.Graph({
+        container,
+        width: 500,
+        height: 500,
+        type: 'graph',
+        data,
+        layout: {
+          type: 'circular',
+          animated: true,
+          center: [250, 250],
+          radius: 200,
+        },
+      });
+
+      graph.once('afterlayout', async () => {
+        const nodesData = graph.getAllNodesData();
+        expect(nodesData[0].data.x).toBe(450);
+        expect(nodesData[0].data.y).toBe(250);
+
+        await graph.layout({
+          type: 'circular',
+          center: [250, 250],
+          radius: 100,
+          animated: true,
+          animationEffectTiming: {
+            duration: 1000,
+            easing: 'in-out-bounce',
+          },
+        });
+
+        await graph.layout({
+          type: 'random',
+          animated: true,
+          animationEffectTiming: {
+            duration: 1000,
+          },
+        });
+
+        await graph.layout({
+          type: 'circular',
+          center: [250, 250],
+          radius: 200,
+          animated: false,
+        });
+
+        graph.destroy();
+        done();
+      });
+    }, 500);
   });
 
   it('should stop animated layout process with `stopLayout`.', (done) => {

--- a/packages/g6/tests/unit/layout-spec.ts
+++ b/packages/g6/tests/unit/layout-spec.ts
@@ -6,29 +6,6 @@ document.querySelector('body')!.appendChild(container);
 
 describe('layout', () => {
   let graph: any;
-  // it.only('should use `x/y` properties of nodes when layout is unset.', (done) => {
-  //   // - 没有配置 layout，只要部分节点数据中有 x y 的时候，直接使用数据中的坐标，没有 x y 的部分就初始化为 0 0
-  //   // - 没有配置 layout，数据中没有 x y，使用 grid 布局进行初始化
-  //   graph = new G6.Graph({
-  //     container,
-  //     width: 500,
-  //     height: 500,
-  //     type: 'graph',
-  //     data,
-  //   });
-
-  //   graph.once('afterlayout', () => {
-  //     const nodesData = graph.getAllNodesData();
-  //     expect(nodesData[0].data.x).toBe(125);
-  //     expect(nodesData[0].data.y).toBe(75);
-
-  //     expect(nodesData[1].data.x).toBe(225);
-  //     expect(nodesData[1].data.y).toBe(75);
-
-  //     // graph.destroy();
-  //     done();
-  //   });
-  // });
 
   it('should use grid as default when layout is unset in spec.', (done) => {
     graph = new G6.Graph({


### PR DESCRIPTION
#4339 

* 关闭 G 的样式解析以提升性能
* 增加 spec 中未指定 `layout` 的处理：
```js
// 初始化时未指定布局
graph = new G6.Graph({
  container,
  width: 500,
  height: 500,
  type: 'graph',
  data,
});
```

此时应用默认值的逻辑如下：
* `data` 数据中所有节点都不包含用户指定的 `x/y`，应用 grid 布局
* `data` 数据中有部分节点指定了 `x/y`，不使用任何内置布局，认为是用户自定义布局，此时未指定的坐标默认为 0

测试用例：https://github.com/antvis/G6/pull/4345/files#diff-1ebcdba2da6b0c76dd377fd9d508056cd4a8e3952ae22594d176dab467ac799cR10-R120