### PR TITLE
[TBD] feat: v5-edge-polyline

### DIFF
--- a/packages/g6/src/stdlib/index.ts
+++ b/packages/g6/src/stdlib/index.ts
@@ -30,6 +30,8 @@ import { CubicEdge } from './item/edge/cubic';
 import { CubicHorizonEdge } from './item/edge/cubic-horizon';
 import { CubicVerticalEdge } from './item/edge/cubic-vertical';
 import { Quadratic } from './item/edge/quadratic';
+import { Polyline } from './item/edge/polyline'
+
 
 const stdLib = {
   transforms: {
@@ -75,6 +77,7 @@ const stdLib = {
     'cubic-horizon-edge': CubicHorizonEdge,
     'cubic-vertical-edge': CubicVerticalEdge,
     'quadratic-edge': Quadratic,
+    'polyline-edge': Polyline,
   },
   combos: {},
 };

--- a/packages/g6/src/stdlib/item/edge/index.ts
+++ b/packages/g6/src/stdlib/item/edge/index.ts
@@ -1,2 +1,3 @@
 export * from './line';
 export * from './quadratic';
+export * from './polyline'

--- a/packages/g6/src/stdlib/item/edge/polyline.ts
+++ b/packages/g6/src/stdlib/item/edge/polyline.ts
@@ -1,3 +1,4 @@
+import { keys } from '@antv/util';
 import { Point } from '../../../types/common';
 import {
     EdgeDisplayModel,
@@ -84,7 +85,7 @@ export class Polyline extends BaseEdge {
             'keyShape',
             {
                 ...keyShapeStyle,
-                points: [[sourcePoint.x, sourcePoint.y], [400, 500], [targetPoint.x, targetPoint.y]],
+                points: [[sourcePoint.x, sourcePoint.y], ...keyShapeStyle.points, [targetPoint.x, targetPoint.y]],
             },
             shapeMap,
             model,

--- a/packages/g6/src/stdlib/item/edge/polyline.ts
+++ b/packages/g6/src/stdlib/item/edge/polyline.ts
@@ -1,0 +1,93 @@
+import { Point } from '../../../types/common';
+import {
+    EdgeDisplayModel,
+    EdgeModelData,
+    EdgeShapeMap,
+} from '../../../types/edge';
+import { State } from '../../../types/item';
+import { BaseEdge } from './base';
+
+export class Polyline extends BaseEdge {
+    public type = 'line-edge';
+    public defaultStyles = {
+        keyShape: {
+            x1: 0,
+            y1: 0,
+            z1: 0,
+            x2: 0,
+            y2: 0,
+            z2: 0,
+            isBillboard: true,
+        },
+    };
+    constructor(props) {
+        super(props);
+        // suggest to merge default styles like this to avoid style value missing
+        // this.defaultStyles = mergeStyles([this.baseDefaultStyles, this.defaultStyles]);
+    }
+    public draw(
+        model: EdgeDisplayModel,
+        sourcePoint: Point,
+        targetPoint: Point,
+        shapeMap: EdgeShapeMap,
+        diffData?: { previous: EdgeModelData; current: EdgeModelData },
+        diffState?: { previous: State[]; current: State[] },
+    ): EdgeShapeMap {
+        const { data = {} } = model;
+
+        const shapes: EdgeShapeMap = { keyShape: undefined };
+
+        shapes.keyShape = this.drawKeyShape(
+            model,
+            sourcePoint,
+            targetPoint,
+            shapeMap,
+            diffData,
+        );
+
+        if (data.haloShape) {
+            shapes.haloShape = this.drawHaloShape(model, shapeMap, diffData);
+        }
+
+        if (data.labelShape) {
+            shapes.labelShape = this.drawLabelShape(model, shapeMap, diffData);
+        }
+
+        // labelBackgroundShape
+        if (data.labelBackgroundShape) {
+            shapes.labelBackgroundShape = this.drawLabelBackgroundShape(
+                model,
+                shapeMap,
+                diffData,
+            );
+        }
+
+        if (data.iconShape) {
+            shapes.iconShape = this.drawIconShape(model, shapeMap, diffData);
+        }
+
+        // TODO: other shapes
+
+        return shapes;
+    }
+    public drawKeyShape(
+        model: EdgeDisplayModel,
+        sourcePoint: Point,
+        targetPoint: Point,
+        shapeMap: EdgeShapeMap,
+        diffData?: { previous: EdgeModelData; current: EdgeModelData },
+        diffState?: { previous: State[]; current: State[] },
+    ) {
+        const { keyShape: keyShapeStyle } = this.mergedStyles;
+        return this.upsertShape(
+            'polyline',
+            'keyShape',
+            {
+                ...keyShapeStyle,
+                points: [[sourcePoint.x, sourcePoint.y], [400, 500], [targetPoint.x, targetPoint.y]],
+            },
+            shapeMap,
+            model,
+        );
+    }
+}

--- a/packages/g6/tests/intergration/demo/polyline.ts
+++ b/packages/g6/tests/intergration/demo/polyline.ts
@@ -1,0 +1,77 @@
+import G6 from '../../../src/index';
+import { container, height, width } from '../../datasets/const';
+
+export default () => {
+    const data = {
+        nodes: [
+            {
+                id: 1,
+                data: {
+                    x: 100,
+                    y: 100,
+                    type: 'circle-node',
+                },
+            },
+            {
+                id: 2,
+                data: {
+                    x: 200,
+                    y: 100,
+                    type: 'circle-node',
+                },
+            },
+        ],
+        edges: [
+            {
+                id: 'edge1',
+                source: 1,
+                target: 2,
+                data: {
+                    type: 'polyline-edge'
+                }
+            }
+        ]
+    };
+
+
+    const edge: ((data: any) => any) = (edgeInnerModel: any) => {
+
+        const { id, data } = edgeInnerModel
+        return {
+            id,
+            data: {
+                ...data,
+                keyShape: {
+                    points: [[200, 300]]
+                }
+            }
+        }
+    }
+    const graph = new G6.Graph({
+        container,
+        width,
+        height,
+        data,
+        type: 'graph',
+        modes: {
+            default: ['click-select', 'drag-canvas', 'zoom-canvas', 'drag-node'],
+        },
+        node: (nodeInnerModel: any) => {
+            const { id, data } = nodeInnerModel;
+            // 返回值类型见下方 DisplayNodeModel 类型
+            return {
+                id,
+                data: {
+                    ...data,
+                    keyShape: {
+                        r: 16
+                    },
+                }
+            }
+        },
+        edge,
+    });
+
+    return graph;
+
+}

--- a/packages/g6/tests/intergration/index.ts
+++ b/packages/g6/tests/intergration/index.ts
@@ -24,6 +24,7 @@ import cubic_edge from './item/edge/cubic-edge';
 import cubic_horizon_edge from './item/edge/cubic-horizon-edge';
 import cubic_vertical_edge from './item/edge/cubic-vertical-edge';
 import tooltip from './demo/tooltip';
+import polyline from './demo/polyline';
 
 export {
   behaviors_activateRelations,
@@ -51,5 +52,6 @@ export {
   cubic_edge,
   cubic_horizon_edge,
   cubic_vertical_edge,
-  tooltip
+  tooltip,
+  polyline
 };


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->
- 只做了传入控制点数组，绘制折线的功能。 
- polyline的keyShapeStyleProps类型里面似乎只支持传入points，需要添加其他的参数。
#### 效果：
<img width="504" alt="image" src="https://github.com/antvis/G6/assets/55946653/fc964277-ee28-4cb1-aa4b-866fcb4b585d">
