### PR TITLE
fix: fix issue that cause workflow failed

### DIFF
--- a/.github/workflows/issue_hunt_replay.yml
+++ b/.github/workflows/issue_hunt_replay.yml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
       - name: Comment on Issue
-        if: ${{ github.event.label.name == 'IH: Reward/悬赏' }}
+        if: ${{ github.event.label.name == 'Reward/悬赏' }}
         uses: peter-evans/create-or-update-comment@v3
         with:
           issue-number: ${{ github.event.issue.number }}

--- a/ISSUEHUNT.en-US.md
+++ b/ISSUEHUNT.en-US.md
@@ -6,7 +6,7 @@ The Issue Hunt Program is an incentive program proposed by AntV to encourage com
 
 ## How to Participate in Issue Hunt?
 
-1. Find an issue that interests you. (issue with 'IH: Reward/ reward' tag)
+1. Find an issue that interests you. (issue with 'Reward/悬赏' tag)
 2. Contribute code to the issue.
 3. Earn rewards.
 
@@ -21,7 +21,7 @@ Both project maintainers and community contributors can set rewards for issues.
 
 If you are a project maintainer, you can set the reward amount for an issue by using a label. For example:
 
-`IH: Reward/悬赏`, `$10` means the reward amount for this issue is $10.
+`Reward/悬赏`, `$10` means the reward amount for this issue is $10.
 
 If you are a community contributor, you can reward the issue **you proposed** or the issue **you want to be resolved** on [Issue Hunt](https://oss.issuehunt.io/r/antvis/G6/issues).
 
@@ -51,7 +51,7 @@ If a reward is initiated by a project maintainer through GitHub, we will distrib
 
 ## Issue Claiming
 
-To avoid multiple people claiming the same issue simultaneously, you can leave a comment below an issue marked with IH: Reward/悬赏. The project maintainer will reply within 24 hours to confirm if you can claim the issue and add the IH: Claimed/已认领 label to the issue.
+To avoid multiple people claiming the same issue simultaneously, you can leave a comment below an issue marked with `Reward/悬赏`. The project maintainer will reply within 24 hours to confirm if you can claim the issue and add the `Claimed/已认领` label to the issue.
 
 Your claiming comment should include the following information (copy and edit the template to reply):
 

--- a/ISSUEHUNT.md
+++ b/ISSUEHUNT.md
@@ -6,7 +6,7 @@ Issue Hunt 计划是 AntV 为了鼓励社区贡献者参与到 AntV 项目中来
 
 ## 如何参与 Issue Hunt?
 
-1. 找到你感兴趣的 issue (带有 `IH: Reward/悬赏` 标签的 issue)
+1. 找到你感兴趣的 issue (带有 `Reward/悬赏` 标签的 issue)
 2. 为 issue 贡献代码
 3. 获得奖励
 
@@ -21,7 +21,7 @@ Issue Hunt 计划是 AntV 为了鼓励社区贡献者参与到 AntV 项目中来
 
 如果你是项目维护者，你可以在 Issue 上以 Label 的形式设置奖励金额，例如：
 
-`IH: Reward/悬赏`, `$10` 表示这个 Issue 的奖励金额为 10 美元。
+`Reward/悬赏`, `$10` 表示这个 Issue 的奖励金额为 10 美元。
 
 如果你是社区工作者，你可以到[Issue Hunt](https://oss.issuehunt.io/r/antvis/G6/issues)上为**你提出的**/**你希望尽快解决的** issue 进行悬赏。
 
@@ -51,7 +51,7 @@ Issue Hunt 计划是 AntV 为了鼓励社区贡献者参与到 AntV 项目中来
 
 ## 项目认领
 
-为了避免多人同时认领同一个 issue，你可以在被标记了 `IH: Reward/悬赏` 的 issue 下方留言，项目维护者会在 24 小时内回复你是否可以认领该 issue，并在 issue 上添加 `IH: Claimed/已认领` 标签。
+为了避免多人同时认领同一个 issue，你可以在被标记了 `Reward/悬赏` 的 issue 下方留言，项目维护者会在 24 小时内回复你是否可以认领该 issue，并在 issue 上添加 `Claimed/已认领` 标签。
 
 你的认领留言应包含以下信息(请复制后编辑回复)：
 


### PR DESCRIPTION
Github Workflow 对引号内冒号敏感
之前的标签名为 `IH: Reward/悬赏` 会有异常，因此改为 `Reward/悬赏`