### PR TITLE
V5 fix label shape error

### DIFF
--- a/packages/g6/src/stdlib/item/edge/base.ts
+++ b/packages/g6/src/stdlib/item/edge/base.ts
@@ -378,7 +378,7 @@ export abstract class BaseEdge {
       shapeStyle.height = h;
     }
 
-    if (labelShapeProps) {
+    if (labelShape) {
       const referShape = labelBackgroundShape || labelShape;
       const referBounds =
         this.boundsCache.labelBackgroundShapeGeometry ||

--- a/packages/g6/tests/intergration/demo/bugReproduce.ts
+++ b/packages/g6/tests/intergration/demo/bugReproduce.ts
@@ -1,9 +1,6 @@
 import G6 from '../../../src/index';
 import { container, height, width } from '../../datasets/const';
 
-// 1. Now, G6v5 already supports users to use different types of id
-// 2. At the same time, it also supports users to pass in mixed type ids.
-// 3. like: id:1, id:'2', id:'node1', etc.
 export default () => {
     const data = {
         nodes: [
@@ -12,31 +9,76 @@ export default () => {
                 data: {
                     x: 100,
                     y: 100,
-                    badgeShapes: {
-                        tag: 'badgeShape',
-                        position: 'topRight', // Support ’topRight‘,’topLeft‘ and some other positions that contain uppercase ‘Right’ or ‘Left’.
-                        text: 'label'
-                    }
-                }
+                    type: 'circle-node',
+                },
             },
             {
-                id: '2',
+                id: 2,
                 data: {
                     x: 200,
                     y: 100,
-                }
+                    type: 'circle-node',
+                },
             },
         ],
+        edges: [
+            {
+                id: 'edge1',
+                source: 1,
+                target: 2,
+                data: {
+                    type: 'line-edge'
+                }
+            }
+        ]
     };
+
+
+    const edge: ((data: any) => any) = (edgeInnerModel: any) => {
+
+        const { id, data } = edgeInnerModel
+        return {
+            id,
+            data: {
+                ...data,
+                // labelShape: {
+                //     text: 'label',
+                //     position: 'bottom',
+                // },
+                iconShape: {
+                    // img: 'https://gw.alipayobjects.com/zos/basement_prod/012bcf4f-423b-4922-8c24-32a89f8c41ce.svg',
+                    text: 'label',
+                },
+                labelBackgroundShape: {
+                    fill: 'red'
+                },
+            }
+        }
+    }
     const graph = new G6.Graph({
         container,
         width,
         height,
         data,
         type: 'graph',
+        modes: {
+            default: ['click-select', 'drag-canvas', 'zoom-canvas', 'drag-node'],
+        },
+        node: (nodeInnerModel: any) => {
+            const { id, data } = nodeInnerModel;
+            return {
+                id,
+                data: {
+                    ...data,
+                    keyShape: {
+                        r: 16
+                    },
+                }
+            }
+        },
+        edge,
     });
 
-
-    return graph
+    return graph;
 
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->


- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->
The reason for this bug is that `Boolean(labelShapeProps)` is always **true** value, so the below code snippet always enters `if` block and never turn to the `else` block. 
When the users do not set `labelShape` but `iconShape`, `referShape` is `undefined`, then throw the error.
- old version:
```typescript
if (labelShapeProps) {
      const referShape = labelBackgroundShape || labelShape;
      const referBounds =
        this.boundsCache.labelBackgroundShapeGeometry ||
        this.boundsCache.labelShapeGeometry ||
        referShape.getGeometryBounds();
}else{
   //...
}
```

I replace `labelShapeProps` with `labelShape` to fix the bug. When the user hasn't set `labelShape` configuration, it will turn to `else` block to handle this.
```typescript
if (labelShape) {
      const referShape = labelBackgroundShape || labelShape;
      const referBounds =
        this.boundsCache.labelBackgroundShapeGeometry ||
        this.boundsCache.labelShapeGeometry ||
        referShape.getGeometryBounds();
}else{
   //...
}
```