### PR TITLE
docs: fix issue hunt description typos

### DIFF
--- a/ISSUEHUNT.en-US.md
+++ b/ISSUEHUNT.en-US.md
@@ -13,7 +13,7 @@ The Issue Hunt Program is an incentive program proposed by AntV to encourage com
 ## How to Find Issues You Like?
 
 - Find issues that interest you on [Issue Hunt](https://oss.issuehunt.io/r/antvis/G6/issues)
-- Find issues you like on [GitHub](https://github.com/antvis/G6/issues?q=is%3Aopen+is%3Aissue+label%3A%22IH%3A+Reward%2F%E6%82%AC%E8%B5%8F%22)
+- Find issues you like on [GitHub](https://github.com/antvis/G6/issues?q=is%3Aopen+is%3Aissue+label%3AReward%2F%E6%82%AC%E8%B5%8F)
 
 ## Set Rewards for Issues
 

--- a/ISSUEHUNT.md
+++ b/ISSUEHUNT.md
@@ -13,7 +13,7 @@ Issue Hunt 计划是 AntV 为了鼓励社区贡献者参与到 AntV 项目中来
 ## 如何找到你喜欢的 Issues?
 
 1. 从 [Issue Hunt](https://oss.issuehunt.io/r/antvis/G6/issues) 上找到你感兴趣的 issues
-2. 从 [GitHub](https://github.com/antvis/G6/issues?q=is%3Aopen+is%3Aissue+label%3A%22IH%3A+Reward%2F%E6%82%AC%E8%B5%8F%22) 上找到你喜欢的 issues
+2. 从 [GitHub](https://github.com/antvis/G6/issues?q=is%3Aopen+is%3Aissue+label%3AReward%2F%E6%82%AC%E8%B5%8F) 上找到你喜欢的 issues
 
 ## 为 Issues 设置悬赏
 


### PR DESCRIPTION
`IH: Reward/悬赏` -> `Reward/悬赏` 后忘更新链接了