### PR TITLE
使用相机实现视口相关功能

### DIFF
--- a/packages/g6/src/runtime/controller/index.ts
+++ b/packages/g6/src/runtime/controller/index.ts
@@ -2,5 +2,6 @@ export * from './data';
 export * from './interaction';
 export * from './item';
 export * from './layout';
+export * from './viewport';
 export * from './theme';
 export * from './extension';

--- a/packages/g6/src/runtime/controller/item.ts
+++ b/packages/g6/src/runtime/controller/item.ts
@@ -1,16 +1,16 @@
-import { GraphChange, ID } from '@antv/graphlib';
-import { ComboModel, IGraph } from '../../types';
-import registry from '../../stdlib';
-import { getExtension } from '../../util/extension';
-import { GraphCore } from '../../types/data';
-import { NodeDisplayModel, NodeEncode, NodeModel, NodeModelData } from '../../types/node';
-import { EdgeDisplayModel, EdgeEncode, EdgeModel, EdgeModelData } from '../../types/edge';
-import Node from '../../item/node';
-import Edge from '../../item/edge';
-import Combo from '../../item/combo';
 import { Group } from '@antv/g';
-import { ITEM_TYPE } from '../../types/item';
+import { GraphChange, ID } from '@antv/graphlib';
+import Combo from '../../item/combo';
+import Edge from '../../item/edge';
+import Node from '../../item/node';
+import registry from '../../stdlib';
+import { ComboModel, IGraph } from '../../types';
 import { ComboDisplayModel, ComboEncode } from '../../types/combo';
+import { GraphCore } from '../../types/data';
+import { EdgeDisplayModel, EdgeEncode, EdgeModel, EdgeModelData } from '../../types/edge';
+import { ITEM_TYPE } from '../../types/item';
+import { NodeDisplayModel, NodeEncode, NodeModel, NodeModelData } from '../../types/node';
+import { getExtension } from '../../util/extension';
 
 /**
  * Manages and stores the node / edge / combo items.
@@ -50,7 +50,7 @@ export class ItemController {
   constructor(graph: IGraph<any>) {
     this.graph = graph;
     // get mapper for node / edge / combo
-    const { node, edge, combo, nodeState, edgeState, comboState }  = graph.getSpecification();
+    const { node, edge, combo, nodeState, edgeState, comboState } = graph.getSpecification();
     this.nodeMapper = node;
     this.edgeMapper = edge;
     this.comboMapper = combo;
@@ -255,9 +255,9 @@ export class ItemController {
    *   value: state value
    * }
    */
