### PR TITLE
fix: Node dragging starting one event too late.

### DIFF
--- a/packages/pc/src/behavior/drag-combo.ts
+++ b/packages/pc/src/behavior/drag-combo.ts
@@ -48,6 +48,7 @@ export default {
   },
   getEvents(): { [key in G6Event]?: string } {
     return {
+      'combo:mousedown': 'onMouseDown',
       'combo:dragstart': 'onDragStart',
       'combo:drag': 'onDrag',
       'combo:dragend': 'onDragEnd',
@@ -73,6 +74,12 @@ export default {
       return false;
     }
     return true;
+  },
+  onMouseDown(evt: IG6GraphEvent) {
+    this.origin = {
+      x: evt.x,
+      y: evt.y,
+    };
   },
   onDragStart(evt: IG6GraphEvent) {
     const graph: IGraph = this.graph;
@@ -121,11 +128,6 @@ export default {
 
     this.point = {};
     this.originPoint = {};
-
-    this.origin = {
-      x: evt.x,
-      y: evt.y,
-    };
 
     this.currentItemChildCombos = [];
 

--- a/packages/pc/src/behavior/drag-node.ts
+++ b/packages/pc/src/behavior/drag-node.ts
@@ -74,6 +74,7 @@ export default {
     this.mousedown = {
       item: evt.item,
       target: evt.target,
+      origin: { x: evt.x, y: evt.y }
     };
     this.dragstart = true;
     self.onDragStart(evt);
@@ -104,6 +105,7 @@ export default {
     this.mousedown = {
       item: evt.item,
       target: evt.target,
+      origin: { x: evt.x, y: evt.y }
     };
 
     // 绑定浏览器监听，触发拖拽结束，结束拖拽时移除
@@ -217,10 +219,7 @@ export default {
       });
     }
 
-    this.origin = {
-      x: evt.x,
-      y: evt.y,
-    };
+    this.origin = this.mousedown.origin;
 
     this.point = {};
     this.originPoint = {};

--- a/packages/site/.dumi/pages/largegraph.en.tsx
+++ b/packages/site/.dumi/pages/largegraph.en.tsx
@@ -1,0 +1,3 @@
+import LargeGraph from './largegraph.zh';
+
+export default LargeGraph;

--- a/packages/site/.dumi/pages/largegraph.zh.tsx
+++ b/packages/site/.dumi/pages/largegraph.zh.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import Page from '../../pages/largegraph';
+import { Header } from '@antv/dumi-theme-antv/dist/slots/Header';
+import { Footer } from '@antv/dumi-theme-antv/dist/slots/Footer';
+
+const LargeGraph: React.FC = () => {
+  return (
+    <>
+      <Header />
+      <Page />
+      <Footer />
+    </>
+  );
+};
+
+export default LargeGraph;

--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -46,7 +46,8 @@
     "insert-css": "^2.0.0",
     "typedoc": "^0.17.6",
     "typedoc-plugin-markdown": "^2.2.11",
-    "typescript": "^4.6.3"
+    "typescript": "^4.6.3",
+    "react-i18next": "^11.1.0"
   },
   "resolutions": {
     "@types/react": "^16.9.35"

--- a/packages/site/pages/canvas-menu.tsx
+++ b/packages/site/pages/canvas-menu.tsx
@@ -1,0 +1,529 @@
+import React, { useState, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  EyeOutlined,
+  EyeInvisibleOutlined,
+  NodeIndexOutlined,
+  DisconnectOutlined,
+  TagOutlined,
+  SearchOutlined,
+  HighlightOutlined,
+} from '@ant-design/icons';
+
+const isBrowser = typeof window !== 'undefined';
+const G6 = isBrowser ? require('@antv/g6') : null;
+const insertCss = isBrowser ? require('insert-css') : null;
+const modifyCSS = isBrowser ? require('@antv/dom-util/lib/modify-css').default : null;
+
+if (isBrowser) {
+  insertCss(`
+  #canvas-menu {
+    position: absolute;
+    z-index: 2;
+    left: 16px;
+    top: 80px;
+    width: fit-content;
+    padding: 8px 16px;
+    background-color: rgba(54, 59, 64, 0);
+    border-radius: 24px;
+    box-shadow: 0 5px 18px 0 rgba(0, 0, 0, 0);
+    font-family: PingFangSC-Semibold;
+    transition: all 0.2s linear;
+  }
+  #canvas-menu:hover {
+    background-color: rgba(54, 59, 64, 1);
+    box-shadow: 0 5px 18px 0 rgba(0, 0, 0, 0.6);
+  }
+  .icon-span {
+    padding-left: 8px;
+    padding-right: 8px;
+    cursor: pointer;
+  }
+  #search-node-input {
+    background-color: rgba(60, 60, 60, 0.95);
+    border-radius: 21px;
+    width: 100px;
+    border-color: rgba(80, 80, 80, 0.95);
+    border-style: solid;
+    color: rgba(255, 255, 255, 0.85);
+  }
+  #submit-button {
+    background-color: rgba(82, 115, 224, 0.2);
+    border-radius: 21px;
+    border-color: rgb(82, 115, 224);
+    border-style: solid;
+    color: rgba(152, 165, 254, 1);
+    margin-left: 4px;
+  }
+  .menu-tip {
+    position: absolute;
+    right: calc(30% + 32px);
+    width: fit-content;
+    height: 40px;
+    line-height: 40px;
+    top: 80px;
+    padding-left: 16px;
+    padding-right: 16px;
+    background-color: rgba(54, 59, 64, 0.5);
+    color: rgba(255, 255, 255, 0.65);
+    border-radius: 8px;
+    transition: all 0.2s linear;
+    font-family: PingFangSC-Semibold;
+  }
+  #g6-canavs-menu-item-tip {
+    position: absolute;
+    background-color: rgba(0,0,0, 0.65);
+    padding: 10px;
+    box-shadow: rgba(0, 0, 0, 0.6) 0px 0px 10px;
+    width: fit-content;
+    color: #fff;
+    border-radius: 8px;
+    font-size: 12px;
+    height: fit-content;
+    font-family: PingFangSC-Semibold;
+    transition: all 0.2s linear;
+  }
+`);
+}
+
+let fishEye = null;
+
+const CanvasMenu: React.FC<{
+  graph: any;
+  clickFisheyeIcon: (onlyDisable?: boolean) => void;
+  clickLassoIcon: (onlyDisable?: boolean) => void;
+  fisheyeEnabled: boolean;
+  lassoEnabled: boolean;
+  edgeLabelVisible: boolean;
+  setEdgeLabelVisible: (vis: boolean) => void;
+  searchNode: (id: string) => boolean;
+  handleFindPath: () => void;
+  stopLayout: () => void;
+}> = ({
+  graph,
+  clickFisheyeIcon,
+  clickLassoIcon,
+  fisheyeEnabled,
+  lassoEnabled,
+  stopLayout,
+  edgeLabelVisible,
+  setEdgeLabelVisible,
+  searchNode,
+  handleFindPath,
+}) => {
+  const { t } = useTranslation();
+
+  // menu tip, 例如 “按下 ESC 退出鱼眼”
+  const [menuTip, setMenuTip] = useState({
+    text: '',
+    display: 'none',
+    opacity: 0,
+  });
+
+  // menu item tip
+  const [menuItemTip, setMenuItemTip] = useState({
+    text: '',
+    display: 'none',
+    opacity: 0,
+  });
+
+  const [enableSearch, setEnableSearch] = useState(false);
+
+  const [enableSelectPathEnd, setEnableSelectPathEnd] = useState(false);
+
+  const clickEdgeLabelController = () => {
+    setEdgeLabelVisible(!edgeLabelVisible);
+  };
+
+  const handleEnableSearch = () => {
+    // 关闭 lasso 框选
+    if (lassoEnabled) clickLassoIcon(true);
+    // 关闭选择路径端点
+    if (enableSelectPathEnd) setEnableSelectPathEnd(false);
+    // 关闭搜索节点框
+    if (enableSearch) setEnableSearch(false);
+    // 关闭 fisheye
+    if (fisheyeEnabled && fishEye) {
+      graph.removePlugin(fishEye);
+      clickFisheyeIcon(true);
+    }
+    setEnableSearch((old) => {
+      if (old) {
+        // 设置 menuTip
+        setMenuTip({
+          text: '',
+          display: 'none',
+          opacity: 0,
+        });
+        return false;
+      }
+
+      // 设置 menuTip
+      setMenuTip({
+        text: t('输入需要搜索的节点 ID，并点击 Submit 按钮'),
+        display: 'block',
+        opacity: 1,
+      });
+      return true;
+    });
+  };
+  // 放大
+  const handleZoomOut = () => {
+    if (!graph || graph.destroyed) return;
+    const current = graph.getZoom();
+    const canvas = graph.get('canvas');
+    const point = canvas.getPointByClient(canvas.get('width') / 2, canvas.get('height') / 2);
+    const pixelRatio = canvas.get('pixelRatio') || 1;
+    const ratio = 1 + 0.05 * 5;
+    if (ratio * current > 5) {
+      return;
+    }
+    graph.zoom(ratio, { x: point.x / pixelRatio, y: point.y / pixelRatio });
+  };
+
+  // 缩小
+  const handleZoomIn = () => {
+    if (!graph || graph.destroyed) return;
+
+    const current = graph.getZoom();
+    const canvas = graph.get('canvas');
+    const point = canvas.getPointByClient(canvas.get('width') / 2, canvas.get('height') / 2);
+    const pixelRatio = canvas.get('pixelRatio') || 1;
+    const ratio = 1 - 0.05 * 5;
+    if (ratio * current < 0.3) {
+      return;
+    }
+    graph.zoom(ratio, { x: point.x / pixelRatio, y: point.y / pixelRatio });
+  };
+
+  const handleFitViw = () => {
+    if (!graph || graph.destroyed) return;
+    graph.fitView(16);
+  };
+
+  const handleSearchNode = () => {
+    const value = (document.getElementById('search-node-input') as HTMLInputElement).value;
+    const found = searchNode(value);
+    if (!found)
+      setMenuTip({
+        text: t('没有找到该节点'),
+        display: 'block',
+        opacity: 1,
+      });
+  };
+
+  const showItemTip = (e, text) => {
+    const { clientX: x, clientY: y } = e;
+    setMenuItemTip({
+      text,
+      display: 'block',
+      opacity: 1,
+    });
+    const tipDom = document.getElementById('g6-canavs-menu-item-tip');
+    modifyCSS(tipDom, {
+      top: `${124}px`,
+      left: `${x - 20}px`,
+      zIndex: 100,
+    });
+  };
+
+  const hideItemTip = () => {
+    setMenuItemTip({
+      text: '',
+      display: 'none',
+      opacity: 0,
+    });
+    const tipDom = document.getElementById('g6-canavs-menu-item-tip');
+    modifyCSS(tipDom, {
+      zIndex: -100,
+    });
+  };
+  /**
+   * 打开或关闭鱼眼放大功能
+   */
+  const toggleFishEye = () => {
+    if (!graph || graph.destroyed) return;
+
+    // 设置鼠标样式为默认
+    graph.get('canvas').setCursor('default');
+
+    // 关闭 FishEye
+    if (fisheyeEnabled && fishEye) {
+      graph.removePlugin(fishEye);
+      graph.setMode('default');
+
+      // 设置 menuTip
+      setMenuTip({
+        text: t('按下 Esc 键退出鱼眼放大镜'),
+        display: 'none',
+        opacity: 0,
+      });
+    } else {
+      // 停止布局
+      stopLayout();
+
+      // 关闭 lasso 框选
+      if (lassoEnabled) clickLassoIcon(true);
+      // 关闭选择路径端点
+      if (enableSelectPathEnd) setEnableSelectPathEnd(false);
+      // 关闭搜索节点框
+      if (enableSearch) setEnableSearch(false);
+
+      // 设置 menuTip
+      setMenuTip({
+        text: t('按下 Esc 键退出鱼眼放大镜'),
+        display: 'block',
+        opacity: 1,
+      });
+
+      // 将交互模式切换到鱼眼只读模式，即不能缩放画布、框选节点、拉索选择节点等可能和鱼眼有冲突的操作
+      graph.setMode('fisheyeMode');
+      // 开启 FishEye
+      fishEye = new G6.Fisheye({
+        r: 249,
+        scaleRByWheel: true,
+        minR: 100,
+        maxR: 500,
+        // showLabel: true,
+      });
+
+      graph.addPlugin(fishEye);
+    }
+    clickFisheyeIcon();
+  };
+
+  // 开启 lasso select 功能
+  const enabledLassoSelect = () => {
+    if (!graph || graph.destroyed) return;
+    clickLassoIcon();
+    if (!lassoEnabled) {
+      graph.setMode('lassoSelect');
+
+      // 设置鼠标样式为十字形
+      graph.get('canvas').setCursor('crosshair');
+
+      // 关闭 fisheye
+      if (fisheyeEnabled && fishEye) {
+        graph.removePlugin(fishEye);
+        clickFisheyeIcon(true);
+      }
+      // 关闭选择路径端点
+      if (enableSelectPathEnd) setEnableSelectPathEnd(false);
+      // 关闭搜索节点框
+      if (enableSearch) setEnableSearch(false);
+
+      // 设置 menuTip
+      setMenuTip({
+        text: t('按下 Esc 键退出拉索选择模式'),
+        display: 'block',
+        opacity: 1,
+      });
+    } else {
+      graph.setMode('default');
+
+      // 设置鼠标样式为默认
+      graph.get('canvas').setCursor('default');
+
+      // 设置 menuTip
+      setMenuTip({
+        text: t('按下 Esc 键退出拉索选择模式'),
+        display: 'none',
+        opacity: 0,
+      });
+    }
+  };
+
+  // 开启选择两个节点显示最短路径
+  const handleEnableSelectPathEnd = () => {
+    setEnableSelectPathEnd((old) => {
+      if (!old) {
+        graph.setMode('default');
+        // 关闭 fisheye
+        if (fishEye) {
+          graph.removePlugin(fishEye);
+          clickFisheyeIcon(true);
+        }
+        // 关闭 lasso 框选
+        if (lassoEnabled) clickLassoIcon(true);
+
+        // 关闭搜索节点框
+        if (enableSearch) setEnableSearch(false);
+
+        // 设置 menuTip
+        setMenuTip({
+          text: t('按住 SHIFT 键并点选两个节点作为路径起终点'),
+          display: 'block',
+          opacity: 1,
+        });
+        return true;
+      }
+      // 设置 menuTip
+      setMenuTip({
+        text: '',
+        display: 'none',
+        opacity: 0,
+      });
+      return false;
+    });
+  };
+
+  const escListener = (e) => {
+    if (!graph || graph.destroyed) return;
+    if (e.key !== 'Escape') return;
+    if (fishEye) {
+      graph.removePlugin(fishEye);
+      clickFisheyeIcon(true);
+    }
+    // 关闭 lasso 框选
+    graph.setMode('default');
+    // 关闭搜索节点框
+    setEnableSearch(false);
+    // 关闭选择路径端点
+    setEnableSelectPathEnd(false);
+
+    // 设置鼠标样式为默认
+    graph.get('canvas').setCursor('default');
+    clickLassoIcon(true);
+
+    // 设置 menuTip
+    setMenuTip({
+      text: t('按下 Esc 键退出当前模式'),
+      display: 'none',
+      opacity: 0,
+    });
+  };
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      window.addEventListener('keydown', escListener.bind(this));
+      return window.removeEventListener('keydown', escListener.bind(this));
+    }
+  }, []);
+
+  const iconStyle = {
+    disable: { color: 'rgba(255, 255, 255, 0.85)' },
+    enable: { color: 'rgba(82, 115, 224, 1)' },
+  };
+
+  return (
+    <>
+      <div id="canvas-menu">
+        <div className="icon-container">
+          <span
+            className="icon-span"
+            style={{ backgroundColor: 'rgba(0, 0, 0, 0)' }}
+            onClick={clickEdgeLabelController}
+            onMouseEnter={(e) =>
+              showItemTip(e, edgeLabelVisible ? t('隐藏边标签') : t('显示边标签'))
+            }
+            onMouseLeave={hideItemTip}
+          >
+            {edgeLabelVisible ? (
+              <DisconnectOutlined style={iconStyle.enable} />
+            ) : (
+              <TagOutlined style={iconStyle.disable} />
+            )}
+          </span>
+          <span
+            className="icon-span"
+            onClick={toggleFishEye}
+            onMouseEnter={(e) =>
+              showItemTip(e, fisheyeEnabled ? t('关闭鱼眼放大镜') : t('打开鱼眼放大镜'))
+            }
+            onMouseLeave={hideItemTip}
+          >
+            {fisheyeEnabled ? (
+              <EyeInvisibleOutlined style={iconStyle.enable} />
+            ) : (
+              <EyeOutlined style={iconStyle.disable} />
+            )}
+          </span>
+          <span
+            className="icon-span"
+            onClick={enabledLassoSelect}
+            onMouseEnter={(e) =>
+              showItemTip(e, lassoEnabled ? t('关闭拉索选择模式') : t('打开拉索选择模式'))
+            }
+            onMouseLeave={hideItemTip}
+          >
+            <HighlightOutlined style={lassoEnabled ? iconStyle.enable : iconStyle.disable} />
+          </span>
+          <span
+            className="icon-span"
+            onClick={handleEnableSelectPathEnd}
+            onMouseEnter={(e) => showItemTip(e, t('搜索最短路径'))}
+            onMouseLeave={hideItemTip}
+          >
+            <NodeIndexOutlined style={enableSelectPathEnd ? iconStyle.enable : iconStyle.disable} />
+          </span>
+          <span className="icon-span" style={{ width: 'fit-content', ...iconStyle.disable }}>
+            <span
+              className="zoom-icon"
+              onClick={handleZoomIn}
+              onMouseEnter={(e) => showItemTip(e, t('缩小'))}
+              onMouseLeave={hideItemTip}
+            >
+              -
+            </span>
+            <span
+              className="zoom-icon"
+              onClick={handleFitViw}
+              onMouseEnter={(e) => showItemTip(e, t('图内容适配容器，快捷键：ctrl + 1'))}
+              onMouseLeave={hideItemTip}
+              style={{ paddingLeft: '8px', paddingRight: '8px' }}
+            >
+              FIT
+            </span>
+            <span
+              className="zoom-icon"
+              onClick={handleZoomOut}
+              onMouseEnter={(e) => showItemTip(e, t('放大'))}
+              onMouseLeave={hideItemTip}
+            >
+              +
+            </span>
+          </span>
+          <span
+            className="icon-span"
+            onClick={handleEnableSearch}
+            onMouseEnter={(e) => showItemTip(e, t('输入 ID 搜索节点'))}
+            onMouseLeave={hideItemTip}
+          >
+            <SearchOutlined style={enableSearch ? iconStyle.enable : iconStyle.disable} />
+          </span>
+          {enableSearch && (
+            <span
+              onMouseEnter={(e) => showItemTip(e, t('输入需要搜索的节点 ID，并点击 Submit 按钮'))}
+              onMouseLeave={hideItemTip}
+            >
+              <input type="text" id="search-node-input" />
+              <button id="submit-button" onClick={handleSearchNode}>
+                Submit
+              </button>
+            </span>
+          )}
+          {enableSelectPathEnd && (
+            <span
+              onMouseEnter={(e) =>
+                showItemTip(e, t('选择有且仅有两个节点作为端点，并点击 Find Path 按钮'))
+              }
+              onMouseLeave={hideItemTip}
+            >
+              <button id="submit-button" onClick={handleFindPath}>
+                Find Path
+              </button>
+            </span>
+          )}
+        </div>
+      </div>
+      <div className="menu-tip" style={{ opacity: menuTip.opacity }}>
+        {menuTip.text}
+      </div>
+      <div id="g6-canavs-menu-item-tip" style={{ opacity: menuItemTip.opacity }}>
+        {menuItemTip.text}
+      </div>
+    </>
+  );
+};
+
+export default CanvasMenu;

