### PR TITLE
fix: halo styles for rect node

### DIFF
--- a/packages/g6/src/item/combo.ts
+++ b/packages/g6/src/item/combo.ts
@@ -15,8 +15,8 @@ interface IProps {
   model: ComboModel;
   renderExtensions: any;
   containerGroup: Group;
-  mapper: DisplayMapper;
-  stateMapper: {
+  mapper?: DisplayMapper;
+  stateMapper?: {
     [stateName: string]: DisplayMapper;
   };
   zoom?: number;

--- a/packages/g6/src/item/edge.ts
+++ b/packages/g6/src/item/edge.ts
@@ -13,8 +13,8 @@ interface IProps {
   model: EdgeModel;
   renderExtensions: any; // TODO: type
   containerGroup: Group;
-  mapper: DisplayMapper;
-  stateMapper: {
+  mapper?: DisplayMapper;
+  stateMapper?: {
     [stateName: string]: DisplayMapper;
   };
   sourceItem: Node;

--- a/packages/g6/src/item/item.ts
+++ b/packages/g6/src/item/item.ts
@@ -72,7 +72,7 @@ export default abstract class Item implements IItem {
   public animations: IAnimation[];
 
   public themeStyles: {
-    default?: ItemShapeStyles;
+    default: ItemShapeStyles;
     [stateName: string]: ItemShapeStyles;
   };
   /** The zoom strategy to show and hide shapes according to their lod. */

--- a/packages/g6/src/item/node.ts
+++ b/packages/g6/src/item/node.ts
@@ -20,8 +20,8 @@ interface IProps {
   model: NodeModel | ComboModel;
   renderExtensions: any;
   containerGroup: Group;
-  mapper: DisplayMapper;
-  stateMapper: {
+  mapper?: DisplayMapper;
+  stateMapper?: {
     [stateName: string]: DisplayMapper;
   };
   zoom?: number;
@@ -36,7 +36,7 @@ interface IProps {
 }
 export default class Node extends Item {
   public type: 'node' | 'combo';
-  private anchorPointsCache: Point[];
+  private anchorPointsCache: Point[] | undefined;
 
   constructor(props: IProps) {
     super(props);
@@ -140,10 +140,10 @@ export default class Node extends Item {
   ) {
     const { group } = this;
     const { x, y, z = 0, animates, disableAnimate } = displayModel.data;
-    if (isNaN(x) || isNaN(y) || isNaN(z)) return;
+    if (isNaN(x as number) || isNaN(y as number) || isNaN(z)) return;
     if (!disableAnimate && animates?.update) {
       const groupAnimates = animates.update.filter(
-        ({ shapeId, fields }) =>
+        ({ shapeId, fields = [] }) =>
           (!shapeId || shapeId === 'group') &&
           (fields.includes('x') || fields.includes('y')),
       );

--- a/packages/g6/src/item/node.ts
+++ b/packages/g6/src/item/node.ts
@@ -247,8 +247,8 @@ export default class Node extends Item {
           keyShape.getLocalBounds();
         intersectPoint = getRectIntersectByPoint(
           {
-            x: bbox.halfExtents[0],
-            y: bbox.halfExtents[1],
+            x: x + bbox.min[0],
+            y: y + bbox.min[1],
             width: bbox.max[0] - bbox.min[0],
             height: bbox.max[1] - bbox.min[1],
           },

--- a/packages/g6/src/stdlib/behavior/drag-node.ts
+++ b/packages/g6/src/stdlib/behavior/drag-node.ts
@@ -206,7 +206,7 @@ export default class DragNode extends Behavior {
       this.originPositions = selectedNodeIds
         .map((id) => {
           if (!this.graph.getNodeData(id)) {
-            console.log('node does not exist', id);
+            console.warn('node does not exist', id);
             return;
           }
           const { x, y } = this.graph.getNodeData(id).data as {

--- a/packages/g6/src/stdlib/item/node/base.ts
+++ b/packages/g6/src/stdlib/item/node/base.ts
@@ -416,8 +416,9 @@ export abstract class BaseNode {
       nodeName as SHAPE_TYPE,
       'haloShape',
       {
-        ...attributes,
         ...keyShapeStyle,
+        // actual attributes in the keyShape has higher priority than the style config props of keyShape
+        ...attributes,
         stroke: attributes.fill,
         ...haloShapeStyle,
         batchKey: 'halo',

--- a/packages/g6/src/types/theme.ts
+++ b/packages/g6/src/types/theme.ts
@@ -47,16 +47,15 @@ export type ThemeObjectOptionsOf<T extends ThemeRegistry = {}> = {
 
 /** Default and stateStyle for an item */
 export type NodeStyleSet = {
-  default?: NodeShapeStyles;
-  seledted?: NodeShapeStyles;
+  default: NodeShapeStyles;
   [stateName: string]: NodeShapeStyles;
 };
 export type EdgeStyleSet = {
-  default?: EdgeShapeStyles;
+  default: EdgeShapeStyles;
   [stateName: string]: EdgeShapeStyles;
 };
 export type ComboStyleSet = {
-  default?: ComboShapeStyles;
+  default: ComboShapeStyles;
   [stateName: string]: ComboShapeStyles;
 };
 

--- a/packages/g6/src/util/event.ts
+++ b/packages/g6/src/util/event.ts
@@ -1,6 +1,7 @@
 import { IElement } from '@antv/g';
 import { ID } from '@antv/graphlib';
 import { IG6GraphEvent, IGraph } from 'types';
+import { GraphCore } from '../types/data';
 
 export type ItemInfo = {
   itemType: 'canvas' | 'node' | 'edge' | 'combo';
@@ -60,4 +61,69 @@ export const getContextMenuEventProps = (
         );
     },
   };
+};
+
+type GroupedChanges = {
+  NodeRemoved: [];
+  EdgeRemoved: [];
+  NodeAdded: [];
+  EdgeAdded: [];
+  NodeDataUpdated: [];
+  EdgeUpdated: [];
+  EdgeDataUpdated: [];
+  TreeStructureChanged: [];
+};
+
+/**
+ * Group the changes with change types from graphCore's changes.
+ * @param graphCore
+ * @param changes
+ * @returns
+ */
+export const getGroupedChanges = (
+  graphCore: GraphCore,
+  changes,
+): GroupedChanges => {
+  const groupedChanges: GroupedChanges = {
+    NodeRemoved: [],
+    EdgeRemoved: [],
+    NodeAdded: [],
+    EdgeAdded: [],
+    NodeDataUpdated: [],
+    EdgeUpdated: [],
+    EdgeDataUpdated: [],
+    TreeStructureChanged: [],
+  };
+  changes.forEach((change) => {
+    const { type: changeType } = change;
+    if (
+      ['NodeDataUpdated', 'EdgeUpdated', 'EdgeDataUpdated'].includes(changeType)
+    ) {
+      const { id: oid } = change;
+      if (!graphCore.hasNode(oid) && !graphCore.hasEdge(oid)) {
+        const nid = Number(oid);
+        if ((!isNaN(nid) && graphCore.hasNode(nid)) || graphCore.hasEdge(nid)) {
+          groupedChanges[changeType].push({ ...change, id: nid });
+        }
+        return;
+      }
+    } else if (changeType === 'TreeStructureChanged') {
+      groupedChanges[changeType].push(change);
+      return;
+    } else {
+      const { id: oid } = change.value;
+      if (!graphCore.hasNode(oid) && !graphCore.hasEdge(oid)) {
+        const nid = Number(oid);
+        if ((!isNaN(nid) && graphCore.hasNode(nid)) || graphCore.hasEdge(nid)) {
+          groupedChanges[changeType].push({
+            ...change,
+            value: { ...change.value, id: nid },
+          });
+        }
+        return;
+      }
+    }
+    groupedChanges[changeType].push(change);
+  });
+  return groupedChanges;
 };

--- a/packages/g6/src/util/event.ts
+++ b/packages/g6/src/util/event.ts
@@ -1,7 +1,18 @@
 import { IElement } from '@antv/g';
-import { ID } from '@antv/graphlib';
-import { IG6GraphEvent, IGraph } from 'types';
+import {
+  EdgeAdded,
+  EdgeDataUpdated,
+  EdgeRemoved,
+  EdgeUpdated,
+  ID,
+  NodeAdded,
+  NodeDataUpdated,
+  NodeRemoved,
+  TreeStructureChanged,
+} from '@antv/graphlib';
+import { IG6GraphEvent, IGraph, NodeModelData } from '../types';
 import { GraphCore } from '../types/data';
+import { EdgeModelData } from '../types/edge';
 
 export type ItemInfo = {
   itemType: 'canvas' | 'node' | 'edge' | 'combo';
@@ -64,14 +75,14 @@ export const getContextMenuEventProps = (
 };
 
 type GroupedChanges = {
-  NodeRemoved: [];
-  EdgeRemoved: [];
-  NodeAdded: [];
-  EdgeAdded: [];
-  NodeDataUpdated: [];
-  EdgeUpdated: [];
-  EdgeDataUpdated: [];
-  TreeStructureChanged: [];
+  NodeRemoved: NodeRemoved<NodeModelData>[];
+  EdgeRemoved: EdgeRemoved<EdgeModelData>[];
+  NodeAdded: NodeAdded<NodeModelData>[];
+  EdgeAdded: EdgeAdded<EdgeModelData>[];
+  NodeDataUpdated: NodeDataUpdated<NodeModelData>[];
+  EdgeUpdated: EdgeUpdated<EdgeModelData>[];
+  EdgeDataUpdated: EdgeDataUpdated<EdgeModelData>[];
+  TreeStructureChanged: TreeStructureChanged[];
 };
 
 /**

--- a/packages/g6/src/util/zoom.ts
+++ b/packages/g6/src/util/zoom.ts
@@ -5,10 +5,14 @@ import { LodStrategy, LodStrategyObj } from '../types/item';
  * @param lodStrategy
  * @returns
  */
-export const formatLodStrategy = (lodStrategy: LodStrategy): LodStrategyObj => {
-  const { levels, animateCfg } = lodStrategy || {};
-  if (!levels) return undefined;
+export const formatLodStrategy = (
+  lodStrategy?: LodStrategy,
+): LodStrategyObj | undefined => {
+  if (!lodStrategy) return;
+  const { levels, animateCfg } = lodStrategy;
+  if (!levels) return;
   const primaryLevel = levels.find((level) => level.primary);
+  if (!primaryLevel) return;
   const primaryIndex = levels.indexOf(primaryLevel);
   const formattedLevels = {};
   levels.forEach((level, i) => {

--- a/packages/g6/tests/demo/demo/rect.ts
+++ b/packages/g6/tests/demo/demo/rect.ts
@@ -37,6 +37,13 @@ export default () => {
         },
       },
     ],
+    edges: [
+      {
+        source: 1,
+        target: 2,
+        data: {},
+      },
+    ],
   };
 
   const graph = new G6.Graph({

--- a/packages/g6/tests/demo/demo/rect.ts
+++ b/packages/g6/tests/demo/demo/rect.ts
@@ -9,7 +9,7 @@ export default () => {
         data: {
           x: 100,
           y: 100,
-          type: 'rect-node',
+          type: 'circle-node',
         },
       },
       {


### PR DESCRIPTION
- fix: halo styles for rect node
Actual attributes in the keyShape have higher priority than the style config props of keyShape. The wrong style:

![image](https://github.com/antvis/G6/assets/29593318/4da62701-8599-4728-b2d1-f5f5badbd60b)


Correct style:

![image](https://github.com/antvis/G6/assets/29593318/0009375a-f949-4f80-af62-796b50e1cee4)


- fix: number id of nodes and edges cause item not found problem in item update functions;