-  private onItemStateChange(param: { ids: ID[], states: string[], value: boolean }) {
+  private onItemStateChange(param: { ids: ID[]; states: string[]; value: boolean }) {
     const { ids, states, value } = param;
-    ids.forEach(id => {
+    ids.forEach((id) => {
       const item = this.itemMap[id];
       if (!item) {
         console.warn(`Fail to set state for item ${id}, which is not exist.`);
@@ -267,7 +267,7 @@ export class ItemController {
         // clear all the states
         item.clearStates(states);
       } else {
-        states.forEach(state => item.setState(state, value));
+        states.forEach((state) => item.setState(state, value));
       }
     });
   }
@@ -331,7 +331,7 @@ export class ItemController {
    */
   public findIdByState(itemType: ITEM_TYPE, state: string, value: string | boolean = true) {
     const ids = [];
-    Object.values(this.itemMap).forEach(item => {
+    Object.values(this.itemMap).forEach((item) => {
       if (item.getType() !== itemType) return;
       if (item.hasState(state) === value) ids.push(item.getID());
     });
@@ -351,5 +351,9 @@ export class ItemController {
       return false;
     }
     return item.hasState(state);
+  }
+
+  public getItemById(id: ID) {
+    return this.itemMap[id];
   }
 }

--- a/packages/g6/src/runtime/controller/viewport.ts
+++ b/packages/g6/src/runtime/controller/viewport.ts
@@ -22,7 +22,8 @@ export class ViewportController {
 
   private async onViewportChange({ transform, effectTiming }: ViewportChangeHookParams) {
     const camera = this.graph.canvas.getCamera();
-    const { translate, rotate, zoom, origin } = transform;
+    const { translate, rotate, zoom, origin = this.graph.getViewportCenter() } = transform;
+    const currentZoom = camera.getZoom();
 
     if (effectTiming) {
       const { duration = 1000, easing = 'linear', easingFunction } = effectTiming;
@@ -43,7 +44,7 @@ export class ViewportController {
 
       if (zoom) {
         const { ratio } = zoom;
-        landmarkOptions.zoom = camera.getZoom() * ratio;
+        landmarkOptions.zoom = currentZoom * ratio;
       }
 
       if (rotate) {
@@ -65,7 +66,7 @@ export class ViewportController {
     } else {
       if (translate) {
         const { dx = 0, dy = 0 } = translate;
-        camera.pan(-dx, -dy);
+        camera.pan(-dx / currentZoom, -dy / currentZoom);
       }
 
       if (rotate) {
@@ -82,8 +83,7 @@ export class ViewportController {
 
       if (zoom) {
         const { ratio } = zoom;
-        const vp = this.graph.canvas.canvas2Viewport(origin!);
-        camera.setZoomByViewportPoint(camera.getZoom() * ratio, [vp.x, vp.y]);
+        camera.setZoomByViewportPoint(currentZoom * ratio, [origin.x, origin.y]);
       }
     }
   }

--- a/packages/g6/src/runtime/controller/viewport.ts
+++ b/packages/g6/src/runtime/controller/viewport.ts
@@ -1,0 +1,101 @@
+import { ICamera, PointLike } from '@antv/g';
+import { IGraph } from '../../types';
+import { CameraAnimationOptions } from '../../types/animate';
+import { ViewportChangeHookParams } from '../../types/hook';
+
+let landmarkCounter = 0;
+
+export class ViewportController {
+  public graph: IGraph;
+
+  constructor(graph: IGraph<any>) {
+    this.graph = graph;
+    this.tap();
+  }
+
+  /**
+   * Subscribe the lifecycle of graph.
+   */
+  private tap() {
+    this.graph.hooks.viewportchange.tap(this.onViewportChange.bind(this));
+  }
+
+  private async onViewportChange({ action, options }: ViewportChangeHookParams) {
+    const camera = this.graph.canvas.getCamera();
+    if (action === 'translate') {
+      await this.translate(options, camera);
+    } else if (action === 'rotate') {
+    } else if (action === 'zoom') {
+      await this.zoom(options, camera);
+    }
+  }
+
+  private async translate(
+    options: {
+      dx: number;
+      dy: number;
+      effectTiming?: CameraAnimationOptions;
+    },
+    camera: ICamera,
+  ) {
+    const { dx, dy, effectTiming } = options;
+    if (effectTiming) {
+      const { duration = 1000, easing = 'linear', easingFunction } = effectTiming;
+      const [px, py] = camera.getPosition();
+      const [fx, fy] = camera.getFocalPoint();
+
+      const landmark = camera.createLandmark(`mark${landmarkCounter++}`, {
+        position: [px - dx, py - dy],
+        focalPoint: [fx - dx, fy - dy],
+      });
+
+      return new Promise((resolve) => {
+        camera.gotoLandmark(landmark, {
+          duration: Number(duration),
+          easing,
+          easingFunction,
+          onfinish: () => {
+            resolve(undefined);
+          },
+        });
+      });
+    } else {
+      camera.pan(-dx, -dy);
+    }
+  }
+
+  private async zoom(
+    options: {
+      zoom: number;
+      center: PointLike;
+      effectTiming?: CameraAnimationOptions | undefined;
+    },
+    camera: ICamera,
+  ) {
+    const { zoom, center, effectTiming } = options;
+    if (effectTiming) {
+      const { duration = 1000, easing = 'linear', easingFunction, onfinish } = effectTiming;
+      const landmark = camera.createLandmark(`mark${landmarkCounter++}`, {
+        position: [center.x, center.y],
+        focalPoint: [center.x, center.y],
+        zoom,
+      });
+
+      return new Promise((resolve) => {
+        camera.gotoLandmark(landmark, {
+          duration: Number(duration),
+          easing,
+          easingFunction,
+          onfinish: () => {
+            resolve(undefined);
+          },
+        });
+      });
+    } else {
+      const vp = this.graph.canvas.canvas2Viewport(center);
+      camera.setZoomByViewportPoint(zoom, [vp.x, vp.y]);
+    }
+  }
+
+  destroy() {}
+}

--- a/packages/g6/src/types/animate.ts
+++ b/packages/g6/src/types/animate.ts
@@ -52,6 +52,4 @@ export interface AnimateAttr {
 }
 
 export interface CameraAnimationOptions
-  extends Pick<IAnimationEffectTiming, 'duration' | 'easing' | 'easingFunction'> {
-  onfinish: any;
-}
+  extends Pick<IAnimationEffectTiming, 'duration' | 'easing' | 'easingFunction'> {}

--- a/packages/g6/src/types/animate.ts
+++ b/packages/g6/src/types/animate.ts
@@ -1,3 +1,5 @@
+import { IAnimationEffectTiming } from '@antv/g';
+
 export interface AnimateCfg {
   /**
    * Whether enable animation.
@@ -39,7 +41,7 @@ export interface AnimateCfg {
    * @type {function}
    */
   resumeCallback?: () => void;
-};
+}
 
 export type AnimateWhen = 'show' | 'exit' | 'update' | 'last';
 
@@ -47,4 +49,9 @@ export interface AnimateAttr {
   when: AnimateWhen;
   type: string;
   [param: string]: unknown;
+}
+
+export interface CameraAnimationOptions
+  extends Pick<IAnimationEffectTiming, 'duration' | 'easing' | 'easingFunction'> {
+  onfinish: any;
 }

--- a/packages/g6/src/types/graph.ts
+++ b/packages/g6/src/types/graph.ts
@@ -176,6 +176,11 @@ export interface IGraph<B extends BehaviorRegistry = BehaviorRegistry> extends E
    */
   translateTo: (point: PointLike, effectTiming?: CameraAnimationOptions) => Promise<void>;
   /**
+   * Return the current zoom level of camera.
+   * @returns current zoom
+   */
+  getZoom: () => number;
+  /**
    * Zoom the graph with a relative ratio.
    * @param ratio relative ratio to zoom
    * @param center zoom center
@@ -218,6 +223,10 @@ export interface IGraph<B extends BehaviorRegistry = BehaviorRegistry> extends E
     effectTiming?: CameraAnimationOptions,
   ) => Promise<void>;
   /**
+   * Stop the current transition of transform immediately.
+   */
+  stopTransformTransition: () => void;
+  /**
    * Return the center of viewport, e.g. for a 500 * 500 canvas, its center is [250, 250].
    */
   getViewportCenter: () => PointLike;
@@ -248,7 +257,7 @@ export interface IGraph<B extends BehaviorRegistry = BehaviorRegistry> extends E
    * @param item node/edge/combo item or its id
    * @param effectTiming animation configurations
    */
-  focusItem: (id: ID, effectTiming?: CameraAnimationOptions) => Promise<void>;
+  focusItem: (id: ID | ID[], effectTiming?: CameraAnimationOptions) => Promise<void>;
 
   // ===== item operations =====
   /**

--- a/packages/g6/src/types/graph.ts
+++ b/packages/g6/src/types/graph.ts
@@ -2,17 +2,17 @@ import EventEmitter from '@antv/event-emitter';
 import { Canvas } from '@antv/g';
 import { ID } from '@antv/graphlib';
 import { Hooks } from '../types/hook';
-import { AnimateCfg } from './animate';
+import { CameraAnimationOptions } from './animate';
 import { BehaviorObjectOptionsOf, BehaviorOptionsOf, BehaviorRegistry } from './behavior';
 import { ComboModel, ComboUserModel } from './combo';
 import { Padding, Point } from './common';
-import { DataChangeType, GraphData } from './data';
+import { GraphData } from './data';
 import { EdgeModel, EdgeUserModel } from './edge';
 import { ITEM_TYPE } from './item';
 import { LayoutOptions } from './layout';
 import { NodeModel, NodeUserModel } from './node';
 import { Specification } from './spec';
-import { FitViewRules, GraphAlignment } from './view';
+import { FitViewRules } from './view';
 
 export interface IGraph<B extends BehaviorRegistry = BehaviorRegistry> extends EventEmitter {
   hooks: Hooks;
@@ -166,63 +166,58 @@ export interface IGraph<B extends BehaviorRegistry = BehaviorRegistry> extends E
    * Move the graph with a relative vector.
    * @param dx x of the relative vector
    * @param dy y of the relative vector
-   * @param animateCfg animation configurations
-   * @returns
-   * @group View
+   * @param effectTiming animation configurations
    */
-  move: (dx: number, dy: number, animateCfg?: AnimateCfg) => void;
+  move: (dx: number, dy: number, effectTiming?: CameraAnimationOptions) => void;
   /**
    * Move the graph and align to a point.
    * @param x position on the canvas to align
    * @param y position on the canvas to align
-   * @param alignment alignment of the graph content
-   * @param animateCfg animation configurations
-   * @returns
-   * @group View
+   * @param effectTiming animation configurations
    */
-  moveTo: (x: number, y: number, alignment: GraphAlignment, animateCfg?: AnimateCfg) => void;
+  moveTo: (x: number, y: number, effectTiming?: CameraAnimationOptions) => void;
   /**
    * Zoom the graph with a relative ratio.
    * @param ratio relative ratio to zoom
    * @param center zoom center
-   * @param animateCfg animation configurations
+   * @param effectTiming animation configurations
    * @returns
    * @group View
    */
-  zoom: (ratio: number, center?: Point, animateCfg?: AnimateCfg) => void;
+  zoom: (ratio: number, center?: Point, effectTiming?: CameraAnimationOptions) => void;
   /**
    * Zoom the graph to a specified ratio.
    * @param toRatio specified ratio
    * @param center zoom center
-   * @param animateCfg animation configurations
+   * @param effectTiming animation configurations
    * @returns
    * @group View
    */
-  zoomTo: (toRatio: number, center?: Point, animateCfg?: AnimateCfg) => void;
+  zoomTo: (toRatio: number, center?: Point, effectTiming?: CameraAnimationOptions) => void;
   /**
    * Fit the graph content to the view.
    * @param padding padding while fitting
    * @param rules rules for fitting
-   * @param animateCfg animation configurations
+   * @param effectTiming animation configurations
    * @returns
    * @group View
    */
-  fitView: (padding?: Padding, rules?: FitViewRules, animateCfg?: AnimateCfg) => void;
+  fitView: (padding?: Padding, rules?: FitViewRules, effectTiming?: CameraAnimationOptions) => void;
   /**
    * Fit the graph center to the view center.
-   * @param animateCfg animation configurations
+   * @param effectTiming animation configurations
    * @returns
    * @group View
    */
-  fitCenter: (animateCfg?: AnimateCfg) => void;
+  fitCenter: (effectTiming?: CameraAnimationOptions) => void;
   /**
    * Move the graph to make the item align the view center.
    * @param item node/edge/combo item or its id
-   * @param animateCfg animation configurations
+   * @param effectTiming animation configurations
    * @returns
    * @group View
    */
-  focusItem: (ids: ID | ID[], animateCfg?: AnimateCfg) => void;
+  focusItem: (ids: ID | ID[], effectTiming?: CameraAnimationOptions) => void;
 
   // ===== item operations =====
   /**

--- a/packages/g6/src/types/graph.ts
+++ b/packages/g6/src/types/graph.ts
@@ -218,16 +218,22 @@ export interface IGraph<B extends BehaviorRegistry = BehaviorRegistry> extends E
     effectTiming?: CameraAnimationOptions,
   ) => Promise<void>;
   /**
+   * Return the center of viewport, e.g. for a 500 * 500 canvas, its center is [250, 250].
+   */
+  getViewportCenter: () => PointLike;
+  /**
    * Fit the graph content to the view.
-   * @param padding padding while fitting
-   * @param rules rules for fitting
+   * @param options.padding padding while fitting
+   * @param options.rules rules for fitting
    * @param effectTiming animation configurations
    * @returns
    * @group View
    */
   fitView: (
-    padding?: Padding,
-    rules?: FitViewRules,
+    options?: {
+      padding: Padding;
+      rules: FitViewRules;
+    },
     effectTiming?: CameraAnimationOptions,
   ) => Promise<void>;
   /**

--- a/packages/g6/src/types/graph.ts
+++ b/packages/g6/src/types/graph.ts
@@ -1,5 +1,5 @@
 import EventEmitter from '@antv/event-emitter';
-import { Canvas } from '@antv/g';
+import { Canvas, PointLike } from '@antv/g';
 import { ID } from '@antv/graphlib';
 import { Hooks } from '../types/hook';
 import { CameraAnimationOptions } from './animate';
@@ -12,7 +12,7 @@ import { ITEM_TYPE } from './item';
 import { LayoutOptions } from './layout';
 import { NodeModel, NodeUserModel } from './node';
 import { Specification } from './spec';
-import { FitViewRules } from './view';
+import { FitViewRules, GraphTransformOptions } from './view';
 
 export interface IGraph<B extends BehaviorRegistry = BehaviorRegistry> extends EventEmitter {
   hooks: Hooks;
@@ -168,32 +168,55 @@ export interface IGraph<B extends BehaviorRegistry = BehaviorRegistry> extends E
    * @param dy y of the relative vector
    * @param effectTiming animation configurations
    */
-  move: (dx: number, dy: number, effectTiming?: CameraAnimationOptions) => void;
+  translate: (dx: number, dy: number, effectTiming?: CameraAnimationOptions) => Promise<void>;
   /**
    * Move the graph and align to a point.
-   * @param x position on the canvas to align
-   * @param y position on the canvas to align
+   * @param point position on the canvas to align
    * @param effectTiming animation configurations
    */
-  moveTo: (x: number, y: number, effectTiming?: CameraAnimationOptions) => void;
+  translateTo: (point: PointLike, effectTiming?: CameraAnimationOptions) => Promise<void>;
   /**
    * Zoom the graph with a relative ratio.
    * @param ratio relative ratio to zoom
    * @param center zoom center
    * @param effectTiming animation configurations
-   * @returns
-   * @group View
    */
-  zoom: (ratio: number, center?: Point, effectTiming?: CameraAnimationOptions) => void;
+  zoom: (ratio: number, center?: Point, effectTiming?: CameraAnimationOptions) => Promise<void>;
   /**
    * Zoom the graph to a specified ratio.
    * @param toRatio specified ratio
    * @param center zoom center
    * @param effectTiming animation configurations
-   * @returns
-   * @group View
    */
-  zoomTo: (toRatio: number, center?: Point, effectTiming?: CameraAnimationOptions) => void;
+  zoomTo: (toRatio: number, center?: Point, effectTiming?: CameraAnimationOptions) => Promise<void>;
+  /**
+   * Rotate the graph with a relative angle in clockwise.
+   * @param angle
+   * @param center
+   * @param effectTiming
+   */
+  rotate: (angle: number, center?: Point, effectTiming?: CameraAnimationOptions) => Promise<void>;
+  /**
+   * Rotate the graph to an absolute angle in clockwise.
+   * @param toAngle
+   * @param center
+   * @param effectTiming
+   */
+  rotateTo: (
+    toAngle: number,
+    center?: Point,
+    effectTiming?: CameraAnimationOptions,
+  ) => Promise<void>;
+
+  /**
+   * Transform the graph with a CSS-Transform-like syntax.
+   * @param options
+   * @param effectTiming
+   */
+  transform: (
+    options: GraphTransformOptions,
+    effectTiming?: CameraAnimationOptions,
+  ) => Promise<void>;
   /**
    * Fit the graph content to the view.
    * @param padding padding while fitting
@@ -202,22 +225,24 @@ export interface IGraph<B extends BehaviorRegistry = BehaviorRegistry> extends E
    * @returns
    * @group View
    */
-  fitView: (padding?: Padding, rules?: FitViewRules, effectTiming?: CameraAnimationOptions) => void;
+  fitView: (
+    padding?: Padding,
+    rules?: FitViewRules,
+    effectTiming?: CameraAnimationOptions,
+  ) => Promise<void>;
   /**
    * Fit the graph center to the view center.
    * @param effectTiming animation configurations
    * @returns
    * @group View
    */
-  fitCenter: (effectTiming?: CameraAnimationOptions) => void;
+  fitCenter: (effectTiming?: CameraAnimationOptions) => Promise<void>;
   /**
    * Move the graph to make the item align the view center.
    * @param item node/edge/combo item or its id
    * @param effectTiming animation configurations
-   * @returns
-   * @group View
    */
-  focusItem: (ids: ID | ID[], effectTiming?: CameraAnimationOptions) => void;
+  focusItem: (id: ID, effectTiming?: CameraAnimationOptions) => Promise<void>;
 
   // ===== item operations =====
   /**

--- a/packages/g6/src/types/hook.ts
+++ b/packages/g6/src/types/hook.ts
@@ -1,9 +1,11 @@
-import { DataChangeType, GraphCore, GraphData } from "./data";
-import { NodeModelData } from "./node";
-import { EdgeModelData } from "./edge";
-import { ITEM_TYPE } from "./item";
-import { GraphChange, ID } from "@antv/graphlib";
-import { LayoutOptions } from "./layout";
+import { PointLike } from '@antv/g';
+import { GraphChange, ID } from '@antv/graphlib';
+import { CameraAnimationOptions } from './animate';
+import { DataChangeType, GraphCore, GraphData } from './data';
+import { EdgeModelData } from './edge';
+import { ITEM_TYPE } from './item';
+import { LayoutOptions } from './layout';
+import { NodeModelData } from './node';
 
 export interface IHook<T> {
   name: string;
@@ -14,14 +16,39 @@ export interface IHook<T> {
   emitLinearAsync: (param: T) => Promise<void>;
 }
 
+export type ViewportChangeHookParams =
+  | {
+      action: 'translate';
+      options: {
+        dx: number;
+        dy: number;
+        effectTiming?: CameraAnimationOptions;
+      };
+    }
+  | {
+      action: 'rotate';
+      options: {
+        angle: number;
+        effectTiming?: CameraAnimationOptions;
+      };
+    }
+  | {
+      action: 'zoom';
+      options: {
+        zoom: number;
+        center: PointLike;
+        effectTiming?: CameraAnimationOptions;
+      };
+    };
+
 export interface Hooks {
   init: IHook<void>;
   // data
-  'datachange': IHook<{
+  datachange: IHook<{
     type: DataChangeType;
-    data: GraphData
+    data: GraphData;
   }>;
-  'itemchange': IHook<{
+  itemchange: IHook<{
     type: ITEM_TYPE;
     changes: GraphChange<NodeModelData, EdgeModelData>[];
     graphCore: GraphCore;
@@ -35,12 +62,12 @@ export interface Hooks {
     modes: string[];
     behaviors: (string | { type: string; key: string })[];
   }>;
-  'itemstatechange': IHook<{
-    ids: ID[],
-    states?: string[],
-    value?: boolean
+  itemstatechange: IHook<{
+    ids: ID[];
+    states?: string[];
+    value?: boolean;
   }>; // TODO: define param template
-  // 'viewportchange': IHook<any>; // TODO: define param template
+  viewportchange: IHook<ViewportChangeHookParams>;
   // 'destroy': IHook<any>; // TODO: define param template
   // TODO: more timecycles here
 }

--- a/packages/g6/src/types/hook.ts
+++ b/packages/g6/src/types/hook.ts
@@ -1,4 +1,3 @@
-import { PointLike } from '@antv/g';
 import { GraphChange, ID } from '@antv/graphlib';
 import { CameraAnimationOptions } from './animate';
 import { DataChangeType, GraphCore, GraphData } from './data';
@@ -6,6 +5,7 @@ import { EdgeModelData } from './edge';
 import { ITEM_TYPE } from './item';
 import { LayoutOptions } from './layout';
 import { NodeModelData } from './node';
+import { GraphTransformOptions } from './view';
 
 export interface IHook<T> {
   name: string;
@@ -16,30 +16,10 @@ export interface IHook<T> {
   emitLinearAsync: (param: T) => Promise<void>;
 }
 
-export type ViewportChangeHookParams =
-  | {
-      action: 'translate';
-      options: {
-        dx: number;
-        dy: number;
-        effectTiming?: CameraAnimationOptions;
-      };
-    }
-  | {
-      action: 'rotate';
-      options: {
-        angle: number;
-        effectTiming?: CameraAnimationOptions;
-      };
-    }
-  | {
-      action: 'zoom';
-      options: {
-        zoom: number;
-        center: PointLike;
-        effectTiming?: CameraAnimationOptions;
-      };
-    };
+export type ViewportChangeHookParams = {
+  transform: GraphTransformOptions;
+  effectTiming?: CameraAnimationOptions;
+};
 
 export interface Hooks {
   init: IHook<void>;

--- a/packages/g6/src/types/view.ts
+++ b/packages/g6/src/types/view.ts
@@ -4,4 +4,27 @@ export interface FitViewRules {
   ratioRule?: 'max' | 'min'; // Ratio rule to fit.
 }
 
-export type GraphAlignment = 'left-top' | 'right-top' | 'left-bottom' | 'right-bottom' | 'center' | [number, number];
+export type GraphAlignment =
+  | 'left-top'
+  | 'right-top'
+  | 'left-bottom'
+  | 'right-bottom'
+  | 'center'
+  | [number, number];
+
+export type GraphTransformOptions = {
+  translate?: {
+    dx: number;
+    dy: number;
+  };
+  rotate?: {
+    angle: number;
+  };
+  zoom?: {
+    ratio: number;
+  };
+  origin?: {
+    x: number;
+    y: number;
+  };
+};

--- a/packages/g6/src/util/shape.ts
+++ b/packages/g6/src/util/shape.ts
@@ -114,7 +114,7 @@ export const updateShapes = (
  * @param defaultArr default value
  * @returns [padding-top, padding-right, padding-bottom, padding-left]
  */
-export const formatPadding = (value, defaultArr = [4, 4, 4, 4]) => {
+export const formatPadding = (value?: number | number[], defaultArr = [4, 4, 4, 4]) => {
   if (isArray(value)) {
     switch (value.length) {
       case 0:
@@ -135,20 +135,20 @@ export const formatPadding = (value, defaultArr = [4, 4, 4, 4]) => {
  * Merge two shape map including undefined value in incoming map.
  * @param styleMap1 shapes' styles map as current map
  * @param styleMap2 shapes' styles map as incoming map
- * @returns 
+ * @returns
  */
 export const mergeStyles = (styleMap1, styleMap2) => {
   const mergedStyle = clone(styleMap1);
-  Object.keys(styleMap2).forEach(shapeId => {
+  Object.keys(styleMap2).forEach((shapeId) => {
     const style = styleMap2[shapeId];
     mergedStyle[shapeId] = mergedStyle[shapeId] || {};
-    Object.keys(style).forEach(styleName => {
+    Object.keys(style).forEach((styleName) => {
       const value = style[styleName];
       mergedStyle[shapeId][styleName] = value;
     });
   });
   return mergedStyle;
-}
+};
 
 export const DEFAULT_LABEL_BG_PADDING = [4, 4, 4, 4];
 /** Default shape style to avoid shape value missing */

--- a/packages/g6/tests/unit/view-spec.ts
+++ b/packages/g6/tests/unit/view-spec.ts
@@ -3,6 +3,8 @@ import { Circle } from '@antv/g';
 import G6, { IGraph, stdLib } from '../../src/index';
 import { data } from '../datasets/dataset1';
 const container = document.createElement('div');
+
+// document.getElementById('__jest-electron-test-results__')?.style.position = 'absolute';
 document.querySelector('body')!.appendChild(container);
 
 describe('viewport', () => {
@@ -57,15 +59,15 @@ describe('viewport', () => {
       });
 
       graph.once('viewportchange', ({ translate }) => {
-        expect(translate.dx).toBe(-249);
-        expect(translate.dy).toBe(-249);
+        expect(translate.dx).toBe(-250);
+        expect(translate.dy).toBe(-250);
         const [px, py] = graph.canvas.getCamera().getPosition();
-        expect(px).toBe(250);
-        expect(py).toBe(250);
+        expect(px).toBe(251);
+        expect(py).toBe(251);
       });
 
       await graph.translateTo(
-        { x: 250, y: 250 },
+        { x: 500, y: 500 },
         {
           duration: 2000,
           easing: 'ease-in',
@@ -327,6 +329,33 @@ describe('viewport', () => {
         },
       });
 
+      graph.once('viewportchange', ({ zoom }) => {
+        expect(zoom.ratio).toBe(0.5);
+        expect(graph.canvas.getCamera().getZoom()).toBe(0.5);
+      });
+      await graph.transform({
+        zoom: {
+          ratio: 0.5,
+        },
+        origin: { x: 0, y: 0 },
+      });
+
+      await graph.transform({
+        translate: {
+          dx: 250,
+          dy: 250,
+        },
+        zoom: {
+          ratio: 4,
+        },
+      });
+      await graph.transform({
+        translate: {
+          dx: -250,
+          dy: -250,
+        },
+      });
+
       // graph.once('viewportchange', ({ rotate }) => {
       //   // expect(rotate.angle).toBe(0);
       //   expect(graph.canvas.getCamera().getZoom()).toBe(0.5);
@@ -368,11 +397,11 @@ describe('viewport', () => {
       });
 
       graph.once('viewportchange', ({ translate }) => {
-        expect(translate.dx).toBe(-249);
-        expect(translate.dy).toBe(-249);
+        expect(translate.dx).toBeCloseTo(-249);
+        expect(translate.dy).toBeCloseTo(-249);
         const [px, py] = graph.canvas.getCamera().getPosition();
-        expect(px).toBe(250);
-        expect(py).toBe(250);
+        expect(px).toBeCloseTo(250);
+        expect(py).toBeCloseTo(250);
       });
 
       await graph.fitCenter({
@@ -380,13 +409,14 @@ describe('viewport', () => {
         easing: 'ease-in',
       });
 
+      await graph.zoom(0.5);
       await graph.translate(249, 249);
       graph.once('viewportchange', ({ translate }) => {
-        expect(translate.dx).toBe(-249);
-        expect(translate.dy).toBe(-249);
+        expect(translate.dx).toBeCloseTo(-249);
+        expect(translate.dy).toBeCloseTo(-249);
         const [px, py] = graph.canvas.getCamera().getPosition();
-        expect(px).toBe(250);
-        expect(py).toBe(250);
+        expect(px).toBeCloseTo(250);
+        expect(py).toBeCloseTo(250);
       });
       await graph.fitCenter();
 
@@ -421,8 +451,8 @@ describe('viewport', () => {
 
       graph.once('viewportchange', () => {
         const [px, py] = graph.canvas.getCamera().getPosition();
-        expect(px).toBe(450);
-        expect(py).toBe(250);
+        expect(px).toBeCloseTo(450);
+        expect(py).toBeCloseTo(250);
       });
       await graph.focusItem('Argentina', {
         duration: 1000,
@@ -451,6 +481,79 @@ describe('viewport', () => {
       graph.focusItem('Argentina');
 
       graph.focusItem('Non existed node');
+
+      graph.destroy();
+      done();
+    });
+  });
+
+  it('should fitView with transition correctly.', (done) => {
+    graph = new G6.Graph({
+      container,
+      width: 500,
+      height: 500,
+      type: 'graph',
+      data,
+      layout: {
+        type: 'circular',
+        center: [250, 250],
+        radius: 200,
+      },
+    });
+
+    graph.once('afterlayout', async () => {
+      const nodesData = graph.getAllNodesData();
+      expect(nodesData[0].id).toBe('Argentina');
+      expect(nodesData[0].data.x).toBe(450);
+      expect(nodesData[0].data.y).toBe(250);
+
+      expect(nodesData[4].id).toBe('Colombia');
+      expect(nodesData[4].data.x).toBeCloseTo(391.421356237309);
+      expect(nodesData[4].data.y).toBeCloseTo(391.4213562373095);
+
+      graph.once('viewportchange', () => {
+        const [px, py] = graph.canvas.getCamera().getPosition();
+        expect(px).toBeCloseTo(450);
+        expect(py).toBeCloseTo(250);
+      });
+      await graph.focusItem('Argentina', {
+        duration: 1000,
+        easing: 'ease-in',
+      });
+      await graph.zoom(0.5, undefined, {
+        duration: 1000,
+        easing: 'ease-in',
+      });
+      await graph.fitView(
+        {
+          padding: [50, 50, 50, 50],
+        },
+        {
+          duration: 1000,
+          easing: 'ease-in',
+        },
+      );
+      await graph.translate(100, 100, {
+        duration: 1000,
+        easing: 'ease-in',
+      });
+      await graph.fitView(
+        {
+          padding: [150, 100],
+          rules: {
+            direction: 'both',
+            ratioRule: 'min',
+          },
+        },
+        {
+          duration: 1000,
+          easing: 'ease-in',
+        },
+      );
+      await graph.fitView(undefined, {
+        duration: 1000,
+        easing: 'ease-in',
+      });
 
       graph.destroy();
       done();

--- a/packages/g6/tests/unit/view-spec.ts
+++ b/packages/g6/tests/unit/view-spec.ts
@@ -1,4 +1,5 @@
 import { Graph, Layout, LayoutMapping } from '@antv/layout';
+import { Circle } from '@antv/g';
 import G6, { IGraph, stdLib } from '../../src/index';
 import { data } from '../datasets/dataset1';
 const container = document.createElement('div');
@@ -21,12 +22,12 @@ describe('viewport', () => {
     });
 
     graph.once('afterlayout', () => {
-      graph.move(250, 250);
+      graph.translate(250, 250);
       let [px, py] = graph.canvas.getCamera().getPosition();
       expect(px).toBe(0);
       expect(py).toBe(0);
 
-      graph.move(-250, -250);
+      graph.translate(-250, -250);
       [px, py] = graph.canvas.getCamera().getPosition();
       expect(px).toBe(250);
       expect(py).toBe(250);
@@ -51,21 +52,25 @@ describe('viewport', () => {
     });
 
     graph.once('afterlayout', async () => {
-      await graph.move(249, 249, {
+      await graph.translate(249, 249, {
         duration: 1000,
       });
 
-      graph.once('viewportchange', ({ action, options: { camera } }) => {
-        expect(action).toBe('translate');
-        const [px, py] = camera.getPosition();
+      graph.once('viewportchange', ({ translate }) => {
+        expect(translate.dx).toBe(-249);
+        expect(translate.dy).toBe(-249);
+        const [px, py] = graph.canvas.getCamera().getPosition();
         expect(px).toBe(250);
         expect(py).toBe(250);
       });
 
-      await graph.moveTo(250, 250, {
-        duration: 2000,
-        easing: 'ease-in',
-      });
+      await graph.translateTo(
+        { x: 250, y: 250 },
+        {
+          duration: 2000,
+          easing: 'ease-in',
+        },
+      );
 
       graph.destroy();
       done();
@@ -87,23 +92,29 @@ describe('viewport', () => {
     });
 
     graph.once('afterlayout', async () => {
-      graph.once('viewportchange', ({ action, options: { camera } }) => {
-        expect(action).toBe('zoom');
-        expect(camera.getZoom()).toBe(0.5);
+      graph.once('viewportchange', ({ zoom }) => {
+        expect(zoom.ratio).toBe(0.5);
+        expect(graph.canvas.getCamera().getZoom()).toBe(0.5);
       });
       await graph.zoom(0.5, { x: 250, y: 250 });
 
-      graph.once('viewportchange', ({ action, options: { camera } }) => {
-        expect(action).toBe('zoom');
-        expect(camera.getZoom()).toBe(1);
+      graph.once('viewportchange', ({ zoom }) => {
+        expect(zoom.ratio).toBe(2);
+        expect(graph.canvas.getCamera().getZoom()).toBe(1);
       });
       await graph.zoom(2, { x: 250, y: 250 });
 
-      graph.once('viewportchange', ({ action, options: { camera } }) => {
-        expect(action).toBe('zoom');
-        expect(camera.getZoom()).toBe(1.2);
+      const op = graph.canvas.canvas2Viewport({ x: 450, y: 250 });
+      graph.once('viewportchange', ({ zoom }) => {
+        expect(zoom.ratio).toBe(1.2);
+        expect(graph.canvas.getCamera().getZoom()).toBe(1.2);
+
+        // Zoom origin should be fixed.
+        const { x, y } = graph.canvas.canvas2Viewport({ x: 450, y: 250 });
+        expect(x).toBeCloseTo(op.x);
+        expect(y).toBeCloseTo(op.y);
       });
-      await graph.zoomTo(1.2, { x: 250, y: 250 });
+      await graph.zoomTo(1.2, { x: 450, y: 250 });
 
       graph.destroy();
       done();
@@ -125,9 +136,9 @@ describe('viewport', () => {
     });
 
     graph.once('afterlayout', async () => {
-      graph.once('viewportchange', ({ action, options: { camera } }) => {
-        expect(action).toBe('zoom');
-        expect(camera.getZoom()).toBe(0.5);
+      graph.once('viewportchange', ({ zoom }) => {
+        expect(zoom.ratio).toBe(0.5);
+        expect(graph.canvas.getCamera().getZoom()).toBe(0.5);
       });
       await graph.zoom(
         0.5,
@@ -137,9 +148,11 @@ describe('viewport', () => {
         },
       );
 
-      graph.once('viewportchange', ({ action, options: { camera } }) => {
-        expect(action).toBe('zoom');
-        expect(camera.getZoom()).toBe(1);
+      graph.once('viewportchange', ({ zoom }) => {
+        expect(zoom.ratio).toBe(2);
+        expect(graph.canvas.getCamera().getZoom()).toBe(1);
+        expect(graph.canvas.getCamera().getPosition()[0]).toBe(250);
+        expect(graph.canvas.getCamera().getPosition()[1]).toBe(250);
       });
       await graph.zoom(
         2,
@@ -149,33 +162,295 @@ describe('viewport', () => {
         },
       );
 
-      graph.once('viewportchange', ({ action, options: { camera } }) => {
-        expect(action).toBe('zoom');
-        expect(camera.getZoom()).toBe(3);
-        expect(camera.getPosition()[0]).toBe(1);
-        expect(camera.getPosition()[1]).toBe(1);
-      });
-      await graph.zoomTo(
-        3,
-        { x: 1, y: 1 },
-        {
-          duration: 1000,
-        },
-      );
+      // const op = graph.canvas.canvas2Viewport({ x: 450, y: 250 });
+      // graph.once('viewportchange', ({ zoom }) => {
+      //   expect(zoom.ratio).toBe(3);
+      //   expect(graph.canvas.getCamera().getZoom()).toBe(3);
+      //   // Zoom origin should be fixed.
+      //   const { x, y } = graph.canvas.canvas2Viewport({ x: 450, y: 250 });
+      //   expect(x).toBeCloseTo(op.x);
+      //   expect(y).toBeCloseTo(op.y);
+      // });
+      // await graph.zoomTo(
+      //   3,
+      //   { x: 450, y: 250 },
+      //   {
+      //     duration: 1000,
+      //   },
+      // );
 
-      graph.once('viewportchange', ({ action, options: { camera } }) => {
-        expect(action).toBe('zoom');
-        expect(camera.getZoom()).toBe(1);
-        expect(camera.getPosition()[0]).toBe(250);
-        expect(camera.getPosition()[1]).toBe(250);
+      // graph.once('viewportchange', ({ zoom }) => {
+      //   expect(zoom.ratio).toBe(1 / 3);
+      //   expect(graph.canvas.getCamera().getZoom()).toBe(1);
+      //   expect(graph.canvas.getCamera().getPosition()[0]).toBe(250);
+      //   expect(graph.canvas.getCamera().getPosition()[1]).toBe(250);
+      // });
+      // await graph.zoomTo(
+      //   1,
+      //   { x: 250, y: 250 },
+      //   {
+      //     duration: 1000,
+      //   },
+      // );
+
+      graph.destroy();
+      done();
+    });
+  });
+
+  it('should rotate viewport correctly.', (done) => {
+    graph = new G6.Graph({
+      container,
+      width: 500,
+      height: 500,
+      type: 'graph',
+      data,
+      layout: {
+        type: 'circular',
+        center: [250, 250],
+        radius: 200,
+      },
+    });
+
+    graph.once('afterlayout', async () => {
+      graph.once('viewportchange', ({ rotate }) => {
+        expect(rotate.angle).toBe(30);
+        expect(graph.canvas.getCamera().getRoll()).toBe(30);
       });
-      await graph.zoomTo(
-        1,
-        { x: 250, y: 250 },
-        {
-          duration: 1000,
+      await graph.rotateTo(30, undefined, {
+        duration: 1000,
+      });
+
+      graph.once('viewportchange', ({ rotate }) => {
+        expect(rotate.angle).toBe(30);
+        expect(graph.canvas.getCamera().getRoll()).toBe(60);
+      });
+      await graph.rotateTo(60, undefined, {
+        duration: 1000,
+      });
+
+      graph.once('viewportchange', ({ rotate }) => {
+        expect(rotate.angle).toBe(-30);
+        expect(graph.canvas.getCamera().getRoll()).toBe(30);
+      });
+      await graph.rotateTo(30, undefined, {
+        duration: 1000,
+      });
+
+      graph.once('viewportchange', ({ rotate }) => {
+        expect(rotate.angle).toBe(-29);
+        expect(graph.canvas.getCamera().getRoll()).toBe(1);
+      });
+      // without animation
+      await graph.rotate(-29);
+
+      graph.destroy();
+      done();
+    });
+  });
+
+  it('should transform viewport without animation correctly.', (done) => {
+    graph = new G6.Graph({
+      container,
+      width: 500,
+      height: 500,
+      type: 'graph',
+      data,
+      layout: {
+        type: 'circular',
+        center: [250, 250],
+        radius: 200,
+      },
+    });
+
+    graph.once('afterlayout', async () => {
+      const origin = new Circle({
+        style: {
+          cx: 450,
+          cy: 250,
+          r: 30,
+          fill: 'green',
+          opacity: 0.5,
         },
-      );
+      });
+      graph.canvas.appendChild(origin);
+
+      // graph.once('viewportchange', ({ zoom }) => {
+      //   expect(zoom.ratio).toBe(0.5);
+      //   expect(graph.canvas.getCamera().getZoom()).toBe(0.5);
+      // });
+      // await graph.transform({
+      //   zoom: {
+      //     ratio: 0.5,
+      //   },
+      //   origin: { x: 250, y: 250 },
+      // });
+
+      // graph.once('viewportchange', ({ zoom, rotate }) => {
+      //   expect(zoom.ratio).toBe(2);
+      //   expect(rotate.angle).toBe(30);
+      //   expect(graph.canvas.getCamera().getZoom()).toBe(1);
+      //   expect(graph.canvas.getCamera().getRoll()).toBe(30);
+      // });
+      // await graph.transform({
+      //   zoom: {
+      //     ratio: 2,
+      //   },
+      //   rotate: {
+      //     angle: 30,
+      //   },
+      //   origin: { x: 250, y: 250 },
+      // });
+
+      // graph.once('viewportchange', ({ rotate }) => {
+      //   expect(rotate.angle).toBe(-30);
+      //   expect(graph.canvas.getCamera().getZoom()).toBe(1);
+      //   expect(graph.canvas.getCamera().getRoll()).toBe(0);
+      // });
+      // await graph.transform({
+      //   rotate: {
+      //     angle: -30,
+      //   },
+      //   origin: { x: 250, y: 250 },
+      // });
+
+      graph.once('viewportchange', ({ translate }) => {
+        expect(translate.dx).toBe(-250);
+        expect(translate.dy).toBe(-250);
+        // expect(graph.canvas.getCamera().getZoom()).toBe(0.5);
+        // expect(graph.canvas.getCamera().getRoll()).toBe(0);
+      });
+      await graph.transform({
+        translate: {
+          dx: -250,
+          dy: -250,
+        },
+      });
+
+      // graph.once('viewportchange', ({ rotate }) => {
+      //   // expect(rotate.angle).toBe(0);
+      //   expect(graph.canvas.getCamera().getZoom()).toBe(0.5);
+      //   // expect(graph.canvas.getCamera().getRoll()).toBe(0);
+      // });
+      // await graph.transform({
+      //   // rotate: {
+      //   //   angle: 0,
+      //   // },
+      //   zoom: {
+      //     ratio: 1,
+      //   },
+      //   origin: { x: 450, y: 250 },
+      // });
+
+      graph.destroy();
+      origin.destroy();
+      done();
+    });
+  });
+
+  it('should fitCenter with transition correctly.', (done) => {
+    graph = new G6.Graph({
+      container,
+      width: 500,
+      height: 500,
+      type: 'graph',
+      data,
+      layout: {
+        type: 'circular',
+        center: [250, 250],
+        radius: 200,
+      },
+    });
+
+    graph.once('afterlayout', async () => {
+      await graph.translate(249, 249, {
+        duration: 1000,
+      });
+
+      graph.once('viewportchange', ({ translate }) => {
+        expect(translate.dx).toBe(-249);
+        expect(translate.dy).toBe(-249);
+        const [px, py] = graph.canvas.getCamera().getPosition();
+        expect(px).toBe(250);
+        expect(py).toBe(250);
+      });
+
+      await graph.fitCenter({
+        duration: 2000,
+        easing: 'ease-in',
+      });
+
+      await graph.translate(249, 249);
+      graph.once('viewportchange', ({ translate }) => {
+        expect(translate.dx).toBe(-249);
+        expect(translate.dy).toBe(-249);
+        const [px, py] = graph.canvas.getCamera().getPosition();
+        expect(px).toBe(250);
+        expect(py).toBe(250);
+      });
+      await graph.fitCenter();
+
+      graph.destroy();
+      done();
+    });
+  });
+
+  it('should focusItem with transition correctly.', (done) => {
+    graph = new G6.Graph({
+      container,
+      width: 500,
+      height: 500,
+      type: 'graph',
+      data,
+      layout: {
+        type: 'circular',
+        center: [250, 250],
+        radius: 200,
+      },
+    });
+
+    graph.once('afterlayout', async () => {
+      const nodesData = graph.getAllNodesData();
+      expect(nodesData[0].id).toBe('Argentina');
+      expect(nodesData[0].data.x).toBe(450);
+      expect(nodesData[0].data.y).toBe(250);
+
+      expect(nodesData[4].id).toBe('Colombia');
+      expect(nodesData[4].data.x).toBeCloseTo(391.421356237309);
+      expect(nodesData[4].data.y).toBeCloseTo(391.4213562373095);
+
+      graph.once('viewportchange', () => {
+        const [px, py] = graph.canvas.getCamera().getPosition();
+        expect(px).toBe(450);
+        expect(py).toBe(250);
+      });
+      await graph.focusItem('Argentina', {
+        duration: 1000,
+        easing: 'ease-in',
+      });
+
+      graph.once('viewportchange', () => {
+        const [px, py] = graph.canvas.getCamera().getPosition();
+        expect(px).toBeCloseTo(391.421356237309);
+        expect(py).toBeCloseTo(391.4213562373095);
+      });
+      await graph.focusItem('Colombia', {
+        duration: 1000,
+      });
+
+      await graph.focusItem('Spain', {
+        duration: 1000,
+        easing: 'ease-in',
+      });
+
+      graph.once('viewportchange', () => {
+        const [px, py] = graph.canvas.getCamera().getPosition();
+        expect(px).toBe(450);
+        expect(py).toBe(250);
+      });
+      graph.focusItem('Argentina');
+
+      graph.focusItem('Non existed node');
 
       graph.destroy();
       done();

--- a/packages/g6/tests/unit/view-spec.ts
+++ b/packages/g6/tests/unit/view-spec.ts
@@ -1,0 +1,184 @@
+import { Graph, Layout, LayoutMapping } from '@antv/layout';
+import G6, { IGraph, stdLib } from '../../src/index';
+import { data } from '../datasets/dataset1';
+const container = document.createElement('div');
+document.querySelector('body')!.appendChild(container);
+
+describe('viewport', () => {
+  let graph: any;
+  it('should translate viewport without animation correctly.', (done) => {
+    graph = new G6.Graph({
+      container,
+      width: 500,
+      height: 500,
+      type: 'graph',
+      data,
+      layout: {
+        type: 'circular',
+        center: [250, 250],
+        radius: 100,
+      },
+    });
+
+    graph.once('afterlayout', () => {
+      graph.move(250, 250);
+      let [px, py] = graph.canvas.getCamera().getPosition();
+      expect(px).toBe(0);
+      expect(py).toBe(0);
+
+      graph.move(-250, -250);
+      [px, py] = graph.canvas.getCamera().getPosition();
+      expect(px).toBe(250);
+      expect(py).toBe(250);
+
+      graph.destroy();
+      done();
+    });
+  });
+
+  it('should translate viewport with animation correctly.', (done) => {
+    graph = new G6.Graph({
+      container,
+      width: 500,
+      height: 500,
+      type: 'graph',
+      data,
+      layout: {
+        type: 'circular',
+        center: [250, 250],
+        radius: 200,
+      },
+    });
+
+    graph.once('afterlayout', async () => {
+      await graph.move(249, 249, {
+        duration: 1000,
+      });
+
+      graph.once('viewportchange', ({ action, options: { camera } }) => {
+        expect(action).toBe('translate');
+        const [px, py] = camera.getPosition();
+        expect(px).toBe(250);
+        expect(py).toBe(250);
+      });
+
+      await graph.moveTo(250, 250, {
+        duration: 2000,
+        easing: 'ease-in',
+      });
+
+      graph.destroy();
+      done();
+    });
+  });
+
+  it('should zoom viewport without animation correctly.', (done) => {
+    graph = new G6.Graph({
+      container,
+      width: 500,
+      height: 500,
+      type: 'graph',
+      data,
+      layout: {
+        type: 'circular',
+        center: [250, 250],
+        radius: 200,
+      },
+    });
+
+    graph.once('afterlayout', async () => {
+      graph.once('viewportchange', ({ action, options: { camera } }) => {
+        expect(action).toBe('zoom');
+        expect(camera.getZoom()).toBe(0.5);
+      });
+      await graph.zoom(0.5, { x: 250, y: 250 });
+
+      graph.once('viewportchange', ({ action, options: { camera } }) => {
+        expect(action).toBe('zoom');
+        expect(camera.getZoom()).toBe(1);
+      });
+      await graph.zoom(2, { x: 250, y: 250 });
+
+      graph.once('viewportchange', ({ action, options: { camera } }) => {
+        expect(action).toBe('zoom');
+        expect(camera.getZoom()).toBe(1.2);
+      });
+      await graph.zoomTo(1.2, { x: 250, y: 250 });
+
+      graph.destroy();
+      done();
+    });
+  });
+
+  it('should zoom viewport with animation correctly.', (done) => {
+    graph = new G6.Graph({
+      container,
+      width: 500,
+      height: 500,
+      type: 'graph',
+      data,
+      layout: {
+        type: 'circular',
+        center: [250, 250],
+        radius: 200,
+      },
+    });
+
+    graph.once('afterlayout', async () => {
+      graph.once('viewportchange', ({ action, options: { camera } }) => {
+        expect(action).toBe('zoom');
+        expect(camera.getZoom()).toBe(0.5);
+      });
+      await graph.zoom(
+        0.5,
+        { x: 250, y: 250 },
+        {
+          duration: 2000,
+        },
+      );
+
+      graph.once('viewportchange', ({ action, options: { camera } }) => {
+        expect(action).toBe('zoom');
+        expect(camera.getZoom()).toBe(1);
+      });
+      await graph.zoom(
+        2,
+        { x: 250, y: 250 },
+        {
+          duration: 2000,
+        },
+      );
+
+      graph.once('viewportchange', ({ action, options: { camera } }) => {
+        expect(action).toBe('zoom');
+        expect(camera.getZoom()).toBe(3);
+        expect(camera.getPosition()[0]).toBe(1);
+        expect(camera.getPosition()[1]).toBe(1);
+      });
+      await graph.zoomTo(
+        3,
+        { x: 1, y: 1 },
+        {
+          duration: 1000,
+        },
+      );
+
+      graph.once('viewportchange', ({ action, options: { camera } }) => {
+        expect(action).toBe('zoom');
+        expect(camera.getZoom()).toBe(1);
+        expect(camera.getPosition()[0]).toBe(250);
+        expect(camera.getPosition()[1]).toBe(250);
+      });
+      await graph.zoomTo(
+        1,
+        { x: 250, y: 250 },
+        {
+          duration: 1000,
+        },
+      );
+
+      graph.destroy();
+      done();
+    });
+  });
+});


### PR DESCRIPTION
#4344 

TODO：
- [x] fitView
- [x] 需要增加一个停止变换的方法，在视口变换过程中随时可终止
- [x] focusItem 的第一个参数需要接受 ID 数组吗？
- [x] 是否需要在 Graph 上透出 Camera 相关的参数，例如 4.0 中的 [getZoom](https://g6.antv.antgroup.com/api/graph-func/transform#graphgetzoom)。如果需要的话，可以补充当前的相机位置和旋转角度：
```js
graph.getZoom(); // 当前缩放等级，例如 2
graph.getCameraRoll(); // 当前相机旋转角度，例如 30 度
graph.getCameraPosition(); // 当前相机在 Canvas 坐标系下的位置
```
