### PR TITLE
fix: data validate with data update

### DIFF
--- a/packages/g6/src/runtime/controller/data.ts
+++ b/packages/g6/src/runtime/controller/data.ts
@@ -41,7 +41,7 @@ import { getExtension } from '../../util/extension';
 export class DataController {
   public graph: IGraph;
   public extensions = [];
-  public preCheck: (data: GraphData) => GraphData;
+  public preCheck: (data: GraphData, userGraphCore?: GraphCore) => GraphData;
   /**
    * User input data.
    */
@@ -167,19 +167,20 @@ export class DataController {
    */
   private onDataChange(param: { data: DataConfig; type: DataChangeType }) {
     const { data, type: changeType } = param;
+    const { userGraphCore } = this;
     const change = () => {
       switch (changeType) {
         case 'remove':
-          this.removeData(this.preCheck?.(data as GraphData));
+          this.removeData(this.preCheck?.(data as GraphData, userGraphCore));
           break;
         case 'update':
           this.updateData(data);
           break;
         case 'moveCombo':
-          this.moveCombo(this.preCheck?.(data as GraphData));
+          this.moveCombo(this.preCheck?.(data as GraphData, userGraphCore));
           break;
         case 'addCombo':
-          this.addCombo(this.preCheck?.(data as GraphData));
+          this.addCombo(this.preCheck?.(data as GraphData, userGraphCore));
           break;
         default:
           // changeType is 'replace' | 'mergeReplace' | 'union'
@@ -187,7 +188,6 @@ export class DataController {
           break;
       }
     };
-    const { userGraphCore } = this;
     if (userGraphCore) {
       userGraphCore.batch(change);
     } else {
@@ -516,7 +516,7 @@ export class DataController {
 
     return {
       type: type || 'graphData',
-      data: this.preCheck(data as GraphData),
+      data: this.preCheck(data as GraphData, this.userGraphCore),
     };
   }
 

--- a/packages/g6/src/stdlib/data/validateData.ts
+++ b/packages/g6/src/stdlib/data/validateData.ts
@@ -107,7 +107,7 @@ export const validateData = (
       if (
         !nodeIdMap.has(source) &&
         !comboIdMap.has(source) &&
-        (!userGraphCore || !userGraphCore.hasEdge(source))
+        (!userGraphCore || !userGraphCore.hasNode(source))
       ) {
         console.error(
           `The edge with id ${id} will be ignored since its source ${source} is not existed in nodes and combos.`,
@@ -117,7 +117,7 @@ export const validateData = (
       if (
         !nodeIdMap.has(target) &&
         !comboIdMap.has(target) &&
-        (!userGraphCore || !userGraphCore.hasEdge(target))
+        (!userGraphCore || !userGraphCore.hasNode(target))
       ) {
         console.error(
           `The edge with id ${id} will be ignored since its target ${target} is not existed in nodes and combos.`,

--- a/packages/g6/src/stdlib/data/validateData.ts
+++ b/packages/g6/src/stdlib/data/validateData.ts
@@ -1,3 +1,4 @@
+import { GraphCore } from '../../types/data';
 import {
   GraphData,
   ComboUserModel,
@@ -8,9 +9,13 @@ import {
 /**
  * Validate and format the graph data.
  * @param data input user data.
+ * @param userGraphCore the graph core stores the previous data.
  * @returns formatted data.
  */
-export const validateData = (data: GraphData): GraphData => {
+export const validateData = (
+  data: GraphData,
+  userGraphCore?: GraphCore,
+): GraphData => {
   const { nodes, edges, combos } = data;
   const idMap = new Map();
   const nodeIdMap = new Map();
@@ -49,9 +54,11 @@ export const validateData = (data: GraphData): GraphData => {
     .filter(Boolean) as ComboUserModel[];
 
   formattedCombos?.forEach((combo) => {
+    const { parentId } = combo.data;
     if (
-      combo.data.parentId !== undefined &&
-      !comboIdMap.has(combo.data.parentId)
+      parentId !== undefined &&
+      !comboIdMap.has(parentId) &&
+      (!userGraphCore || !userGraphCore.hasNode(parentId))
     ) {
       console.error(
         `The parentId of combo with id ${combo.id} will be removed since it is not exist in combos.`,
@@ -63,10 +70,13 @@ export const validateData = (data: GraphData): GraphData => {
   const formattedNodes = nodes
     ?.map((node) => {
       if (!idAndDataCheck(node, 'node')) return false;
+      const { parentId } = node.data;
       if (
-        node.data.parentId !== undefined &&
-        !comboIdMap.has(node.data.parentId)
+        parentId !== undefined &&
+        !comboIdMap.has(parentId) &&
+        (!userGraphCore || !userGraphCore.hasNode(parentId))
       ) {
+        // TODO: parentId is a node in userGraphCore
         console.error(
           `The parentId of node with id ${node.id} will be removed since it is not exist in combos.`,
         );
@@ -94,13 +104,21 @@ export const validateData = (data: GraphData): GraphData => {
         );
         return false;
       }
-      if (!nodeIdMap.has(source) && !comboIdMap.has(source)) {
+      if (
+        !nodeIdMap.has(source) &&
+        !comboIdMap.has(source) &&
+        (!userGraphCore || !userGraphCore.hasEdge(source))
+      ) {
         console.error(
           `The edge with id ${id} will be ignored since its source ${source} is not existed in nodes and combos.`,
         );
         return false;
       }
-      if (!nodeIdMap.has(target) && !comboIdMap.has(target)) {
+      if (
+        !nodeIdMap.has(target) &&
+        !comboIdMap.has(target) &&
+        (!userGraphCore || !userGraphCore.hasEdge(target))
+      ) {
         console.error(
           `The edge with id ${id} will be ignored since its target ${target} is not existed in nodes and combos.`,
         );


### PR DESCRIPTION
fix: data validate with data update

之前数据校验仅检查了增量数据部分，没有结合已有数据。导致如果增量加的边的起点和终点在已有数据中，会被判断为非法的边