### PR TITLE
fix: path node anchor shapes and badge shapes

### DIFF
--- a/packages/g6/package.json
+++ b/packages/g6/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antv/g6",
-  "version": "5.0.0-beta.3",
+  "version": "5.0.0-beta.4",
   "description": "A Graph Visualization Framework in JavaScript",
   "keywords": [
     "antv",

--- a/packages/g6/src/index.ts
+++ b/packages/g6/src/index.ts
@@ -14,7 +14,7 @@ runtime.enableCSSParsing = false;
  * Extend the graph class with std lib
  */
 
-const version = '5.0.0-beta.3';
+const version = '5.0.0-beta.4';
 
 const Graph = extend(EmptyGraph, stdLib);
 

--- a/packages/g6/src/stdlib/item/node/base.ts
+++ b/packages/g6/src/stdlib/item/node/base.ts
@@ -579,8 +579,8 @@ export abstract class BaseNode {
     const keyShapeWidth = keyShapeBBox.max[0] - keyShapeBBox.min[0];
     const keyShapeHeight = keyShapeBBox.max[1] - keyShapeBBox.min[1];
     const defaultPosition: [number, number] = [
-      keyShapeBBox.max[0],
-      keyShapeBBox.min[1],
+      keyShapeBBox.max[0] - keyShapeBBox.center[0],
+      keyShapeBBox.min[1] - keyShapeBBox.center[1],
     ]; //topRight
     if (position instanceof Array) {
       return [
@@ -755,8 +755,6 @@ export abstract class BaseNode {
         (text as string).length <= 1
           ? bgHeight
           : Math.max(bgHeight, bbox.max[0] - bbox.min[0]) + 8;
-      let bgX = isLeft ? pos.x - bgWidth : pos.x;
-      if (isCenter) bgX = pos.x - bgWidth / 2;
       shapes[bgShapeId] = this.upsertShape(
         'rect',
         bgShapeId,
@@ -767,8 +765,8 @@ export abstract class BaseNode {
           width: bgWidth,
           radius: bgHeight / 2,
           zIndex,
-          x: bgX,
-          y: pos.y,
+          x: bbox.center[0] - bgWidth / 2,
+          y: bbox.center[1] - bgHeight / 2,
           ...otherStyles,
         } as GShapeStyle,
         shapeMap,

--- a/packages/g6/src/stdlib/item/node/diamond.ts
+++ b/packages/g6/src/stdlib/item/node/diamond.ts
@@ -12,7 +12,7 @@ type PathArray = any; //TODO: cannot import type PathArray
 export class DiamondNode extends BaseNode {
   override defaultStyles = {
     keyShape: {
-      size: [50, 30],
+      size: [32, 32],
       x: 0,
       y: 0,
     },

--- a/packages/g6/src/stdlib/item/node/ellipse.ts
+++ b/packages/g6/src/stdlib/item/node/ellipse.ts
@@ -11,8 +11,8 @@ import { BaseNode } from './base';
 export class EllipseNode extends BaseNode {
   override defaultStyles = {
     keyShape: {
-      rx: 30,
-      ry: 20,
+      rx: 16,
+      ry: 12,
       x: 0,
       y: 0,
     },

--- a/packages/g6/src/stdlib/item/node/hexagon.ts
+++ b/packages/g6/src/stdlib/item/node/hexagon.ts
@@ -17,10 +17,10 @@ const offsetAngleMap = {
 export class HexagonNode extends BaseNode {
   override defaultStyles = {
     keyShape: {
-      r: 20,
+      r: 16,
       x: 0,
       y: 0,
-      direction: 'horizontal',
+      direction: 'vertical',
     },
   };
   mergedStyles: NodeShapeStyles;
@@ -166,6 +166,10 @@ export class HexagonNode extends BaseNode {
       const vx = r * Math.cos(angle);
       const vy = r * Math.sin(angle);
       anchorPositionMap[anchorPositionDirection[i]] = [vx, vy];
+    }
+    if (!anchorPositionMap.hasOwnProperty('default')) {
+      anchorPositionMap['default'] =
+        anchorPositionMap[anchorPositionDirection[0]];
     }
     return anchorPositionMap;
   }

--- a/packages/g6/src/stdlib/item/node/image.ts
+++ b/packages/g6/src/stdlib/item/node/image.ts
@@ -46,12 +46,8 @@ export class ImageNode extends BaseNode {
       'keyShape',
       {
         ...this.mergedStyles.keyShape,
-        x:
-          (this.mergedStyles.keyShape!.x as number) -
-          (this.mergedStyles.keyShape!.width as number) / 2,
-        y:
-          (this.mergedStyles.keyShape!.y as number) -
-          (this.mergedStyles.keyShape!.height as number) / 2,
+        x: this.mergedStyles.keyShape!.x,
+        y: this.mergedStyles.keyShape!.y,
         anchor: '0.5 0.5',
       },
       shapeMap,

--- a/packages/g6/src/stdlib/theme/dark.ts
+++ b/packages/g6/src/stdlib/theme/dark.ts
@@ -7,6 +7,7 @@ const textColor = 'rgba(255,255,255,0.85)';
 const nodeColor = 'rgb(34,126,255)';
 const edgeColor = 'rgb(153, 173, 209)';
 const comboFill = 'rgb(253, 253, 253)';
+const comboStroke = 'rgba(153,173,209,1)';
 const disabledFill = '#D0E4FF';
 
 const edgeMainStroke = '#637088';
@@ -105,7 +106,7 @@ export const DarkTheme = {
           },
           haloShape: {
             opacity: 0.45,
-            lineWidth: 20,
+            lineWidth: 12,
             zIndex: -1,
             pointerEvents: 'none',
             visible: true,
@@ -118,7 +119,7 @@ export const DarkTheme = {
           },
           haloShape: {
             opacity: 0.25,
-            lineWidth: 20,
+            lineWidth: 12,
             zIndex: -1,
             pointerEvents: 'none',
             visible: true,
@@ -301,6 +302,23 @@ export const DarkTheme = {
             height: 10,
             padding: [25, 20, 15, 20],
           },
+          labelShape: {
+            ...DEFAULT_TEXT_STYLE,
+            fill: textColor,
+            opacity: 0.85,
+            position: 'bottom',
+            zIndex: 2,
+            lod: 0,
+            maxLines: 1,
+          },
+          labelBackgroundShape: {
+            padding: [2, 4, 2, 4],
+            lineWidth: 0,
+            fill: '#000',
+            opacity: 0.75,
+            zIndex: 1,
+            lod: 0,
+          },
         },
         selected: {
           keyShape: {
@@ -311,11 +329,29 @@ export const DarkTheme = {
           labelShape: {
             fontWeight: 700,
           },
+          haloShape: {
+            opacity: 0.25,
+            lineWidth: 12,
+            pointerEvents: 'none',
+            zIndex: -1,
+            visible: true,
+            stroke: comboStroke,
+            droppable: false,
+          },
         },
         active: {
           keyShape: {
             stroke: nodeStroke,
             lineWidth: 1,
+          },
+          haloShape: {
+            opacity: 0.25,
+            lineWidth: 12,
+            pointerEvents: 'none',
+            zIndex: -1,
+            visible: true,
+            stroke: comboStroke,
+            droppable: false,
           },
         },
         highlight: {
@@ -334,6 +370,9 @@ export const DarkTheme = {
             fill: comboFill,
             lineWidth: 1,
           },
+          labelShape: {
+            opacity: 0.65,
+          },
         },
         disable: {
           keyShape: {
@@ -343,6 +382,31 @@ export const DarkTheme = {
           iconShape: {
             fill: disabledFill,
             opacity: 0.25,
+          },
+          labelShape: {
+            opacity: 0.25,
+          },
+        },
+        collapsed: {
+          keyShape: {
+            ...DEFAULT_SHAPE_STYLE,
+            fill: comboFill,
+            lineWidth: 1,
+            stroke: comboStroke,
+            // the collapsed size
+            r: 16,
+            width: 48,
+            height: 24,
+            padding: [25, 20, 15, 20],
+          },
+          iconShape: {
+            ...DEFAULT_TEXT_STYLE,
+            fill: comboStroke,
+            fontSize: 12,
+            zIndex: 1,
+            lod: -1,
+            contentType: 'childCount',
+            visible: true,
           },
         },
       },

--- a/packages/g6/src/stdlib/theme/light.ts
+++ b/packages/g6/src/stdlib/theme/light.ts
@@ -108,7 +108,7 @@ export const LightTheme = {
           },
           haloShape: {
             opacity: 0.25,
-            lineWidth: 20,
+            lineWidth: 12,
             pointerEvents: 'none',
             zIndex: -1,
             visible: true,
@@ -121,7 +121,7 @@ export const LightTheme = {
           },
           haloShape: {
             opacity: 0.25,
-            lineWidth: 20,
+            lineWidth: 12,
             pointerEvents: 'none',
             zIndex: -1,
             visible: true,
@@ -328,7 +328,7 @@ export const LightTheme = {
           },
           haloShape: {
             opacity: 0.25,
-            lineWidth: 20,
+            lineWidth: 12,
             pointerEvents: 'none',
             zIndex: -1,
             visible: true,
@@ -343,7 +343,7 @@ export const LightTheme = {
           },
           haloShape: {
             opacity: 0.25,
-            lineWidth: 20,
+            lineWidth: 12,
             pointerEvents: 'none',
             zIndex: -1,
             visible: true,

--- a/packages/site/docs/apis/classes/graph/Graph.en.md
+++ b/packages/site/docs/apis/classes/graph/Graph.en.md
@@ -2,7 +2,7 @@
 title: Graph
 ---
 
-[Overview - v5.0.0-beta.3](../../README.en.md) / [Modules](../../modules.en.md) / [graph](../../modules/graph.en.md) / Graph
+[Overview - v5.0.0-beta.4](../../README.en.md) / [Modules](../../modules.en.md) / [graph](../../modules/graph.en.md) / Graph
 
 [graph](../../modules/graph.en.md).Graph
 

--- a/packages/site/docs/apis/classes/graph/Graph.zh.md
+++ b/packages/site/docs/apis/classes/graph/Graph.zh.md
@@ -4,7 +4,7 @@ title: Graph
 
 > 📋 中文文档还在翻译中... 欢迎 PR
 
-[Overview - v5.0.0-beta.3](../../README.zh.md) / [Modules](../../modules.zh.md) / [graph](../../modules/graph.zh.md) / Graph
+[Overview - v5.0.0-beta.4](../../README.zh.md) / [Modules](../../modules.zh.md) / [graph](../../modules/graph.zh.md) / Graph
 
 [graph](../../modules/graph.zh.md).Graph
 

--- a/packages/site/docs/apis/classes/item/CircleNode.en.md
+++ b/packages/site/docs/apis/classes/item/CircleNode.en.md
@@ -2,7 +2,7 @@
 title: CircleNode
 ---
 
-[Overview - v5.0.0-beta.3](../../README.en.md) / [Modules](../../modules.en.md) / [item](../../modules/item.en.md) / CircleNode
+[Overview - v5.0.0-beta.4](../../README.en.md) / [Modules](../../modules.en.md) / [item](../../modules/item.en.md) / CircleNode
 
 [item](../../modules/item.en.md).CircleNode
 

--- a/packages/site/docs/apis/classes/item/CircleNode.zh.md
+++ b/packages/site/docs/apis/classes/item/CircleNode.zh.md
@@ -4,7 +4,7 @@ title: CircleNode
 
 > 📋 中文文档还在翻译中... 欢迎 PR
 
-[Overview - v5.0.0-beta.3](../../README.zh.md) / [Modules](../../modules.zh.md) / [item](../../modules/item.zh.md) / CircleNode
+[Overview - v5.0.0-beta.4](../../README.zh.md) / [Modules](../../modules.zh.md) / [item](../../modules/item.zh.md) / CircleNode
 
 [item](../../modules/item.zh.md).CircleNode
 

--- a/packages/site/docs/apis/classes/item/CustomEdge.en.md
+++ b/packages/site/docs/apis/classes/item/CustomEdge.en.md
@@ -2,7 +2,7 @@
 title: CustomEdge
 ---
 
-[Overview - v5.0.0-beta.3](../../README.en.md) / [Modules](../../modules.en.md) / [item](../../modules/item.en.md) / CustomEdge
+[Overview - v5.0.0-beta.4](../../README.en.md) / [Modules](../../modules.en.md) / [item](../../modules/item.en.md) / CustomEdge
 
 [item](../../modules/item.en.md).CustomEdge
 

--- a/packages/site/docs/apis/classes/item/CustomEdge.zh.md
+++ b/packages/site/docs/apis/classes/item/CustomEdge.zh.md
@@ -4,7 +4,7 @@ title: CustomEdge
 
 > 📋 中文文档还在翻译中... 欢迎 PR
 
-[Overview - v5.0.0-beta.3](../../README.zh.md) / [Modules](../../modules.zh.md) / [item](../../modules/item.zh.md) / CustomEdge
+[Overview - v5.0.0-beta.4](../../README.zh.md) / [Modules](../../modules.zh.md) / [item](../../modules/item.zh.md) / CustomEdge
 
 [item](../../modules/item.zh.md).CustomEdge
 

--- a/packages/site/docs/apis/classes/item/CustomNode.en.md
+++ b/packages/site/docs/apis/classes/item/CustomNode.en.md
@@ -2,7 +2,7 @@
 title: CustomNode
 ---
 
-[Overview - v5.0.0-beta.3](../../README.en.md) / [Modules](../../modules.en.md) / [item](../../modules/item.en.md) / CustomNode
+[Overview - v5.0.0-beta.4](../../README.en.md) / [Modules](../../modules.en.md) / [item](../../modules/item.en.md) / CustomNode
 
 [item](../../modules/item.en.md).CustomNode
 

--- a/packages/site/docs/apis/classes/item/CustomNode.zh.md
+++ b/packages/site/docs/apis/classes/item/CustomNode.zh.md
@@ -4,7 +4,7 @@ title: CustomNode
 
 > 📋 中文文档还在翻译中... 欢迎 PR
 
-[Overview - v5.0.0-beta.3](../../README.zh.md) / [Modules](../../modules.zh.md) / [item](../../modules/item.zh.md) / CustomNode
+[Overview - v5.0.0-beta.4](../../README.zh.md) / [Modules](../../modules.zh.md) / [item](../../modules/item.zh.md) / CustomNode
 
 [item](../../modules/item.zh.md).CustomNode
 

--- a/packages/site/docs/apis/classes/item/CustomNode3D.en.md
+++ b/packages/site/docs/apis/classes/item/CustomNode3D.en.md
@@ -2,7 +2,7 @@
 title: CustomNode3D
 ---
 
-[Overview - v5.0.0-beta.3](../../README.en.md) / [Modules](../../modules.en.md) / [item](../../modules/item.en.md) / CustomNode3D
+[Overview - v5.0.0-beta.4](../../README.en.md) / [Modules](../../modules.en.md) / [item](../../modules/item.en.md) / CustomNode3D
 
 [item](../../modules/item.en.md).CustomNode3D
 

--- a/packages/site/docs/apis/classes/item/CustomNode3D.zh.md
+++ b/packages/site/docs/apis/classes/item/CustomNode3D.zh.md
@@ -4,7 +4,7 @@ title: CustomNode3D
 
 > 📋 中文文档还在翻译中... 欢迎 PR
 
-[Overview - v5.0.0-beta.3](../../README.zh.md) / [Modules](../../modules.zh.md) / [item](../../modules/item.zh.md) / CustomNode3D
+[Overview - v5.0.0-beta.4](../../README.zh.md) / [Modules](../../modules.zh.md) / [item](../../modules/item.zh.md) / CustomNode3D
 
 [item](../../modules/item.zh.md).CustomNode3D
 

--- a/packages/site/docs/apis/classes/item/DiamondNode.en.md
+++ b/packages/site/docs/apis/classes/item/DiamondNode.en.md
@@ -2,7 +2,7 @@
 title: DiamondNode
 ---
 
-[Overview - v5.0.0-beta.3](../../README.en.md) / [Modules](../../modules.en.md) / [item](../../modules/item.en.md) / DiamondNode
+[Overview - v5.0.0-beta.4](../../README.en.md) / [Modules](../../modules.en.md) / [item](../../modules/item.en.md) / DiamondNode
 
 [item](../../modules/item.en.md).DiamondNode
 

--- a/packages/site/docs/apis/classes/item/DiamondNode.zh.md
+++ b/packages/site/docs/apis/classes/item/DiamondNode.zh.md
@@ -4,7 +4,7 @@ title: DiamondNode
 
 > 📋 中文文档还在翻译中... 欢迎 PR
 
-[Overview - v5.0.0-beta.3](../../README.zh.md) / [Modules](../../modules.zh.md) / [item](../../modules/item.zh.md) / DiamondNode
+[Overview - v5.0.0-beta.4](../../README.zh.md) / [Modules](../../modules.zh.md) / [item](../../modules/item.zh.md) / DiamondNode
 
 [item](../../modules/item.zh.md).DiamondNode
 

--- a/packages/site/docs/apis/classes/item/DonutNode.en.md
+++ b/packages/site/docs/apis/classes/item/DonutNode.en.md
@@ -2,7 +2,7 @@
 title: DonutNode
 ---
 
-[Overview - v5.0.0-beta.3](../../README.en.md) / [Modules](../../modules.en.md) / [item](../../modules/item.en.md) / DonutNode
+[Overview - v5.0.0-beta.4](../../README.en.md) / [Modules](../../modules.en.md) / [item](../../modules/item.en.md) / DonutNode
 
 [item](../../modules/item.en.md).DonutNode
 

--- a/packages/site/docs/apis/classes/item/DonutNode.zh.md
+++ b/packages/site/docs/apis/classes/item/DonutNode.zh.md
@@ -4,7 +4,7 @@ title: DonutNode
 
 > 📋 中文文档还在翻译中... 欢迎 PR
 
-[Overview - v5.0.0-beta.3](../../README.zh.md) / [Modules](../../modules.zh.md) / [item](../../modules/item.zh.md) / DonutNode
+[Overview - v5.0.0-beta.4](../../README.zh.md) / [Modules](../../modules.zh.md) / [item](../../modules/item.zh.md) / DonutNode
 
 [item](../../modules/item.zh.md).DonutNode
 

--- a/packages/site/docs/apis/classes/item/EllipseNode.en.md
+++ b/packages/site/docs/apis/classes/item/EllipseNode.en.md
@@ -2,7 +2,7 @@
 title: EllipseNode
 ---
 
-[Overview - v5.0.0-beta.3](../../README.en.md) / [Modules](../../modules.en.md) / [item](../../modules/item.en.md) / EllipseNode
+[Overview - v5.0.0-beta.4](../../README.en.md) / [Modules](../../modules.en.md) / [item](../../modules/item.en.md) / EllipseNode
 
 [item](../../modules/item.en.md).EllipseNode
 

--- a/packages/site/docs/apis/classes/item/EllipseNode.zh.md
+++ b/packages/site/docs/apis/classes/item/EllipseNode.zh.md
@@ -4,7 +4,7 @@ title: EllipseNode
 
 > 📋 中文文档还在翻译中... 欢迎 PR
 
-[Overview - v5.0.0-beta.3](../../README.zh.md) / [Modules](../../modules.zh.md) / [item](../../modules/item.zh.md) / EllipseNode
+[Overview - v5.0.0-beta.4](../../README.zh.md) / [Modules](../../modules.zh.md) / [item](../../modules/item.zh.md) / EllipseNode
 
 [item](../../modules/item.zh.md).EllipseNode
 

--- a/packages/site/docs/apis/classes/item/HexagonNode.en.md
+++ b/packages/site/docs/apis/classes/item/HexagonNode.en.md
@@ -2,7 +2,7 @@
 title: HexagonNode
 ---
 
-[Overview - v5.0.0-beta.3](../../README.en.md) / [Modules](../../modules.en.md) / [item](../../modules/item.en.md) / HexagonNode
+[Overview - v5.0.0-beta.4](../../README.en.md) / [Modules](../../modules.en.md) / [item](../../modules/item.en.md) / HexagonNode
 
 [item](../../modules/item.en.md).HexagonNode
 

--- a/packages/site/docs/apis/classes/item/HexagonNode.zh.md
+++ b/packages/site/docs/apis/classes/item/HexagonNode.zh.md
@@ -4,7 +4,7 @@ title: HexagonNode
 
 > 📋 中文文档还在翻译中... 欢迎 PR
 
-[Overview - v5.0.0-beta.3](../../README.zh.md) / [Modules](../../modules.zh.md) / [item](../../modules/item.zh.md) / HexagonNode
+[Overview - v5.0.0-beta.4](../../README.zh.md) / [Modules](../../modules.zh.md) / [item](../../modules/item.zh.md) / HexagonNode
 
 [item](../../modules/item.zh.md).HexagonNode
 

--- a/packages/site/docs/apis/classes/item/ModelRectNode.en.md
+++ b/packages/site/docs/apis/classes/item/ModelRectNode.en.md
@@ -2,7 +2,7 @@
 title: ModelRectNode
 ---
 
-[Overview - v5.0.0-beta.3](../../README.en.md) / [Modules](../../modules.en.md) / [item](../../modules/item.en.md) / ModelRectNode
+[Overview - v5.0.0-beta.4](../../README.en.md) / [Modules](../../modules.en.md) / [item](../../modules/item.en.md) / ModelRectNode
 
 [item](../../modules/item.en.md).ModelRectNode
 

--- a/packages/site/docs/apis/classes/item/ModelRectNode.zh.md
+++ b/packages/site/docs/apis/classes/item/ModelRectNode.zh.md
@@ -4,7 +4,7 @@ title: ModelRectNode
 
 > 📋 中文文档还在翻译中... 欢迎 PR
 
-[Overview - v5.0.0-beta.3](../../README.zh.md) / [Modules](../../modules.zh.md) / [item](../../modules/item.zh.md) / ModelRectNode
+[Overview - v5.0.0-beta.4](../../README.zh.md) / [Modules](../../modules.zh.md) / [item](../../modules/item.zh.md) / ModelRectNode
 
 [item](../../modules/item.zh.md).ModelRectNode
 

--- a/packages/site/docs/apis/classes/item/RectNode.en.md
+++ b/packages/site/docs/apis/classes/item/RectNode.en.md
@@ -2,7 +2,7 @@
 title: RectNode
 ---
 
-[Overview - v5.0.0-beta.3](../../README.en.md) / [Modules](../../modules.en.md) / [item](../../modules/item.en.md) / RectNode
+[Overview - v5.0.0-beta.4](../../README.en.md) / [Modules](../../modules.en.md) / [item](../../modules/item.en.md) / RectNode
 
 [item](../../modules/item.en.md).RectNode
 

--- a/packages/site/docs/apis/classes/item/RectNode.zh.md
+++ b/packages/site/docs/apis/classes/item/RectNode.zh.md
@@ -4,7 +4,7 @@ title: RectNode
 
 > 📋 中文文档还在翻译中... 欢迎 PR
 
-[Overview - v5.0.0-beta.3](../../README.zh.md) / [Modules](../../modules.zh.md) / [item](../../modules/item.zh.md) / RectNode
+[Overview - v5.0.0-beta.4](../../README.zh.md) / [Modules](../../modules.zh.md) / [item](../../modules/item.zh.md) / RectNode
 
 [item](../../modules/item.zh.md).RectNode
 

--- a/packages/site/docs/apis/classes/item/SphereNode.en.md
+++ b/packages/site/docs/apis/classes/item/SphereNode.en.md
@@ -2,7 +2,7 @@
 title: SphereNode
 ---
 
-[Overview - v5.0.0-beta.3](../../README.en.md) / [Modules](../../modules.en.md) / [item](../../modules/item.en.md) / SphereNode
+[Overview - v5.0.0-beta.4](../../README.en.md) / [Modules](../../modules.en.md) / [item](../../modules/item.en.md) / SphereNode
 
 [item](../../modules/item.en.md).SphereNode
 

--- a/packages/site/docs/apis/classes/item/SphereNode.zh.md
+++ b/packages/site/docs/apis/classes/item/SphereNode.zh.md
@@ -4,7 +4,7 @@ title: SphereNode
 
 > 📋 中文文档还在翻译中... 欢迎 PR
 
-[Overview - v5.0.0-beta.3](../../README.zh.md) / [Modules](../../modules.zh.md) / [item](../../modules/item.zh.md) / SphereNode
+[Overview - v5.0.0-beta.4](../../README.zh.md) / [Modules](../../modules.zh.md) / [item](../../modules/item.zh.md) / SphereNode
 
 [item](../../modules/item.zh.md).SphereNode
 

--- a/packages/site/docs/apis/classes/item/StarNode.en.md
+++ b/packages/site/docs/apis/classes/item/StarNode.en.md
@@ -2,7 +2,7 @@
 title: StarNode
 ---
 
-[Overview - v5.0.0-beta.3](../../README.en.md) / [Modules](../../modules.en.md) / [item](../../modules/item.en.md) / StarNode
+[Overview - v5.0.0-beta.4](../../README.en.md) / [Modules](../../modules.en.md) / [item](../../modules/item.en.md) / StarNode
 
 [item](../../modules/item.en.md).StarNode
 

--- a/packages/site/docs/apis/classes/item/StarNode.zh.md
+++ b/packages/site/docs/apis/classes/item/StarNode.zh.md
@@ -4,7 +4,7 @@ title: StarNode
 
 > 📋 中文文档还在翻译中... 欢迎 PR
 
-[Overview - v5.0.0-beta.3](../../README.zh.md) / [Modules](../../modules.zh.md) / [item](../../modules/item.zh.md) / StarNode
+[Overview - v5.0.0-beta.4](../../README.zh.md) / [Modules](../../modules.zh.md) / [item](../../modules/item.zh.md) / StarNode
 
 [item](../../modules/item.zh.md).StarNode
 

--- a/packages/site/docs/apis/classes/item/TriangleNode.en.md
+++ b/packages/site/docs/apis/classes/item/TriangleNode.en.md
@@ -2,7 +2,7 @@
 title: TriangleNode
 ---
 
-[Overview - v5.0.0-beta.3](../../README.en.md) / [Modules](../../modules.en.md) / [item](../../modules/item.en.md) / TriangleNode
+[Overview - v5.0.0-beta.4](../../README.en.md) / [Modules](../../modules.en.md) / [item](../../modules/item.en.md) / TriangleNode
 
 [item](../../modules/item.en.md).TriangleNode
 

--- a/packages/site/docs/apis/classes/item/TriangleNode.zh.md
+++ b/packages/site/docs/apis/classes/item/TriangleNode.zh.md
@@ -4,7 +4,7 @@ title: TriangleNode
 
 > 📋 中文文档还在翻译中... 欢迎 PR
 
-[Overview - v5.0.0-beta.3](../../README.zh.md) / [Modules](../../modules.zh.md) / [item](../../modules/item.zh.md) / TriangleNode
+[Overview - v5.0.0-beta.4](../../README.zh.md) / [Modules](../../modules.zh.md) / [item](../../modules/item.zh.md) / TriangleNode
 
 [item](../../modules/item.zh.md).TriangleNode
 

--- a/packages/site/docs/apis/enums/item/BadgePosition.en.md
+++ b/packages/site/docs/apis/enums/item/BadgePosition.en.md
@@ -2,7 +2,7 @@
 title: BadgePosition
 ---
 
-[Overview - v5.0.0-beta.3](../../README.en.md) / [Modules](../../modules.en.md) / [item](../../modules/item.en.md) / BadgePosition
+[Overview - v5.0.0-beta.4](../../README.en.md) / [Modules](../../modules.en.md) / [item](../../modules/item.en.md) / BadgePosition
 
 [item](../../modules/item.en.md).BadgePosition
 

--- a/packages/site/docs/apis/enums/item/BadgePosition.zh.md
+++ b/packages/site/docs/apis/enums/item/BadgePosition.zh.md
@@ -4,7 +4,7 @@ title: BadgePosition
 
 > 📋 中文文档还在翻译中... 欢迎 PR
 
-[Overview - v5.0.0-beta.3](../../README.zh.md) / [Modules](../../modules.zh.md) / [item](../../modules/item.zh.md) / BadgePosition
+[Overview - v5.0.0-beta.4](../../README.zh.md) / [Modules](../../modules.zh.md) / [item](../../modules/item.zh.md) / BadgePosition
 
 [item](../../modules/item.zh.md).BadgePosition
 

--- a/packages/site/docs/apis/interfaces/behaviors/ActivateRelationsOptions.en.md
+++ b/packages/site/docs/apis/interfaces/behaviors/ActivateRelationsOptions.en.md
@@ -2,7 +2,7 @@
 title: ActivateRelationsOptions
 ---
 
-[Overview - v5.0.0-beta.3](../../README.en.md) / [Modules](../../modules.en.md) / [behaviors](../../modules/behaviors.en.md) / ActivateRelationsOptions
+[Overview - v5.0.0-beta.4](../../README.en.md) / [Modules](../../modules.en.md) / [behaviors](../../modules/behaviors.en.md) / ActivateRelationsOptions
 
 [behaviors](../../modules/behaviors.en.md).ActivateRelationsOptions
 

--- a/packages/site/docs/apis/interfaces/behaviors/ActivateRelationsOptions.zh.md
+++ b/packages/site/docs/apis/interfaces/behaviors/ActivateRelationsOptions.zh.md
@@ -2,7 +2,7 @@
 title: ActivateRelationsOptions
 ---
 
-[Overview - v5.0.0-beta.3](../../README.zh.md) / [Modules](../../modules.zh.md) / [behaviors](../../modules/behaviors.zh.md) / ActivateRelationsOptions
+[Overview - v5.0.0-beta.4](../../README.zh.md) / [Modules](../../modules.zh.md) / [behaviors](../../modules/behaviors.zh.md) / ActivateRelationsOptions
 
 [behaviors](../../modules/behaviors.zh.md).ActivateRelationsOptions
 

--- a/packages/site/docs/apis/interfaces/behaviors/BrushSelectOptions.en.md
+++ b/packages/site/docs/apis/interfaces/behaviors/BrushSelectOptions.en.md
@@ -2,7 +2,7 @@
 title: BrushSelectOptions
 ---
 
-[Overview - v5.0.0-beta.3](../../README.en.md) / [Modules](../../modules.en.md) / [behaviors](../../modules/behaviors.en.md) / BrushSelectOptions
+[Overview - v5.0.0-beta.4](../../README.en.md) / [Modules](../../modules.en.md) / [behaviors](../../modules/behaviors.en.md) / BrushSelectOptions
 
 [behaviors](../../modules/behaviors.en.md).BrushSelectOptions
 

--- a/packages/site/docs/apis/interfaces/behaviors/BrushSelectOptions.zh.md
+++ b/packages/site/docs/apis/interfaces/behaviors/BrushSelectOptions.zh.md
@@ -2,7 +2,7 @@
 title: BrushSelectOptions
 ---
 
-[Overview - v5.0.0-beta.3](../../README.en.md) / [Modules](../../modules.en.md) / [behaviors](../../modules/behaviors.en.md) / BrushSelectOptions
+[Overview - v5.0.0-beta.4](../../README.en.md) / [Modules](../../modules.en.md) / [behaviors](../../modules/behaviors.en.md) / BrushSelectOptions
 
 [behaviors](../../modules/behaviors.en.md).BrushSelectOptions
 

--- a/packages/site/docs/apis/interfaces/behaviors/CollapseExpandComboOptions.en.md
+++ b/packages/site/docs/apis/interfaces/behaviors/CollapseExpandComboOptions.en.md
@@ -2,7 +2,7 @@
 title: CollapseExpandComboOptions
 ---
 
-[Overview - v5.0.0-beta.3](../../README.en.md) / [Modules](../../modules.en.md) / [behaviors](../../modules/behaviors.en.md) / CollapseExpandComboOptions
+[Overview - v5.0.0-beta.4](../../README.en.md) / [Modules](../../modules.en.md) / [behaviors](../../modules/behaviors.en.md) / CollapseExpandComboOptions
 
 [behaviors](../../modules/behaviors.en.md).CollapseExpandComboOptions
 

--- a/packages/site/docs/apis/interfaces/behaviors/CollapseExpandComboOptions.zh.md
+++ b/packages/site/docs/apis/interfaces/behaviors/CollapseExpandComboOptions.zh.md
@@ -2,7 +2,7 @@
 title: CollapseExpandComboOptions
 ---
 
-[Overview - v5.0.0-beta.3](../../README.en.md) / [Modules](../../modules.en.md) / [behaviors](../../modules/behaviors.en.md) / CollapseExpandComboOptions
+[Overview - v5.0.0-beta.4](../../README.en.md) / [Modules](../../modules.en.md) / [behaviors](../../modules/behaviors.en.md) / CollapseExpandComboOptions
 
 [behaviors](../../modules/behaviors.en.md).CollapseExpandComboOptions
 

--- a/packages/site/docs/apis/interfaces/behaviors/DragCanvasOptions.en.md
+++ b/packages/site/docs/apis/interfaces/behaviors/DragCanvasOptions.en.md
@@ -2,7 +2,7 @@
 title: DragCanvasOptions
 ---
 
-[Overview - v5.0.0-beta.3](../../README.en.md) / [Modules](../../modules.en.md) / [behaviors](../../modules/behaviors.en.md) / DragCanvasOptions
+[Overview - v5.0.0-beta.4](../../README.en.md) / [Modules](../../modules.en.md) / [behaviors](../../modules/behaviors.en.md) / DragCanvasOptions
 
 [behaviors](../../modules/behaviors.en.md).DragCanvasOptions
 

--- a/packages/site/docs/apis/interfaces/behaviors/DragCanvasOptions.zh.md
+++ b/packages/site/docs/apis/interfaces/behaviors/DragCanvasOptions.zh.md
@@ -2,7 +2,7 @@
 title: DragCanvasOptions
 ---
 
-[Overview - v5.0.0-beta.3](../../README.en.md) / [Modules](../../modules.en.md) / [behaviors](../../modules/behaviors.en.md) / DragCanvasOptions
+[Overview - v5.0.0-beta.4](../../README.en.md) / [Modules](../../modules.en.md) / [behaviors](../../modules/behaviors.en.md) / DragCanvasOptions
 
 [behaviors](../../modules/behaviors.en.md).DragCanvasOptions
 

--- a/packages/site/docs/apis/interfaces/behaviors/DragComboOptions.en.md
+++ b/packages/site/docs/apis/interfaces/behaviors/DragComboOptions.en.md
@@ -2,7 +2,7 @@
 title: DragComboOptions
 ---
 
-[Overview - v5.0.0-beta.3](../../README.en.md) / [Modules](../../modules.en.md) / [behaviors](../../modules/behaviors.en.md) / DragComboOptions
+[Overview - v5.0.0-beta.4](../../README.en.md) / [Modules](../../modules.en.md) / [behaviors](../../modules/behaviors.en.md) / DragComboOptions
 
 [behaviors](../../modules/behaviors.en.md).DragComboOptions
 

--- a/packages/site/docs/apis/interfaces/behaviors/DragComboOptions.zh.md
+++ b/packages/site/docs/apis/interfaces/behaviors/DragComboOptions.zh.md
@@ -2,7 +2,7 @@
 title: DragComboOptions
 ---
 
-[Overview - v5.0.0-beta.3](../../README.en.md) / [Modules](../../modules.en.md) / [behaviors](../../modules/behaviors.en.md) / DragComboOptions
+[Overview - v5.0.0-beta.4](../../README.en.md) / [Modules](../../modules.en.md) / [behaviors](../../modules/behaviors.en.md) / DragComboOptions
 
 [behaviors](../../modules/behaviors.en.md).DragComboOptions
 

--- a/packages/site/docs/apis/interfaces/behaviors/DragNodeOptions.en.md
+++ b/packages/site/docs/apis/interfaces/behaviors/DragNodeOptions.en.md
@@ -2,7 +2,7 @@
 title: DragNodeOptions
 ---
 
-[Overview - v5.0.0-beta.3](../../README.en.md) / [Modules](../../modules.en.md) / [behaviors](../../modules/behaviors.en.md) / DragNodeOptions
+[Overview - v5.0.0-beta.4](../../README.en.md) / [Modules](../../modules.en.md) / [behaviors](../../modules/behaviors.en.md) / DragNodeOptions
 
 [behaviors](../../modules/behaviors.en.md).DragNodeOptions
 

--- a/packages/site/docs/apis/interfaces/behaviors/DragNodeOptions.zh.md
+++ b/packages/site/docs/apis/interfaces/behaviors/DragNodeOptions.zh.md
@@ -2,7 +2,7 @@
 title: DragNodeOptions
 ---
 
-[Overview - v5.0.0-beta.3](../../README.en.md) / [Modules](../../modules.en.md) / [behaviors](../../modules/behaviors.en.md) / DragNodeOptions
+[Overview - v5.0.0-beta.4](../../README.en.md) / [Modules](../../modules.en.md) / [behaviors](../../modules/behaviors.en.md) / DragNodeOptions
 
 [behaviors](../../modules/behaviors.en.md).DragNodeOptions
 

--- a/packages/site/docs/apis/interfaces/behaviors/HoverActivateOptions.en.md
+++ b/packages/site/docs/apis/interfaces/behaviors/HoverActivateOptions.en.md
@@ -2,7 +2,7 @@
 title: HoverActivateOptions
 ---
 
-[Overview - v5.0.0-beta.3](../../README.en.md) / [Modules](../../modules.en.md) / [behaviors](../../modules/behaviors.en.md) / HoverActivateOptions
+[Overview - v5.0.0-beta.4](../../README.en.md) / [Modules](../../modules.en.md) / [behaviors](../../modules/behaviors.en.md) / HoverActivateOptions
 
 [behaviors](../../modules/behaviors.en.md).HoverActivateOptions
 

--- a/packages/site/docs/apis/interfaces/behaviors/HoverActivateOptions.zh.md
+++ b/packages/site/docs/apis/interfaces/behaviors/HoverActivateOptions.zh.md
@@ -2,7 +2,7 @@
 title: HoverActivateOptions
 ---
 
-[Overview - v5.0.0-beta.3](../../README.en.md) / [Modules](../../modules.en.md) / [behaviors](../../modules/behaviors.en.md) / HoverActivateOptions
+[Overview - v5.0.0-beta.4](../../README.en.md) / [Modules](../../modules.en.md) / [behaviors](../../modules/behaviors.en.md) / HoverActivateOptions
 
 [behaviors](../../modules/behaviors.en.md).HoverActivateOptions
 

--- a/packages/site/docs/apis/interfaces/behaviors/IG6GraphEvent.en.md
+++ b/packages/site/docs/apis/interfaces/behaviors/IG6GraphEvent.en.md
@@ -2,7 +2,7 @@
 title: IG6GraphEvent
 ---
 
-[Overview - v5.0.0-beta.3](../../README.en.md) / [Modules](../../modules.en.md) / [behaviors](../../modules/behaviors.en.md) / IG6GraphEvent
+[Overview - v5.0.0-beta.4](../../README.en.md) / [Modules](../../modules.en.md) / [behaviors](../../modules/behaviors.en.md) / IG6GraphEvent
 
 [behaviors](../../modules/behaviors.en.md).IG6GraphEvent
 

--- a/packages/site/docs/apis/interfaces/behaviors/Options.en.md
+++ b/packages/site/docs/apis/interfaces/behaviors/Options.en.md
@@ -2,7 +2,7 @@
 title: Options
 ---
 
-[Overview - v5.0.0-beta.3](../../README.en.md) / [Modules](../../modules.en.md) / [behaviors](../../modules/behaviors.en.md) / Options
+[Overview - v5.0.0-beta.4](../../README.en.md) / [Modules](../../modules.en.md) / [behaviors](../../modules/behaviors.en.md) / Options
 
 [behaviors](../../modules/behaviors.en.md).Options
 

--- a/packages/site/docs/apis/interfaces/behaviors/Options.zh.md
+++ b/packages/site/docs/apis/interfaces/behaviors/Options.zh.md
@@ -2,7 +2,7 @@
 title: Options
 ---
 
-[概述-v5.0.0-beta.3]（../../ readme.zh.md）/[模块]（../../ modules.zh.md）/[capingiors]（../。 ./modules/behaviors.zh.md）/options
+[概述-v5.0.0-beta.4]（../../ readme.zh.md）/[模块]（../../ modules.zh.md）/[capingiors]（../。 ./modules/behaviors.zh.md）/options
 
 [行为]（../../模块/cravicy.zh.md）.options
 

--- a/packages/site/docs/apis/interfaces/behaviors/OrbitCanvas3DOptions.en.md
+++ b/packages/site/docs/apis/interfaces/behaviors/OrbitCanvas3DOptions.en.md
@@ -2,7 +2,7 @@
 title: OrbitCanvas3DOptions
 ---
 
-[Overview - v5.0.0-beta.3](../../README.en.md) / [Modules](../../modules.en.md) / [behaviors](../../modules/behaviors.en.md) / OrbitCanvas3DOptions
+[Overview - v5.0.0-beta.4](../../README.en.md) / [Modules](../../modules.en.md) / [behaviors](../../modules/behaviors.en.md) / OrbitCanvas3DOptions
 
 [behaviors](../../modules/behaviors.en.md).OrbitCanvas3DOptions
 

--- a/packages/site/docs/apis/interfaces/behaviors/OrbitCanvas3DOptions.zh.md
+++ b/packages/site/docs/apis/interfaces/behaviors/OrbitCanvas3DOptions.zh.md
@@ -2,7 +2,7 @@
 title: OrbitCanvas3DOptions
 ---
 
-[概述-v5.0.0-beta.3]（../../ readme.zh.md）/[模块]（../../ modules.zh.md）/[capingiors]（../。 ./modules/behaviors.zh.md）/orbitcanvas3doptions
+[概述-v5.0.0-beta.4]（../../ readme.zh.md）/[模块]（../../ modules.zh.md）/[capingiors]（../。 ./modules/behaviors.zh.md）/orbitcanvas3doptions
 
 [行为]（../../模块/bepand.zh.md）.orbitcanvas3doptions
 

--- a/packages/site/docs/apis/interfaces/behaviors/RotateCanvas3DOptions.en.md
+++ b/packages/site/docs/apis/interfaces/behaviors/RotateCanvas3DOptions.en.md
@@ -2,7 +2,7 @@
 title: RotateCanvas3DOptions
 ---
 
-[Overview - v5.0.0-beta.3](../../README.en.md) / [Modules](../../modules.en.md) / [behaviors](../../modules/behaviors.en.md) / RotateCanvas3DOptions
+[Overview - v5.0.0-beta.4](../../README.en.md) / [Modules](../../modules.en.md) / [behaviors](../../modules/behaviors.en.md) / RotateCanvas3DOptions
 
 [behaviors](../../modules/behaviors.en.md).RotateCanvas3DOptions
 

--- a/packages/site/docs/apis/interfaces/behaviors/RotateCanvas3DOptions.zh.md
+++ b/packages/site/docs/apis/interfaces/behaviors/RotateCanvas3DOptions.zh.md
@@ -2,7 +2,7 @@
 title: RotateCanvas3DOptions
 ---
 
-[概述-v5.0.0-beta.3]（../../ readme.zh.md）/[模块]（../../ modules.zh.md）/[capingiors]（../。 ./modules/behaviors.zh.md）/rotatecanvas3doptions
+[概述-v5.0.0-beta.4]（../../ readme.zh.md）/[模块]（../../ modules.zh.md）/[capingiors]（../。 ./modules/behaviors.zh.md）/rotatecanvas3doptions
 
 [行为]（../../模块/cravuciors.zh.md）.rotatecanvas3doptions
 

--- a/packages/site/docs/apis/interfaces/behaviors/TrackCanvas3DOptions.en.md
+++ b/packages/site/docs/apis/interfaces/behaviors/TrackCanvas3DOptions.en.md
@@ -2,7 +2,7 @@
 title: TrackCanvas3DOptions
 ---
 
-[Overview - v5.0.0-beta.3](../../README.en.md) / [Modules](../../modules.en.md) / [behaviors](../../modules/behaviors.en.md) / TrackCanvas3DOptions
+[Overview - v5.0.0-beta.4](../../README.en.md) / [Modules](../../modules.en.md) / [behaviors](../../modules/behaviors.en.md) / TrackCanvas3DOptions
 
 [behaviors](../../modules/behaviors.en.md).TrackCanvas3DOptions
 

--- a/packages/site/docs/apis/interfaces/behaviors/TrackCanvas3DOptions.zh.md
+++ b/packages/site/docs/apis/interfaces/behaviors/TrackCanvas3DOptions.zh.md
@@ -2,7 +2,7 @@
 title: TrackCanvas3DOptions
 ---
 
-[概述-v5.0.0-beta.3]（../../ readme.zh.md）/[模块]（../../ modules.zh.md）/[capingiors]（../。 ./modules/behaviors.zh.md）/trackcanvas3doptions
+[概述-v5.0.0-beta.4]（../../ readme.zh.md）/[模块]（../../ modules.zh.md）/[capingiors]（../。 ./modules/behaviors.zh.md）/trackcanvas3doptions
 
 [行为]（../../模块/bepandiors.zh.md）.trackcanvas3doptions
 

--- a/packages/site/docs/apis/interfaces/behaviors/ZoomCanvas3DOptions.en.md
+++ b/packages/site/docs/apis/interfaces/behaviors/ZoomCanvas3DOptions.en.md
@@ -2,7 +2,7 @@
 title: ZoomCanvas3DOptions
 ---
 
-[Overview - v5.0.0-beta.3](../../README.en.md) / [Modules](../../modules.en.md) / [behaviors](../../modules/behaviors.en.md) / ZoomCanvas3DOptions
+[Overview - v5.0.0-beta.4](../../README.en.md) / [Modules](../../modules.en.md) / [behaviors](../../modules/behaviors.en.md) / ZoomCanvas3DOptions
 
 [behaviors](../../modules/behaviors.en.md).ZoomCanvas3DOptions
 

--- a/packages/site/docs/apis/interfaces/behaviors/ZoomCanvas3DOptions.zh.md
+++ b/packages/site/docs/apis/interfaces/behaviors/ZoomCanvas3DOptions.zh.md
@@ -2,7 +2,7 @@
 title: ZoomCanvas3DOptions
 ---
 
-[概述-v5.0.0-beta.3]（../../ readme.zh.md）/[模块]（../../ modules.zh.md）/[capingiors]（../。 ./modules/behaviors.zh.md）/zoomcanvas3doptions
+[概述-v5.0.0-beta.4]（../../ readme.zh.md）/[模块]（../../ modules.zh.md）/[capingiors]（../。 ./modules/behaviors.zh.md）/zoomcanvas3doptions
 
 [行为]（../../模块/bepandiors.zh.md）.zoomcanvas3doptions
 

--- a/packages/site/docs/apis/interfaces/behaviors/ZoomCanvasOptions.en.md
+++ b/packages/site/docs/apis/interfaces/behaviors/ZoomCanvasOptions.en.md
@@ -2,7 +2,7 @@
 title: ZoomCanvasOptions
 ---
 
-[Overview - v5.0.0-beta.3](../../README.en.md) / [Modules](../../modules.en.md) / [behaviors](../../modules/behaviors.en.md) / ZoomCanvasOptions
+[Overview - v5.0.0-beta.4](../../README.en.md) / [Modules](../../modules.en.md) / [behaviors](../../modules/behaviors.en.md) / ZoomCanvasOptions
 
 [behaviors](../../modules/behaviors.en.md).ZoomCanvasOptions
 

--- a/packages/site/docs/apis/interfaces/behaviors/ZoomCanvasOptions.zh.md
+++ b/packages/site/docs/apis/interfaces/behaviors/ZoomCanvasOptions.zh.md
@@ -2,7 +2,7 @@
 title: ZoomCanvasOptions
 ---
 
-[概述-v5.0.0-beta.3]（../../ readme.zh.md）/[模块]（../../ modules.zh.md）/[capingiors]（../。 ./modules/behaviors.zh.md）/zoomcanvasoptions
+[概述-v5.0.0-beta.4]（../../ readme.zh.md）/[模块]（../../ modules.zh.md）/[capingiors]（../。 ./modules/behaviors.zh.md）/zoomcanvasoptions
 
 [行为]（../../模块/bepand.zh.md）.zoomcanvasoptions
 

--- a/packages/site/docs/apis/interfaces/graph/GraphData.en.md
+++ b/packages/site/docs/apis/interfaces/graph/GraphData.en.md
@@ -2,7 +2,7 @@
 title: GraphData
 ---
 
-[Overview - v5.0.0-beta.3](../../README.en.md) / [Modules](../../modules.en.md) / [graph](../../modules/graph.en.md) / GraphData
+[Overview - v5.0.0-beta.4](../../README.en.md) / [Modules](../../modules.en.md) / [graph](../../modules/graph.en.md) / GraphData
 
 [graph](../../modules/graph.en.md).GraphData
 

--- a/packages/site/docs/apis/interfaces/graph/GraphData.zh.md
+++ b/packages/site/docs/apis/interfaces/graph/GraphData.zh.md
@@ -4,7 +4,7 @@ title: GraphData
 
 > 📋 中文文档还在翻译中... 欢迎 PR
 
-[Overview - v5.0.0-beta.3](../../README.zh.md) / [Modules](../../modules.zh.md) / [graph](../../modules/graph.zh.md) / GraphData
+[Overview - v5.0.0-beta.4](../../README.zh.md) / [Modules](../../modules.zh.md) / [graph](../../modules/graph.zh.md) / GraphData
 
 [graph](../../modules/graph.zh.md).GraphData
 

--- a/packages/site/docs/apis/interfaces/graph/IGraph.en.md
+++ b/packages/site/docs/apis/interfaces/graph/IGraph.en.md
@@ -2,7 +2,7 @@
 title: IGraph
 ---
 
-[Overview - v5.0.0-beta.3](../../README.en.md) / [Modules](../../modules.en.md) / [graph](../../modules/graph.en.md) / IGraph
+[Overview - v5.0.0-beta.4](../../README.en.md) / [Modules](../../modules.en.md) / [graph](../../modules/graph.en.md) / IGraph
 
 [graph](../../modules/graph.en.md).IGraph
 

--- a/packages/site/docs/apis/interfaces/graph/IGraph.zh.md
+++ b/packages/site/docs/apis/interfaces/graph/IGraph.zh.md
@@ -4,7 +4,7 @@ title: IGraph
 
 > 📋 中文文档还在翻译中... 欢迎 PR
 
-[Overview - v5.0.0-beta.3](../../README.zh.md) / [Modules](../../modules.zh.md) / [graph](../../modules/graph.zh.md) / IGraph
+[Overview - v5.0.0-beta.4](../../README.zh.md) / [Modules](../../modules.zh.md) / [graph](../../modules/graph.zh.md) / IGraph
 
 [graph](../../modules/graph.zh.md).IGraph
 

--- a/packages/site/docs/apis/interfaces/graph/Specification.en.md
+++ b/packages/site/docs/apis/interfaces/graph/Specification.en.md
@@ -2,7 +2,7 @@
 title: Specification
 ---
 
-[Overview - v5.0.0-beta.3](../../README.en.md) / [Modules](../../modules.en.md) / [graph](../../modules/graph.en.md) / Specification
+[Overview - v5.0.0-beta.4](../../README.en.md) / [Modules](../../modules.en.md) / [graph](../../modules/graph.en.md) / Specification
 
 [graph](../../modules/graph.en.md).Specification
 

--- a/packages/site/docs/apis/interfaces/graph/Specification.zh.md
+++ b/packages/site/docs/apis/interfaces/graph/Specification.zh.md
@@ -4,7 +4,7 @@ title: Specification
 
 > 📋 中文文档还在翻译中... 欢迎 PR
 
-[Overview - v5.0.0-beta.3](../../README.zh.md) / [Modules](../../modules.zh.md) / [graph](../../modules/graph.zh.md) / Specification
+[Overview - v5.0.0-beta.4](../../README.zh.md) / [Modules](../../modules.zh.md) / [graph](../../modules/graph.zh.md) / Specification
 
 [graph](../../modules/graph.zh.md).Specification
 

--- a/packages/site/docs/apis/interfaces/item/CircleStyleProps.en.md
+++ b/packages/site/docs/apis/interfaces/item/CircleStyleProps.en.md
@@ -2,7 +2,7 @@
 title: CircleStyleProps
 ---
 
-[Overview - v5.0.0-beta.3](../../README.en.md) / [Modules](../../modules.en.md) / [item](../../modules/item.en.md) / CircleStyleProps
+[Overview - v5.0.0-beta.4](../../README.en.md) / [Modules](../../modules.en.md) / [item](../../modules/item.en.md) / CircleStyleProps
 
 [item](../../modules/item.en.md).CircleStyleProps
 

--- a/packages/site/docs/apis/interfaces/item/CircleStyleProps.zh.md
+++ b/packages/site/docs/apis/interfaces/item/CircleStyleProps.zh.md
@@ -4,7 +4,7 @@ title: CircleStyleProps
 
 > 📋 中文文档还在翻译中... 欢迎 PR
 
-[Overview - v5.0.0-beta.3](../../README.zh.md) / [Modules](../../modules.zh.md) / [item](../../modules/item.zh.md) / CircleStyleProps
+[Overview - v5.0.0-beta.4](../../README.zh.md) / [Modules](../../modules.zh.md) / [item](../../modules/item.zh.md) / CircleStyleProps
 
 [item](../../modules/item.zh.md).CircleStyleProps
 

--- a/packages/site/docs/apis/interfaces/item/CubeGeometryProps.en.md
+++ b/packages/site/docs/apis/interfaces/item/CubeGeometryProps.en.md
@@ -2,7 +2,7 @@
 title: CubeGeometryProps
 ---
 
-[Overview - v5.0.0-beta.3](../../README.en.md) / [Modules](../../modules.en.md) / [item](../../modules/item.en.md) / CubeGeometryProps
+[Overview - v5.0.0-beta.4](../../README.en.md) / [Modules](../../modules.en.md) / [item](../../modules/item.en.md) / CubeGeometryProps
 
 [item](../../modules/item.en.md).CubeGeometryProps
 

--- a/packages/site/docs/apis/interfaces/item/CubeGeometryProps.zh.md
+++ b/packages/site/docs/apis/interfaces/item/CubeGeometryProps.zh.md
@@ -4,7 +4,7 @@ title: CubeGeometryProps
 
 > 📋 中文文档还在翻译中... 欢迎 PR
 
-[Overview - v5.0.0-beta.3](../../README.zh.md) / [Modules](../../modules.zh.md) / [item](../../modules/item.zh.md) / CubeGeometryProps
+[Overview - v5.0.0-beta.4](../../README.zh.md) / [Modules](../../modules.zh.md) / [item](../../modules/item.zh.md) / CubeGeometryProps
 
 [item](../../modules/item.zh.md).CubeGeometryProps
 

--- a/packages/site/docs/apis/interfaces/item/EllipseStyleProps.en.md
+++ b/packages/site/docs/apis/interfaces/item/EllipseStyleProps.en.md
@@ -2,7 +2,7 @@
 title: EllipseStyleProps
 ---
 
-[Overview - v5.0.0-beta.3](../../README.en.md) / [Modules](../../modules.en.md) / [item](../../modules/item.en.md) / EllipseStyleProps
+[Overview - v5.0.0-beta.4](../../README.en.md) / [Modules](../../modules.en.md) / [item](../../modules/item.en.md) / EllipseStyleProps
 
 [item](../../modules/item.en.md).EllipseStyleProps
 

--- a/packages/site/docs/apis/interfaces/item/EllipseStyleProps.zh.md
+++ b/packages/site/docs/apis/interfaces/item/EllipseStyleProps.zh.md
@@ -4,7 +4,7 @@ title: EllipseStyleProps
 
 > 📋 中文文档还在翻译中... 欢迎 PR
 
-[Overview - v5.0.0-beta.3](../../README.zh.md) / [Modules](../../modules.zh.md) / [item](../../modules/item.zh.md) / EllipseStyleProps
+[Overview - v5.0.0-beta.4](../../README.zh.md) / [Modules](../../modules.zh.md) / [item](../../modules/item.zh.md) / EllipseStyleProps
 
 [item](../../modules/item.zh.md).EllipseStyleProps
 

--- a/packages/site/docs/apis/interfaces/item/IAnchorPositionMap.en.md
+++ b/packages/site/docs/apis/interfaces/item/IAnchorPositionMap.en.md
@@ -2,7 +2,7 @@
 title: IAnchorPositionMap
 ---
 
-[Overview - v5.0.0-beta.3](../../README.en.md) / [Modules](../../modules.en.md) / [item](../../modules/item.en.md) / IAnchorPositionMap
+[Overview - v5.0.0-beta.4](../../README.en.md) / [Modules](../../modules.en.md) / [item](../../modules/item.en.md) / IAnchorPositionMap
 
 [item](../../modules/item.en.md).IAnchorPositionMap
 

--- a/packages/site/docs/apis/interfaces/item/IAnchorPositionMap.zh.md
+++ b/packages/site/docs/apis/interfaces/item/IAnchorPositionMap.zh.md
@@ -4,7 +4,7 @@ title: IAnchorPositionMap
 
 > 📋 中文文档还在翻译中... 欢迎 PR
 
-[Overview - v5.0.0-beta.3](../../README.zh.md) / [Modules](../../modules.zh.md) / [item](../../modules/item.zh.md) / IAnchorPositionMap
+[Overview - v5.0.0-beta.4](../../README.zh.md) / [Modules](../../modules.zh.md) / [item](../../modules/item.zh.md) / IAnchorPositionMap
 
 [item](../../modules/item.zh.md).IAnchorPositionMap
 

--- a/packages/site/docs/apis/interfaces/item/ImageStyleProps.en.md
+++ b/packages/site/docs/apis/interfaces/item/ImageStyleProps.en.md
@@ -2,7 +2,7 @@
 title: ImageStyleProps
 ---
 
-[Overview - v5.0.0-beta.3](../../README.en.md) / [Modules](../../modules.en.md) / [item](../../modules/item.en.md) / ImageStyleProps
+[Overview - v5.0.0-beta.4](../../README.en.md) / [Modules](../../modules.en.md) / [item](../../modules/item.en.md) / ImageStyleProps
 
 [item](../../modules/item.en.md).ImageStyleProps
 

--- a/packages/site/docs/apis/interfaces/item/ImageStyleProps.zh.md
+++ b/packages/site/docs/apis/interfaces/item/ImageStyleProps.zh.md
@@ -4,7 +4,7 @@ title: ImageStyleProps
 
 > 📋 中文文档还在翻译中... 欢迎 PR
 
-[Overview - v5.0.0-beta.3](../../README.zh.md) / [Modules](../../modules.zh.md) / [item](../../modules/item.zh.md) / ImageStyleProps
+[Overview - v5.0.0-beta.4](../../README.zh.md) / [Modules](../../modules.zh.md) / [item](../../modules/item.zh.md) / ImageStyleProps
 
 [item](../../modules/item.zh.md).ImageStyleProps
 

--- a/packages/site/docs/apis/interfaces/item/LineStyleProps.en.md
+++ b/packages/site/docs/apis/interfaces/item/LineStyleProps.en.md
@@ -2,7 +2,7 @@
 title: LineStyleProps
 ---
 
-[Overview - v5.0.0-beta.3](../../README.en.md) / [Modules](../../modules.en.md) / [item](../../modules/item.en.md) / LineStyleProps
+[Overview - v5.0.0-beta.4](../../README.en.md) / [Modules](../../modules.en.md) / [item](../../modules/item.en.md) / LineStyleProps
 
 [item](../../modules/item.en.md).LineStyleProps
 

--- a/packages/site/docs/apis/interfaces/item/LineStyleProps.zh.md
+++ b/packages/site/docs/apis/interfaces/item/LineStyleProps.zh.md
@@ -4,7 +4,7 @@ title: LineStyleProps
 
 > 📋 中文文档还在翻译中... 欢迎 PR
 
-[Overview - v5.0.0-beta.3](../../README.zh.md) / [Modules](../../modules.zh.md) / [item](../../modules/item.zh.md) / LineStyleProps
+[Overview - v5.0.0-beta.4](../../README.zh.md) / [Modules](../../modules.zh.md) / [item](../../modules/item.zh.md) / LineStyleProps
 
 [item](../../modules/item.zh.md).LineStyleProps
 

--- a/packages/site/docs/apis/interfaces/item/NodeShapeStyles.en.md
+++ b/packages/site/docs/apis/interfaces/item/NodeShapeStyles.en.md
@@ -2,7 +2,7 @@
 title: NodeShapeStyles
 ---
 
-[Overview - v5.0.0-beta.3](../../README.en.md) / [Modules](../../modules.en.md) / [item](../../modules/item.en.md) / NodeShapeStyles
+[Overview - v5.0.0-beta.4](../../README.en.md) / [Modules](../../modules.en.md) / [item](../../modules/item.en.md) / NodeShapeStyles
 
 [item](../../modules/item.en.md).NodeShapeStyles
 

--- a/packages/site/docs/apis/interfaces/item/NodeShapeStyles.zh.md
+++ b/packages/site/docs/apis/interfaces/item/NodeShapeStyles.zh.md
@@ -4,7 +4,7 @@ title: NodeShapeStyles
 
 > 📋 中文文档还在翻译中... 欢迎 PR
 
-[Overview - v5.0.0-beta.3](../../README.zh.md) / [Modules](../../modules.zh.md) / [item](../../modules/item.zh.md) / NodeShapeStyles
+[Overview - v5.0.0-beta.4](../../README.zh.md) / [Modules](../../modules.zh.md) / [item](../../modules/item.zh.md) / NodeShapeStyles
 
 [item](../../modules/item.zh.md).NodeShapeStyles
 

--- a/packages/site/docs/apis/interfaces/item/NodeUserModelData.en.md
+++ b/packages/site/docs/apis/interfaces/item/NodeUserModelData.en.md
@@ -2,7 +2,7 @@
 title: NodeUserModelData
 ---
 
-[Overview - v5.0.0-beta.3](../../README.en.md) / [Modules](../../modules.en.md) / [item](../../modules/item.en.md) / NodeUserModelData
+[Overview - v5.0.0-beta.4](../../README.en.md) / [Modules](../../modules.en.md) / [item](../../modules/item.en.md) / NodeUserModelData
 
 [item](../../modules/item.en.md).NodeUserModelData
 

--- a/packages/site/docs/apis/interfaces/item/NodeUserModelData.zh.md
+++ b/packages/site/docs/apis/interfaces/item/NodeUserModelData.zh.md
@@ -4,7 +4,7 @@ title: NodeUserModelData
 
 > 📋 中文文档还在翻译中... 欢迎 PR
 
-[Overview - v5.0.0-beta.3](../../README.zh.md) / [Modules](../../modules.zh.md) / [item](../../modules/item.zh.md) / NodeUserModelData
+[Overview - v5.0.0-beta.4](../../README.zh.md) / [Modules](../../modules.zh.md) / [item](../../modules/item.zh.md) / NodeUserModelData
 
 [item](../../modules/item.zh.md).NodeUserModelData
 

--- a/packages/site/docs/apis/interfaces/item/PathStyleProps.en.md
+++ b/packages/site/docs/apis/interfaces/item/PathStyleProps.en.md
@@ -2,7 +2,7 @@
 title: PathStyleProps
 ---
 
-[Overview - v5.0.0-beta.3](../../README.en.md) / [Modules](../../modules.en.md) / [item](../../modules/item.en.md) / PathStyleProps
+[Overview - v5.0.0-beta.4](../../README.en.md) / [Modules](../../modules.en.md) / [item](../../modules/item.en.md) / PathStyleProps
 
 [item](../../modules/item.en.md).PathStyleProps
 

--- a/packages/site/docs/apis/interfaces/item/PathStyleProps.zh.md
+++ b/packages/site/docs/apis/interfaces/item/PathStyleProps.zh.md
@@ -4,7 +4,7 @@ title: PathStyleProps
 
 > 📋 中文文档还在翻译中... 欢迎 PR
 
-[Overview - v5.0.0-beta.3](../../README.zh.md) / [Modules](../../modules.zh.md) / [item](../../modules/item.zh.md) / PathStyleProps
+[Overview - v5.0.0-beta.4](../../README.zh.md) / [Modules](../../modules.zh.md) / [item](../../modules/item.zh.md) / PathStyleProps
 
 [item](../../modules/item.zh.md).PathStyleProps
 

--- a/packages/site/docs/apis/interfaces/item/PlaneGeometryProps.en.md
+++ b/packages/site/docs/apis/interfaces/item/PlaneGeometryProps.en.md
@@ -2,7 +2,7 @@
 title: PlaneGeometryProps
 ---
 
-[Overview - v5.0.0-beta.3](../../README.en.md) / [Modules](../../modules.en.md) / [item](../../modules/item.en.md) / PlaneGeometryProps
+[Overview - v5.0.0-beta.4](../../README.en.md) / [Modules](../../modules.en.md) / [item](../../modules/item.en.md) / PlaneGeometryProps
 
 [item](../../modules/item.en.md).PlaneGeometryProps
 

--- a/packages/site/docs/apis/interfaces/item/PlaneGeometryProps.zh.md
+++ b/packages/site/docs/apis/interfaces/item/PlaneGeometryProps.zh.md
@@ -4,7 +4,7 @@ title: PlaneGeometryProps
 
 > 📋 中文文档还在翻译中... 欢迎 PR
 
-[Overview - v5.0.0-beta.3](../../README.zh.md) / [Modules](../../modules.zh.md) / [item](../../modules/item.zh.md) / PlaneGeometryProps
+[Overview - v5.0.0-beta.4](../../README.zh.md) / [Modules](../../modules.zh.md) / [item](../../modules/item.zh.md) / PlaneGeometryProps
 
 [item](../../modules/item.zh.md).PlaneGeometryProps
 

--- a/packages/site/docs/apis/interfaces/item/PolygonStyleProps.en.md
+++ b/packages/site/docs/apis/interfaces/item/PolygonStyleProps.en.md
@@ -2,7 +2,7 @@
 title: PolygonStyleProps
 ---
 
-[Overview - v5.0.0-beta.3](../../README.en.md) / [Modules](../../modules.en.md) / [item](../../modules/item.en.md) / PolygonStyleProps
+[Overview - v5.0.0-beta.4](../../README.en.md) / [Modules](../../modules.en.md) / [item](../../modules/item.en.md) / PolygonStyleProps
 
 [item](../../modules/item.en.md).PolygonStyleProps
 

--- a/packages/site/docs/apis/interfaces/item/PolygonStyleProps.zh.md
+++ b/packages/site/docs/apis/interfaces/item/PolygonStyleProps.zh.md
@@ -4,7 +4,7 @@ title: PolygonStyleProps
 
 > 📋 中文文档还在翻译中... 欢迎 PR
 
-[Overview - v5.0.0-beta.3](../../README.zh.md) / [Modules](../../modules.zh.md) / [item](../../modules/item.zh.md) / PolygonStyleProps
+[Overview - v5.0.0-beta.4](../../README.zh.md) / [Modules](../../modules.zh.md) / [item](../../modules/item.zh.md) / PolygonStyleProps
 
 [item](../../modules/item.zh.md).PolygonStyleProps
 

--- a/packages/site/docs/apis/interfaces/item/PolylineStyleProps.en.md
+++ b/packages/site/docs/apis/interfaces/item/PolylineStyleProps.en.md
@@ -2,7 +2,7 @@
 title: PolylineStyleProps
 ---
 
-[Overview - v5.0.0-beta.3](../../README.en.md) / [Modules](../../modules.en.md) / [item](../../modules/item.en.md) / PolylineStyleProps
+[Overview - v5.0.0-beta.4](../../README.en.md) / [Modules](../../modules.en.md) / [item](../../modules/item.en.md) / PolylineStyleProps
 
 [item](../../modules/item.en.md).PolylineStyleProps
 

--- a/packages/site/docs/apis/interfaces/item/PolylineStyleProps.zh.md
+++ b/packages/site/docs/apis/interfaces/item/PolylineStyleProps.zh.md
@@ -4,7 +4,7 @@ title: PolylineStyleProps
 
 > 📋 中文文档还在翻译中... 欢迎 PR
 
-[Overview - v5.0.0-beta.3](../../README.zh.md) / [Modules](../../modules.zh.md) / [item](../../modules/item.zh.md) / PolylineStyleProps
+[Overview - v5.0.0-beta.4](../../README.zh.md) / [Modules](../../modules.zh.md) / [item](../../modules/item.zh.md) / PolylineStyleProps
 
 [item](../../modules/item.zh.md).PolylineStyleProps
 

--- a/packages/site/docs/apis/interfaces/item/RectStyleProps.en.md
+++ b/packages/site/docs/apis/interfaces/item/RectStyleProps.en.md
@@ -2,7 +2,7 @@
 title: RectStyleProps
 ---
 
-[Overview - v5.0.0-beta.3](../../README.en.md) / [Modules](../../modules.en.md) / [item](../../modules/item.en.md) / RectStyleProps
+[Overview - v5.0.0-beta.4](../../README.en.md) / [Modules](../../modules.en.md) / [item](../../modules/item.en.md) / RectStyleProps
 
 [item](../../modules/item.en.md).RectStyleProps
 

--- a/packages/site/docs/apis/interfaces/item/RectStyleProps.zh.md
+++ b/packages/site/docs/apis/interfaces/item/RectStyleProps.zh.md
@@ -4,7 +4,7 @@ title: RectStyleProps
 
 > 📋 中文文档还在翻译中... 欢迎 PR
 
-[Overview - v5.0.0-beta.3](../../README.zh.md) / [Modules](../../modules.zh.md) / [item](../../modules/item.zh.md) / RectStyleProps
+[Overview - v5.0.0-beta.4](../../README.zh.md) / [Modules](../../modules.zh.md) / [item](../../modules/item.zh.md) / RectStyleProps
 
 [item](../../modules/item.zh.md).RectStyleProps
 

--- a/packages/site/docs/apis/interfaces/item/SphereGeometryProps.en.md
+++ b/packages/site/docs/apis/interfaces/item/SphereGeometryProps.en.md
@@ -2,7 +2,7 @@
 title: SphereGeometryProps
 ---
 
-[Overview - v5.0.0-beta.3](../../README.en.md) / [Modules](../../modules.en.md) / [item](../../modules/item.en.md) / SphereGeometryProps
+[Overview - v5.0.0-beta.4](../../README.en.md) / [Modules](../../modules.en.md) / [item](../../modules/item.en.md) / SphereGeometryProps
 
 [item](../../modules/item.en.md).SphereGeometryProps
 

--- a/packages/site/docs/apis/interfaces/item/SphereGeometryProps.zh.md
+++ b/packages/site/docs/apis/interfaces/item/SphereGeometryProps.zh.md
@@ -4,7 +4,7 @@ title: SphereGeometryProps
 
 > 📋 中文文档还在翻译中... 欢迎 PR
 
-[Overview - v5.0.0-beta.3](../../README.zh.md) / [Modules](../../modules.zh.md) / [item](../../modules/item.zh.md) / SphereGeometryProps
+[Overview - v5.0.0-beta.4](../../README.zh.md) / [Modules](../../modules.zh.md) / [item](../../modules/item.zh.md) / SphereGeometryProps
 
 [item](../../modules/item.zh.md).SphereGeometryProps
 

--- a/packages/site/docs/apis/interfaces/item/TextStyleProps.en.md
+++ b/packages/site/docs/apis/interfaces/item/TextStyleProps.en.md
@@ -2,7 +2,7 @@
 title: TextStyleProps
 ---
 
-[Overview - v5.0.0-beta.3](../../README.en.md) / [Modules](../../modules.en.md) / [item](../../modules/item.en.md) / TextStyleProps
+[Overview - v5.0.0-beta.4](../../README.en.md) / [Modules](../../modules.en.md) / [item](../../modules/item.en.md) / TextStyleProps
 
 [item](../../modules/item.en.md).TextStyleProps
 

--- a/packages/site/docs/apis/interfaces/item/TextStyleProps.zh.md
+++ b/packages/site/docs/apis/interfaces/item/TextStyleProps.zh.md
@@ -4,7 +4,7 @@ title: TextStyleProps
 
 > 📋 中文文档还在翻译中... 欢迎 PR
 
-[Overview - v5.0.0-beta.3](../../README.zh.md) / [Modules](../../modules.zh.md) / [item](../../modules/item.zh.md) / TextStyleProps
+[Overview - v5.0.0-beta.4](../../README.zh.md) / [Modules](../../modules.zh.md) / [item](../../modules/item.zh.md) / TextStyleProps
 
 [item](../../modules/item.zh.md).TextStyleProps
 

--- a/packages/site/docs/apis/interfaces/item/TorusGeometryProps.en.md
+++ b/packages/site/docs/apis/interfaces/item/TorusGeometryProps.en.md
@@ -2,7 +2,7 @@
 title: TorusGeometryProps
 ---
 
-[Overview - v5.0.0-beta.3](../../README.en.md) / [Modules](../../modules.en.md) / [item](../../modules/item.en.md) / TorusGeometryProps
+[Overview - v5.0.0-beta.4](../../README.en.md) / [Modules](../../modules.en.md) / [item](../../modules/item.en.md) / TorusGeometryProps
 
 [item](../../modules/item.en.md).TorusGeometryProps
 

--- a/packages/site/docs/apis/interfaces/item/TorusGeometryProps.zh.md
+++ b/packages/site/docs/apis/interfaces/item/TorusGeometryProps.zh.md
@@ -4,7 +4,7 @@ title: TorusGeometryProps
 
 > 📋 中文文档还在翻译中... 欢迎 PR
 
-[Overview - v5.0.0-beta.3](../../README.zh.md) / [Modules](../../modules.zh.md) / [item](../../modules/item.zh.md) / TorusGeometryProps
+[Overview - v5.0.0-beta.4](../../README.zh.md) / [Modules](../../modules.zh.md) / [item](../../modules/item.zh.md) / TorusGeometryProps
 
 [item](../../modules/item.zh.md).TorusGeometryProps
 

--- a/packages/site/docs/apis/interfaces/layout/CircularLayoutOptions.en.md
+++ b/packages/site/docs/apis/interfaces/layout/CircularLayoutOptions.en.md
@@ -2,7 +2,7 @@
 title: CircularLayoutOptions
 ---
 
-[Overview - v5.0.0-beta.3](../../README.en.md) / [Modules](../../modules.en.md) / [layout](../../modules/layout.en.md) / CircularLayoutOptions
+[Overview - v5.0.0-beta.4](../../README.en.md) / [Modules](../../modules.en.md) / [layout](../../modules/layout.en.md) / CircularLayoutOptions
 
 [layout](../../modules/layout.en.md).CircularLayoutOptions
 

--- a/packages/site/docs/apis/interfaces/layout/CircularLayoutOptions.zh.md
+++ b/packages/site/docs/apis/interfaces/layout/CircularLayoutOptions.zh.md
@@ -4,7 +4,7 @@ title: CircularLayoutOptions
 
 > 📋 中文文档还在翻译中... 欢迎 PR
 
-[Overview - v5.0.0-beta.3](../../README.zh.md) / [Modules](../../modules.zh.md) / [layout](../../modules/layout.zh.md) / CircularLayoutOptions
+[Overview - v5.0.0-beta.4](../../README.zh.md) / [Modules](../../modules.zh.md) / [layout](../../modules/layout.zh.md) / CircularLayoutOptions
 
 [layout](../../modules/layout.zh.md).CircularLayoutOptions
 

--- a/packages/site/docs/apis/interfaces/layout/ComboCombinedLayoutOptions.en.md
+++ b/packages/site/docs/apis/interfaces/layout/ComboCombinedLayoutOptions.en.md
@@ -2,7 +2,7 @@
 title: ComboCombinedLayoutOptions
 ---
 
-[Overview - v5.0.0-beta.3](../../README.en.md) / [Modules](../../modules.en.md) / [layout](../../modules/layout.en.md) / ComboCombinedLayoutOptions
+[Overview - v5.0.0-beta.4](../../README.en.md) / [Modules](../../modules.en.md) / [layout](../../modules/layout.en.md) / ComboCombinedLayoutOptions
 
 [layout](../../modules/layout.en.md).ComboCombinedLayoutOptions
 

--- a/packages/site/docs/apis/interfaces/layout/ComboCombinedLayoutOptions.zh.md
+++ b/packages/site/docs/apis/interfaces/layout/ComboCombinedLayoutOptions.zh.md
@@ -4,7 +4,7 @@ title: ComboCombinedLayoutOptions
 
 > 📋 中文文档还在翻译中... 欢迎 PR
 
-[Overview - v5.0.0-beta.3](../../README.zh.md) / [Modules](../../modules.zh.md) / [layout](../../modules/layout.zh.md) / ComboCombinedLayoutOptions
+[Overview - v5.0.0-beta.4](../../README.zh.md) / [Modules](../../modules.zh.md) / [layout](../../modules/layout.zh.md) / ComboCombinedLayoutOptions
 
 [layout](../../modules/layout.zh.md).ComboCombinedLayoutOptions
 

--- a/packages/site/docs/apis/interfaces/layout/ConcentricLayoutOptions.en.md
+++ b/packages/site/docs/apis/interfaces/layout/ConcentricLayoutOptions.en.md
@@ -2,7 +2,7 @@
 title: ConcentricLayoutOptions
 ---
 
-[Overview - v5.0.0-beta.3](../../README.en.md) / [Modules](../../modules.en.md) / [layout](../../modules/layout.en.md) / ConcentricLayoutOptions
+[Overview - v5.0.0-beta.4](../../README.en.md) / [Modules](../../modules.en.md) / [layout](../../modules/layout.en.md) / ConcentricLayoutOptions
 
 [layout](../../modules/layout.en.md).ConcentricLayoutOptions
 

--- a/packages/site/docs/apis/interfaces/layout/ConcentricLayoutOptions.zh.md
+++ b/packages/site/docs/apis/interfaces/layout/ConcentricLayoutOptions.zh.md
@@ -4,7 +4,7 @@ title: ConcentricLayoutOptions
 
 > 📋 中文文档还在翻译中... 欢迎 PR
 
-[Overview - v5.0.0-beta.3](../../README.zh.md) / [Modules](../../modules.zh.md) / [layout](../../modules/layout.zh.md) / ConcentricLayoutOptions
+[Overview - v5.0.0-beta.4](../../README.zh.md) / [Modules](../../modules.zh.md) / [layout](../../modules/layout.zh.md) / ConcentricLayoutOptions
 
 [layout](../../modules/layout.zh.md).ConcentricLayoutOptions
 

--- a/packages/site/docs/apis/interfaces/layout/D3ForceLayoutOptions.en.md
+++ b/packages/site/docs/apis/interfaces/layout/D3ForceLayoutOptions.en.md
@@ -2,7 +2,7 @@
 title: D3ForceLayoutOptions
 ---
 
-[Overview - v5.0.0-beta.3](../../README.en.md) / [Modules](../../modules.en.md) / [layout](../../modules/layout.en.md) / D3ForceLayoutOptions
+[Overview - v5.0.0-beta.4](../../README.en.md) / [Modules](../../modules.en.md) / [layout](../../modules/layout.en.md) / D3ForceLayoutOptions
 
 [layout](../../modules/layout.en.md).D3ForceLayoutOptions
 

--- a/packages/site/docs/apis/interfaces/layout/D3ForceLayoutOptions.zh.md
+++ b/packages/site/docs/apis/interfaces/layout/D3ForceLayoutOptions.zh.md
@@ -4,7 +4,7 @@ title: D3ForceLayoutOptions
 
 > 📋 中文文档还在翻译中... 欢迎 PR
 
-[Overview - v5.0.0-beta.3](../../README.zh.md) / [Modules](../../modules.zh.md) / [layout](../../modules/layout.zh.md) / D3ForceLayoutOptions
+[Overview - v5.0.0-beta.4](../../README.zh.md) / [Modules](../../modules.zh.md) / [layout](../../modules/layout.zh.md) / D3ForceLayoutOptions
 
 [layout](../../modules/layout.zh.md).D3ForceLayoutOptions
 

--- a/packages/site/docs/apis/interfaces/layout/DagreLayoutOptions.en.md
+++ b/packages/site/docs/apis/interfaces/layout/DagreLayoutOptions.en.md
@@ -2,7 +2,7 @@
 title: DagreLayoutOptions
 ---
 
-[Overview - v5.0.0-beta.3](../../README.en.md) / [Modules](../../modules.en.md) / [layout](../../modules/layout.en.md) / DagreLayoutOptions
+[Overview - v5.0.0-beta.4](../../README.en.md) / [Modules](../../modules.en.md) / [layout](../../modules/layout.en.md) / DagreLayoutOptions
 
 [layout](../../modules/layout.en.md).DagreLayoutOptions
 

--- a/packages/site/docs/apis/interfaces/layout/DagreLayoutOptions.zh.md
+++ b/packages/site/docs/apis/interfaces/layout/DagreLayoutOptions.zh.md
@@ -4,7 +4,7 @@ title: DagreLayoutOptions
 
 > 📋 中文文档还在翻译中... 欢迎 PR
 
-[Overview - v5.0.0-beta.3](../../README.zh.md) / [Modules](../../modules.zh.md) / [layout](../../modules/layout.zh.md) / DagreLayoutOptions
+[Overview - v5.0.0-beta.4](../../README.zh.md) / [Modules](../../modules.zh.md) / [layout](../../modules/layout.zh.md) / DagreLayoutOptions
 
 [layout](../../modules/layout.zh.md).DagreLayoutOptions
 

--- a/packages/site/docs/apis/interfaces/layout/ForceAtlas2LayoutOptions.en.md
+++ b/packages/site/docs/apis/interfaces/layout/ForceAtlas2LayoutOptions.en.md
@@ -2,7 +2,7 @@
 title: ForceAtlas2LayoutOptions
 ---
 
-[Overview - v5.0.0-beta.3](../../README.en.md) / [Modules](../../modules.en.md) / [layout](../../modules/layout.en.md) / ForceAtlas2LayoutOptions
+[Overview - v5.0.0-beta.4](../../README.en.md) / [Modules](../../modules.en.md) / [layout](../../modules/layout.en.md) / ForceAtlas2LayoutOptions
 
 [layout](../../modules/layout.en.md).ForceAtlas2LayoutOptions
 

--- a/packages/site/docs/apis/interfaces/layout/ForceAtlas2LayoutOptions.zh.md
+++ b/packages/site/docs/apis/interfaces/layout/ForceAtlas2LayoutOptions.zh.md
@@ -4,7 +4,7 @@ title: ForceAtlas2LayoutOptions
 
 > 📋 中文文档还在翻译中... 欢迎 PR
 
-[Overview - v5.0.0-beta.3](../../README.zh.md) / [Modules](../../modules.zh.md) / [layout](../../modules/layout.zh.md) / ForceAtlas2LayoutOptions
+[Overview - v5.0.0-beta.4](../../README.zh.md) / [Modules](../../modules.zh.md) / [layout](../../modules/layout.zh.md) / ForceAtlas2LayoutOptions
 
 [layout](../../modules/layout.zh.md).ForceAtlas2LayoutOptions
 

--- a/packages/site/docs/apis/interfaces/layout/ForceLayoutOptions.en.md
+++ b/packages/site/docs/apis/interfaces/layout/ForceLayoutOptions.en.md
@@ -2,7 +2,7 @@
 title: ForceLayoutOptions
 ---
 
-[Overview - v5.0.0-beta.3](../../README.en.md) / [Modules](../../modules.en.md) / [layout](../../modules/layout.en.md) / ForceLayoutOptions
+[Overview - v5.0.0-beta.4](../../README.en.md) / [Modules](../../modules.en.md) / [layout](../../modules/layout.en.md) / ForceLayoutOptions
 
 [layout](../../modules/layout.en.md).ForceLayoutOptions
 

--- a/packages/site/docs/apis/interfaces/layout/ForceLayoutOptions.zh.md
+++ b/packages/site/docs/apis/interfaces/layout/ForceLayoutOptions.zh.md
@@ -4,7 +4,7 @@ title: ForceLayoutOptions
 
 > 📋 中文文档还在翻译中... 欢迎 PR
 
-[Overview - v5.0.0-beta.3](../../README.zh.md) / [Modules](../../modules.zh.md) / [layout](../../modules/layout.zh.md) / ForceLayoutOptions
+[Overview - v5.0.0-beta.4](../../README.zh.md) / [Modules](../../modules.zh.md) / [layout](../../modules/layout.zh.md) / ForceLayoutOptions
 
 [layout](../../modules/layout.zh.md).ForceLayoutOptions
 

--- a/packages/site/docs/apis/interfaces/layout/FruchtermanLayoutOptions.en.md
+++ b/packages/site/docs/apis/interfaces/layout/FruchtermanLayoutOptions.en.md
@@ -2,7 +2,7 @@
 title: FruchtermanLayoutOptions
 ---
 
-[Overview - v5.0.0-beta.3](../../README.en.md) / [Modules](../../modules.en.md) / [layout](../../modules/layout.en.md) / FruchtermanLayoutOptions
+[Overview - v5.0.0-beta.4](../../README.en.md) / [Modules](../../modules.en.md) / [layout](../../modules/layout.en.md) / FruchtermanLayoutOptions
 
 [layout](../../modules/layout.en.md).FruchtermanLayoutOptions
 

--- a/packages/site/docs/apis/interfaces/layout/FruchtermanLayoutOptions.zh.md
+++ b/packages/site/docs/apis/interfaces/layout/FruchtermanLayoutOptions.zh.md
@@ -4,7 +4,7 @@ title: FruchtermanLayoutOptions
 
 > 📋 中文文档还在翻译中... 欢迎 PR
 
-[Overview - v5.0.0-beta.3](../../README.zh.md) / [Modules](../../modules.zh.md) / [layout](../../modules/layout.zh.md) / FruchtermanLayoutOptions
+[Overview - v5.0.0-beta.4](../../README.zh.md) / [Modules](../../modules.zh.md) / [layout](../../modules/layout.zh.md) / FruchtermanLayoutOptions
 
 [layout](../../modules/layout.zh.md).FruchtermanLayoutOptions
 

--- a/packages/site/docs/apis/interfaces/layout/GridLayoutOptions.en.md
+++ b/packages/site/docs/apis/interfaces/layout/GridLayoutOptions.en.md
@@ -2,7 +2,7 @@
 title: GridLayoutOptions
 ---
 
-[Overview - v5.0.0-beta.3](../../README.en.md) / [Modules](../../modules.en.md) / [layout](../../modules/layout.en.md) / GridLayoutOptions
+[Overview - v5.0.0-beta.4](../../README.en.md) / [Modules](../../modules.en.md) / [layout](../../modules/layout.en.md) / GridLayoutOptions
 
 [layout](../../modules/layout.en.md).GridLayoutOptions
 

--- a/packages/site/docs/apis/interfaces/layout/GridLayoutOptions.zh.md
+++ b/packages/site/docs/apis/interfaces/layout/GridLayoutOptions.zh.md
@@ -4,7 +4,7 @@ title: GridLayoutOptions
 
 > 📋 中文文档还在翻译中... 欢迎 PR
 
-[Overview - v5.0.0-beta.3](../../README.zh.md) / [Modules](../../modules.zh.md) / [layout](../../modules/layout.zh.md) / GridLayoutOptions
+[Overview - v5.0.0-beta.4](../../README.zh.md) / [Modules](../../modules.zh.md) / [layout](../../modules/layout.zh.md) / GridLayoutOptions
 
 [layout](../../modules/layout.zh.md).GridLayoutOptions
 

--- a/packages/site/docs/apis/interfaces/layout/MDSLayoutOptions.en.md
+++ b/packages/site/docs/apis/interfaces/layout/MDSLayoutOptions.en.md
@@ -2,7 +2,7 @@
 title: MDSLayoutOptions
 ---
 
-[Overview - v5.0.0-beta.3](../../README.en.md) / [Modules](../../modules.en.md) / [layout](../../modules/layout.en.md) / MDSLayoutOptions
+[Overview - v5.0.0-beta.4](../../README.en.md) / [Modules](../../modules.en.md) / [layout](../../modules/layout.en.md) / MDSLayoutOptions
 
 [layout](../../modules/layout.en.md).MDSLayoutOptions
 

--- a/packages/site/docs/apis/interfaces/layout/MDSLayoutOptions.zh.md
+++ b/packages/site/docs/apis/interfaces/layout/MDSLayoutOptions.zh.md
@@ -4,7 +4,7 @@ title: MDSLayoutOptions
 
 > 📋 中文文档还在翻译中... 欢迎 PR
 
-[Overview - v5.0.0-beta.3](../../README.zh.md) / [Modules](../../modules.zh.md) / [layout](../../modules/layout.zh.md) / MDSLayoutOptions
+[Overview - v5.0.0-beta.4](../../README.zh.md) / [Modules](../../modules.zh.md) / [layout](../../modules/layout.zh.md) / MDSLayoutOptions
 
 [layout](../../modules/layout.zh.md).MDSLayoutOptions
 

--- a/packages/site/docs/apis/interfaces/layout/RadialLayoutOptions.en.md
+++ b/packages/site/docs/apis/interfaces/layout/RadialLayoutOptions.en.md
@@ -2,7 +2,7 @@
 title: RadialLayoutOptions
 ---
 
-[Overview - v5.0.0-beta.3](../../README.en.md) / [Modules](../../modules.en.md) / [layout](../../modules/layout.en.md) / RadialLayoutOptions
+[Overview - v5.0.0-beta.4](../../README.en.md) / [Modules](../../modules.en.md) / [layout](../../modules/layout.en.md) / RadialLayoutOptions
 
 [layout](../../modules/layout.en.md).RadialLayoutOptions
 

--- a/packages/site/docs/apis/interfaces/layout/RadialLayoutOptions.zh.md
+++ b/packages/site/docs/apis/interfaces/layout/RadialLayoutOptions.zh.md
@@ -4,7 +4,7 @@ title: RadialLayoutOptions
 
 > 📋 中文文档还在翻译中... 欢迎 PR
 
-[Overview - v5.0.0-beta.3](../../README.zh.md) / [Modules](../../modules.zh.md) / [layout](../../modules/layout.zh.md) / RadialLayoutOptions
+[Overview - v5.0.0-beta.4](../../README.zh.md) / [Modules](../../modules.zh.md) / [layout](../../modules/layout.zh.md) / RadialLayoutOptions
 
 [layout](../../modules/layout.zh.md).RadialLayoutOptions
 

--- a/packages/site/docs/apis/modules.en.md
+++ b/packages/site/docs/apis/modules.en.md
@@ -2,7 +2,7 @@
 title: modules
 ---
 
-[Overview - v5.0.0-beta.3](README.en.md) / Modules
+[Overview - v5.0.0-beta.4](README.en.md) / Modules
 
 ## Modules
 

--- a/packages/site/docs/apis/modules.zh.md
+++ b/packages/site/docs/apis/modules.zh.md
@@ -4,7 +4,7 @@ title: modules
 
 > 📋 中文文档还在翻译中... 欢迎 PR
 
-[Overview - v5.0.0-beta.3](README.zh.md) / Modules
+[Overview - v5.0.0-beta.4](README.zh.md) / Modules
 
 ## Modules
 

--- a/packages/site/docs/apis/modules/behaviors.en.md
+++ b/packages/site/docs/apis/modules/behaviors.en.md
@@ -2,7 +2,7 @@
 title: behaviors
 ---
 
-[Overview - v5.0.0-beta.3](../README.en.md) / [Modules](../modules.en.md) / behaviors
+[Overview - v5.0.0-beta.4](../README.en.md) / [Modules](../modules.en.md) / behaviors
 
 ## Interfaces
 

--- a/packages/site/docs/apis/modules/behaviors.zh.md
+++ b/packages/site/docs/apis/modules/behaviors.zh.md
@@ -4,7 +4,7 @@ title: behaviors
 
 > 📋 中文文档还在翻译中... 欢迎 PR
 
-[Overview - v5.0.0-beta.3](../README.zh.md) / [Modules](../modules.zh.md) / behaviors
+[Overview - v5.0.0-beta.4](../README.zh.md) / [Modules](../modules.zh.md) / behaviors
 
 ## Interfaces
 

--- a/packages/site/docs/apis/modules/graph.en.md
+++ b/packages/site/docs/apis/modules/graph.en.md
@@ -2,7 +2,7 @@
 title: graph
 ---
 
-[Overview - v5.0.0-beta.3](../README.en.md) / [Modules](../modules.en.md) / graph
+[Overview - v5.0.0-beta.4](../README.en.md) / [Modules](../modules.en.md) / graph
 
 ## Interfaces
 

--- a/packages/site/docs/apis/modules/graph.zh.md
+++ b/packages/site/docs/apis/modules/graph.zh.md
@@ -4,7 +4,7 @@ title: graph
 
 > 📋 中文文档还在翻译中... 欢迎 PR
 
-[Overview - v5.0.0-beta.3](../README.zh.md) / [Modules](../modules.zh.md) / graph
+[Overview - v5.0.0-beta.4](../README.zh.md) / [Modules](../modules.zh.md) / graph
 
 ## Interfaces
 

--- a/packages/site/docs/apis/modules/item.en.md
+++ b/packages/site/docs/apis/modules/item.en.md
@@ -2,7 +2,7 @@
 title: item
 ---
 
-[Overview - v5.0.0-beta.3](../README.en.md) / [Modules](../modules.en.md) / item
+[Overview - v5.0.0-beta.4](../README.en.md) / [Modules](../modules.en.md) / item
 
 ## Interfaces
 

--- a/packages/site/docs/apis/modules/item.zh.md
+++ b/packages/site/docs/apis/modules/item.zh.md
@@ -4,7 +4,7 @@ title: item
 
 > 📋 中文文档还在翻译中... 欢迎 PR
 
-[Overview - v5.0.0-beta.3](../README.zh.md) / [Modules](../modules.zh.md) / item
+[Overview - v5.0.0-beta.4](../README.zh.md) / [Modules](../modules.zh.md) / item
 
 ## Interfaces
 

--- a/packages/site/docs/apis/modules/layout.en.md
+++ b/packages/site/docs/apis/modules/layout.en.md
@@ -2,7 +2,7 @@
 title: layout
 ---
 
-[Overview - v5.0.0-beta.3](../README.en.md) / [Modules](../modules.en.md) / layout
+[Overview - v5.0.0-beta.4](../README.en.md) / [Modules](../modules.en.md) / layout
 
 ## Interfaces
 

--- a/packages/site/docs/apis/modules/layout.zh.md
+++ b/packages/site/docs/apis/modules/layout.zh.md
@@ -4,7 +4,7 @@ title: layout
 
 > 📋 中文文档还在翻译中... 欢迎 PR
 
-[Overview - v5.0.0-beta.3](../README.zh.md) / [Modules](../modules.zh.md) / layout
+[Overview - v5.0.0-beta.4](../README.zh.md) / [Modules](../modules.zh.md) / layout
 
 ## Interfaces
 

--- a/packages/site/docs/apis/modules/plugins.en.md
+++ b/packages/site/docs/apis/modules/plugins.en.md
@@ -2,7 +2,7 @@
 title: plugins
 ---
 
-[Overview - v5.0.0-beta.3](../README.en.md) / [Modules](../modules.en.md) / plugins
+[Overview - v5.0.0-beta.4](../README.en.md) / [Modules](../modules.en.md) / plugins
 
 ## Interfaces
 

--- a/packages/site/docs/apis/modules/plugins.zh.md
+++ b/packages/site/docs/apis/modules/plugins.zh.md
@@ -4,7 +4,7 @@ title: plugins
 
 > 📋 中文文档还在翻译中... 欢迎 PR
 
-[Overview - v5.0.0-beta.3](../README.zh.md) / [Modules](../modules.zh.md) / plugins
+[Overview - v5.0.0-beta.4](../README.zh.md) / [Modules](../modules.zh.md) / plugins
 
 ## Interfaces
 

--- a/packages/site/docs/apis/modules/types.en.md
+++ b/packages/site/docs/apis/modules/types.en.md
@@ -2,4 +2,4 @@
 title: types
 ---
 
-[Overview - v5.0.0-beta.3](../README.en.md) / [Modules](../modules.en.md) / types
+[Overview - v5.0.0-beta.4](../README.en.md) / [Modules](../modules.en.md) / types

--- a/packages/site/docs/apis/modules/types.zh.md
+++ b/packages/site/docs/apis/modules/types.zh.md
@@ -4,4 +4,4 @@ title: types
 
 > 📋 中文文档还在翻译中... 欢迎 PR
 
-[Overview - v5.0.0-beta.3](../README.zh.md) / [Modules](../modules.zh.md) / types
+[Overview - v5.0.0-beta.4](../README.zh.md) / [Modules](../modules.zh.md) / types

--- a/packages/site/docs/apis/modules/util.en.md
+++ b/packages/site/docs/apis/modules/util.en.md
@@ -2,7 +2,7 @@
 title: util
 ---
 
-[Overview - v5.0.0-beta.3](../README.en.md) / [Modules](../modules.en.md) / util
+[Overview - v5.0.0-beta.4](../README.en.md) / [Modules](../modules.en.md) / util
 
 ## Functions
 

--- a/packages/site/docs/apis/modules/util.zh.md
+++ b/packages/site/docs/apis/modules/util.zh.md
@@ -4,7 +4,7 @@ title: util
 
 > 📋 中文文档还在翻译中... 欢迎 PR
 
-[Overview - v5.0.0-beta.3](../README.zh.md) / [Modules](../modules.zh.md) / util
+[Overview - v5.0.0-beta.4](../README.zh.md) / [Modules](../modules.zh.md) / util
 
 ## Functions
 

--- a/packages/site/docs/manual/getting-started.zh.md
+++ b/packages/site/docs/manual/getting-started.zh.md
@@ -21,7 +21,7 @@ order: 1
 **Step 1:** 使用命令行在项目目录下执行以下命令：
 
 ```bash
- npm install --save @antv/g6@5.0.0-beta.3
+ npm install --save @antv/g6@5.0.0-beta.4
 ```
 
 **Step 2:** 在需要用的 G6 的 JS 文件中导入：
@@ -39,7 +39,7 @@ import { Graph } from '@antv/g6';
 
 <span style="background-color: rgb(251, 233, 231); color: rgb(139, 53, 56)"><strong>⚠️ 注意:</strong></span>
 
-- 在  `{$version}` 中填写版本号，例如  `5.0.0-beta.3`；
+- 在  `{$version}` 中填写版本号，例如  `5.0.0-beta.4`；
 - 最新版可以在  <a href='https://www.npmjs.com/package/@antv/g6' target='_blank'>NPM</a>  查看最新版本及版本号；
 - 详情参考 Github 分支：<a href='https://github.com/antvis/g6/tree/v5' target='_blank'>https://github.com/antvis/g6/tree/v5</a>。
 
@@ -141,7 +141,7 @@ graph.read(data); // 读取 Step 2 中的数据源到图上
     <div id="container"></div>
 
     /* 引入 G6 */
-    <script src="https://gw.alipayobjects.com/os/lib/antv/g6/5.0.0-beta.3/dist/g6.min.js"></script>
+    <script src="https://gw.alipayobjects.com/os/lib/antv/g6/5.0.0-beta.4/dist/g6.min.js"></script>
 
     <script>
       // 定义数据源

--- a/packages/site/docs/manual/introduction.en.md
+++ b/packages/site/docs/manual/introduction.en.md
@@ -73,7 +73,7 @@ G6 concentrates on the principle of 'good by default'. In addition, the custom m
 ## Installation (5.0 Beta)
 
 ```bash
-$ npm install @antv/g6@5.0.0-beta.3
+$ npm install @antv/g6@5.0.0-beta.4
 ```
 
 ## Usage (5.0 Beta)

--- a/packages/site/docs/manual/introduction.zh.md
+++ b/packages/site/docs/manual/introduction.zh.md
@@ -61,7 +61,7 @@ GIF 未完整加载，[点此看原图](https://mdn.alipayobjects.com/huamei_qa8
 ## 安装 (5.0 Beta)
 
 ```bash
-$ npm install @antv/g6@5.0.0-beta.3
+$ npm install @antv/g6@5.0.0-beta.4
 ```
 
 ## 使用 (5.0 Beta)

--- a/packages/site/docs/manual/tutorial/behavior.en.md
+++ b/packages/site/docs/manual/tutorial/behavior.en.md
@@ -160,7 +160,7 @@ Here is the complete code:
   </head>
   <body>
     <div id="container"></div>
-    <script src="https://gw.alipayobjects.com/os/lib/antv/g6/5.0.0-beta.3/dist/g6.min.js"></script>
+    <script src="https://gw.alipayobjects.com/os/lib/antv/g6/5.0.0-beta.4/dist/g6.min.js"></script>
     <script>
       const { Graph: GraphBase, extend, Extensions } = G6;
 

--- a/packages/site/docs/manual/tutorial/behavior.zh.md
+++ b/packages/site/docs/manual/tutorial/behavior.zh.md
@@ -160,7 +160,7 @@ graph.on('元素类型:事件名', (e) => {
   </head>
   <body>
     <div id="container"></div>
-    <script src="https://gw.alipayobjects.com/os/lib/antv/g6/5.0.0-beta.3/dist/g6.min.js"></script>
+    <script src="https://gw.alipayobjects.com/os/lib/antv/g6/5.0.0-beta.4/dist/g6.min.js"></script>
     <script>
       const { Graph: GraphBase, extend, Extensions } = G6;
 

--- a/packages/site/docs/manual/tutorial/elements.en.md
+++ b/packages/site/docs/manual/tutorial/elements.en.md
@@ -363,7 +363,7 @@ Here is the complete code:
   </head>
   <body>
     <div id="container"></div>
-    <script src="https://gw.alipayobjects.com/os/lib/antv/g6/5.0.0-beta.3/dist/g6.min.js"></script>
+    <script src="https://gw.alipayobjects.com/os/lib/antv/g6/5.0.0-beta.4/dist/g6.min.js"></script>
     <script>
       const { Graph: GraphBase, extend, Extensions } = G6;
 

--- a/packages/site/docs/manual/tutorial/elements.zh.md
+++ b/packages/site/docs/manual/tutorial/elements.zh.md
@@ -354,7 +354,7 @@ const graph = new Graph({
   </head>
   <body>
     <div id="container"></div>
-    <script src="https://gw.alipayobjects.com/os/lib/antv/g6/5.0.0-beta.3/dist/g6.min.js"></script>
+    <script src="https://gw.alipayobjects.com/os/lib/antv/g6/5.0.0-beta.4/dist/g6.min.js"></script>
     <script>
       const { Graph: GraphBase, extend, Extensions } = G6;
 

--- a/packages/site/docs/manual/tutorial/example.en.md
+++ b/packages/site/docs/manual/tutorial/example.en.md
@@ -150,7 +150,7 @@ The complete code is as follows:
   </head>
   <body>
     <div id="container"></div>
-    <script src="https://gw.alipayobjects.com/os/lib/antv/g6/5.0.0-beta.3/dist/g6.min.js"></script>
+    <script src="https://gw.alipayobjects.com/os/lib/antv/g6/5.0.0-beta.4/dist/g6.min.js"></script>
     <script>
       const graph = new G6.Graph({
         container: 'container',

--- a/packages/site/docs/manual/tutorial/example.zh.md
+++ b/packages/site/docs/manual/tutorial/example.zh.md
@@ -149,7 +149,7 @@ graph.read(data); // 加载数据
   </head>
   <body>
     <div id="container"></div>
-    <script src="https://gw.alipayobjects.com/os/lib/antv/g6/5.0.0-beta.3/dist/g6.min.js"></script>
+    <script src="https://gw.alipayobjects.com/os/lib/antv/g6/5.0.0-beta.4/dist/g6.min.js"></script>
     <script>
       const graph = new G6.Graph({
         container: 'container',

--- a/packages/site/docs/manual/tutorial/layout.en.md
+++ b/packages/site/docs/manual/tutorial/layout.en.md
@@ -78,7 +78,7 @@ Here is the complete code:
   </head>
   <body>
     <div id="container"></div>
-    <script src="https://gw.alipayobjects.com/os/lib/antv/g6/5.0.0-beta.3/dist/g6.min.js"></script>
+    <script src="https://gw.alipayobjects.com/os/lib/antv/g6/5.0.0-beta.4/dist/g6.min.js"></script>
     <script>
       const { Graph: GraphBase, extend, Extensions } = G6;
 

--- a/packages/site/docs/manual/tutorial/layout.zh.md
+++ b/packages/site/docs/manual/tutorial/layout.zh.md
@@ -76,7 +76,7 @@ const graph = new Graph({
   </head>
   <body>
     <div id="container"></div>
-    <script src="https://gw.alipayobjects.com/os/lib/antv/g6/5.0.0-beta.3/dist/g6.min.js"></script>
+    <script src="https://gw.alipayobjects.com/os/lib/antv/g6/5.0.0-beta.4/dist/g6.min.js"></script>
     <script>
       const { Graph: GraphBase, extend, Extensions } = G6;
 

--- a/packages/site/docs/manual/tutorial/preface.en.md
+++ b/packages/site/docs/manual/tutorial/preface.en.md
@@ -52,7 +52,7 @@ Create a new index.html file and add the following code:
   </head>
   <body>
     <!-- Import G6 5.0 beta -->
-    <script src="https://gw.alipayobjects.com/os/lib/antv/g6/5.0.0-beta.3/dist/g6.min.js"></script>
+    <script src="https://gw.alipayobjects.com/os/lib/antv/g6/5.0.0-beta.4/dist/g6.min.js"></script>
 
     <script>
       console.log(G6);

--- a/packages/site/docs/manual/tutorial/preface.zh.md
+++ b/packages/site/docs/manual/tutorial/preface.zh.md
@@ -50,7 +50,7 @@ G6 是一个图可视化引擎。它提供了图的绘制、布局、分析、�
   </head>
   <body>
     <!-- 引入 G6 5.0 beta -->
-    <script src="https://gw.alipayobjects.com/os/lib/antv/g6/5.0.0-beta.3/dist/g6.min.js"></script>
+    <script src="https://gw.alipayobjects.com/os/lib/antv/g6/5.0.0-beta.4/dist/g6.min.js"></script>
 
     <script>
       console.log(G6);

--- a/packages/site/examples/item/defaultNodes/demo/circle.js
+++ b/packages/site/examples/item/defaultNodes/demo/circle.js
@@ -56,8 +56,9 @@ const graph = new G6.Graph({
         ...data,
         type: 'circle-node',
         labelShape: {
-          text: 'label',
+          text: id,
           position: 'bottom',
+          maxWidth: '500%',
         },
         labelBackgroundShape: {},
         iconShape: {

--- a/packages/site/examples/item/defaultNodes/demo/circle.js
+++ b/packages/site/examples/item/defaultNodes/demo/circle.js
@@ -3,54 +3,33 @@ import G6 from '@antv/g6';
 const data = {
   nodes: [
     {
-      id: 'node1',
-      data: {
-        x: 250,
-        y: 150,
-      },
+      id: 'circle',
+      data: {},
     },
     {
       id: 'circle-active',
-      data: {
-        x: 250,
-        y: 300,
-      },
+      data: {},
     },
     {
       id: 'circle-selected',
-      data: {
-        x: 250,
-        y: 450,
-      },
+      data: {},
     },
 
     {
       id: 'circle-highlight',
-      data: {
-        x: 400,
-        y: 150,
-      },
+      data: {},
     },
     {
       id: 'circle-inactive',
-      data: {
-        x: 400,
-        y: 300,
-      },
+      data: {},
     },
     {
       id: 'circle-badges',
-      data: {
-        x: 400,
-        y: 450,
-      },
+      data: {},
     },
     {
       id: 'circle-anchorShapes',
-      data: {
-        x: 550,
-        y: 150,
-      },
+      data: {},
     },
   ],
 };
@@ -66,6 +45,9 @@ const graph = new G6.Graph({
     default: ['zoom-canvas', 'drag-canvas', 'drag-node', 'click-select'],
   },
   data,
+  layout: {
+    type: 'grid',
+  },
   node: (model) => {
     const { id, data } = model;
     const config = {

--- a/packages/site/examples/item/defaultNodes/demo/diamond.js
+++ b/packages/site/examples/item/defaultNodes/demo/diamond.js
@@ -1,13 +1,40 @@
 import { Graph, Extensions, extend } from '@antv/g6';
+const ExtGraph = extend(Graph, {
+  nodes: {
+    'diamond-node': Extensions.DiamondNode,
+  },
+});
 
 const data = {
   nodes: [
     {
       id: 'diamond',
-      data: {
-        x: 250,
-        y: 150,
-      },
+      data: {},
+    },
+    {
+      id: 'diamond-active',
+      data: {},
+    },
+    {
+      id: 'diamond-selected',
+      data: {},
+    },
+
+    {
+      id: 'diamond-highlight',
+      data: {},
+    },
+    {
+      id: 'diamond-inactive',
+      data: {},
+    },
+    {
+      id: 'diamond-badges',
+      data: {},
+    },
+    {
+      id: 'diamond-anchorShapes',
+      data: {},
     },
   ],
 };
@@ -15,13 +42,6 @@ const data = {
 const container = document.getElementById('container');
 const width = container.scrollWidth;
 const height = container.scrollHeight || 500;
-
-const ExtGraph = extend(Graph, {
-  nodes: {
-    'diamond-node': Extensions.DiamondNode,
-  },
-});
-
 const graph = new ExtGraph({
   container: 'container',
   width,
@@ -30,53 +50,82 @@ const graph = new ExtGraph({
     default: ['zoom-canvas', 'drag-canvas', 'drag-node', 'click-select'],
   },
   data,
-  node: {
-    type: 'diamond-node',
-    labelShape: {
-      text: {
-        fields: ['id'],
-        formatter: (model) => model.id,
-      },
-      position: 'bottom',
-    },
-    labelBackgroundShape: {},
-    anchorShapes: [
-      {
-        position: [0, 0.5],
-      },
-      {
-        position: [0.5, 0],
-      },
-      {
-        position: [0.5, 1],
-      },
-    ],
-    iconShape: {
-      img: 'https://gw.alipayobjects.com/zos/basement_prod/012bcf4f-423b-4922-8c24-32a89f8c41ce.svg',
-      width: 20,
-      height: 20,
-    },
-    badgeShapes: [
-      {
-        text: 'A',
-        position: 'rightTop',
-      },
-    ],
-    animates: {
-      update: [
-        {
-          fields: ['opacity'],
-          shapeId: 'haloShape',
-          states: ['selected', 'active'],
-        },
-        {
-          fields: ['lineWidth'],
-          shapeId: 'keyShape',
-          states: ['selected', 'active'],
-        },
-      ],
-    },
+  layout: {
+    type: 'grid',
   },
+  node: (model) => {
+    const { id, data } = model;
+    const config = {
+      id,
+      data: {
+        ...data,
+        type: 'diamond-node',
+        labelShape: {
+          text: id,
+          position: 'bottom',
+          maxWidth: '500%',
+        },
+        labelBackgroundShape: {},
+        iconShape: {
+          img: 'https://gw.alipayobjects.com/zos/basement_prod/012bcf4f-423b-4922-8c24-32a89f8c41ce.svg',
+        },
+        animates: {
+          update: [
+            {
+              fields: ['opacity'],
+              shapeId: 'haloShape',
+              states: ['selected', 'active'],
+            },
+            {
+              fields: ['lineWidth'],
+              shapeId: 'keyShape',
+              states: ['selected', 'active'],
+            },
+          ],
+        },
+      },
+    };
+    if (id.includes('badges')) {
+      config.data.badgeShapes = [
+        {
+          text: 'A',
+          position: 'rightTop',
+        },
+        {
+          text: 'Important',
+          position: 'right',
+        },
+        {
+          text: 'Notice',
+          position: 'rightBottom',
+        },
+      ];
+    }
+    if (id.includes('anchorShapes')) {
+      config.data.anchorShapes = [
+        {
+          position: [0, 0.5],
+        },
+        {
+          position: [0.5, 0],
+        },
+        {
+          position: [0.5, 1],
+        },
+        {
+          position: [1, 0.5],
+        },
+      ];
+    }
+    return config;
+  },
+});
+
+graph.on('afterrender', (e) => {
+  graph.setItemState('diamond-active', 'active', true);
+  graph.setItemState('diamond-selected', 'selected', true);
+  graph.setItemState('diamond-highlight', 'highlight', true);
+  graph.setItemState('diamond-inactive', 'inactive', true);
 });
 
 if (typeof window !== 'undefined')

--- a/packages/site/examples/item/defaultNodes/demo/ellipse.js
+++ b/packages/site/examples/item/defaultNodes/demo/ellipse.js
@@ -62,8 +62,9 @@ const graph = new ExtGraph({
         ...data,
         type: 'ellipse-node',
         labelShape: {
-          text: 'label',
+          text: id,
           position: 'bottom',
+          maxWidth: '500%',
         },
         labelBackgroundShape: {},
         iconShape: {

--- a/packages/site/examples/item/defaultNodes/demo/ellipse.js
+++ b/packages/site/examples/item/defaultNodes/demo/ellipse.js
@@ -9,54 +9,33 @@ const ExtGraph = extend(Graph, {
 const data = {
   nodes: [
     {
-      id: 'node1',
-      data: {
-        x: 250,
-        y: 150,
-      },
+      id: 'ellipse',
+      data: {},
     },
     {
       id: 'ellipse-active',
-      data: {
-        x: 250,
-        y: 300,
-      },
+      data: {},
     },
     {
       id: 'ellipse-selected',
-      data: {
-        x: 250,
-        y: 450,
-      },
+      data: {},
     },
 
     {
       id: 'ellipse-highlight',
-      data: {
-        x: 400,
-        y: 150,
-      },
+      data: {},
     },
     {
       id: 'ellipse-inactive',
-      data: {
-        x: 400,
-        y: 300,
-      },
+      data: {},
     },
     {
       id: 'ellipse-badges',
-      data: {
-        x: 400,
-        y: 450,
-      },
+      data: {},
     },
     {
       id: 'ellipse-anchorShapes',
-      data: {
-        x: 550,
-        y: 150,
-      },
+      data: {},
     },
   ],
 };
@@ -72,6 +51,9 @@ const graph = new ExtGraph({
     default: ['zoom-canvas', 'drag-canvas', 'drag-node', 'click-select'],
   },
   data,
+  layout: {
+    type: 'grid',
+  },
   node: (model) => {
     const { id, data } = model;
     const config = {

--- a/packages/site/examples/item/defaultNodes/demo/hexagon.js
+++ b/packages/site/examples/item/defaultNodes/demo/hexagon.js
@@ -1,27 +1,40 @@
 import { Graph, Extensions, extend } from '@antv/g6';
+const ExtGraph = extend(Graph, {
+  nodes: {
+    'hexagon-node': Extensions.HexagonNode,
+  },
+});
 
 const data = {
   nodes: [
     {
       id: 'hexagon',
-      data: {
-        x: 250,
-        y: 150,
-        type: 'hexagon-node',
-        keyShape: {
-          /**
-           * 六边形的半径，默认为 20
-           * the radius of the hexagon, default is 20
-           */
-          r: 20,
-          /**
-           * 六边形方向，默认为 horizontal
-           * the direction of the hexagon, default is 'horizontal'
-           * supported value: 'horizontal' | 'vertical'
-           */
-          direction: 'horizontal',
-        },
-      },
+      data: {},
+    },
+    {
+      id: 'hexagon-active',
+      data: {},
+    },
+    {
+      id: 'hexagon-selected',
+      data: {},
+    },
+
+    {
+      id: 'hexagon-highlight',
+      data: {},
+    },
+    {
+      id: 'hexagon-inactive',
+      data: {},
+    },
+    {
+      id: 'hexagon-badges',
+      data: {},
+    },
+    {
+      id: 'hexagon-anchorShapes',
+      data: {},
     },
   ],
 };
@@ -29,13 +42,6 @@ const data = {
 const container = document.getElementById('container');
 const width = container.scrollWidth;
 const height = container.scrollHeight || 500;
-
-const ExtGraph = extend(Graph, {
-  nodes: {
-    'hexagon-node': Extensions.HexagonNode,
-  },
-});
-
 const graph = new ExtGraph({
   container: 'container',
   width,
@@ -44,37 +50,88 @@ const graph = new ExtGraph({
     default: ['zoom-canvas', 'drag-canvas', 'drag-node', 'click-select'],
   },
   data,
-  node: {
-    labelShape: {
-      text: {
-        fields: ['id'],
-        formatter: (model) => model.id,
-      },
-      position: 'bottom',
-    },
-    labelBackgroundShape: {
-      fill: 'red',
-    },
-    anchorShapes: [
-      {
-        position: [0, 0.5],
-        r: 2,
-        fill: 'red',
-      },
-    ],
-    iconShape: {
-      img: 'https://gw.alipayobjects.com/zos/basement_prod/012bcf4f-423b-4922-8c24-32a89f8c41ce.svg',
-      width: 20,
-      height: 20,
-    },
-    badgeShapes: [
-      {
-        text: '1',
-        position: 'rightTop',
-        color: 'blue',
-      },
-    ],
+  layout: {
+    type: 'grid',
   },
+  node: (model) => {
+    const { id, data } = model;
+    const config = {
+      id,
+      data: {
+        ...data,
+        type: 'hexagon-node',
+        labelShape: {
+          text: id,
+          position: 'bottom',
+          maxWidth: '500%',
+        },
+        labelBackgroundShape: {},
+        iconShape: {
+          img: 'https://gw.alipayobjects.com/zos/basement_prod/012bcf4f-423b-4922-8c24-32a89f8c41ce.svg',
+        },
+        animates: {
+          update: [
+            {
+              fields: ['opacity'],
+              shapeId: 'haloShape',
+              states: ['selected', 'active'],
+            },
+            {
+              fields: ['lineWidth'],
+              shapeId: 'keyShape',
+              states: ['selected', 'active'],
+            },
+          ],
+        },
+      },
+    };
+    if (id.includes('badges')) {
+      config.data.badgeShapes = [
+        {
+          text: 'A',
+          position: 'rightTop',
+        },
+        {
+          text: 'Important',
+          position: 'right',
+        },
+        {
+          text: 'Notice',
+          position: 'rightBottom',
+        },
+      ];
+    }
+    if (id.includes('anchorShapes')) {
+      config.data.anchorShapes = [
+        {
+          position: 'top',
+        },
+        {
+          position: 'rightTop',
+        },
+        {
+          position: 'leftTop',
+        },
+        {
+          position: 'rightBottom',
+        },
+        {
+          position: 'leftBottom',
+        },
+        {
+          position: 'bottom',
+        },
+      ];
+    }
+    return config;
+  },
+});
+
+graph.on('afterrender', (e) => {
+  graph.setItemState('hexagon-active', 'active', true);
+  graph.setItemState('hexagon-selected', 'selected', true);
+  graph.setItemState('hexagon-highlight', 'highlight', true);
+  graph.setItemState('hexagon-inactive', 'inactive', true);
 });
 
 if (typeof window !== 'undefined')

--- a/packages/site/examples/item/defaultNodes/demo/image.js
+++ b/packages/site/examples/item/defaultNodes/demo/image.js
@@ -66,6 +66,9 @@ const graph = new G6.Graph({
     default: ['zoom-canvas', 'drag-canvas', 'drag-node', 'click-select'],
   },
   data,
+  layout: {
+    type: 'grid',
+  },
   node: (model) => {
     const { id, data } = model;
     const config = {

--- a/packages/site/examples/item/defaultNodes/demo/image.js
+++ b/packages/site/examples/item/defaultNodes/demo/image.js
@@ -80,8 +80,9 @@ const graph = new G6.Graph({
           src: 'https://gw.alipayobjects.com/mdn/rms_6ae20b/afts/img/A*N4ZMS7gHsUIAAAAAAAAAAABkARQnAQ',
         },
         labelShape: {
-          text: 'label',
+          text: id,
           position: 'bottom',
+          maxWidth: '500%',
         },
         labelBackgroundShape: {},
         haloShape: {},

--- a/packages/site/examples/item/defaultNodes/demo/meta.json
+++ b/packages/site/examples/item/defaultNodes/demo/meta.json
@@ -10,7 +10,7 @@
         "zh": "圆形",
         "en": "Circle"
       },
-      "screenshot": "https://mdn.alipayobjects.com/huamei_qa8qxu/afts/img/A*hdvGT4kEmOAAAAAAAAAAAAAADmJ7AQ/original"
+      "screenshot": "https://mdn.alipayobjects.com/huamei_qa8qxu/afts/img/A*SuPdRLp1PQgAAAAAAAAAAAAADmJ7AQ/original"
     },
     {
       "filename": "donut.js",
@@ -21,20 +21,12 @@
       "screenshot": "https://mdn.alipayobjects.com/huamei_qa8qxu/afts/img/A*c5f5Q7XuOWoAAAAAAAAAAAAADmJ7AQ/original"
     },
     {
-      "filename": "ellipse.js",
-      "title": {
-        "zh": "椭圆",
-        "en": "Ellipse"
-      },
-      "screenshot": "https://mdn.alipayobjects.com/huamei_qa8qxu/afts/img/A*S9gxRJiRMEkAAAAAAAAAAAAADmJ7AQ/original"
-    },
-    {
       "filename": "rect.js",
       "title": {
         "zh": "矩形",
         "en": "Rect"
       },
-      "screenshot": "https://mdn.alipayobjects.com/huamei_qa8qxu/afts/img/A*VGpITb2jm7IAAAAAAAAAAAAADmJ7AQ/original"
+      "screenshot": "https://mdn.alipayobjects.com/huamei_qa8qxu/afts/img/A*etLSQYZnJAAAAAAAAAAAAAAADmJ7AQ/original"
     },
     {
       "filename": "radiusRect.js",
@@ -42,7 +34,23 @@
         "zh": "圆角矩形",
         "en": "Radius Rect"
       },
-      "screenshot": "https://mdn.alipayobjects.com/huamei_qa8qxu/afts/img/A*R45pQLK7pgYAAAAAAAAAAAAADmJ7AQ/original"
+      "screenshot": "https://mdn.alipayobjects.com/huamei_qa8qxu/afts/img/A*r03cSIy59-UAAAAAAAAAAAAADmJ7AQ/original"
+    },
+    {
+      "filename": "diamond.js",
+      "title": {
+        "zh": "菱形",
+        "en": "Diamond"
+      },
+      "screenshot": "https://mdn.alipayobjects.com/huamei_qa8qxu/afts/img/A*oUSlSZt6rCoAAAAAAAAAAAAADmJ7AQ/original"
+    },
+    {
+      "filename": "hexagon.js",
+      "title": {
+        "zh": "六边形",
+        "en": "Hexagon"
+      },
+      "screenshot": "https://mdn.alipayobjects.com/huamei_qa8qxu/afts/img/A*muosSr4ft8QAAAAAAAAAAAAADmJ7AQ/original"
     },
     {
       "filename": "image.js",
@@ -51,6 +59,22 @@
         "en": "Image"
       },
       "screenshot": "https://mdn.alipayobjects.com/huamei_qa8qxu/afts/img/A*NPG3SL_n-CYAAAAAAAAAAAAADmJ7AQ/original"
+    },
+    {
+      "filename": "ellipse.js",
+      "title": {
+        "zh": "椭圆",
+        "en": "Ellipse"
+      },
+      "screenshot": "https://mdn.alipayobjects.com/huamei_qa8qxu/afts/img/A*Vdq4Rb3ESOoAAAAAAAAAAAAADmJ7AQ/original"
+    },
+    {
+      "filename": "star.js",
+      "title": {
+        "zh": "星形",
+        "en": "Star"
+      },
+      "screenshot": "https://mdn.alipayobjects.com/huamei_qa8qxu/afts/img/A*YSVjSLyYNwIAAAAAAAAAAAAADmJ7AQ/original"
     },
     {
       "filename": "modelRect.js",

--- a/packages/site/examples/item/defaultNodes/demo/radiusRect.js
+++ b/packages/site/examples/item/defaultNodes/demo/radiusRect.js
@@ -3,54 +3,33 @@ import G6 from '@antv/g6';
 const data = {
   nodes: [
     {
-      id: 'node1',
-      data: {
-        x: 250,
-        y: 150,
-      },
+      id: 'rect',
+      data: {},
     },
     {
       id: 'rect-active',
-      data: {
-        x: 250,
-        y: 300,
-      },
+      data: {},
     },
     {
       id: 'rect-selected',
-      data: {
-        x: 250,
-        y: 450,
-      },
+      data: {},
     },
 
     {
       id: 'rect-highlight',
-      data: {
-        x: 400,
-        y: 150,
-      },
+      data: {},
     },
     {
       id: 'rect-inactive',
-      data: {
-        x: 400,
-        y: 300,
-      },
+      data: {},
     },
     {
       id: 'rect-badges',
-      data: {
-        x: 400,
-        y: 450,
-      },
+      data: {},
     },
     {
       id: 'rect-anchorShapes',
-      data: {
-        x: 550,
-        y: 150,
-      },
+      data: {},
     },
   ],
 };
@@ -66,6 +45,9 @@ const graph = new G6.Graph({
     default: ['zoom-canvas', 'drag-canvas', 'drag-node', 'click-select'],
   },
   data,
+  layout: {
+    type: 'grid',
+  },
   node: (model) => {
     const { id, data } = model;
     const config = {
@@ -74,7 +56,7 @@ const graph = new G6.Graph({
         ...data,
         type: 'rect-node',
         keyShape: {
-          radius: 10,
+          radius: 4,
         },
         labelShape: {
           text: 'label',

--- a/packages/site/examples/item/defaultNodes/demo/radiusRect.js
+++ b/packages/site/examples/item/defaultNodes/demo/radiusRect.js
@@ -59,8 +59,9 @@ const graph = new G6.Graph({
           radius: 4,
         },
         labelShape: {
-          text: 'label',
+          text: id,
           position: 'bottom',
+          maxWidth: '500%',
         },
         labelBackgroundShape: {},
         iconShape: {

--- a/packages/site/examples/item/defaultNodes/demo/rect.js
+++ b/packages/site/examples/item/defaultNodes/demo/rect.js
@@ -3,54 +3,33 @@ import G6 from '@antv/g6';
 const data = {
   nodes: [
     {
-      id: 'node1',
-      data: {
-        x: 250,
-        y: 150,
-      },
+      id: 'rect',
+      data: {},
     },
     {
       id: 'rect-active',
-      data: {
-        x: 250,
-        y: 300,
-      },
+      data: {},
     },
     {
       id: 'rect-selected',
-      data: {
-        x: 250,
-        y: 450,
-      },
+      data: {},
     },
 
     {
       id: 'rect-highlight',
-      data: {
-        x: 400,
-        y: 150,
-      },
+      data: {},
     },
     {
       id: 'rect-inactive',
-      data: {
-        x: 400,
-        y: 300,
-      },
+      data: {},
     },
     {
       id: 'rect-badges',
-      data: {
-        x: 400,
-        y: 450,
-      },
+      data: {},
     },
     {
       id: 'rect-anchorShapes',
-      data: {
-        x: 550,
-        y: 150,
-      },
+      data: {},
     },
   ],
 };
@@ -66,6 +45,9 @@ const graph = new G6.Graph({
     default: ['zoom-canvas', 'drag-canvas', 'drag-node', 'click-select'],
   },
   data,
+  layout: {
+    type: 'grid',
+  },
   node: (model) => {
     const { id, data } = model;
     const config = {

--- a/packages/site/examples/item/defaultNodes/demo/rect.js
+++ b/packages/site/examples/item/defaultNodes/demo/rect.js
@@ -56,8 +56,9 @@ const graph = new G6.Graph({
         ...data,
         type: 'rect-node',
         labelShape: {
-          text: 'label',
+          text: id,
           position: 'bottom',
+          maxWidth: '500%',
         },
         labelBackgroundShape: {},
         iconShape: {

--- a/packages/site/examples/item/defaultNodes/demo/star.js
+++ b/packages/site/examples/item/defaultNodes/demo/star.js
@@ -1,26 +1,40 @@
 import { Graph, Extensions, extend } from '@antv/g6';
+const ExtGraph = extend(Graph, {
+  nodes: {
+    'star-node': Extensions.StarNode,
+  },
+});
 
 const data = {
   nodes: [
     {
-      id: 'node1',
-      data: {
-        x: 250,
-        y: 150,
-        type: 'star-node',
-        keyShape: {
-          /**
-           * 星形的外部半径，默认为 20
-           * outer radius of the star，默认为 20
-           */
-          // outerR: 20,
-          /**
-           * 星形的内部半径，默认为 7.5
-           * inner radius of the star，默认为 7.5
-           */
-          // innerR: 7.5
-        },
-      },
+      id: 'star',
+      data: {},
+    },
+    {
+      id: 'star-active',
+      data: {},
+    },
+    {
+      id: 'star-selected',
+      data: {},
+    },
+
+    {
+      id: 'star-highlight',
+      data: {},
+    },
+    {
+      id: 'star-inactive',
+      data: {},
+    },
+    {
+      id: 'star-badges',
+      data: {},
+    },
+    {
+      id: 'star-anchorShapes',
+      data: {},
     },
   ],
 };
@@ -28,13 +42,6 @@ const data = {
 const container = document.getElementById('container');
 const width = container.scrollWidth;
 const height = container.scrollHeight || 500;
-
-const ExtGraph = extend(Graph, {
-  nodes: {
-    'star-node': Extensions.StarNode,
-  },
-});
-
 const graph = new ExtGraph({
   container: 'container',
   width,
@@ -43,34 +50,85 @@ const graph = new ExtGraph({
     default: ['zoom-canvas', 'drag-canvas', 'drag-node', 'click-select'],
   },
   data,
-  node: {
-    labelShape: {
-      text: 'label',
-      position: 'bottom',
-    },
-    labelBackgroundShape: {
-      fill: 'red',
-    },
-    anchorShapes: [
-      {
-        position: [0, 0.5],
-        r: 2,
-        fill: 'red',
-      },
-    ],
-    iconShape: {
-      img: 'https://gw.alipayobjects.com/zos/basement_prod/012bcf4f-423b-4922-8c24-32a89f8c41ce.svg',
-      width: 20,
-      height: 20,
-    },
-    badgeShapes: [
-      {
-        text: '1',
-        position: 'rightTop',
-        color: 'blue',
-      },
-    ],
+  layout: {
+    type: 'grid',
   },
+  node: (model) => {
+    const { id, data } = model;
+    const config = {
+      id,
+      data: {
+        ...data,
+        type: 'star-node',
+        labelShape: {
+          text: id,
+          position: 'bottom',
+          maxWidth: '500%',
+        },
+        labelBackgroundShape: {},
+        iconShape: {
+          img: 'https://gw.alipayobjects.com/zos/basement_prod/012bcf4f-423b-4922-8c24-32a89f8c41ce.svg',
+        },
+        animates: {
+          update: [
+            {
+              fields: ['opacity'],
+              shapeId: 'haloShape',
+              states: ['selected', 'active'],
+            },
+            {
+              fields: ['lineWidth'],
+              shapeId: 'keyShape',
+              states: ['selected', 'active'],
+            },
+          ],
+        },
+      },
+    };
+    if (id.includes('badges')) {
+      config.data.badgeShapes = [
+        {
+          text: 'A',
+          position: 'rightTop',
+        },
+        {
+          text: 'Important',
+          position: 'right',
+        },
+        {
+          text: 'Notice',
+          position: 'rightBottom',
+        },
+      ];
+    }
+    if (id.includes('anchorShapes')) {
+      config.data.anchorShapes = [
+        {
+          position: 'top',
+        },
+        {
+          position: 'right',
+        },
+        {
+          position: 'left',
+        },
+        {
+          position: 'leftBottom',
+        },
+        {
+          position: 'rightBottom',
+        },
+      ];
+    }
+    return config;
+  },
+});
+
+graph.on('afterrender', (e) => {
+  graph.setItemState('star-active', 'active', true);
+  graph.setItemState('star-selected', 'selected', true);
+  graph.setItemState('star-highlight', 'highlight', true);
+  graph.setItemState('star-inactive', 'inactive', true);
 });
 
 if (typeof window !== 'undefined')


### PR DESCRIPTION
fix: path node anchor shapes and badge shapes

badge 的文本不居中问题，修复后：
![image](https://github.com/antvis/G6/assets/29593318/8935ddb0-0cdf-46a8-997a-bc026e410cc8)

不同内置节点各状态下样式：

![image](https://github.com/antvis/G6/assets/29593318/851bfa7d-a248-45cd-a239-f7efbb191984)
![image](https://github.com/antvis/G6/assets/29593318/4d1ac3d0-6c9d-429b-947a-cb403cdfa2f1)
![image](https://github.com/antvis/G6/assets/29593318/b8412ab8-edb9-4673-af0a-6c40b08caffe)
![image](https://github.com/antvis/G6/assets/29593318/799713bc-fb0d-4eb5-a3da-4b67a7923da2)
