### PR TITLE
feat: v5-quadratic

### DIFF
--- a/packages/g6/src/stdlib/index.ts
+++ b/packages/g6/src/stdlib/index.ts
@@ -24,7 +24,7 @@ import RotateCanvas3D from './behavior/rotate-canvas-3d';
 import TrackCanvas3D from './behavior/track-canvas-3d';
 import OrbitCanvas3D from './behavior/orbit-canvas-3d';
 import { HoverActivate } from './behavior/hover-activate';
-
+import { Quadratic } from './item/edge';
 const stdLib = {
   transforms: {
     comboFromNode,
@@ -63,6 +63,7 @@ const stdLib = {
   },
   edges: {
     'line-edge': LineEdge,
+    'quadratic-edge': Quadratic
   },
   combos: {},
 };

--- a/packages/g6/src/stdlib/item/edge/index.ts
+++ b/packages/g6/src/stdlib/item/edge/index.ts
@@ -1,1 +1,2 @@
 export * from './line';
+export * from './quadratic'

--- a/packages/g6/src/stdlib/item/edge/quadratic.ts
+++ b/packages/g6/src/stdlib/item/edge/quadratic.ts
@@ -1,0 +1,119 @@
+import { Point } from '../../../types/common';
+import {
+    EdgeDisplayModel,
+    EdgeModelData,
+    EdgeShapeMap,
+} from '../../../types/edge';
+import { State } from '../../../types/item';
+import { BaseEdge } from './base';
+
+export class Quadratic extends BaseEdge {
+    public type = 'line-edge';
+    public defaultStyles = {
+        keyShape: {
+            controlPoints: [0, 0], //precise x-axis, y-axis coordinates of control points
+            curvePosition: 0,  //control point coordinates described by percentage,range 0 to 1
+            curveOffset: [0, 0], //a point coordinate that quadratic curve to
+            stroke: '#000000',
+            isBillboard: true,
+        },
+    };
+    constructor(props) {
+        super(props);
+        // suggest to merge default styles like this to avoid style value missing
+        // this.defaultStyles = mergeStyles([this.baseDefaultStyles, this.defaultStyles]);
+    }
+    public draw(
+        model: EdgeDisplayModel,
+        sourcePoint: Point,
+        targetPoint: Point,
+        shapeMap: EdgeShapeMap,
+        diffData?: { previous: EdgeModelData; current: EdgeModelData },
+        diffState?: { previous: State[]; current: State[] },
+    ): EdgeShapeMap {
+        const { data = {} } = model;
+
+        const shapes: EdgeShapeMap = { keyShape: undefined };
+
+        shapes.keyShape = this.drawKeyShape(
+            model,
+            sourcePoint,
+            targetPoint,
+            shapeMap,
+            diffData,
+        );
+
+        if (data.haloShape) {
+            shapes.haloShape = this.drawHaloShape(model, shapeMap, diffData);
+        }
+
+        if (data.labelShape) {
+            shapes.labelShape = this.drawLabelShape(model, shapeMap, diffData);
+        }
+
+        // labelBackgroundShape
+        if (data.labelBackgroundShape) {
+            shapes.labelBackgroundShape = this.drawLabelBackgroundShape(
+                model,
+                shapeMap,
+                diffData,
+            );
+        }
+
+        if (data.iconShape) {
+            shapes.iconShape = this.drawIconShape(model, shapeMap, diffData);
+        }
+
+        // TODO: other shapes
+        return shapes;
+    }
+
+    public drawKeyShape(
+        model: EdgeDisplayModel,
+        sourcePoint: Point,
+        targetPoint: Point,
+        shapeMap: EdgeShapeMap,
+        diffData?: { previous: EdgeModelData; current: EdgeModelData },
+        diffState?: { previous: State[]; current: State[] },
+    ) {
+        const { keyShape: keyShapeStyle } = this.mergedStyles as any;
+
+        const controlPoint = this.getControlPoint(sourcePoint, targetPoint, keyShapeStyle.curvePosition, keyShapeStyle.controlPoints, keyShapeStyle.curveOffset);
+        return this.upsertShape(
+            'path',
+            'keyShape',
+            {
+                ...keyShapeStyle,
+                path: [['M', sourcePoint.x, sourcePoint.y], ['Q', controlPoint.x, controlPoint.y, targetPoint.x, targetPoint.y]],
+            },
+            shapeMap,
+            model,
+        );
+    }
+
+    /**
+     * calculate the control point by curvePosition|controlPoints|curveOffset
+     * @param startPoint: source point position of edge
+     * @param endPoint target point position of edge
+     * @param percent the proportion of control points' in the segment, Range 0 to 1
+     * @param controlPoints the control point position 
+     * @param offset the curveOffset
+     * @returns control points
+     */
+    private getControlPoint: (startPoint: Point,
+        endPoint: Point,
+        percent: number,
+        controlPoints: number[],
+        offset: number[]
+    ) => Point = (
+        startPoint: Point,
+        endPoint: Point,
+        percent = 0,
+        controlPoints,
+        offset,
+    ) => ({
+        x: (1 - percent) * startPoint.x + percent * endPoint.x + controlPoints[0] + offset[0],
+        y: (1 - percent) * startPoint.y + percent * endPoint.y + controlPoints[1] + offset[1],
+    })
+
+}

--- a/packages/g6/tests/intergration/demo/quadratic.ts
+++ b/packages/g6/tests/intergration/demo/quadratic.ts
@@ -41,9 +41,9 @@ export default () => {
             data: {
                 ...data,
                 keyShape: {
-                    controlPoints: [0, 0],
-                    curvePosition: 0.5,
-                    curveOffset: [10, 10],
+                    controlPoints: [150, 100],
+                    // curvePosition: 0.5,
+                    curveOffset: [0, 20],
                     stroke: 'blue'
                 },
                 // iconShape: {

--- a/packages/g6/tests/intergration/demo/quadratic.ts
+++ b/packages/g6/tests/intergration/demo/quadratic.ts
@@ -1,0 +1,91 @@
+import G6 from '../../../src/index';
+import { container, height, width } from '../../datasets/const';
+
+export default () => {
+    const data = {
+        nodes: [
+            {
+                id: 1,
+                data: {
+                    x: 100,
+                    y: 100,
+                    type: 'circle-node',
+                },
+            },
+            {
+                id: 2,
+                data: {
+                    x: 200,
+                    y: 100,
+                    type: 'circle-node',
+                },
+            },
+        ],
+        edges: [
+            {
+                id: 'edge1',
+                source: 1,
+                target: 2,
+                data: {
+                    type: 'quadratic'
+                }
+            }
+        ]
+    };
+
+    const edge: ((data: any) => any) = (edgeInnerModel: any) => {
+
+        const { id, data } = edgeInnerModel
+        return {
+            id,
+            data: {
+                ...data,
+                keyShape: {
+                    controlPoints: [0, 0],
+                    curvePosition: 0.5,
+                    curveOffset: [10, 10],
+                    stroke: 'blue'
+                },
+                // iconShape: {
+                //    // img: 'https://gw.alipayobjects.com/zos/basement_prod/012bcf4f-423b-4922-8c24-32a89f8c41ce.svg',
+                //     text: 'label',
+                //     fill: 'blue'
+                // },
+                labelShape: {
+                    text: 'label',
+                    position: 'middle',
+                    fill: 'blue'
+                },
+                labelBackgroundShape: {
+                    fill: 'white'
+                },
+            }
+        }
+    }
+    const graph = new G6.Graph({
+        container,
+        width,
+        height,
+        data,
+        type: 'graph',
+        modes: {
+            default: ['click-select', 'drag-canvas', 'zoom-canvas', 'drag-node'],
+        },
+        node: (nodeInnerModel: any) => {
+            const { id, data } = nodeInnerModel;
+            return {
+                id,
+                data: {
+                    ...data,
+                    keyShape: {
+                        r: 16
+                    },
+                }
+            }
+        },
+        edge,
+    });
+
+    return graph;
+
+}

--- a/packages/g6/tests/intergration/demo/quadratic.ts
+++ b/packages/g6/tests/intergration/demo/quadratic.ts
@@ -27,7 +27,7 @@ export default () => {
                 source: 1,
                 target: 2,
                 data: {
-                    type: 'quadratic'
+                    type: 'quadratic-edge'
                 }
             }
         ]

--- a/packages/g6/tests/intergration/index.ts
+++ b/packages/g6/tests/intergration/index.ts
@@ -17,6 +17,7 @@ import demoFor4 from './demo/demoFor4';
 import bugReproduce from './demo/bugReproduce';
 import rect from './demo/rect';
 import visual from './visual/visual';
+import quadratic from './demo/quadratic';
 export {
   behaviors_activateRelations,
   layouts_circular,
@@ -37,4 +38,5 @@ export {
   bugReproduce,
   rect,
   visual,
+  quadratic
 };

--- a/packages/g6/tests/unit/quadratic-spec.ts
+++ b/packages/g6/tests/unit/quadratic-spec.ts
@@ -1,0 +1,284 @@
+// @ts-nocheck
+
+import { DisplayObject } from '@antv/g';
+import { clone } from '@antv/util';
+import G6, {
+  EdgeDisplayModel,
+  Graph,
+  IGraph,
+  NodeDisplayModel,
+} from '../../src/index';
+import { LineEdge } from '../../src/stdlib/item/edge';
+import { CircleNode } from '../../src/stdlib/item/node';
+import { NodeModelData, NodeShapeMap } from '../../src/types/node';
+import { extend } from '../../src/util/extend';
+import { upsertShape } from '../../src/util/shape';
+
+const container = document.createElement('div');
+const width = document.getElementById('container')?.clientWidth;
+const height = document.getElementById('container')?.clientHeight;
+document.querySelector('body').appendChild(container);
+
+let graph: IGraph<any>;
+
+const data = {
+  nodes: [
+    {
+      id: 1,
+      data: {
+        x: 100,
+        y: 100,
+        type: 'circle-node',
+      },
+    },
+    {
+      id: 2,
+      data: {
+        x: 200,
+        y: 100,
+        type: 'circle-node',
+      },
+    },
+  ],
+  edges: [
+    {
+      id: 'edge1',
+      source: 1,
+      target: 2,
+      data: {
+        type: 'quadratic'
+      }
+    }
+  ]
+};
+
+const edge: ((data: any) => any) = (edgeInnerModel: any) => {
+
+  const { id, data } = edgeInnerModel
+  return {
+    id,
+    data: {
+      keyShape: {
+        controlPoints: [0, 0],
+        curvePosition: 0.5,
+        curveOffset: [10, 10],
+        stroke: 'blue'
+      },
+      // iconShape: {
+      //    // img: 'https://gw.alipayobjects.com/zos/basement_prod/012bcf4f-423b-4922-8c24-32a89f8c41ce.svg',
+      //     text: 'label',
+      //     fill: 'blue'
+      // },
+      labelShape: {
+        text: 'label',
+        position: 'middle',
+        fill: 'blue'
+      },
+      labelBackgroundShape: {
+        fill: 'white'
+      },
+      ...data,
+    }
+  }
+}
+
+describe('edge item', () => {
+  it('new graph with two nodes and one edge', (done) => {
+    graph = new G6.Graph({
+      container,
+      width,
+      height,
+      data,
+      type: 'graph',
+      modes: {
+        default: ['click-select', 'drag-canvas', 'zoom-canvas', 'drag-node'],
+      },
+      node: (nodeInnerModel: any) => {
+        const { id, data } = nodeInnerModel;
+        return {
+          id,
+          data: {
+            ...data,
+            keyShape: {
+              r: 16
+            },
+          }
+        }
+      },
+      edge,
+    });
+
+    graph.on('afterrender', () => {
+      const edgeItem = graph.itemController.itemMap['edge1'];
+      expect(edgeItem).not.toBe(undefined);
+      expect(edgeItem.shapeMap.labelShape.attributes.text).toBe('label');
+      expect(edgeItem.shapeMap.labelShape.attributes.position).toBe('middle');
+      expect(edgeItem.shapeMap.labelShape.attributes.fill).toBe('blue');
+      expect(edgeItem.labelBackgroundShape.attributes.fill).toBe('white');
+      done();
+    });
+  });
+
+  it('update edge label', (done) => {
+    const padding = [4, 16, 4, 8];
+    graph.updateData('edge', {
+      id: 'edge1',
+      data: {
+        labelShape: {
+          text: 'edge-label',
+        },
+        labelBackgroundShape: {
+          radius: 10,
+          padding,
+          fill: '#f00',
+        },
+        iconShape: {
+          text: 'A',
+          fill: '#f00',
+        },
+      },
+    });
+    const edgeItem = graph.itemController.itemMap['edge1'];
+    expect(edgeItem.shapeMap.labelShape).not.toBe(undefined);
+    expect(edgeItem.shapeMap.labelShape.attributes.text).toBe('edge-label');
+    const fill = edgeItem.shapeMap.labelShape.attributes.fill;
+    expect(fill).toBe('rgba(0,0,0,0.85)');
+    let labelBounds = edgeItem.shapeMap.labelShape.getGeometryBounds();
+    expect(edgeItem.shapeMap.labelBackgroundShape.attributes.width).toBe(
+      labelBounds.max[0] - labelBounds.min[0] + padding[1] + padding[3],
+    );
+    expect(edgeItem.shapeMap.labelBackgroundShape.attributes.height).toBe(
+      labelBounds.max[1] - labelBounds.min[1] + padding[0] + padding[2],
+    );
+
+    graph.updateData('edge', {
+      id: 'edge1',
+      data: {
+        labelShape: {
+          fill: '#00f',
+          position: 'start',
+        },
+      },
+    });
+    expect(edgeItem.shapeMap.labelShape.attributes.fill).toBe('#00f');
+    expect(
+      edgeItem.shapeMap.labelShape.attributes.x -
+      edgeItem.shapeMap.labelBackgroundShape.attributes.x,
+    ).toBe(padding[3]);
+    labelBounds = edgeItem.shapeMap.labelShape.getGeometryBounds();
+    const labelWidth = labelBounds.max[0] - labelBounds.min[0];
+    const labelHeight = labelBounds.max[1] - labelBounds.min[1];
+    const labelBgBounds =
+      edgeItem.shapeMap.labelBackgroundShape.getGeometryBounds();
+    const labelBgWidth = labelBgBounds.max[0] - labelBgBounds.min[0];
+    const labelBgHeight = labelBgBounds.max[1] - labelBgBounds.min[1];
+    expect(labelBgWidth - labelWidth).toBe(padding[1] + padding[3]);
+    expect(labelBgHeight - labelHeight).toBe(padding[0] + padding[2]);
+
+    graph.updateData('edge', {
+      id: 'edge1',
+      data: {
+        labelShape: undefined,
+      },
+    });
+    expect(edgeItem.shapeMap.labelShape).toBe(undefined);
+    expect(edgeItem.shapeMap.labelBackgroundShape).toBe(undefined);
+    done();
+  });
+  it('update edge icon', (done) => {
+    // add image icon to follow the label at path's center
+    graph.updateData('edge', {
+      id: 'edge1',
+      data: {
+        labelShape: {
+          text: 'abcddd',
+          fill: '#f00',
+          position: 'center',
+        },
+        iconShape: {
+          text: '',
+          img: 'https://gw.alipayobjects.com/zos/basement_prod/012bcf4f-423b-4922-8c24-32a89f8c41ce.svg',
+          // text: 'A',
+          fill: '#f00',
+          fontSize: 20,
+        },
+      },
+    });
+    const edgeItem = graph.itemController.itemMap['edge1'];
+    let { labelShape, iconShape, labelBackgroundShape } = edgeItem.shapeMap;
+    expect(iconShape.attributes.x + iconShape.attributes.width + 6).toBe(
+      labelBackgroundShape.getGeometryBounds().min[0] +
+      labelBackgroundShape.attributes.x,
+    );
+    expect(iconShape.attributes.transform).toBe(
+      labelBackgroundShape.attributes.transform,
+    );
+    expect(
+      Math.floor(iconShape.attributes.y + iconShape.attributes.height / 2),
+    ).toBeCloseTo(
+      Math.floor(
+        labelBackgroundShape.getGeometryBounds().center[1] +
+        labelBackgroundShape.attributes.y,
+      ),
+      0.01,
+    );
+
+    // update icon to be a text
+    graph.updateData('edge', {
+      id: 'edge1',
+      data: {
+        iconShape: {
+          text: 'A',
+          fill: '#f00',
+          fontWeight: 800,
+        },
+      },
+    });
+    labelShape = edgeItem.shapeMap['labelShape'];
+    iconShape = edgeItem.shapeMap['iconShape'];
+    labelBackgroundShape = edgeItem.shapeMap['labelBackgroundShape'];
+    expect(iconShape.attributes.x + iconShape.attributes.fontSize + 6).toBe(
+      labelBackgroundShape.getGeometryBounds().min[0] +
+      labelBackgroundShape.attributes.x,
+    );
+    expect(iconShape.attributes.transform).toBe(
+      labelBackgroundShape.attributes.transform,
+    );
+    expect(
+      Math.floor(iconShape.attributes.y + iconShape.attributes.fontSize / 2),
+    ).toBeCloseTo(
+      Math.floor(
+        labelBackgroundShape.getGeometryBounds().center[1] +
+        labelBackgroundShape.attributes.y,
+      ),
+      0.01,
+    );
+
+    // move label to the start, and the icon follows
+    graph.updateData('edge', {
+      id: 'edge1',
+      data: {
+        labelShape: {
+          position: 'start',
+        },
+      },
+    });
+    labelShape = edgeItem.shapeMap['labelShape'];
+    iconShape = edgeItem.shapeMap['iconShape'];
+    labelBackgroundShape = edgeItem.shapeMap['labelBackgroundShape'];
+    expect(iconShape.attributes.x + iconShape.attributes.fontSize + 6).toBe(
+      labelBackgroundShape.getGeometryBounds().min[0] +
+      labelBackgroundShape.attributes.x,
+    );
+    expect(iconShape.attributes.transform).toBe(
+      labelShape.attributes.transform,
+    );
+    expect(iconShape.attributes.y + iconShape.attributes.fontSize / 2).toBe(
+      labelBackgroundShape.getGeometryBounds().center[1] +
+      labelBackgroundShape.attributes.y,
+    );
+    graph.destroy();
+    done();
+  });
+});
+


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ x ] `npm test` passes
- [ x ] tests and/or benchmarks are included
- [ x ] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->

### Issue Hunt: #4576 
### 实现
- 沿用了v4的参数，`curvePosition`,`controlPoints`,`curveOffset`。
    - curvePosition：表示要在线段的百分之几位置添加控制点，是一个0-1的数
    - controlPoints：具体的控制点，因为是二次贝塞尔曲线，因此只允许添加一个组坐标（如果需要多个控制点可以使用cubic）
    - curveOffset：控制点距离两端点连线的距离，可理解为控制边的弯曲程度
- 添加了单元测试


### 其他
1. 完成了基本功能的迁移，但是类型没有加上，因为我发现类似于`LineStyleProps`,`PathStyleProps`都写在了@antv/g-lite里面，必须继承`BaseStyleProps`。
3. 我直接在代码中使用了as any来逃避了类型检查，请问我这边应该如何加上这个`QuadraticStyleProps` interface 呢？
4. keyShape中还需要有其他的参数吗？
5. 可以帮忙review一下，我会按照你们的建议进行修改