--- a/packages/site/pages/large-graph-register.tsx
+++ b/packages/site/pages/large-graph-register.tsx
@@ -1,0 +1,571 @@
+import React from 'react';
+
+import isArray from '@antv/util/lib/is-array';
+import isNumber from '@antv/util/lib/is-number';
+
+const isBrowser = typeof window !== 'undefined';
+const G6 = isBrowser ? require('@antv/g6') : null;
+
+const duration = 2000;
+const animateOpacity = 0.6;
+const animateBackOpacity = 0.1;
+const virtualEdgeOpacity = 0.1;
+const realEdgeOpacity = 0.2;
+
+const darkBackColor = 'rgb(43, 47, 51)';
+const disableColor = '#777';
+const theme = 'dark';
+const subjectColors = [
+  '#3D76DD',
+  '#19A576',
+  '#65789B',
+  '#B98700',
+  '#5349E0',
+  '#5AB8DB',
+  '#7B48A1',
+  '#D77622',
+  '#008685',
+  '#D37099',
+];
+
+export const colorSets = G6
+  ? G6.Util.getColorSetsBySubjectColors(subjectColors, darkBackColor, theme, disableColor)
+  : [];
+
+export const global = {
+  node: {
+    style: {
+      fill: '#2B384E',
+    },
+    labelCfg: {
+      style: {
+        fill: '#acaeaf',
+        stroke: '#191b1c',
+      },
+    },
+    stateStyles: {
+      focus: {
+        fill: '#2B384E',
+      },
+    },
+  },
+  edge: {
+    style: {
+      stroke: '#acaeaf',
+      realEdgeStroke: '#acaeaf', //'#f00',
+      realEdgeOpacity,
+      strokeOpacity: realEdgeOpacity,
+    },
+    labelCfg: {
+      style: {
+        fill: '#acaeaf',
+        realEdgeStroke: '#acaeaf', //'#f00',
+        realEdgeOpacity: 0.5,
+        stroke: '#191b1c',
+      },
+    },
+    stateStyles: {
+      focus: {
+        stroke: '#fff', // '#3C9AE8',
+      },
+    },
+  },
+};
+
+if (G6) {
+  // Custom super node
+  G6.registerNode(
+    'aggregated-node',
+    {
+      draw(cfg: any, group) {
+        let width = 53,
+          height = 27;
+        const style = cfg.style || {};
+        const colorSet = cfg.colorSet || colorSets[0];
+
+        // halo for hover
+        group.addShape('rect', {
+          attrs: {
+            x: -width * 0.55,
+            y: -height * 0.6,
+            width: width * 1.1,
+            height: height * 1.2,
+            fill: colorSet.mainFill,
+            opacity: 0.9,
+            lineWidth: 0,
+            radius: (height / 2 || 13) * 1.2,
+          },
+          name: 'halo-shape',
+          visible: false,
+        });
+
+        // focus stroke for hover
+        group.addShape('rect', {
+          attrs: {
+            x: -width * 0.55,
+            y: -height * 0.6,
+            width: width * 1.1,
+            height: height * 1.2,
+            fill: colorSet.mainFill, // '#3B4043',
+            stroke: '#AAB7C4',
+            lineWidth: 1,
+            lineOpacty: 0.85,
+            radius: (height / 2 || 13) * 1.2,
+          },
+          name: 'stroke-shape',
+          visible: false,
+        });
+
+        const keyShape = group.addShape('rect', {
+          attrs: {
+            ...style,
+            x: -width / 2,
+            y: -height / 2,
+            width,
+            height,
+            fill: colorSet.mainFill, // || '#3B4043',
+            stroke: colorSet.mainStroke,
+            lineWidth: 2,
+            cursor: 'pointer',
+            radius: height / 2 || 13,
+            lineDash: [2, 2],
+          },
+          name: 'aggregated-node-keyShape',
+        });
+
+        let labelStyle = {};
+        if (cfg.labelCfg) {
+          labelStyle = Object.assign(labelStyle, cfg.labelCfg.style);
+        }
+        group.addShape('text', {
+          attrs: {
+            text: `${cfg.count}`,
+            x: 0,
+            y: 0,
+            textAlign: 'center',
+            textBaseline: 'middle',
+            cursor: 'pointer',
+            fontSize: 12,
+            fill: '#fff',
+            opacity: 0.85,
+            fontWeight: 400,
+          },
+          name: 'count-shape',
+          className: 'count-shape',
+          draggable: true,
+        });
+
+        // tag for new node
+        if (cfg.new) {
+          group.addShape('circle', {
+            attrs: {
+              x: width / 2 - 3,
+              y: -height / 2 + 3,
+              r: 4,
+              fill: '#6DD400',
+              lineWidth: 0.5,
+              stroke: '#FFFFFF',
+            },
+            name: 'typeNode-tag-circle',
+          });
+        }
+        return keyShape;
+      },
+      setState: (name, value, item) => {
+        const group = item.get('group');
+        if (name === 'layoutEnd' && value) {
+          const labelShape = group.find((e) => e.get('name') === 'text-shape');
+          if (labelShape) labelShape.set('visible', true);
+        } else if (name === 'hover') {
+          if (item.hasState('focus')) {
+            return;
+          }
+          const halo = group.find((e) => e.get('name') === 'halo-shape');
+          const keyShape: any = item.getKeyShape();
+          const colorSet = item.getModel().colorSet || colorSets[0];
+          if (value) {
+            halo && halo.show();
+            keyShape.attr('fill', colorSet.activeFill);
+          } else {
+            halo && halo.hide();
+            keyShape.attr('fill', colorSet.mainFill);
+          }
+        } else if (name === 'focus') {
+          const stroke = group.find((e) => e.get('name') === 'stroke-shape');
+          const keyShape: any = item.getKeyShape();
+          const colorSet = item.getModel().colorSet || colorSets[0];
+          if (value) {
+            stroke && stroke.show();
+            keyShape.attr('fill', colorSet.selectedFill);
+          } else {
+            stroke && stroke.hide();
+            keyShape.attr('fill', colorSet.mainFill);
+          }
+        }
+      },
+      update: undefined,
+    },
+    'single-node',
+  );
+
+  // Custom real node
+  G6.registerNode(
+    'real-node',
+    {
+      draw(cfg: any, group) {
+        let r = 30;
+        if (isNumber(cfg.size)) {
+          r = (cfg.size as number) / 2;
+        } else if (isArray(cfg.size)) {
+          r = cfg.size[0] / 2;
+        }
+        const style = cfg.style || {};
+        const colorSet = cfg.colorSet || colorSets[0];
+
+        // halo for hover
+        group.addShape('circle', {
+          attrs: {
+            x: 0,
+            y: 0,
+            r: r + 5,
+            fill: style.fill || colorSet.mainFill || '#2B384E',
+            opacity: 0.9,
+            lineWidth: 0,
+          },
+          name: 'halo-shape',
+          visible: false,
+        });
+
+        // focus stroke for hover
+        group.addShape('circle', {
+          attrs: {
+            x: 0,
+            y: 0,
+            r: r + 5,
+            fill: style.fill || colorSet.mainFill || '#2B384E',
+            stroke: '#fff',
+            strokeOpacity: 0.85,
+            lineWidth: 1,
+          },
+          name: 'stroke-shape',
+          visible: false,
+        });
+
+        const keyShape = group.addShape('circle', {
+          attrs: {
+            ...style,
+            x: 0,
+            y: 0,
+            r,
+            fill: colorSet.mainFill,
+            stroke: colorSet.mainStroke,
+            lineWidth: 2,
+            cursor: 'pointer',
+          },
+          name: 'aggregated-node-keyShape',
+        });
+
+        let labelStyle = {};
+        if (cfg.labelCfg) {
+          labelStyle = Object.assign(labelStyle, cfg.labelCfg.style);
+        }
+
+        if (cfg.label) {
+          const text = cfg.label;
+          let labelStyle: any = {};
+          let refY = 0;
+          if (cfg.labelCfg) {
+            labelStyle = Object.assign(labelStyle, cfg.labelCfg.style);
+            refY += cfg.labelCfg.refY || 0;
+          }
+          let offsetY = 0;
+          const fontSize = labelStyle.fontSize < 8 ? 8 : labelStyle.fontSize;
+          const lineNum = (cfg.labelLineNum as number) || 1;
+          offsetY = lineNum * (fontSize || 12);
+          group.addShape('text', {
+            attrs: {
+              text,
+              x: 0,
+              y: r + refY + offsetY + 5,
+              textAlign: 'center',
+              textBaseLine: 'alphabetic',
+              cursor: 'pointer',
+              fontSize,
+              fill: '#fff',
+              opacity: 0.85,
+              fontWeight: 400,
+              stroke: global.edge.labelCfg.style.stroke,
+            },
+            name: 'text-shape',
+            className: 'text-shape',
+          });
+        }
+
+        // tag for new node
+        if (cfg.new) {
+          group.addShape('circle', {
+            attrs: {
+              x: r - 3,
+              y: -r + 3,
+              r: 4,
+              fill: '#6DD400',
+              lineWidth: 0.5,
+              stroke: '#FFFFFF',
+            },
+            name: 'typeNode-tag-circle',
+          });
+        }
+
+        return keyShape;
+      },
+      setState: (name, value, item) => {
+        const group = item.get('group');
+        if (name === 'layoutEnd' && value) {
+          const labelShape = group.find((e) => e.get('name') === 'text-shape');
+          if (labelShape) labelShape.set('visible', true);
+        } else if (name === 'hover') {
+          if (item.hasState('focus')) {
+            return;
+          }
+          const halo = group.find((e) => e.get('name') === 'halo-shape');
+          const keyShape: any = item.getKeyShape();
+          const colorSet = item.getModel().colorSet || colorSets[0];
+          if (value) {
+            halo && halo.show();
+            keyShape.attr('fill', colorSet.activeFill);
+          } else {
+            halo && halo.hide();
+            keyShape.attr('fill', colorSet.mainFill);
+          }
+        } else if (name === 'focus') {
+          const stroke = group.find((e) => e.get('name') === 'stroke-shape');
+          const label = group.find((e) => e.get('name') === 'text-shape');
+          const keyShape: any = item.getKeyShape();
+          const colorSet = item.getModel().colorSet || colorSets[0];
+          if (value) {
+            stroke && stroke.show();
+            keyShape.attr('fill', colorSet.selectedFill);
+            label && label.attr('fontWeight', 800);
+          } else {
+            stroke && stroke.hide();
+            keyShape.attr('fill', colorSet.mainFill); // '#2B384E'
+            label && label.attr('fontWeight', 400);
+          }
+        }
+      },
+      update: undefined,
+    },
+    'aggregated-node',
+  ); // 这样可以继承 aggregated-node 的 setState
+
+  // Custom the quadratic edge for multiple edges between one node pair
+  G6.registerEdge(
+    'custom-quadratic',
+    {
+      setState: (name, value, item) => {
+        const group = item.get('group');
+        const model = item.getModel();
+        if (name === 'focus') {
+          const back = group.find((ele) => ele.get('name') === 'back-line');
+          if (back) {
+            back.stopAnimate();
+            back.remove();
+            back.destroy();
+          }
+          const keyShape = group.find((ele) => ele.get('name') === 'edge-shape');
+          const arrow: any = model.style.endArrow;
+          if (value) {
+            if (keyShape.cfg.animation) {
+              keyShape.stopAnimate(true);
+            }
+            keyShape.attr({
+              strokeOpacity: animateOpacity,
+              opacity: animateOpacity,
+              stroke: '#fff',
+              endArrow: {
+                ...arrow,
+                stroke: '#fff',
+                fill: '#fff',
+              },
+            });
+            if (model.isReal) {
+              const { lineWidth, path, endArrow, stroke } = keyShape.attr();
+              const back = group.addShape('path', {
+                attrs: {
+                  lineWidth,
+                  path,
+                  stroke,
+                  endArrow,
+                  opacity: animateBackOpacity,
+                },
+                name: 'back-line',
+              });
+              back.toBack();
+              const length = keyShape.getTotalLength();
+              keyShape.animate(
+                (ratio) => {
+                  // the operations in each frame. Ratio ranges from 0 to 1 indicating the prograss of the animation. Returns the modified configurations
+                  const startLen = ratio * length;
+                  // Calculate the lineDash
+                  const cfg = {
+                    lineDash: [startLen, length - startLen],
+                  };
+                  return cfg;
+                },
+                {
+                  repeat: true, // Whether executes the animation repeatly
+                  duration, // the duration for executing once
+                },
+              );
+            } else {
+              let index = 0;
+              const lineDash = keyShape.attr('lineDash');
+              const totalLength = lineDash[0] + lineDash[1];
+              keyShape.animate(
+                () => {
+                  index++;
+                  if (index > totalLength) {
+                    index = 0;
+                  }
+                  const res = {
+                    lineDash,
+                    lineDashOffset: -index,
+                  };
+                  // returns the modified configurations here, lineDash and lineDashOffset here
+                  return res;
+                },
+                {
+                  repeat: true, // whether executes the animation repeatly
+                  duration, // the duration for executing once
+                },
+              );
+            }
+          } else {
+            keyShape.stopAnimate();
+            const stroke = '#acaeaf';
+            const opacity = model.isReal ? realEdgeOpacity : virtualEdgeOpacity;
+            keyShape.attr({
+              stroke,
+              strokeOpacity: opacity,
+              opacity,
+              endArrow: {
+                ...arrow,
+                stroke,
+                fill: stroke,
+              },
+            });
+          }
+        }
+      },
+    },
+    'quadratic',
+  );
+
+  // Custom the line edge for single edge between one node pair
+  G6.registerEdge(
+    'custom-line',
+    {
+      setState: (name, value, item) => {
+        const group = item.get('group');
+        const model = item.getModel();
+        if (name === 'focus') {
+          const keyShape = group.find((ele) => ele.get('name') === 'edge-shape');
+          const back = group.find((ele) => ele.get('name') === 'back-line');
+          if (back) {
+            back.stopAnimate();
+            back.remove();
+            back.destroy();
+          }
+          const arrow: any = model.style.endArrow;
+          if (value) {
+            if (keyShape.cfg.animation) {
+              keyShape.stopAnimate(true);
+            }
+            keyShape.attr({
+              strokeOpacity: animateOpacity,
+              opacity: animateOpacity,
+              stroke: '#fff',
+              endArrow: {
+                ...arrow,
+                stroke: '#fff',
+                fill: '#fff',
+              },
+            });
+            if (model.isReal) {
+              const { path, stroke, lineWidth } = keyShape.attr();
+              const back = group.addShape('path', {
+                attrs: {
+                  path,
+                  stroke,
+                  lineWidth,
+                  opacity: animateBackOpacity,
+                },
+                name: 'back-line',
+              });
+              back.toBack();
+              const length = keyShape.getTotalLength();
+              keyShape.animate(
+                (ratio) => {
+                  // the operations in each frame. Ratio ranges from 0 to 1 indicating the prograss of the animation. Returns the modified configurations
+                  const startLen = ratio * length;
+                  // Calculate the lineDash
+                  const cfg = {
+                    lineDash: [startLen, length - startLen],
+                  };
+                  return cfg;
+                },
+                {
+                  repeat: true, // Whether executes the animation repeatly
+                  duration, // the duration for executing once
+                },
+              );
+            } else {
+              const lineDash = keyShape.attr('lineDash');
+              const totalLength = lineDash[0] + lineDash[1];
+              let index = 0;
+              keyShape.animate(
+                () => {
+                  index++;
+                  if (index > totalLength) {
+                    index = 0;
+                  }
+                  const res = {
+                    lineDash,
+                    lineDashOffset: -index,
+                  };
+                  // returns the modified configurations here, lineDash and lineDashOffset here
+                  return res;
+                },
+                {
+                  repeat: true, // whether executes the animation repeatly
+                  duration, // the duration for executing once
+                },
+              );
+            }
+          } else {
+            keyShape.stopAnimate();
+            const stroke = '#acaeaf';
+            const opacity = model.isReal ? realEdgeOpacity : virtualEdgeOpacity;
+            keyShape.attr({
+              stroke,
+              strokeOpacity: opacity,
+              opacity: opacity,
+              endArrow: {
+                ...arrow,
+                stroke,
+                fill: stroke,
+              },
+            });
+          }
+        }
+      },
+    },
+    'single-edge',
+  );
+}
+
+const reacComponent = () => {
+  return <></>;
+};
+
+export default reacComponent;

