### PR TITLE
G6官网文档格式错误修复 （文档位置：API/元素方法和配置/combo实例方法）

### DIFF
--- a/packages/site/docs/api/Items/comboMethods.zh.md
+++ b/packages/site/docs/api/Items/comboMethods.zh.md
@@ -19,7 +19,7 @@ Combo 继承自 Node，具有 Node 的所有特性。本文仅介绍 Combo 类�
 const elements = combo.getChildren();
 ```
 
-###combo. getNodes()
+### combo.getNodes()
 
 获取 Combo 中所有子节点。
 
@@ -27,7 +27,7 @@ const elements = combo.getChildren();
 
 - 返回值类型为 `INode[]`。
 
-###combo. getCombos()
+### combo.getCombos()
 
 获取 Combo 中所有子 combo。
 
@@ -35,7 +35,7 @@ const elements = combo.getChildren();
 
 - 返回值类型为 `ICombo[]`。
 
-###combo. addChild(item: INode | ICombo)
+### combo.addChild(item: INode | ICombo)
 
 向 Combo 中添加子 Node 或子 Combo。
 
@@ -59,7 +59,7 @@ const node = graph.findById('node1');
 const result = combo.addChild(node);
 ```
 
-###combo. addNode(node: string | INode)
+### combo.addNode(node: string | INode)
 
 向 combo 中添加节点。
 
@@ -74,7 +74,7 @@ const result = combo.addChild(node);
 - 类型： `boolean`；
 - 含义：返回 `true` 表示添加成功。
 
-###combo. addCombo(combo: ICombo)
+### combo.addCombo(combo: ICombo)
 
 向 combo 中添加 combo。
 
@@ -89,7 +89,7 @@ const result = combo.addChild(node);
 - 类型： `boolean`；
 - 含义：返回 `true` 表示添加成功。
 
-###combo. removeChild(item: ICombo | INode)
+### combo.removeChild(item: ICombo | INode)
 
 移除子元素（子节点或子 combo）。
 
@@ -104,7 +104,7 @@ const result = combo.addChild(node);
 - 类型： `boolean`；
 - 含义：返回 `true` 表示移除成功。
 
-###combo. removeCombo(combo: ICombo)
+### combo.removeCombo(combo: ICombo)
 
 移除指定的子 combo。注意：移除后 `combo` 不再属于该父 Combo，但没有被删除。需要删除 `combo` 请调用 [graph.removeItem](/zh/docs/api/Graph#removeitemitem)
 
@@ -119,7 +119,7 @@ const result = combo.addChild(node);
 - 类型： `boolean`；
 - 含义：返回 `true` 表示移除成功。
 
-###combo. removeNode(node: INode)
+### combo.removeNode(node: INode)
 
 移除指定的子 Node。注意：移除后该节点不再属于该 Combo，但没有被删除。需要删除节点请调用 [graph.removeItem](/zh/docs/api/Graph#removeitemitem)
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x ] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->
###### 问题描述
G6官网文档格式有误，位置在API/元素方法和配置/combo实例方法，问题截图如下：
![修复之前](https://github.com/antvis/G6/assets/5163952/8bccc0b7-59fa-4abf-a00b-1c2337d6ff73)
###### 修复方案
把packages/site/docs/api/Items/comboMethods.zh.md中的格式问题修复正确。

