### PR TITLE
chore: make the error message more readable

### DIFF
--- a/packages/g6/src/item/item.ts
+++ b/packages/g6/src/item/item.ts
@@ -121,6 +121,15 @@ export default abstract class Item implements IItem {
     const lodStrategy = modelLodStrategy
       ? formatLodStrategy(modelLodStrategy)
       : theme.lodStrategy;
+    if (!RenderExtension) {
+      if (this.type === 'node') {
+        throw new Error(`TypeError: RenderExtension is not a constructor. The '${type}' in your data haven't been registered. You can use built-in node types like 'rect-node', 'circle-node' or create a custom node type as you like.`);
+      } else if (this.type == 'edge') {
+        throw new Error(`TypeError: RenderExtension is not a constructor. The '${type}' in your data haven't been registered. You can use built-in edge types like 'line-edge', 'quadratic-edge','cubic-edge' or create a custom edge type as you like.`);
+      } else {
+        throw new Error(`TypeError: RenderExtension is not a constructor. The '${type}' haven't been registered.`);
+      }
+    }
     this.renderExt = new RenderExtension({
       themeStyles: this.themeStyles.default,
       lodStrategy,

--- a/packages/g6/tests/intergration/demo/bugReproduce.ts
+++ b/packages/g6/tests/intergration/demo/bugReproduce.ts
@@ -17,7 +17,7 @@ export default () => {
                 data: {
                     x: 200,
                     y: 100,
-                    type: 'circle-node',
+                    type: 'star-node',
                 },
             },
         ],
@@ -27,7 +27,7 @@ export default () => {
                 source: 1,
                 target: 2,
                 data: {
-                    type: 'line-edge'
+                    type: 'custom-edge'
                 }
             }
         ]


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md
-->

### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

### Description of change

<!-- Provide a description of the change below this comment. -->
Sometimes, in the data, The users may made an error in the `type` attribute or passed in an unregistered shape by mistake, like this:
```typescript
    const data = {
        nodes: [
            {
                id: 1,
                data: {
                    x: 100,
                    y: 100,
                    type: 'circle-node',
                },
            },
            {
                id: 2,
                data: {
                    x: 200,
                    y: 100,
                    type: 'star-node',
                },
            },
        ],
        edges: [
            {
                id: 'edge1',
                source: 1,
                target: 2,
                data: {
                    type: 'custom-edge'
                }
            }
        ]
    };
```

If the `star-node` and `custom-edge` haven't been registered, An error message will be :"TypeError: RenderExtension is not a constructor." 
It seems be better to make this error message more readable to remind users of where is the original error from, making it easier for users to troubleshoot and modify.

#### old version
```typescript
const lodStrategy = modelLodStrategy
      ? formatLodStrategy(modelLodStrategy)
      : theme.lodStrategy;
    this.renderExt = new RenderExtension({
      themeStyles: this.themeStyles.default,
      lodStrategy,
      device: this.device,
      zoom: this.zoom,
    });
```
<img width="987" alt="image" src="https://github.com/antvis/G6/assets/55946653/8502224f-5a26-4bbb-9ec6-66d82059ad4f">


#### new version
```typescript
const lodStrategy = modelLodStrategy
      ? formatLodStrategy(modelLodStrategy)
      : theme.lodStrategy;
    if (!RenderExtension) {
      if (this.type === 'node') {
        throw new Error(`TypeError: RenderExtension is not a constructor. The '${type}' in your data haven't been registered. You can use built-in node types like 'rect-node', 'circle-node' or create a custom node type as you like.`);
      } else if (this.type == 'edge') {
        throw new Error(`TypeError: RenderExtension is not a constructor. The '${type}' in your data haven't been registered. You can use built-in edge types like 'line-edge', 'quadratic-edge','cubic-edge' or create a custom edge type as you like.`);
      } else {
        throw new Error(`TypeError: RenderExtension is not a constructor. The '${type}' haven't been registered.`);
      }
    }
    this.renderExt = new RenderExtension({
      themeStyles: this.themeStyles.default,
      lodStrategy,
      device: this.device,
      zoom: this.zoom,
    });
```
<img width="1374" alt="image" src="https://github.com/antvis/G6/assets/55946653/56aba858-9330-4978-a796-7be7fc935cca">
<img width="1378" alt="image" src="https://github.com/antvis/G6/assets/55946653/2d9075f4-e7ea-4c44-b456-d2165a10c3f9">