--- a/packages/site/pages/largegraph.tsx
+++ b/packages/site/pages/largegraph.tsx
@@ -1,0 +1,1285 @@
+import React, { useEffect, useState } from 'react';
+import { colorSets, global } from './large-graph-register';
+import { uniqueId } from '@antv/util';
+import { useTranslation } from 'react-i18next';
+import CanvasMenu from './canvas-menu';
+import LegendPanel from './legend-panel';
+
+const isBrowser = typeof window !== 'undefined';
+const G6 = isBrowser ? require('@antv/g6') : null;
+const insertCss = isBrowser ? require('insert-css') : null;
+
+let labelPropagation = null;
+let louvain = null;
+let findShortestPath = null;
+
+if (isBrowser) {
+  labelPropagation = G6.Algorithm.labelPropagation;
+  louvain = G6.Algorithm.louvain;
+  findShortestPath = G6.Algorithm.findShortestPath;
+  insertCss(`
+		.g6-component-contextmenu {
+			position: absolute;
+			z-index: 2;
+			list-style-type: none;
+			background-color: #363b40;
+			border-radius: 6px;
+			font-size: 14px;
+			color: hsla(0,0%,100%,.85);
+			width: fit-content;
+			transition: opacity .2s;
+			text-align: center;
+			padding: 0px 20px 0px 20px;
+			box-shadow: 0 5px 18px 0 rgba(0, 0, 0, 0.6);
+			border: 0px;
+		}
+		.g6-component-contextmenu ul {
+			padding-left: 0px;
+			margin: 0;
+		}
+		.g6-component-contextmenu li {
+			cursor: pointer;
+			list-style-type: none;
+			list-style: none;
+			margin-left: 0;
+			line-height: 38px;
+	}
+		}
+		.g6-component-contextmenu li:hover {
+			color: #aaa;
+		}
+	`);
+}
+
+const NODESIZEMAPPING = 'degree';
+const SMALLGRAPHLABELMAXLENGTH = 5;
+let labelMaxLength = SMALLGRAPHLABELMAXLENGTH;
+const DEFAULTNODESIZE = 20;
+const DEFAULTAGGREGATEDNODESIZE = 53;
+const NODE_LIMIT = 40; // TODO: find a proper number for maximum node number on the canvas
+
+let graph = null;
+let originData;
+let currentUnproccessedData = { nodes: [], edges: [] };
+let nodeMap = {};
+let aggregatedNodeMap = {};
+let hiddenItemIds = []; // 隐藏的元素 id 数组
+let largeGraphMode = true;
+let cachePositions = {};
+let manipulatePosition = undefined;
+let descreteNodeCenter;
+let layout = {
+  type: '',
+  instance: null,
+  destroyed: true,
+};
+let expandArray = [];
+let collapseArray = [];
+let shiftKeydown = false;
+let CANVAS_WIDTH = 800,
+  CANVAS_HEIGHT = 800;
+
+const descendCompare = (p) => {
+  // 这是比较函数
+  return function (m, n) {
+    const a = m[p];
+    const b = n[p];
+    return b - a; // 降序
+  };
+};
+
+const clearFocusItemState = (graph) => {
+  if (!graph) return;
+  clearFocusNodeState(graph);
+  clearFocusEdgeState(graph);
+};
+
+// 清除图上所有节点的 focus 状态及相应样式
+const clearFocusNodeState = (graph) => {
+  const focusNodes = graph.findAllByState('node', 'focus');
+  focusNodes.forEach((fnode) => {
+    graph.setItemState(fnode, 'focus', false); // false
+  });
+};
+
+// 清除图上所有边的 focus 状态及相应样式
+const clearFocusEdgeState = (graph) => {
+  const focusEdges = graph.findAllByState('edge', 'focus');
+  focusEdges.forEach((fedge) => {
+    graph.setItemState(fedge, 'focus', false);
+  });
+};
+
+// 截断长文本。length 为文本截断后长度，elipsis 是后缀
+const formatText = (text, length = 5, elipsis = '...') => {
+  if (!text) return '';
+  if (text.length > length) {
+    return `${text.substr(0, length)}${elipsis}`;
+  }
+  return text;
+};
+
+const labelFormatter = (text: string, minLength: number = 10): string => {
+  if (text && text.split('').length > minLength) return `${text.substr(0, minLength)}...`;
+  return text;
+};
+
+const processNodesEdges = (
+  nodes,
+  edges,
+  width,
+  height,
+  largeGraphMode,
+  edgeLabelVisible,
+  isNewGraph = false,
+) => {
+  if (!nodes || nodes.length === 0) return {};
+  const currentNodeMap = {};
+  let maxNodeCount = -Infinity;
+  const paddingRatio = 0.3;
+  const paddingLeft = paddingRatio * width;
+  const paddingTop = paddingRatio * height;
+  nodes.forEach((node) => {
+    node.type = node.level === 0 ? 'real-node' : 'aggregated-node';
+    node.isReal = node.level === 0 ? true : false;
+    node.label = `${node.id}`;
+    node.labelLineNum = undefined;
+    node.oriLabel = node.label;
+    node.label = formatText(node.label, labelMaxLength, '...');
+    node.degree = 0;
+    node.inDegree = 0;
+    node.outDegree = 0;
+    if (currentNodeMap[node.id]) {
+      console.warn('node exists already!', node.id);
+      node.id = `${node.id}${Math.random()}`;
+    }
+    currentNodeMap[node.id] = node;
+    if (node.count > maxNodeCount) maxNodeCount = node.count;
+    const cachePosition = cachePositions ? cachePositions[node.id] : undefined;
+    if (cachePosition) {
+      node.x = cachePosition.x;
+      node.y = cachePosition.y;
+      node.new = false;
+    } else {
+      node.new = isNewGraph ? false : true;
+      if (manipulatePosition && !node.x && !node.y) {
+        node.x = manipulatePosition.x + 30 * Math.cos(Math.random() * Math.PI * 2);
+        node.y = manipulatePosition.y + 30 * Math.sin(Math.random() * Math.PI * 2);
+      }
+    }
+  });
+
+  let maxCount = -Infinity;
+  let minCount = Infinity;
+  // let maxCount = 0;
+  edges.forEach((edge) => {
+    // to avoid the dulplicated id to nodes
+    if (!edge.id) edge.id = uniqueId('edge');
+    else if (edge.id.split('-')[0] !== 'edge') edge.id = `edge-${edge.id}`;
+    // TODO: delete the following line after the queried data is correct
+    if (!currentNodeMap[edge.source] || !currentNodeMap[edge.target]) {
+      console.warn('edge source target does not exist', edge.source, edge.target, edge.id);
+      return;
+    }
+    const sourceNode = currentNodeMap[edge.source];
+    const targetNode = currentNodeMap[edge.target];
+
+    if (!sourceNode || !targetNode)
+      console.warn('source or target is not defined!!!', edge, sourceNode, targetNode);
+
+    // calculate the degree
+    sourceNode.degree++;
+    targetNode.degree++;
+    sourceNode.outDegree++;
+    targetNode.inDegree++;
+
+    if (edge.count > maxCount) maxCount = edge.count;
+    if (edge.count < minCount) minCount = edge.count;
+  });
+
+  nodes.sort(descendCompare(NODESIZEMAPPING));
+  const maxDegree = nodes[0].degree || 1;
+
+  const descreteNodes = [];
+  nodes.forEach((node, i) => {
+    // assign the size mapping to the outDegree
+    const countRatio = node.count / maxNodeCount;
+    const isRealNode = node.level === 0;
+    node.size = isRealNode ? DEFAULTNODESIZE : DEFAULTAGGREGATEDNODESIZE;
+    node.isReal = isRealNode;
+    node.labelCfg = {
+      position: 'bottom',
+      offset: 5,
+      style: {
+        fill: global.node.labelCfg.style.fill,
+        fontSize: 6 + countRatio * 6 || 12,
+        stroke: global.node.labelCfg.style.stroke,
+        lineWidth: 3,
+      },
+    };
+
+    if (!node.degree) {
+      descreteNodes.push(node);
+    }
+  });
+
+  const countRange = maxCount - minCount;
+  const minEdgeSize = 1;
+  const maxEdgeSize = 7;
+  const edgeSizeRange = maxEdgeSize - minEdgeSize;
+  edges.forEach((edge) => {
+    // set edges' style
+    const targetNode = currentNodeMap[edge.target];
+
+    const size = ((edge.count - minCount) / countRange) * edgeSizeRange + minEdgeSize || 1;
+    edge.size = size;
+
+    const arrowWidth = Math.max(size / 2 + 2, 3);
+    const arrowLength = 10;
+    const arrowBeging = targetNode.size + arrowLength;
+    let arrowPath = `M ${arrowBeging},0 L ${arrowBeging + arrowLength},-${arrowWidth} L ${arrowBeging + arrowLength
+      },${arrowWidth} Z`;
+    let d = targetNode.size / 2 + arrowLength;
+    if (edge.source === edge.target) {
+      edge.type = 'loop';
+      arrowPath = undefined;
+    }
+    const sourceNode = currentNodeMap[edge.source];
+    const isRealEdge = targetNode.isReal && sourceNode.isReal;
+    edge.isReal = isRealEdge;
+    const stroke = isRealEdge ? global.edge.style.realEdgeStroke : global.edge.style.stroke;
+    const opacity = isRealEdge
+      ? global.edge.style.realEdgeOpacity
+      : global.edge.style.strokeOpacity;
+    const dash = Math.max(size, 2);
+    const lineDash = isRealEdge ? undefined : [dash, dash];
+    edge.style = {
+      stroke,
+      strokeOpacity: opacity,
+      cursor: 'pointer',
+      lineAppendWidth: Math.max(edge.size || 5, 5),
+      fillOpacity: 1,
+      lineDash,
+      endArrow: arrowPath
+        ? {
+          path: arrowPath,
+          d,
+          fill: stroke,
+          strokeOpacity: 0,
+        }
+        : false,
+    };
+    edge.labelCfg = {
+      autoRotate: true,
+      style: {
+        stroke: global.edge.labelCfg.style.stroke,
+        fill: global.edge.labelCfg.style.fill,
+        lineWidth: 4,
+        fontSize: 12,
+        lineAppendWidth: 10,
+        opacity: 1,
+      },
+    };
+    if (!edge.oriLabel) edge.oriLabel = edge.label;
+    if (largeGraphMode || !edgeLabelVisible) edge.label = '';
+    else {
+      edge.label = labelFormatter(edge.label, labelMaxLength);
+    }
+
+    // arrange the other nodes around the hub
+    const sourceDis = sourceNode.size / 2 + 20;
+    const targetDis = targetNode.size / 2 + 20;
+    if (sourceNode.x && !targetNode.x) {
+      targetNode.x = sourceNode.x + sourceDis * Math.cos(Math.random() * Math.PI * 2);
+    }
+    if (sourceNode.y && !targetNode.y) {
+      targetNode.y = sourceNode.y + sourceDis * Math.sin(Math.random() * Math.PI * 2);
+    }
+    if (targetNode.x && !sourceNode.x) {
+      sourceNode.x = targetNode.x + targetDis * Math.cos(Math.random() * Math.PI * 2);
+    }
+    if (targetNode.y && !sourceNode.y) {
+      sourceNode.y = targetNode.y + targetDis * Math.sin(Math.random() * Math.PI * 2);
+    }
+
+    if (!sourceNode.x && !sourceNode.y && manipulatePosition) {
+      sourceNode.x = manipulatePosition.x + 30 * Math.cos(Math.random() * Math.PI * 2);
+      sourceNode.y = manipulatePosition.y + 30 * Math.sin(Math.random() * Math.PI * 2);
+    }
+    if (!targetNode.x && !targetNode.y && manipulatePosition) {
+      targetNode.x = manipulatePosition.x + 30 * Math.cos(Math.random() * Math.PI * 2);
+      targetNode.y = manipulatePosition.y + 30 * Math.sin(Math.random() * Math.PI * 2);
+    }
+  });
+
+  descreteNodeCenter = {
+    x: width - paddingLeft,
+    y: height - paddingTop,
+  };
+  descreteNodes.forEach((node) => {
+    if (!node.x && !node.y) {
+      node.x = descreteNodeCenter.x + 30 * Math.cos(Math.random() * Math.PI * 2);
+      node.y = descreteNodeCenter.y + 30 * Math.sin(Math.random() * Math.PI * 2);
+    }
+  });
+
+  G6.Util.processParallelEdges(edges, 12.5, 'custom-quadratic', 'custom-line');
+  return {
+    maxDegree,
+    edges,
+  };
+};
+
+const getForceLayoutConfig = (graph, largeGraphMode, configSettings?) => {
+  let {
+    linkDistance,
+    edgeStrength,
+    nodeStrength,
+    nodeSpacing,
+    preventOverlap,
+    nodeSize,
+    collideStrength,
+    alpha,
+    alphaDecay,
+    alphaMin,
+  } = configSettings || { preventOverlap: true };
+
+  if (!linkDistance && linkDistance !== 0) linkDistance = 225;
+  if (!edgeStrength && edgeStrength !== 0) edgeStrength = 50;
+  if (!nodeStrength && nodeStrength !== 0) nodeStrength = 200;
+  if (!nodeSpacing && nodeSpacing !== 0) nodeSpacing = 5;
+
+  const config = {
+    type: 'gForce',
+    minMovement: 0.01,
+    maxIteration: 5000,
+    preventOverlap,
+    damping: 0.99,
+    gpuEnabled: largeGraphMode,
+    linkDistance: (d) => {
+      let dist = linkDistance;
+      const sourceNode = nodeMap[d.source] || aggregatedNodeMap[d.source];
+      const targetNode = nodeMap[d.target] || aggregatedNodeMap[d.target];
+      // // 两端都是聚合点
+      // if (sourceNode.level && targetNode.level) dist = linkDistance * 3;
+      // // 一端是聚合点，一端是真实节点
+      // else if (sourceNode.level || targetNode.level) dist = linkDistance * 1.5;
+      if (!sourceNode.level && !targetNode.level) dist = linkDistance * 0.3;
+      return dist;
+    },
+    edgeStrength: (d) => {
+      const sourceNode = nodeMap[d.source] || aggregatedNodeMap[d.source];
+      const targetNode = nodeMap[d.target] || aggregatedNodeMap[d.target];
+      // 聚合节点之间的引力小
+      if (sourceNode.level && targetNode.level) return edgeStrength / 2;
+      // 聚合节点与真实节点之间引力大
+      if (sourceNode.level || targetNode.level) return edgeStrength;
+      return edgeStrength;
+    },
+    nodeStrength: (d) => {
+      // 给离散点引力，让它们聚集
+      if (d.degree === 0) return -10;
+      // 聚合点的斥力大
+      if (d.level) return nodeStrength * 2;
+      return nodeStrength;
+    },
+    nodeSize: (d) => {
+      if (!nodeSize && d.size) return d.size;
+      return 50;
+    },
+    nodeSpacing: (d) => {
+      if (d.degree === 0) return nodeSpacing * 2;
+      if (d.level) return nodeSpacing;
+      return nodeSpacing;
+    },
+    onLayoutEnd: () => {
+      if (largeGraphMode) {
+        graph.getEdges().forEach((edge) => {
+          if (!edge.oriLabel) return;
+          edge.update({
+            label: labelFormatter(edge.oriLabel, labelMaxLength),
+          });
+        });
+      }
+    },
+    tick: () => {
+      graph.refreshPositions();
+    },
+  };
+
+  if (nodeSize) config['nodeSize'] = nodeSize;
+  if (collideStrength) config['collideStrength'] = collideStrength;
+  if (alpha) config['alpha'] = alpha;
+  if (alphaDecay) config['alphaDecay'] = alphaDecay;
+  if (alphaMin) config['alphaMin'] = alphaMin;
+
+  return config;
+};
+
+const hideItems = (graph) => {
+  hiddenItemIds.forEach((id) => {
+    graph.hideItem(id);
+  });
+};
+
+const showItems = (graph) => {
+  graph.getNodes().forEach((node) => {
+    if (!node.isVisible()) graph.showItem(node);
+  });
+  graph.getEdges().forEach((edge) => {
+    if (!edge.isVisible()) edge.showItem(edge);
+  });
+  hiddenItemIds = [];
+};
+
+const handleRefreshGraph = (
+  graph,
+  graphData,
+  width,
+  height,
+  largeGraphMode,
+  edgeLabelVisible,
+  isNewGraph,
+) => {
+  if (!graphData || !graph) return;
+  clearFocusItemState(graph);
+  // reset the filtering
+  graph.getNodes().forEach((node) => {
+    if (!node.isVisible()) node.show();
+  });
+  graph.getEdges().forEach((edge) => {
+    if (!edge.isVisible()) edge.show();
+  });
+
+  let nodes = [],
+    edges = [];
+
+  nodes = graphData?.nodes;
+  const processRes = processNodesEdges(
+    nodes,
+    graphData.edges || [],
+    width,
+    height,
+    largeGraphMode,
+    edgeLabelVisible,
+    isNewGraph,
+  );
+
+  edges = processRes.edges;
+
+  graph.changeData({ nodes, edges });
+
+  hideItems(graph);
+  graph.getNodes().forEach((node) => {
+    node.toFront();
+  });
+
+  layout.instance.stop();
+
+  // 在大数据量时，使用 GPU 布局
+  if (nodes.length > 100) {
+    layout.instance.destroy();
+    const layoutConfig: any = getForceLayoutConfig(graph, true);
+    layoutConfig.center = [width / 2, height / 2];
+    layout.instance = new G6.Layout['gForce'](layoutConfig);
+  }
+
+  // force 需要使用不同 id 的对象才能进行全新的布局，否则会使用原来的引用。因此复制一份节点和边作为 force 的布局数据
+  layout.instance.init({
+    nodes: graphData.nodes,
+    edges,
+  });
+
+  layout.instance.minMovement = 0.0001;
+  layout.instance.getMass = (d) => {
+    const cachePosition = cachePositions[d.id];
+    if (cachePosition) return 5;
+    return 1;
+  };
+
+  layout.instance.execute();
+  return { nodes, edges };
+};
+
+const getMixedGraph = (
+  aggregatedData,
+  originData,
+  nodeMap,
+  aggregatedNodeMap,
+  expandArray,
+  collapseArray,
+) => {
+  let nodes = [],
+    edges = [];
+
+  const expandMap = {},
+    collapseMap = {};
+  expandArray.forEach((expandModel) => {
+    expandMap[expandModel.id] = true;
+  });
+  collapseArray.forEach((collapseModel) => {
+    collapseMap[collapseModel.id] = true;
+  });
+
+  aggregatedData.clusters.forEach((cluster, i) => {
+    if (expandMap[cluster.id]) {
+      nodes = nodes.concat(cluster.nodes);
+      aggregatedNodeMap[cluster.id].expanded = true;
+    } else {
+      nodes.push(aggregatedNodeMap[cluster.id]);
+      aggregatedNodeMap[cluster.id].expanded = false;
+    }
+  });
+  originData.edges.forEach((edge) => {
+    const isSourceInExpandArray = expandMap[nodeMap[edge.source].clusterId];
+    const isTargetInExpandArray = expandMap[nodeMap[edge.target].clusterId];
+    if (isSourceInExpandArray && isTargetInExpandArray) {
+      edges.push(edge);
+    } else if (isSourceInExpandArray) {
+      const targetClusterId = nodeMap[edge.target].clusterId;
+      const vedge = {
+        source: edge.source,
+        target: targetClusterId,
+        id: uniqueId('edge'),
+        label: '',
+      };
+      edges.push(vedge);
+    } else if (isTargetInExpandArray) {
+      const sourceClusterId = nodeMap[edge.source].clusterId;
+      const vedge = {
+        target: edge.target,
+        source: sourceClusterId,
+        id: uniqueId('edge'),
+        label: '',
+      };
+      edges.push(vedge);
+    }
+  });
+  aggregatedData.clusterEdges.forEach((edge) => {
+    if (expandMap[edge.source] || expandMap[edge.target]) return;
+    else edges.push(edge);
+  });
+  return { nodes, edges };
+};
+
+const getNeighborMixedGraph = (
+  centerNodeModel,
+  step,
+  originData,
+  clusteredData,
+  currentData,
+  nodeMap,
+  aggregatedNodeMap,
+  maxNeighborNumPerNode = 5,
+) => {
+  // update the manipulate position for center gravity of the new nodes
+  manipulatePosition = { x: centerNodeModel.x, y: centerNodeModel.y };
+
+  // the neighborSubGraph does not include the centerNodeModel. the elements are all generated new nodes and edges
+  const neighborSubGraph = generateNeighbors(centerNodeModel, step, maxNeighborNumPerNode);
+  // update the origin data
+  originData.nodes = originData.nodes.concat(neighborSubGraph.nodes);
+  originData.edges = originData.edges.concat(neighborSubGraph.edges);
+  // update the origin nodeMap
+  neighborSubGraph.nodes.forEach((node) => {
+    nodeMap[node.id] = node;
+  });
+  // update the clusteredData
+  const clusterId = centerNodeModel.clusterId;
+  clusteredData.clusters.forEach((cluster) => {
+    if (cluster.id !== clusterId) return;
+    cluster.nodes = cluster.nodes.concat(neighborSubGraph.nodes);
+    cluster.sumTot += neighborSubGraph.edges.length;
+  });
+  // update the count
+  aggregatedNodeMap[clusterId].count += neighborSubGraph.nodes.length;
+
+  currentData.nodes = currentData.nodes.concat(neighborSubGraph.nodes);
+  currentData.edges = currentData.edges.concat(neighborSubGraph.edges);
+  return currentData;
+};
+
+const generateNeighbors = (centerNodeModel, step, maxNeighborNumPerNode = 5) => {
+  if (step <= 0) return undefined;
+  let nodes = [],
+    edges = [];
+  const clusterId = centerNodeModel.clusterId;
+  const centerId = centerNodeModel.id;
+  const neighborNum = Math.ceil(Math.random() * maxNeighborNumPerNode);
+  for (let i = 0; i < neighborNum; i++) {
+    const neighborNode = {
+      id: uniqueId('node'),
+      clusterId,
+      level: 0,
+      colorSet: centerNodeModel.colorSet,
+    };
+    nodes.push(neighborNode);
+    const dire = Math.random() > 0.5;
+    const source = dire ? centerId : neighborNode.id;
+    const target = dire ? neighborNode.id : centerId;
+    const neighborEdge = {
+      id: uniqueId('edge'),
+      source,
+      target,
+      label: `${source}-${target}`,
+    };
+    edges.push(neighborEdge);
+    const subNeighbors = generateNeighbors(neighborNode, step - 1, maxNeighborNumPerNode);
+    if (subNeighbors) {
+      nodes = nodes.concat(subNeighbors.nodes);
+      edges = edges.concat(subNeighbors.edges);
+    }
+  }
+  return { nodes, edges };
+};
+
+const getExtractNodeMixedGraph = (
+  extractNodeData,
+  originData,
+  nodeMap,
+  aggregatedNodeMap,
+  currentUnproccessedData,
+) => {
+  const extractNodeId = extractNodeData.id;
+  // const extractNodeClusterId = extractNodeData.clusterId;
+  // push to the current rendering data
+  currentUnproccessedData.nodes.push(extractNodeData);
+  // update the count of aggregatedNodeMap, when to revert?
+  // aggregatedNodeMap[extractNodeClusterId].count --;
+
+  // extract the related edges
+  originData.edges.forEach((edge) => {
+    if (edge.source === extractNodeId) {
+      const targetClusterId = nodeMap[edge.target].clusterId;
+      if (!aggregatedNodeMap[targetClusterId].expanded) {
+        // did not expand, create an virtual edge fromt he extract node to the cluster
+        currentUnproccessedData.edges.push({
+          id: uniqueId('edge'),
+          source: extractNodeId,
+          target: targetClusterId,
+        });
+      } else {
+        // if the cluster is already expanded, push the origin edge
+        currentUnproccessedData.edges.push(edge);
+      }
+    } else if (edge.target === extractNodeId) {
+      const sourceClusterId = nodeMap[edge.source].clusterId;
+      if (!aggregatedNodeMap[sourceClusterId].expanded) {
+        // did not expand, create an virtual edge fromt he extract node to the cluster
+        currentUnproccessedData.edges.push({
+          id: uniqueId('edge'),
+          target: extractNodeId,
+          source: sourceClusterId,
+        });
+      } else {
+        // if the cluster is already expanded, push the origin edge
+        currentUnproccessedData.edges.push(edge);
+      }
+    }
+  });
+  return currentUnproccessedData;
+};
+
+const examAncestors = (model, expandedArray, length, keepTags) => {
+  for (let i = 0; i < length; i++) {
+    const expandedNode = expandedArray[i];
+    if (!keepTags[i] && model.parentId === expandedNode.id) {
+      keepTags[i] = true; // 需要被保留
+      examAncestors(expandedNode, expandedArray, length, keepTags);
+      break;
+    }
+  }
+};
+
+const manageExpandCollapseArray = (nodeNumber, model, collapseArray, expandArray) => {
+  manipulatePosition = { x: model.x, y: model.y };
+
+  // 维护 expandArray，若当前画布节点数高于上限，移出 expandedArray 中非 model 祖先的节点)
+  if (nodeNumber > NODE_LIMIT) {
+    // 若 keepTags[i] 为 true，则 expandedArray 的第 i 个节点需要被保留
+    const keepTags = {};
+    const expandLen = expandArray.length;
+    // 检查 X 的所有祖先并标记 keepTags
+    examAncestors(model, expandArray, expandLen, keepTags);
+    // 寻找 expandedArray 中第一个 keepTags 不为 true 的点
+    let shiftNodeIdx = -1;
+    for (let i = 0; i < expandLen; i++) {
+      if (!keepTags[i]) {
+        shiftNodeIdx = i;
+        break;
+      }
+    }
+    // 如果有符合条件的节点，将其从 expandedArray 中移除
+    if (shiftNodeIdx !== -1) {
+      let foundNode = expandArray[shiftNodeIdx];
+      if (foundNode.level === 2) {
+        let foundLevel1 = false;
+        // 找到 expandedArray 中 parentId = foundNode.id 且 level = 1 的第一个节点
+        for (let i = 0; i < expandLen; i++) {
+          const eNode = expandArray[i];
+          if (eNode.parentId === foundNode.id && eNode.level === 1) {
+            foundLevel1 = true;
+            foundNode = eNode;
+            expandArray.splice(i, 1);
+            break;
+          }
+        }
+        // 若未找到，则 foundNode 不变, 直接删去 foundNode
+        if (!foundLevel1) expandArray.splice(shiftNodeIdx, 1);
+      } else {
+        // 直接删去 foundNode
+        expandArray.splice(shiftNodeIdx, 1);
+      }
+      // const removedNode = expandedArray.splice(shiftNodeIdx, 1); // splice returns an array
+      const idSplits = foundNode.id.split('-');
+      let collapseNodeId;
+      // 去掉最后一个后缀
+      for (let i = 0; i < idSplits.length - 1; i++) {
+        const str = idSplits[i];
+        if (collapseNodeId) collapseNodeId = `${collapseNodeId}-${str}`;
+        else collapseNodeId = str;
+      }
+      const collapseNode = {
+        id: collapseNodeId,
+        parentId: foundNode.id,
+        level: foundNode.level - 1,
+      };
+      collapseArray.push(collapseNode);
+    }
+  }
+
+  const currentNode = {
+    id: model.id,
+    level: model.level,
+    parentId: model.parentId,
+  };
+
+  // 加入当前需要展开的节点
+  expandArray.push(currentNode);
+
+  graph.get('canvas').setCursor('default');
+  return { expandArray, collapseArray };
+};
+
+const cacheNodePositions = (nodes) => {
+  const positionMap = {};
+  const nodeLength = nodes.length;
+  for (let i = 0; i < nodeLength; i++) {
+    const node = nodes[i].getModel();
+    positionMap[node.id] = {
+      x: node.x,
+      y: node.y,
+      level: node.level,
+    };
+  }
+  return positionMap;
+};
+
+const LargeGraph = () => {
+  const { t } = useTranslation();
+
+  const container = React.useRef<HTMLDivElement>(null);
+
+  const [fisheyeEnabled, setFisheyeEnabled] = useState(false);
+  const [lassoEnabled, setLassoEnabled] = useState(false);
+  const [edgeLabelVisible, setEdgeLabelVisible] = useState(false);
+  const [graphInstance, setGraphInstance] = useState(null);
+  const clickFisheyeIcon = (onlyDisable) => {
+    if (onlyDisable) {
+      setFisheyeEnabled(false);
+    } else {
+      setFisheyeEnabled(!fisheyeEnabled);
+    }
+  };
+  const clickLassoIcon = (onlyDisable) => {
+    if (onlyDisable) {
+      setLassoEnabled(false);
+    } else {
+      setLassoEnabled(!lassoEnabled);
+    }
+  };
+
+  const stopLayout = () => {
+    layout.instance.stop();
+  };
+
+  const bindListener = (graph) => {
+    graph.on('keydown', (evt) => {
+      const code = evt.key;
+      if (!code) {
+        return;
+      }
+      if (code.toLowerCase() === 'shift') {
+        shiftKeydown = true;
+      } else {
+        shiftKeydown = false;
+      }
+    });
+    graph.on('keyup', (evt) => {
+      const code = evt.key;
+      if (!code) {
+        return;
+      }
+      if (code.toLowerCase() === 'shift') {
+        shiftKeydown = false;
+      }
+    });
+    graph.on('node:mouseenter', (evt: any) => {
+      const { item } = evt;
+      const model = item.getModel();
+      const currentLabel = model.label;
+      model.oriFontSize = model.labelCfg.style.fontSize;
+      item.update({
+        label: model.oriLabel,
+      });
+      model.oriLabel = currentLabel;
+      graph.setItemState(item, 'hover', true);
+      item.toFront();
+    });
+
+    graph.on('node:mouseleave', (evt: any) => {
+      const { item } = evt;
+      const model = item.getModel();
+      const currentLabel = model.label;
+      item.update({
+        label: model.oriLabel,
+      });
+      model.oriLabel = currentLabel;
+      graph.setItemState(item, 'hover', false);
+    });
+
+    graph.on('edge:mouseenter', (evt: any) => {
+      const { item } = evt;
+      const model = item.getModel();
+      const currentLabel = model.label;
+      item.update({
+        label: model.oriLabel,
+      });
+      model.oriLabel = currentLabel;
+      item.toFront();
+      item.getSource().toFront();
+      item.getTarget().toFront();
+    });
+
+    graph.on('edge:mouseleave', (evt: any) => {
+      const { item } = evt;
+      const model = item.getModel();
+      const currentLabel = model.label;
+      item.update({
+        label: model.oriLabel,
+      });
+      model.oriLabel = currentLabel;
+    });
+    // click node to show the detail drawer
+    graph.on('node:click', (evt: any) => {
+      stopLayout();
+      if (!shiftKeydown) clearFocusItemState(graph);
+      else clearFocusEdgeState(graph);
+      const { item } = evt;
+
+      // highlight the clicked node, it is down by click-select
+      graph.setItemState(item, 'focus', true);
+
+      if (!shiftKeydown) {
+        // 将相关边也高亮
+        const relatedEdges = item.getEdges();
+        relatedEdges.forEach((edge) => {
+          graph.setItemState(edge, 'focus', true);
+        });
+      }
+    });
+
+    // click edge to show the detail of integrated edge drawer
+    graph.on('edge:click', (evt: any) => {
+      stopLayout();
+      if (!shiftKeydown) clearFocusItemState(graph);
+      const { item } = evt;
+      // highlight the clicked edge
+      graph.setItemState(item, 'focus', true);
+    });
+
+    // click canvas to cancel all the focus state
+    graph.on('canvas:click', (evt: any) => {
+      clearFocusItemState(graph);
+    });
+  };
+
+  const searchNode = (id) => {
+    if (!graph || graph.get('destroyed')) return false;
+    const item = graph.findById(id);
+    const originNodeData = nodeMap[id];
+    if (!item && originNodeData) {
+      // does not exit the current mixed graph but in the origin data
+      cachePositions = cacheNodePositions(graph.getNodes());
+      currentUnproccessedData = getExtractNodeMixedGraph(
+        originNodeData,
+        originData,
+        nodeMap,
+        aggregatedNodeMap,
+        currentUnproccessedData,
+      );
+      handleRefreshGraph(
+        graph,
+        currentUnproccessedData,
+        CANVAS_WIDTH,
+        CANVAS_HEIGHT,
+        largeGraphMode,
+        true,
+        false,
+      );
+    }
+    if (!item) return false;
+    if (item && item.getType() !== 'node') return false;
+    graph.focusItem(item, true);
+    clearFocusItemState(graph);
+    graph.setItemState(item, 'focus', true);
+    return true;
+  };
+
+  const findPath = () => {
+    if (!graph || graph.get('destroyed')) return false;
+    const selectedNodes = graph.findAllByState('node', 'focus');
+    if (selectedNodes.length !== 2) {
+      alert('Please Select only Two Nodes two Find the Path!');
+      return;
+    }
+
+    // find the path and highlight the nodes and edges along the path
+    clearFocusItemState(graph);
+    const { path } = findShortestPath(graph, selectedNodes[0].getID(), selectedNodes[1].getID());
+    graph.getEdges().forEach((edge) => {
+      const edgeModel = edge.getModel();
+      const source = edgeModel.source;
+      const target = edgeModel.target;
+      const sourceInPathIdx = path.indexOf(source);
+      const targetInPathIdx = path.indexOf(target);
+      if (sourceInPathIdx === -1 || targetInPathIdx === -1) return;
+      if (Math.abs(sourceInPathIdx - targetInPathIdx) === 1) {
+        edge.toFront();
+        graph.setItemState(edge, 'focus', true);
+      }
+    });
+    path.forEach((id) => {
+      const pathNode = graph.findById(id);
+      pathNode.toFront();
+      graph.setItemState(pathNode, 'focus', true);
+    });
+  };
+
+  useEffect(() => {
+    if (!graph) {
+      fetch('https://gw.alipayobjects.com/os/antvdemo/assets/data/relations.json')
+        .then((res) => res.json())
+        .then((data) => {
+          if (container && container.current) {
+            CANVAS_WIDTH = container.current.offsetWidth;
+            CANVAS_HEIGHT = container.current.offsetHeight;
+          }
+
+          originData = data;
+          nodeMap = {};
+          const clusteredData = louvain(data, false, 'weight');
+          const aggregatedData = { nodes: [], edges: [] };
+          clusteredData.clusters.forEach((cluster, i) => {
+            cluster.nodes.forEach((node) => {
+              node.level = 0;
+              node.label = node.id;
+              node.type = '';
+              node.colorSet = colorSets[i];
+              nodeMap[node.id] = node;
+            });
+            const cnode = {
+              id: cluster.id,
+              type: 'aggregated-node',
+              count: cluster.nodes.length,
+              level: 1,
+              label: cluster.id,
+              colorSet: colorSets[i],
+              idx: i,
+            };
+            aggregatedNodeMap[cluster.id] = cnode;
+            aggregatedData.nodes.push(cnode);
+          });
+          clusteredData.clusterEdges.forEach((clusterEdge) => {
+            const cedge = {
+              ...clusterEdge,
+              size: Math.log(clusterEdge.count as number),
+              label: '',
+              id: uniqueId('edge'),
+            };
+            if (cedge.source === cedge.target) {
+              cedge.type = 'loop';
+              cedge.loopCfg = {
+                dist: 20,
+              };
+            } else cedge.type = 'line';
+            aggregatedData.edges.push(cedge);
+          });
+
+          data.edges.forEach((edge) => {
+            edge.label = `${edge.source}-${edge.target}`;
+            edge.id = uniqueId('edge');
+          });
+
+          currentUnproccessedData = aggregatedData;
+
+          const { edges: processedEdges } = processNodesEdges(
+            currentUnproccessedData.nodes,
+            currentUnproccessedData.edges,
+            CANVAS_WIDTH,
+            CANVAS_HEIGHT,
+            largeGraphMode,
+            true,
+            true,
+          );
+
+          const contextMenu = new G6.Menu({
+            shouldBegin(evt) {
+              if (evt.target && evt.target.isCanvas && evt.target.isCanvas()) return true;
+              if (evt.item) return true;
+              return false;
+            },
+            getContent(evt) {
+              const { item } = evt;
+              if (evt.target && evt.target.isCanvas && evt.target.isCanvas()) {
+                return `<ul>
+                  <li id='show'>${t('显示所有隐藏元素')}</li>
+                  <li id='collapseAll'>${t('聚合所有聚类')}</li>
+                </ul>`;
+              } else if (!item) return;
+              const itemType = item?.getType();
+              const model = item?.getModel();
+              if (itemType && model) {
+                if (itemType === 'node') {
+                  if (model.level !== 0) {
+                    return `<ul>
+                      <li id='expand'>${t('展开该聚合点')}</li>
+                      <li id='hide'>${t('隐藏该节点')}</li>
+                    </ul>`;
+                  } else {
+                    return `<ul>
+                      <li id='collapse'>${t('聚合所属聚类')}</li>
+                      <li id='neighbor-1'>${t('扩展一度关系')}</li>
+                      <li id='neighbor-2'>${t('扩展二度关系')}</li>
+                      <li id='neighbor-3'>${t('扩展三度关系')}</li>
+                      <li id='hide'>${t('隐藏该节点')}</li>
+                    </ul>`;
+                  }
+                } else {
+                  return `<ul>
+                    <li id='hide'>${t('隐藏该边')}</li>
+                  </ul>`;
+                }
+              }
+            },
+            handleMenuClick: (target, item) => {
+              const model = item?.getModel();
+              const liIdStrs = target.id.split('-');
+              let mixedGraphData;
+              switch (liIdStrs[0]) {
+                case 'hide':
+                  graph.hideItem(item);
+                  hiddenItemIds.push(model.id);
+                  break;
+                case 'expand':
+                  const newArray = manageExpandCollapseArray(
+                    graph.getNodes().length,
+                    model,
+                    collapseArray,
+                    expandArray,
+                  );
+                  expandArray = newArray.expandArray;
+                  collapseArray = newArray.collapseArray;
+                  mixedGraphData = getMixedGraph(
+                    clusteredData,
+                    data,
+                    nodeMap,
+                    aggregatedNodeMap,
+                    expandArray,
+                    collapseArray,
+                  );
+                  break;
+                case 'collapse':
+                  const aggregatedNode = aggregatedNodeMap[model.clusterId];
+                  manipulatePosition = { x: aggregatedNode.x, y: aggregatedNode.y };
+                  collapseArray.push(aggregatedNode);
+                  for (let i = 0; i < expandArray.length; i++) {
+                    if (expandArray[i].id === model.clusterId) {
+                      expandArray.splice(i, 1);
+                      break;
+                    }
+                  }
+                  mixedGraphData = getMixedGraph(
+                    clusteredData,
+                    data,
+                    nodeMap,
+                    aggregatedNodeMap,
+                    expandArray,
+                    collapseArray,
+                  );
+                  break;
+                case 'collapseAll':
+                  expandArray = [];
+                  collapseArray = [];
+                  mixedGraphData = getMixedGraph(
+                    clusteredData,
+                    data,
+                    nodeMap,
+                    aggregatedNodeMap,
+                    expandArray,
+                    collapseArray,
+                  );
+                  break;
+                case 'neighbor':
+                  const expandNeighborSteps = parseInt(liIdStrs[1]);
+                  mixedGraphData = getNeighborMixedGraph(
+                    model,
+                    expandNeighborSteps,
+                    data,
+                    clusteredData,
+                    currentUnproccessedData,
+                    nodeMap,
+                    aggregatedNodeMap,
+                    10,
+                  );
+                  break;
+                case 'show':
+                  showItems(graph);
+                  break;
+                default:
+                  break;
+              }
+              if (mixedGraphData) {
+                cachePositions = cacheNodePositions(graph.getNodes());
+                currentUnproccessedData = mixedGraphData;
+                handleRefreshGraph(
+                  graph,
+                  currentUnproccessedData,
+                  CANVAS_WIDTH,
+                  CANVAS_HEIGHT,
+                  largeGraphMode,
+                  true,
+                  false,
+                );
+              }
+            },
+            // offsetX and offsetY include the padding of the parent container
+            // 需要加上父级容器的 padding-left 16 与自身偏移量 10
+            offsetX: 16 + 10,
+            // 需要加上父级容器的 padding-top 24 、画布兄弟元素高度、与自身偏移量 10
+            offsetY: 0,
+            // the types of items that allow the menu show up
+            // 在哪些类型的元素上响应
+            itemTypes: ['node', 'edge', 'canvas'],
+          });
+
+          graph = new G6.Graph({
+            container: container.current as HTMLElement,
+            width: CANVAS_WIDTH,
+            height: CANVAS_HEIGHT,
+            linkCenter: true,
+            minZoom: 0.1,
+            groupByTypes: false,
+            modes: {
+              default: [
+                {
+                  type: 'drag-canvas',
+                  enableOptimize: true,
+                },
+                {
+                  type: 'zoom-canvas',
+                  enableOptimize: true,
+                  optimizeZoom: 0.01,
+                },
+                'drag-node',
+                'shortcuts-call',
+              ],
+              lassoSelect: [
+                {
+                  type: 'zoom-canvas',
+                  enableOptimize: true,
+                },
+                {
+                  type: 'lasso-select',
+                  selectedState: 'focus',
+                  trigger: 'drag',
+                },
+              ],
+              fisheyeMode: [],
+            },
+            defaultNode: {
+              type: 'aggregated-node',
+              size: DEFAULTNODESIZE,
+            },
+            plugins: [contextMenu],
+          });
+
+          graph.get('canvas').set('localRefresh', false);
+
+          const layoutConfig: any = getForceLayoutConfig(graph, largeGraphMode);
+          layoutConfig.center = [CANVAS_WIDTH / 2, CANVAS_HEIGHT / 2];
+          layout.instance = new G6.Layout['gForce'](layoutConfig);
+          layout.instance.init({
+            nodes: currentUnproccessedData.nodes,
+            edges: processedEdges,
+          });
+          layout.instance.execute();
+
+          bindListener(graph);
+          graph.data({ nodes: aggregatedData.nodes, edges: processedEdges });
+          graph.render();
+          setGraphInstance(graph);
+        });
+    }
+  });
+
+  // hide the edge label
+  useEffect(() => {
+    if (!graph || graph.get('destroyed')) return;
+    graph.getEdges().forEach((edge) => {
+      const oriLabel: string = edge.getModel().oriLabel as string;
+      edge.update({
+        label: edgeLabelVisible ? labelFormatter(oriLabel, labelMaxLength) : '',
+      });
+    });
+  }, [edgeLabelVisible]);
+
+  if (typeof window !== 'undefined')
+    window.onresize = () => {
+      if (container && container.current) {
+        CANVAS_WIDTH = container.current.offsetWidth;
+        CANVAS_HEIGHT = container.current.offsetHeight;
+      }
+      if (graph && layout.instance) {
+        layout.instance.center = [CANVAS_WIDTH / 2, CANVAS_HEIGHT / 2];
+        graph.changeSize(CANVAS_WIDTH, CANVAS_HEIGHT);
+      }
+    };
+  return (
+    <>
+      <div
+        ref={container}
+        style={{ backgroundColor: '#2b2f33', height: 'calc(100vh - 100px)', width: '70%' }}
+      />
+      <LegendPanel />
+      {graphInstance && (
+        <>
+          <CanvasMenu
+            graph={graph}
+            clickFisheyeIcon={clickFisheyeIcon}
+            clickLassoIcon={clickLassoIcon}
+            fisheyeEnabled={fisheyeEnabled}
+            lassoEnabled={lassoEnabled}
+            stopLayout={stopLayout}
+            edgeLabelVisible={edgeLabelVisible}
+            setEdgeLabelVisible={setEdgeLabelVisible}
+            searchNode={searchNode}
+            handleFindPath={findPath}
+          />
+        </>
+      )}
+    </>
+  );
+};
+
+export default LargeGraph;

