### PR TITLE
feat: v5-plugin-tooltip

### DIFF
--- a/packages/g6/src/stdlib/index.ts
+++ b/packages/g6/src/stdlib/index.ts
@@ -18,6 +18,7 @@ import lassoSelector from './selector/lasso';
 import rectSelector from './selector/rect';
 import Minimap from './plugin/minimap';
 import Legend from './plugin/legend';
+import Tooltip from './plugin/tooltip';
 import ZoomCanvas from './behavior/zoom-canvas';
 import ZoomCanvas3D from './behavior/zoom-canvas-3d';
 import RotateCanvas3D from './behavior/rotate-canvas-3d';
@@ -59,6 +60,7 @@ const stdLib = {
   plugins: {
     minimap: Minimap,
     legend: Legend,
+    tooltip: Tooltip
   },
   nodes: {
     'circle-node': CircleNode,

--- a/packages/g6/src/stdlib/plugin/tooltip/index.ts
+++ b/packages/g6/src/stdlib/plugin/tooltip/index.ts
@@ -1,8 +1,8 @@
 // TODO: update type define.
-// @ts-nocheck
 import { isString, isArray } from '@antv/util';
 import { createDom, modifyCSS } from '@antv/dom-util';
 import insertCss from 'insert-css';
+import { AABB } from '@antv/g';
 import { IGraph } from '../../../types';
 import { Plugin as Base, IPluginBaseConfig } from '../../../types/plugin';
 import { IG6GraphEvent } from '../../../types/event';
@@ -67,7 +67,7 @@ interface TooltipConfig extends IPluginBaseConfig {
 export default class Tooltip extends Base {
     private tooltip;
     private container;
-    private currentTarget: number | null
+    private currentTarget;
     private asyncTooltip;
     private currentAsyncTarget;
     private hidenTimer; //delay hiding tooltip
@@ -287,7 +287,7 @@ export default class Tooltip extends Base {
             e.itemType === 'node' &&
             fixToNode
         ) {
-            const itemBBox = graph.getRenderBBox(e.itemId);
+            const itemBBox = graph.getRenderBBox(e.itemId) as AABB;
             const itemWidth = itemBBox.max[0] - itemBBox.min[0];
             const itemHeight = itemBBox.max[1] - itemBBox.min[1];
             if (isString(fixToNode)) {

--- a/packages/g6/src/stdlib/plugin/tooltip/index.ts
+++ b/packages/g6/src/stdlib/plugin/tooltip/index.ts
@@ -1,0 +1,274 @@
+// TODO: update type define.
+// @ts-nocheck
+import { isString, isArray } from '@antv/util';
+import { createDom, modifyCSS } from '@antv/dom-util';
+import insertCss from 'insert-css';
+import { IGraph } from '../../../types';
+import { Plugin as Base, IPluginBaseConfig } from '../../../types/plugin';
+import { IG6GraphEvent } from '../../../types/event';
+
+typeof document !== 'undefined' &&
+    insertCss(`
+  .g6-component-tooltip {
+    border: 1px solid #e2e2e2;
+    border-radius: 4px;
+    font-size: 12px;
+    color: #545454;
+    background-color: rgba(255, 255, 255, 0.9);
+    padding: 10px 8px;
+    box-shadow: rgb(174, 174, 174) 0px 0px 10px;
+  }
+  .tooltip-type {
+    padding: 0;
+    margin: 0;
+  }
+  .tooltip-id {
+    color: #531dab;
+  }
+`);
+
+interface TooltipConfig extends IPluginBaseConfig {
+    getContent?: (evt?: IG6GraphEvent) => HTMLDivElement | string | Promise<HTMLDivElement | string>;
+    offsetX?: number;
+    offsetY?: number;
+    shouldBegin?: (evt?: IG6GraphEvent) => boolean;
+    // more detail type instead of "string[]"
+    itemTypes?: ('node' | 'edge' | 'combo' | 'canvas')[];
+    trigger?: 'pointerenter' | 'click';
+    fixToNode?: [number, number] | undefined;
+}
+
+export default class Tooltip extends Base {
+    private tooltip;
+    private container;
+    private currentTarget: number | null
+    private asyncTooltip;
+    private currentAsyncTarget;
+
+    constructor(options?: TooltipConfig) {
+        super(options);
+    }
+
+    public getDefaultCfgs(): TooltipConfig {
+        return {
+            offsetX: 6,
+            offsetY: 6,
+            getContent: (e) => {
+                return `
+        <div class='g6-component-tooltip'>
+          <h4 class='tooltip-type'>类型: ${e.itemType}</h4>
+          <span class='tooltip-id'>ID: ${e.itemId}</span>
+        </div>
+        `;
+            },
+            shouldBegin: (e) => {
+                return true;
+            },
+            itemTypes: ['node', 'edge', 'combo'],
+            trigger: 'pointerenter',
+            fixToNode: undefined,
+        };
+    }
+
+    public getEvents() {
+        if (this.options.trigger === 'click') {
+            return {
+                'node:click': this.onClick,
+                'edge:click': this.onClick,
+                'combo:click': this.onClick,
+                'canvas:click': this.onPointerLeave,
+                afterremoveitem: this.onPointerLeave,
+                contextmenu: this.onPointerLeave,
+                drag: this.onPointerLeave,
+            }
+        }
+
+        return {
+            'node:pointerenter': this.onPointerEnter,
+            'node:pointerleave': this.onPointerLeave,
+            'node:pointermove': this.onPointerMove,
+            'edge:pointerenter': this.onPointerEnter,
+            'edge:pointerleave': this.onPointerLeave,
+            'edge:pointermove': this.onPointerMove,
+            'combo:pointerenter': this.onPointerEnter,
+            'combo:pointerleave': this.onPointerLeave,
+            'combo:pointermove': this.onPointerMove,
+            afterremoveitem: this.onPointerLeave,
+            contextmenu: this.onPointerLeave,
+            'node:drag': this.onPointerLeave,
+        };
+    }
+
+    public init(graph: IGraph) {
+        super.init(graph);
+        const className = this.options.className;
+        const tooltip = createDom(`<div class='${className}'></div>`);
+        modifyCSS(tooltip, { position: 'absolute', visibility: 'hidden', display: 'none' });
+        if (this.options.trigger !== 'click') {
+            tooltip.addEventListener('pointerenter', (e) => {
+                modifyCSS(tooltip, {
+                    visibility: 'visible',
+                    display: 'unset',
+                });
+            });
+            tooltip.addEventListener('pointerleave', (e) => {
+                self.hideTooltip();
+            });
+        }
+        //`container` string type in v5
+        let container: HTMLDivElement | null | string = this.options.container;
+        if (!container) {
+            container = this.graph.container as HTMLDivElement
+        }
+        if (isString(container)) {
+            container = document.getElementById(container) as HTMLDivElement;
+        }
+        container.appendChild(tooltip);
+        this.tooltip = tooltip;
+        this.container = container;
+    }
+
+    public onClick(e: IG6GraphEvent) {
+        if (e.itemId && e.itemType && this.options.itemTypes.indexOf(e.itemType) === -1) return;
+        const { itemId } = e;
+        // click the same item twice, tooltip will be hidden
+        if (this.currentTarget === itemId) {
+            this.currentTarget = null;
+            this.hideTooltip();
+            this.graph.emit('tooltipchange', { itemId: itemId, action: 'hide' });
+        } else {
+            this.currentTarget = itemId;
+            this.showTooltip(e);
+            // this.graph.emit('tooltipchange', { itemId: itemId, action: 'show' });
+        }
+    }
+
+    public onPointerEnter(e: IG6GraphEvent) {
+        if (e.itemId && e.itemType && this.options.itemTypes.indexOf(e.itemType) === -1) return;
+        const { itemId } = e;
+        this.currentTarget = itemId;
+        this.showTooltip(e);
+        this.graph.emit('tooltipchange', { itemId: e.itemId, action: 'show' });
+    }
+
+    public onPointerMove(e: IG6GraphEvent) {
+        if (e.itemId && e.itemType && this.options.itemTypes.indexOf(e.itemType) === -1) return;
+        if (!this.currentTarget || e.itemId !== this.currentTarget) {
+            return;
+        }
+        this.showTooltip(e);
+    }
+
+    public onPointerLeave() {
+        this.hideTooltip();
+        this.graph.emit('tooltipchange', { itemId: this.currentTarget, action: 'hide' });
+        this.currentTarget = null;
+    }
+
+
+    public clearContainer() {
+        this.container.innerHTML = ''
+    }
+
+    public async showTooltip(e: IG6GraphEvent) {
+        if (!e.itemId) {
+            return;
+        }
+        if (e.itemType && this.options.itemTypes.indexOf(e.itemType) === -1) return;
+        const tooltip = this.options.getContent(e);
+        const tooltipDom = this.tooltip;
+        // modify the position first because of the async function
+        const res = this.updatePosition(e);
+        if (isString(tooltip)) {
+            tooltipDom.innerHTML = tooltip;
+        } else if (tooltip instanceof HTMLDivElement) {
+            this.clearContainer();
+            this.container.appendChild(tooltip);
+        } else {
+            //promise type
+            if (!this.asyncTooltip || e.itemId !== this.currentAsyncTarget) {
+                this.asyncTooltip = await this.options.getContent(e);
+                this.currentAsyncTarget = e.itemId;
+            }
+            if (isString(this.asyncTooltip)) {
+                tooltipDom.innerHTML = this.asyncTooltip;
+            } else {
+                this.clearContainer();
+                this.container.appendChild(this.asyncTooltip);
+            }
+        }
+        modifyCSS(tooltipDom, {
+            left: `${res.x}px`,
+            top: `${res.y}px`,
+            visibility: 'visible',
+            display: 'unset'
+        });
+    }
+
+    public hideTooltip() {
+        const tooltip = this.tooltip;
+        if (tooltip) {
+            modifyCSS(tooltip, { visibility: 'hidden', display: 'none' });
+        }
+    }
+
+    public updatePosition(e: IG6GraphEvent): { x: number, y: number } {
+        const shouldBegin = this.options.shouldBegin;
+        const tooltip = this.tooltip;
+        if (!shouldBegin(e)) {
+            modifyCSS(tooltip, {
+                visibility: 'hidden',
+                display: 'none',
+            });
+            return;
+        }
+        const graph: IGraph = this.graph;
+        const width: number = graph.getSize()[0];
+        const height: number = graph.getSize()[1];
+        const offsetX = this.options.offsetX || 0;
+        const offsetY = this.options.offsetY || 0;
+        let point = {
+            x: e.viewport.x,
+            y: e.viewport.y
+        }
+        const fixToNode = this.options.fixToNode;
+        if (
+            e.itemType &&
+            e.itemType === 'node' &&
+            fixToNode &&
+            isArray(fixToNode) &&
+            fixToNode.length >= 2
+        ) {
+            const itemBBox = graph.getRenderBBox(e.itemId);
+            const itemWidth = itemBBox.max[0] - itemBBox.min[0];
+            const itemHeight = itemBBox.max[1] - itemBBox.min[1];
+            point = {
+                x: itemBBox.min[0] + itemWidth * fixToNode[0],
+                y: itemBBox.min[1] + itemHeight * fixToNode[1],
+            };
+        }
+        const { x, y } = point
+        const graphContainer = this.graph.container;
+        const res = {
+            x: x + graphContainer.offsetLeft + offsetX,
+            y: y + graphContainer.offsetTop + offsetY,
+        };
+        //tooltip dom bbox
+        const bbox = tooltip.getBoundingClientRect();
+        if (x + bbox.width + offsetX > width) {
+            res.x -= bbox.width + offsetX;
+        }
+        if (y + bbox.height + offsetY > height) {
+            res.y -= bbox.height + offsetY;
+            if (res.y < 0) {
+                res.y = 0
+            }
+        }
+        return res;
+    }
+
+    public destroy() {
+        this.container.removeChild(this.tooltip);
+    }
+
+}

--- a/packages/g6/src/stdlib/plugin/tooltip/index.ts
+++ b/packages/g6/src/stdlib/plugin/tooltip/index.ts
@@ -171,6 +171,7 @@ export default class Tooltip extends Base {
     }
 
     public async showTooltip(e: IG6GraphEvent) {
+        this.hideTooltip();
         if (!e.itemId) {
             return;
         }

--- a/packages/g6/src/stdlib/plugin/tooltip/index.ts
+++ b/packages/g6/src/stdlib/plugin/tooltip/index.ts
@@ -215,8 +215,11 @@ export default class Tooltip extends Base {
                 tooltipDom.innerHTML = this.options.loadingContent.outerHTML;
             }
             if (!this.asyncTooltip || e.itemId !== this.currentAsyncTarget) {
-                this.asyncTooltip = await this.options.getContent(e);
                 this.currentAsyncTarget = e.itemId;
+                this.asyncTooltip = await this.options.getContent(e);
+            }
+            if (e.itemId != this.currentAsyncTarget) {
+                return;
             }
             if (isString(this.asyncTooltip)) {
                 tooltipDom.innerHTML = this.asyncTooltip;

--- a/packages/g6/tests/intergration/demo/tooltip.ts
+++ b/packages/g6/tests/intergration/demo/tooltip.ts
@@ -1,0 +1,117 @@
+import G6 from '../../../src/index';
+import { container, height, width } from '../../datasets/const';
+
+export default () => {
+    const data = {
+        nodes: [
+            {
+                id: 1,
+                data: {
+                    x: 100,
+                    y: 100,
+                    type: 'rect-node',
+                },
+            },
+            {
+                id: 2,
+                data: {
+                    x: 200,
+                    y: 100,
+                    type: 'rect-node',
+                },
+            },
+            {
+                id: 3,
+                data: {
+                    x: 100,
+                    y: 200,
+                    type: 'rect-node',
+                },
+            },
+            {
+                id: 4,
+                data: {
+                    x: 200,
+                    y: 200,
+                    type: 'rect-node',
+                },
+            },
+        ],
+    };
+
+
+    const graph = new G6.Graph({
+        container,
+        width,
+        height,
+        data,
+        type: 'graph',
+        modes: {
+            default: ['click-select', 'drag-canvas', 'zoom-canvas', 'drag-node'],
+        },
+        plugins: [{
+            key: 'tooltip1',
+            type: 'tooltip',
+            trigger: 'pointerenter',
+            fixToNode: [1, 0.5],
+            /** async string tooltip*/
+            getContent: (e) => {
+                return new Promise((resolve => {
+                    const data = `
+        <div class='g6-component-tooltip'>
+          <h4 class='tooltip-type'>类型: ${e.itemType}</h4>
+          <span class='tooltip-id'>ID: ${e.itemId}</span>
+        </div>
+            `
+                    setTimeout(() => {
+                        resolve(data);
+                    }, 1000);
+                }))
+            }
+        }],
+        /** default tooltip */
+        // plugins: ['tooltip'],
+        node: (nodeInnerModel: any) => {
+            const { id, data } = nodeInnerModel;
+            return {
+                id,
+                data: {
+                    ...data,
+                    keyShape: {
+                        height: 50,
+                        width: 50,
+                    },
+                    labelShape: {
+                        text: 'label',
+                        position: 'bottom',
+                    },
+                    iconShape: {
+                        img: 'https://gw.alipayobjects.com/zos/basement_prod/012bcf4f-423b-4922-8c24-32a89f8c41ce.svg',
+                        // text: 'label',
+                    },
+                    badgeShapes: [
+                        {
+                            text: '1',
+                            position: 'rightTop',
+                            color: 'blue',
+                        },
+                    ],
+                    labelBackgroundShape: {
+                        fill: 'red'
+                    },
+                    anchorShapes: [
+                        {
+                            position: [0, 0.5],
+                            r: 2,
+                            fill: 'red'
+                        },
+
+                    ]
+                }
+            }
+        },
+    });
+
+    return graph;
+
+}

--- a/packages/g6/tests/intergration/demo/tooltip.ts
+++ b/packages/g6/tests/intergration/demo/tooltip.ts
@@ -58,14 +58,14 @@ export default () => {
             getContent: (e) => {
                 return new Promise((resolve => {
                     const data = `
-        <div class='g6-component-tooltip'>
+        <div> 
           <h4 class='tooltip-type'>类型: ${e.itemType}</h4>
           <span class='tooltip-id'>ID: ${e.itemId}</span>
-        </div>
+        </div> 
             `
                     setTimeout(() => {
                         resolve(data);
-                    }, 1000);
+                    }, 5000);
                 }))
             }
         }],

--- a/packages/g6/tests/intergration/demo/tooltip.ts
+++ b/packages/g6/tests/intergration/demo/tooltip.ts
@@ -53,16 +53,16 @@ export default () => {
             key: 'tooltip1',
             type: 'tooltip',
             trigger: 'pointerenter',
-            // fixToNode: [1, 0.5],
+            fixToNode: "top",
             /** async string tooltip*/
             getContent: (e) => {
                 return new Promise((resolve => {
                     const data = `
-        <div> 
-          <h4 class='tooltip-type'>类型: ${e.itemType}</h4>
-          <span class='tooltip-id'>ID: ${e.itemId}</span>
-        </div> 
-            `
+            <div> 
+              <h4 class='tooltip-type'>类型: ${e.itemType}</h4>
+              <span class='tooltip-id'>ID: ${e.itemId}</span>
+            </div> 
+                `
                     setTimeout(() => {
                         resolve(data);
                     }, 5000);

--- a/packages/g6/tests/intergration/demo/tooltip.ts
+++ b/packages/g6/tests/intergration/demo/tooltip.ts
@@ -53,7 +53,7 @@ export default () => {
             key: 'tooltip1',
             type: 'tooltip',
             trigger: 'pointerenter',
-            fixToNode: [1, 0.5],
+            // fixToNode: [1, 0.5],
             /** async string tooltip*/
             getContent: (e) => {
                 return new Promise((resolve => {

--- a/packages/g6/tests/intergration/index.ts
+++ b/packages/g6/tests/intergration/index.ts
@@ -22,6 +22,7 @@ import line_edge from './item/edge/line-edge';
 import cubic_edge from './item/edge/cubic-edge';
 import cubic_horizon_edge from './item/edge/cubic-horizon-edge';
 import cubic_vertical_edge from './item/edge/cubic-vertical-edge';
+import tooltip from './demo/tooltip';
 
 export {
   behaviors_activateRelations,
@@ -48,4 +49,5 @@ export {
   cubic_edge,
   cubic_horizon_edge,
   cubic_vertical_edge,
+  tooltip
 };

--- a/packages/g6/tests/unit/plugins/tooltip-spec.ts
+++ b/packages/g6/tests/unit/plugins/tooltip-spec.ts
@@ -1,0 +1,142 @@
+import { Graph } from '../../../src/index';
+import { pxCompare } from '../util';
+
+const container = document.createElement('div');
+document.querySelector('body').appendChild(container);
+
+const createGraph = (plugins) => {
+    return new Graph({
+        container,
+        width: 500,
+        height: 500,
+        type: 'graph',
+        data: {
+            nodes: [
+                { id: 'node1', data: { x: 100, y: 200 } },
+                { id: 'node2', data: { x: 200, y: 250 } },
+            ],
+            edges: [{ id: 'edge1', source: 'node1', target: 'node2', data: {} }],
+        },
+        node: {
+            labelShape: {
+                text: {
+                    fields: ['id'],
+                    formatter: (model) => {
+                        return model.id;
+                    },
+                },
+            },
+        },
+        modes: {
+            default: ['brush-select'],
+        },
+        plugins,
+    });
+};
+
+describe('tooltip-plugin', () => {
+    it('tooltip with default config', (done) => {
+        const graph = createGraph(['tooltip']);
+        graph.on('afterlayout', (e) => {
+            const toolTipDiv = document.getElementsByClassName(
+                'g6-component-tooltip',
+            )?.[0];
+            expect(toolTipDiv).not.toBe(undefined);
+        });
+    });
+
+    it('tooltip with string config', (done) => {
+        const graph = createGraph(
+            [{
+                key: 'tooltip1',
+                type: 'tooltip',
+                trigger: 'click',
+                getContent: (e) => {
+                    return `
+        <div class='g6-component-tooltip'>
+          <h4 class='tooltip-type'>类型: ${e.itemType}</h4>
+          <span class='tooltip-id'>ID: ${e.itemId}</span>
+        </div>
+            `
+                }
+            }]
+        );
+        graph.on('afterlayout', (e) => {
+            const toolTipDiv = document.getElementsByClassName(
+                'g6-component-tooltip',
+            )?.[0];
+            expect(toolTipDiv).not.toBe(undefined);
+        });
+
+    });
+
+    it('tooltip with fixToNode config', (done) => {
+        const graph = createGraph(
+            [{
+                key: 'tooltip1',
+                type: 'tooltip',
+                fixToNode: [1, 0.5],
+            }]);
+
+        graph.on('afterlayout', (e) => {
+            const toolTipDiv = document.getElementsByClassName(
+                'g6-component-tooltip',
+            )?.[0];
+            expect(toolTipDiv).not.toBe(undefined);
+        });
+    });
+
+    it('tooltip with html element config', (done) => {
+        const graph = createGraph(
+            [{
+                key: 'tooltip1',
+                type: 'tooltip',
+                getContent: (e) => {
+                    const outDiv = document.createElement('div');
+                    outDiv.style.width = '180px';
+                    outDiv.innerHTML = `<h4 class='tooltip-type'>类型: ${e.itemType}</h4>
+          <span class='tooltip-id'>ID: ${e.itemId}</span>`
+                    return outDiv
+                }
+            }],
+        );
+        graph.on('afterlayout', (e) => {
+            const toolTipDiv = document.getElementsByClassName(
+                'g6-component-tooltip',
+            )?.[0];
+            expect(toolTipDiv).not.toBe(undefined);
+        });
+
+    });
+
+    it('tooltip with async `getContent`config', (done) => {
+        const graph = createGraph(
+            [{
+                key: 'tooltip1',
+                type: 'tooltip',
+                trigger: 'click',
+                // fixToNode: [1, 0.5],
+                /** async string tooltip */
+                getContent: (e) => {
+                    return new Promise((resolve => {
+                        const data = `
+        <div class='g6-component-tooltip'>
+          <h4 class='tooltip-type'>类型: ${e.itemType}</h4>
+          <span class='tooltip-id'>ID: ${e.itemId}</span>
+        </div>
+            `
+                        setTimeout(() => {
+                            resolve(data);
+                        }, 1000);
+                    }))
+                }
+            }]
+        );
+        graph.on('afterlayout', (e) => {
+            const toolTipDiv = document.getElementsByClassName(
+                'g6-component-tooltip',
+            )?.[0];
+            expect(toolTipDiv).not.toBe(undefined);
+        });
+    });
+});


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

### Issue Hunt
#4578 
### 效果图
- fixToNode
  <img width="323" alt="image" src="https://github.com/antvis/G6/assets/55946653/4d540d30-bad5-4e88-83d2-fc31a9804708">
- 不fixToNode 
  
![屏幕录制2023-06-27 下午4 35 56](https://github.com/antvis/G6/assets/55946653/b2ddc5a1-db7d-497b-b4e8-4d0959fb9344)


### 修改内容
- 支持动态传入数据，`getContent(e)` 函数目前支持返回` HTMLDivElement | string | Promise<HTMLDivElement | string>`，getContent 变为异步函数，当返回Promise<>类型时，会使用await拿到其中的值，这点与v4不同。初次之外，为了减轻服务器压力，代码中避免了重复fetch。
- 单测测了使用不同配置`getContent`的情况，如果不齐全可以再补 :)

<!-- Provide a description of the change below this comment. -->
