### PR TITLE
Update edge.ts

### DIFF
--- a/packages/core/src/element/edge.ts
+++ b/packages/core/src/element/edge.ts
@@ -474,8 +474,8 @@ Shape.registerEdge(
         const { startPoint, endPoint } = cfg;
         if (cfg.curveOffset === undefined) cfg.curveOffset = this.curveOffset;
         if (cfg.curvePosition === undefined) cfg.curvePosition = this.curvePosition;
-        if (isArray(this.curveOffset)) cfg.curveOffset = cfg.curveOffset[0];
-        if (isArray(this.curvePosition)) cfg.curvePosition = cfg.curveOffset[0];
+        if (isArray(cfg.curveOffset)) cfg.curveOffset = cfg.curveOffset[0];
+        if (isArray(cfg.curvePosition)) cfg.curvePosition = cfg.curveOffset[0];
         const innerPoint = getControlPoint(
           startPoint as Point,
           endPoint as Point,


### PR DESCRIPTION
自定义quadratic类型的getControlPoints方法里isArray判断应该为cfg.curvePosition,cfg.curveOffset，不然传进去curvePosition，curveOffset为数组时路径计算出错

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->
