### PR TITLE
Feat: add  'topRight'  position configuration in BadgesShapes

### DIFF
--- a/packages/g6/src/stdlib/item/node/base.ts
+++ b/packages/g6/src/stdlib/item/node/base.ts
@@ -491,6 +491,7 @@ export abstract class BaseNode {
       const pos = { x: 0, y: 0 };
       switch (position) {
         case 'rightTop':
+        case 'topRight':
           pos.x = keyShapeBBox.max[0] - bgHeight / 2 + offsetX;
           pos.y = keyShapeBBox.min[1] + size / 4 + offsetY;
           break;
@@ -539,7 +540,7 @@ export abstract class BaseNode {
           x: pos.x,
           y: pos.y,
           ...otherStyles,
-          textAlign: position.includes('right') ? 'left' : 'right',
+          textAlign: position.toLowerCase().includes('right') ? 'left' : 'right',
           textBaseline: 'middle',
           zIndex: (zIndex as number) + 1,
         } as GShapeStyle,

--- a/packages/g6/tests/intergration/demo/bugReproduce.ts
+++ b/packages/g6/tests/intergration/demo/bugReproduce.ts
@@ -12,6 +12,11 @@ export default () => {
                 data: {
                     x: 100,
                     y: 100,
+                    badgeShapes: {
+                        tag: 'badgeShape',
+                        position: 'topRight', // Support ’topRight‘,’topLeft‘ and some other positions that contain uppercase ‘Right’ or ‘Left’.
+                        text: 'label'
+                    }
                 }
             },
             {
@@ -29,9 +34,6 @@ export default () => {
         height,
         data,
         type: 'graph',
-        layout: {
-            type: 'grid',
-        },
     });
 
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->

 In the badge function,G6 v5 allows users to pass in `rightTop`, `leftTop`,`topLeft`,`bottomLeft`,`leftBottom`, etc., but not `topRight`. In my opinion, That would be better to add a `topRight` position configuration. 

- old version

```typescript
case 'rightTop':
  pos.x = keyShapeBBox.max[0] - bgHeight / 2 + offsetX;
  pos.y = keyShapeBBox.min[1] + size / 4 + offsetY;
  break;
```

- new version

```typescript
case 'rightTop':
case 'topRight':
  pos.x = keyShapeBBox.max[0] - bgHeight / 2 + offsetX;
  pos.y = keyShapeBBox.min[1] + size / 4 + offsetY;
  break;
```