--- a/packages/site/pages/legend-panel.tsx
+++ b/packages/site/pages/legend-panel.tsx
@@ -1,0 +1,473 @@
+import React, { useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+import { global } from './large-graph-register';
+
+const isBrowser = typeof window !== 'undefined';
+const G6 = isBrowser ? require('@antv/g6') : null;
+const insertCss = isBrowser ? require('insert-css') : null;
+
+if (isBrowser) {
+  insertCss(`
+    #legend-panel {
+      width: 30%;
+      position: absolute;
+      right: 0px;
+      top: 64px;
+      height: 100%;
+      background-color: #34373A;
+      border-left: 2px #444 solid;
+      color: rgba(255, 255, 255, 0.85);
+      text-align: center;
+      box-shadow: 18px 5px 0 0 rgba(0, 0, 0, 0.6);
+    }
+    #legend-panel .legned-title {
+      width: 100%;
+      color: rgba(255, 255, 255, 0.85);
+      text-align: center;
+      margin-bottom: 0px;
+    }
+    #legend-panel #legend-graph-container {
+      width: 100%;
+      height: 250px;
+      background-color: #2b2f33;
+      margin-top: 8px;
+    }
+    #legend-panel #discription-container {
+      margin-top: 16px;
+      padding: 0px 16px;
+      height: calc(100% - 430px);
+      overflow-y: scroll;
+    }
+  `);
+}
+
+let legendGraph = null;
+let CANVAS_WIDTH = 100;
+let CANVAS_HEIGHT = 800;
+
+const LegendPanel = () => {
+  const { t, i18n } = useTranslation();
+  const container = React.useRef<HTMLDivElement>(null);
+  const data = {
+    nodes: [
+      {
+        id: 'aggregated-node-legend',
+        x: 50,
+        y: 30,
+        type: 'aggregated-node',
+        count: 10,
+      },
+      {
+        id: 'real-node-legend',
+        x: 50,
+        y: 90,
+        size: 20,
+        type: 'real-node',
+      },
+      {
+        id: 'aggregated-node-legend-new',
+        x: 50,
+        y: 220,
+        type: 'aggregated-node',
+        count: 10,
+        new: true,
+      },
+      {
+        id: 'real-node-legend-new',
+        x: 100,
+        y: 220,
+        size: 20,
+        type: 'real-node',
+        new: true,
+      },
+    ],
+    edges: [
+      {
+        source: 'aggregated-node-legend',
+        target: 'real-node-legend',
+        type: 'custom-line',
+        isReal: false,
+        size: 4,
+      },
+      {
+        source: 'aggregated-node-legend',
+        target: 'real-node-legend',
+        type: 'custom-line',
+        isReal: true,
+        size: 4,
+      },
+    ],
+  };
+  data.edges.forEach((edge: any) => {
+    const dash = edge.size;
+    const lineDash = edge.isReal ? undefined : [dash, dash];
+    const stroke = edge.isReal ? global.edge.style.realEdgeStroke : global.edge.style.stroke;
+    const opacity = edge.isReal
+      ? global.edge.style.realEdgeOpacity
+      : global.edge.style.strokeOpacity;
+
+    const arrowWidth = Math.max(edge.size / 2 + 2, 3);
+    const arrowLength = 10;
+    const arrowBeging = arrowLength;
+    let arrowPath = `M ${arrowBeging},0 L ${arrowBeging + arrowLength},-${arrowWidth} L ${
+      arrowBeging + arrowLength
+    },${arrowWidth} Z`;
+    let d = arrowLength;
+
+    edge.style = {
+      stroke,
+      strokeOpacity: opacity,
+      cursor: 'pointer',
+      lineAppendWidth: Math.max(edge.size || 5, 5),
+      fillOpacity: 1,
+      lineDash,
+      endArrow: arrowPath
+        ? {
+            path: arrowPath,
+            d,
+            fill: stroke,
+            strokeOpacity: 0,
+          }
+        : false,
+    };
+  });
+  useEffect(() => {
+    if (container && container.current) {
+      CANVAS_WIDTH = container.current.offsetWidth;
+      CANVAS_HEIGHT = container.current.offsetHeight;
+    }
+    if (!legendGraph || legendGraph.get('destroyed')) {
+      legendGraph = new G6.Graph({
+        container: container.current as HTMLElement,
+        width: CANVAS_WIDTH,
+        height: CANVAS_HEIGHT,
+        defaultEdge: {
+          labelCfg: {
+            style: {
+              fill: 'rgba(255, 255, 255, 0.85)',
+            },
+          },
+        },
+      });
+      legendGraph.data(data);
+      legendGraph.render();
+
+      legendGraph.getEdges().forEach((edge) => {
+        if (!edge.getModel().isReal) {
+          legendGraph.updateItem(edge, {
+            source: { x: 20, y: 130 },
+            target: { x: 80, y: 130 },
+            count: 10,
+          });
+        } else {
+          legendGraph.updateItem(edge, {
+            source: { x: 20, y: 170 },
+            target: { x: 80, y: 170 },
+            count: 10,
+          });
+        }
+      });
+
+      const group = legendGraph.getGroup();
+      const textStyle = {
+        fill: 'rgba(255, 255, 255, 0.85)',
+        textBaseline: 'middle',
+        x: 100,
+        fontWeight: 800,
+        fontSize: 14,
+      };
+      const aggregatedNodeText = group.addShape('text', {
+        attrs: {
+          text: t('聚合节点'),
+          y: 20,
+          ...textStyle,
+        },
+      });
+      group.addShape('text', {
+        attrs: {
+          text: t('节点中间的数字代表该聚类所含的节点数量'),
+          y: aggregatedNodeText.getBBox().maxY + 16,
+          ...textStyle,
+          opacity: 0.6,
+          fontSize: 10,
+        },
+      });
+
+      const realNodeText = group.addShape('text', {
+        attrs: {
+          text: t('真实节点'),
+          y: 80,
+          ...textStyle,
+        },
+      });
+      group.addShape('text', {
+        attrs: {
+          text: t('这是一个原数据中的真实节点'),
+          y: realNodeText.getBBox().maxY + 8,
+          ...textStyle,
+          opacity: 0.6,
+          fontSize: 10,
+        },
+      });
+
+      const aggregatedEdgeText = group.addShape('text', {
+        attrs: {
+          text: t('聚合边'),
+          y: 130,
+          ...textStyle,
+        },
+      });
+      group.addShape('text', {
+        attrs: {
+          text: t('至少一个端点是聚合节点'),
+          y: aggregatedEdgeText.getBBox().maxY + 8,
+          ...textStyle,
+          opacity: 0.6,
+          fontSize: 10,
+        },
+      });
+
+      const realEdgeText = group.addShape('text', {
+        attrs: {
+          text: t('真实边'),
+          y: 170,
+          ...textStyle,
+        },
+      });
+      group.addShape('text', {
+        attrs: {
+          text: t('两个端点都是真实节点'),
+          y: realEdgeText.getBBox().maxY + 8,
+          ...textStyle,
+          opacity: 0.6,
+          fontSize: 10,
+        },
+      });
+
+      const newNodeText = group.addShape('text', {
+        attrs: {
+          text: t('绿点标记：新增节点'),
+          y: 210,
+          ...textStyle,
+          x: 130,
+        },
+      });
+      group.addShape('text', {
+        attrs: {
+          text: t('相较于上一次结果，右上方小绿点标记了\n本次更新结果中新增的聚合节点或真实节点'),
+          y: newNodeText.getBBox().maxY + 16,
+          ...textStyle,
+          opacity: 0.6,
+          fontSize: 10,
+          x: 130,
+        },
+      });
+    }
+  });
+
+  if (i18n.language === 'zh') {
+    return (
+      <div id="legend-panel">
+        <h1 className="legned-title">图例与使用方式</h1>
+        <a
+          className="description"
+          href="https://github.com/antvis/G6/blob/master/packages/site/site/pages/largegraph.zh.tsx"
+          target="_blanck"
+        >
+          源代码
+        </a>
+        <div id="legend-graph-container" ref={container} />
+        <div id="discription-container">
+          <span className="description">
+            一些科学研究表明，不超过 500
+            个节点的图可视化是适合终端用户阅读和交互式探索的。根据这个原则，在大规模图上，我们将元数据中的节点通过
+            LOUVAIN
+            聚类算法进行聚合。首先展示被聚合后的图，然后用户可以通过展开聚合节点进行下钻式探索。
+          </span>
+          <span className="description">
+            如果一次聚合后的节点数仍然庞大，可以进行多层次的聚合。为了控制渲染节点的数量，展开多个聚类后，最早被展开的聚类将会被自动收起。这一方案除了满足上述原则，还能减少前端计算和渲染的负担。
+          </span>
+          <br />
+          <br />
+          <h3 className="legned-title">{`<图交互>`}</h3>
+          <img
+            src="https://gw.alipayobjects.com/mdn/rms_f8c6a0/afts/img/A*IgoxQ7wfjCcAAAAAAAAAAAAAARQnAQ"
+            width="120"
+          />{' '}
+          &nbsp; &nbsp; &nbsp; &nbsp;
+          <img
+            src="https://gw.alipayobjects.com/mdn/rms_f8c6a0/afts/img/A*cCk4SrHVfDsAAAAAAAAAAAAAARQnAQ"
+            width="150"
+          />
+          <br />
+          <br />
+          <span className="description">
+            {' '}
+            每个“聚合点”{' '}
+            <img
+              src="https://gw.alipayobjects.com/mdn/rms_f8c6a0/afts/img/A*1y4AS7ucVXMAAAAAAAAAAAAAARQnAQ"
+              width="50"
+            />
+            代表了一个 LOUVAIN 计算出的聚类，包含多个“真实节点”{' '}
+            <img
+              src="https://gw.alipayobjects.com/mdn/rms_f8c6a0/afts/img/A*IOgvSLWF1IQAAAAAAAAAAAAAARQnAQ"
+              width="20"
+            />
+            .<strong>「右击」</strong> 任意节点或边，一个相对应的上下文菜单将会出现。 右击{' '}
+            <img
+              src="https://gw.alipayobjects.com/mdn/rms_f8c6a0/afts/img/A*1y4AS7ucVXMAAAAAAAAAAAAAARQnAQ"
+              width="50"
+            />{' '}
+            并选择“展开聚合节点”，聚合节点将会被该聚类中的真实节点替代，这就是下钻式探索。
+            你也可以通过右击{' '}
+            <img
+              src="https://gw.alipayobjects.com/mdn/rms_f8c6a0/afts/img/A*IOgvSLWF1IQAAAAAAAAAAAAAARQnAQ"
+              width="20"
+            />{' '}
+            并选择“聚合该聚类”将已经展开的节点聚合；或选择 “寻找 k 度邻居”，被选中点的 k
+            度邻居节点将会被融合到当前图中。
+          </span>
+          <br /> <br />
+          <h3 className="legned-title">{`<画布菜单>`}</h3>
+          <img
+            src="https://gw.alipayobjects.com/mdn/rms_f8c6a0/afts/img/A*FKbFRIzj34EAAAAAAAAAAAAAARQnAQ"
+            width="300"
+          />
+          <br />
+          <span>
+            在画布左上角，有一个画布菜单，包含一系列辅助探索的工具。从左到右，它们分别是：
+          </span>
+          <br />
+          <span>
+            <strong>
+              - 显示/隐藏边标签；
+              <br />- 鱼眼放大镜；
+              <br />- 拉索选择模式；
+              <br />- 寻找最短路径（按 SHIFT 点选两个端点）；
+              <br />- 缩小；
+              <br />- 使图内容适应视窗；
+              <br />- 放大；
+              <br />- 搜索一个节点（输入 ID）。
+            </strong>
+          </span>
+          <br /> <br />
+          <h3 className="legned-title">{`<注意>`}</h3>
+          <span>
+            该 demo
+            仅为展示大规模图可视化方案，因此使用的数据是一个较小的、模拟的数据集。除了上述内容外，还有很多其他的功能。愉快地探索吧。希望它对你有所帮助。
+          </span>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div id="legend-panel">
+      <h1 className="legned-title">Legend and Usage</h1>
+      <a
+        className="description"
+        href="https://github.com/antvis/G6/blob/master/packages/site/site/pages/largegraph.zh.tsx"
+        target="_blanck"
+      >
+        Source Code
+      </a>
+      <div id="legend-graph-container" ref={container} />
+      <div id="discription-container">
+        <span className="description">
+          {' '}
+          Some research has found that the graph visulization is readable and interactable for end
+          users under 500 nodes. To reach this principle for large graph, we clustering the source
+          data by LOUVAIN algorithm, and visualize the aggregated graph first. Then, end users are
+          able to do drilling down exploration.
+        </span>
+        <span className="description">
+          {' '}
+          If the number of nodes still large on aggregated graph, we can do multi-level aggregation.
+          To control the number of rendering nodes, the earliest expanded cluster will be collapsed
+          automatically. These rules also help us to avoid overloaded computation and rendering on
+          front-end.
+        </span>
+        <br />
+        <br />
+        <h3 className="legned-title">{`<Graph Interaction>`}</h3>
+        <img
+          src="https://gw.alipayobjects.com/mdn/rms_f8c6a0/afts/img/A*IgoxQ7wfjCcAAAAAAAAAAAAAARQnAQ"
+          width="120"
+        />{' '}
+        &nbsp; &nbsp; &nbsp; &nbsp;
+        <img
+          src="https://gw.alipayobjects.com/mdn/rms_f8c6a0/afts/img/A*cCk4SrHVfDsAAAAAAAAAAAAAARQnAQ"
+          width="150"
+        />
+        <br />
+        <br />
+        <span className="description">
+          {' '}
+          Each 'Aggregated Node'{' '}
+          <img
+            src="https://gw.alipayobjects.com/mdn/rms_f8c6a0/afts/img/A*1y4AS7ucVXMAAAAAAAAAAAAAARQnAQ"
+            width="50"
+          />
+          represents a cluster generated by LOUVAIN, it contains several 'Real Node'{' '}
+          <img
+            src="https://gw.alipayobjects.com/mdn/rms_f8c6a0/afts/img/A*IOgvSLWF1IQAAAAAAAAAAAAAARQnAQ"
+            width="20"
+          />
+          .<strong>「Right Click」</strong> any node or edge on the graph, a corresponding
+          contextmenu will show up. Right click{' '}
+          <img
+            src="https://gw.alipayobjects.com/mdn/rms_f8c6a0/afts/img/A*1y4AS7ucVXMAAAAAAAAAAAAAARQnAQ"
+            width="50"
+          />{' '}
+          and select 'Expand Node', the aggregated node will be replaced by the real nodes of the
+          cluster. You can also right click{' '}
+          <img
+            src="https://gw.alipayobjects.com/mdn/rms_f8c6a0/afts/img/A*IOgvSLWF1IQAAAAAAAAAAAAAARQnAQ"
+            width="20"
+          />{' '}
+          and select 'Collapse the Cluster' to collapse it, or select 'Find k-Degree Neighbor', A
+          neighbor graph of the selected node will be merged into the current graph.
+        </span>
+        <br /> <br />
+        <h3 className="legned-title">{`<The Canvas Menu>`}</h3>
+        <img
+          src="https://gw.alipayobjects.com/mdn/rms_f8c6a0/afts/img/A*FKbFRIzj34EAAAAAAAAAAAAAARQnAQ"
+          width="300"
+        />
+        <br />
+        <span>
+          There is a set of assistant tools on the canvas menu, which is on the left top of the
+          canvas. From left to right, they are:
+        </span>
+        <br />
+        <span>
+          <strong>
+            - Show/Hide Edge Labels;
+            <br />
+            - Fisheye Lens;
+            <br />
+            - Lasso Select Mode;
+            <br />
+            - Find the Shortest Path (by clicking select two end nodes);
+            <br />
+            - Zoom-out;
+            <br />
+            - Fit the Graph to the View Port;
+            <br />
+            - Zoom-in;
+            <br />- Search a Node(by typing the id).
+          </strong>
+        </span>
+        <br /> <br />
+        <h3 className="legned-title">{`<Notice>`}</h3>
+        <span>
+          The demo shows a small mocked dataset just for demonstration. Besides the functions
+          introduced above, there are lots of other functions. We hope it is helpful for you.
+          Explore it and have fun!
+        </span>
+      </div>
+    </div>
+  );
+};
+
+export default LegendPanel;


### PR DESCRIPTION
After these changes, the initial cursor position for the `drag-node` behaviour is saved on the initial mouse down instead of after the first drag event, so the cursor and dragged node don't missalign when dragging starts.