### PR TITLE
fix(typings): graph off 方法支持不传入参数，会移除所有事件监听

### DIFF
--- a/packages/core/src/interface/graph.ts
+++ b/packages/core/src/interface/graph.ts
@@ -640,7 +640,7 @@ export interface IAbstractGraph extends EventEmitter {
   /**
    * 移除指定的監聽函數
    */
-  off: <T = IG6GraphEvent>(eventName: G6Event, callback: (e: T) => void, once?: boolean) => this;
+  off: <T = IG6GraphEvent>(eventName?: G6Event, callback?: (e: T) => void, once?: boolean) => this;
 
 
   /**


### PR DESCRIPTION
##### Description of change

Graph.d.ts 类型定义修改：off 方法参数可选，不传入参数的时候，代表移除所有事件监听

<img width="572" alt="image" src="https://github.com/antvis/G6/assets/15646325/09c5a85d-2b31-4a94-ac5e-5da1cf434f5f">


<!-- Provide a description of the change below this comment. -->
