### PR TITLE
Fix issue#4552, another 404 not found and  typo errors

### DIFF
--- a/packages/site/docs/api/Items/comboMethods.en.md
+++ b/packages/site/docs/api/Items/comboMethods.en.md
@@ -3,7 +3,7 @@ title: combo.*
 order: 3
 ---
 
-Combo inherits from Node. The functions of Node are also available for Combo. This document will only introduce the common functions for Combo Class. All the built-in combos can be found in [Built-in Combos Doc](/en/docs/manual/middle/elements/combos/default-combo) and [demo](/en/examples/item/defaultCombos), Custom Combo can be found in [Custom Combo Doc](/en/docs/manual/middle/elements/combos/custom-combo) and [demo](/en/examples/item/customCombo).
+Combo inherits from Node. The functions of Node are also available for Combo. This document will only introduce the common functions for Combo Class. All the built-in combos can be found in [Built-in Combos Doc](/en/docs/manual/middle/elements/combos/default-combo) and [demo](/en/examples/item/defaultCombos/#circle), Custom Combo can be found in [Custom Combo Doc](/en/docs/manual/middle/elements/combos/custom-combo) and [demo](/en/examples/item/customCombo/#cCircle).
 
 ### combo.getChildren()
 

--- a/packages/site/docs/api/Items/comboMethods.zh.md
+++ b/packages/site/docs/api/Items/comboMethods.zh.md
@@ -3,7 +3,7 @@ title: combo 实例方法
 order: 3
 ---
 
-Combo 继承自 Node，具有 Node 的所有特性。本文仅介绍 Combo 类的通用方法，内置节点见 [内置 Combo 文档](/zh/docs/manual/middle/elements/combos/default-combo) 和 [demo](/zh/examples/item/defaultCombos/#circle)，自定义节点见 [自定义 Combo 文档](/zh/docs/manual/middle/elements/combos/custom-combo) 和 [demo](/zh/examples/item/customCombo/#cCircle)。
+Combo 继承自 Node，具有 Node 的所有特性。本文仅介绍 Combo 类的通用方法，内置Combo见 [内置 Combo 文档](/zh/docs/manual/middle/elements/combos/default-combo) 和 [demo](/zh/examples/item/defaultCombos/#circle)，自定义Combo见 [自定义 Combo 文档](/zh/docs/manual/middle/elements/combos/custom-combo) 和 [demo](/zh/examples/item/customCombo/#cCircle)。
 
 ### combo.getChildren()
 

--- a/packages/site/docs/api/Items/comboMethods.zh.md
+++ b/packages/site/docs/api/Items/comboMethods.zh.md
@@ -3,7 +3,7 @@ title: combo 实例方法
 order: 3
 ---
 
-Combo 继承自 Node，具有 Node 的所有特性。本文仅介绍 Combo 类的通用方法，内置节点见 [内置 Combo 文档](/zh/docs/manual/middle/elements/combos/default-combo) 和 [demo](/zh/examples/item/defaultCombos)，自定义节点见 [自定义 Combo 文档](/zh/docs/manual/middle/elements/combos/custom-combo) 和 [demo](/zh/examples/item/customCombo)。
+Combo 继承自 Node，具有 Node 的所有特性。本文仅介绍 Combo 类的通用方法，内置节点见 [内置 Combo 文档](/zh/docs/manual/middle/elements/combos/default-combo) 和 [demo](/zh/examples/item/defaultCombos/#circle)，自定义节点见 [自定义 Combo 文档](/zh/docs/manual/middle/elements/combos/custom-combo) 和 [demo](/zh/examples/item/customCombo/#cCircle)。
 
 ### combo.getChildren()
 

--- a/packages/site/docs/api/Items/edgeMethods.en.md
+++ b/packages/site/docs/api/Items/edgeMethods.en.md
@@ -3,7 +3,7 @@ title: edge.*
 order: 2
 ---
 
-Edge inherits from item. The functions of Item are also available for Edge. This document will only introduce the common functions for Edge class. All the built-in edges can be found in [Built-in Edges Doc](/en/docs/manual/middle/elements/edges/defaultEdge) and [demo](/en/examples/item/defaultEdges), Custom Edge can be found in [Custom Edge Doc](/en/docs/manual/middle/elements/edges/custom-edge) and [demo](/en/examples/item/customEdge).
+Edge inherits from item. The functions of Item are also available for Edge. This document will only introduce the common functions for Edge class. All the built-in edges can be found in [Built-in Edges Doc](/en/docs/manual/middle/elements/edges/defaultEdge) and [demo](/en/examples/item/defaultEdges/#polyline1), Custom Edge can be found in [Custom Edge Doc](/en/docs/manual/middle/elements/edges/custom-edge) and [demo](/en/examples/item/customEdge/#extraShape).
 
 ### edge.setSource(source)
 

--- a/packages/site/docs/api/Items/edgeMethods.zh.md
+++ b/packages/site/docs/api/Items/edgeMethods.zh.md
@@ -3,7 +3,7 @@ title: edge 实例方法
 order: 2
 ---
 
-Edge 继承自 Item。所以 Item 的方法在 Edge 实例中都可以使用。本文仅介绍 Edge 类的通用方法，内置边见 [内置边文档](/zh/docs/manual/middle/elements/edges/defaultEdge) 和 [demo](/zh/examples/item/defaultEdges)，自定义节点见 [自定义边文档](/zh/docs/manual/middle/elements/edges/custom-edge) 和 [demo](/zh/examples/item/customEdge)。
+Edge 继承自 Item。所以 Item 的方法在 Edge 实例中都可以使用。本文仅介绍 Edge 类的通用方法，内置边见 [内置边文档](/zh/docs/manual/middle/elements/edges/defaultEdge) 和 [demo](/zh/examples/item/defaultEdges/#polyline1)，自定义节点见 [自定义边文档](/zh/docs/manual/middle/elements/edges/custom-edge) 和 [demo](/zh/examples/item/customEdge/#extraShape)。
 
 ### edge.setSource(source)
 

--- a/packages/site/docs/api/Items/edgeMethods.zh.md
+++ b/packages/site/docs/api/Items/edgeMethods.zh.md
@@ -3,7 +3,7 @@ title: edge 实例方法
 order: 2
 ---
 
-Edge 继承自 Item。所以 Item 的方法在 Edge 实例中都可以使用。本文仅介绍 Edge 类的通用方法，内置边见 [内置边文档](/zh/docs/manual/middle/elements/edges/defaultEdge) 和 [demo](/zh/examples/item/defaultEdges/#polyline1)，自定义节点见 [自定义边文档](/zh/docs/manual/middle/elements/edges/custom-edge) 和 [demo](/zh/examples/item/customEdge/#extraShape)。
+Edge 继承自 Item。所以 Item 的方法在 Edge 实例中都可以使用。本文仅介绍 Edge 类的通用方法，内置边见 [内置边文档](/zh/docs/manual/middle/elements/edges/defaultEdge) 和 [demo](/zh/examples/item/defaultEdges/#polyline1)，自定义边见 [自定义边文档](/zh/docs/manual/middle/elements/edges/custom-edge) 和 [demo](/zh/examples/item/customEdge/#extraShape)。
 
 ### edge.setSource(source)
 

--- a/packages/site/docs/api/Items/nodeMethods.en.md
+++ b/packages/site/docs/api/Items/nodeMethods.en.md
@@ -3,7 +3,7 @@ title: node.*
 order: 1
 ---
 
-Node inherits from item. The functions of Item are also available for Node. This document will only introduce the common functions for Node class. All the built-in nodes can be found in [Built-in Nodes Doc](/en/docs/manual/middle/elements/nodes/default-node) and [demo](/en/examples/item/defaultNodes), Custom Node can be found in [Custom Node Doc](/en/docs/manual/middle/elements/nodes/custom-node) and [demo](/en/examples/item/customNode).
+Node inherits from item. The functions of Item are also available for Node. This document will only introduce the common functions for Node class. All the built-in nodes can be found in [Built-in Nodes Doc](/en/docs/manual/middle/elements/nodes/default-node) and [demo](/en/examples/item/defaultNodes#circle), Custom Node can be found in [Custom Node Doc](/en/docs/manual/middle/elements/nodes/custom-node) and [demo](/en/examples/item/customNode/#card).
 
 ### node.lock()
 

--- a/packages/site/docs/api/Items/nodeMethods.zh.md
+++ b/packages/site/docs/api/Items/nodeMethods.zh.md
@@ -3,7 +3,7 @@ title: node 实例方法
 order: 1
 ---
 
-Node 继承自 Item。所以 Item 上面的方法在 Node 实例中都可以调用。本文仅介绍 Node 类的通用方法，内置节点见 [内置节点文档](/zh/docs/manual/middle/elements/nodes/default-node) 和 [demo](/zh/examples/item/defaultNodes)，自定义节点见 [自定义节点文档](/zh/docs/manual/middle/elements/nodes/custom-node) 和 [demo](/zh/examples/item/customNode)。
+Node 继承自 Item。所以 Item 上面的方法在 Node 实例中都可以调用。本文仅介绍 Node 类的通用方法，内置节点见 [内置节点文档](/zh/docs/manual/middle/elements/nodes/default-node) 和 [demo](/zh/examples/item/defaultNodes#circle)，自定义节点见 [自定义节点文档](/zh/docs/manual/middle/elements/nodes/custom-node) 和 [demo](zh/examples/item/customNode/#card)。
 
 ### node.lock()
 

--- a/packages/site/docs/manual/middle/elements/combos/defaultCombo.en.md
+++ b/packages/site/docs/manual/middle/elements/combos/defaultCombo.en.md
@@ -3,7 +3,7 @@ title: Overview of Combos
 order: 0
 ---
 
-> Node Combo is a new feature for V3.5. The [node group](/en/docs/manual/middle/elements/shape/graphics-group) will be deprecated. We recommend to use Combo for node grouping. <a href='/en/examples/item/defaultCombos' target='_blank'>Demo</a>. <br /><img src='https://gw.alipayobjects.com/mdn/rms_f8c6a0/afts/img/A*AngFRpOo4SAAAAAAAAAAAABkARQnAQ' width=600 alt='img'/>
+> Node Combo is a new feature for V3.5. The [node group](/en/docs/manual/middle/elements/shape/graphics-group) will be deprecated. We recommend to use Combo for node grouping. <a href='/en/examples/net/comboLayout#comboCombined' target='_blank'>Demo</a>. <br /><img src='https://gw.alipayobjects.com/mdn/rms_f8c6a0/afts/img/A*AngFRpOo4SAAAAAAAAAAAABkARQnAQ' width=600 alt='img'/>
 
 The built-in Combos in G6 include circle and rect types. <br /> <img src='https://gw.alipayobjects.com/mdn/rms_f8c6a0/afts/img/A*UwaHSKkwoVUAAAAAAAAAAABkARQnAQ' width='250' alt='img'/>
 

--- a/packages/site/docs/manual/middle/elements/combos/defaultCombo.zh.md
+++ b/packages/site/docs/manual/middle/elements/combos/defaultCombo.zh.md
@@ -5,7 +5,7 @@ order: 0
 
 > V3.5 后支持的全新节点分组 Combo 机制。[原节点分组](/zh/docs/manual/middle/elements/shape/graphics-group)即将废除。
 
-对于熟悉图可视化类库的用户来说，节点分组是非常实用的一个功能。此前，G6 已经存在一个节点分组 Node Group 功能，但它的机制无法支持一些较复杂的功能，例如：带有节点分组的图布局、自定义 Combo、嵌套节点分组的均匀 padding、节点与分组的边、分组与分组的边、空的节点分组等。V3.5 推出了全新的节点分组 Combo 机制，能够支持所有常用功能，参考 <a href='/zh/examples/item/defaultCombos' target='_blank'>Demo</a>。 <br /><img src='https://gw.alipayobjects.com/mdn/rms_f8c6a0/afts/img/A*AngFRpOo4SAAAAAAAAAAAABkARQnAQ' width=600 alt='img'/>
+对于熟悉图可视化类库的用户来说，节点分组是非常实用的一个功能。此前，G6 已经存在一个节点分组 Node Group 功能，但它的机制无法支持一些较复杂的功能，例如：带有节点分组的图布局、自定义 Combo、嵌套节点分组的均匀 padding、节点与分组的边、分组与分组的边、空的节点分组等。V3.5 推出了全新的节点分组 Combo 机制，能够支持所有常用功能，参考 <a href='/zh/examples/net/comboLayout#comboCombined' target='_blank'>Demo</a>。 <br /><img src='https://gw.alipayobjects.com/mdn/rms_f8c6a0/afts/img/A*AngFRpOo4SAAAAAAAAAAAABkARQnAQ' width=600 alt='img'/>
 
 G6 的内置 Combo 包括 circle 和 rect 两种类型，分别如下图所示。<br /> <img src='https://gw.alipayobjects.com/mdn/rms_f8c6a0/afts/img/A*UwaHSKkwoVUAAAAAAAAAAABkARQnAQ' width='250' alt='img'/>
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ x] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->

（一）在文档发现几处Demo的URL点击报错404，此PR解决中文与英文文档中的404 not found 错误。经过查看example，发现这个错误是由于URL中没有加上锚点“#”导致的。根据example中的对应地址修改了几处URL。
修改了以下pages：
1.  /manual/middle/elements/combos/default-combo
2. /api/items/combo-methods
3. /api/items/edge-methods
4. /api/items/node-methods

（二）在以下pages中发现有几处笔误，已修改
1. /api/items/combo-methods。将自定义节点与内置节点修改为自定义Combo与内置Combo
2. /api/items/edge-methods。 将自定义节点修改为自定义边
经查阅，仅中文文档出现错误，英文文档无误。