### PR TITLE
feat: add graph download api

### DIFF
--- a/packages/g6/src/runtime/graph.ts
+++ b/packages/g6/src/runtime/graph.ts
@@ -1996,10 +1996,13 @@ export default class Graph<B extends BehaviorRegistry, T extends ThemeRegistry>
     });
     return this.itemController.getTransient(String(id));
   }
-  // ===== download operations =====
 
+  // ===== download operations =====
   /**
-   * 返回可见区域的图的 dataUrl，用于生成图片.
+   * Asynchronously generates a Data URL representation of the canvas content, including
+   * background, main content, and transient canvas.
+   * @param The type of the Data URL (e.g., 'image/png', 'image/jpeg').
+   * @returns A Promise that resolves to the Data URL string.
    */
   public async toDataURL(type?: DataURLType): Promise<string> {
     const backgroundCanvas = this.backgroundCanvas;
@@ -2057,7 +2060,11 @@ export default class Graph<B extends BehaviorRegistry, T extends ThemeRegistry>
   }
 
   /**
-   * 返回全图的 dataUrl，用于生成图片.
+   * Asynchronously generates a Data URL representation of the full canvas content,
+   * including background, main content, and transient canvas, with optional padding.
+   * @param type The type of the Data URL (e.g., 'image/png', 'image/jpeg').
+   * @param imageConfig Configuration options for the image (optional).
+   * @returns A Promise that resolves to the Data URL string.
    */
   public async toFullDataURL(
     type?: DataURLType,
@@ -2164,7 +2171,11 @@ export default class Graph<B extends BehaviorRegistry, T extends ThemeRegistry>
   }
 
   /**
-   * 将dataUrl转换为image
+   * Converts a Data URL to an image file and handles the download of the image.
+   * @param dataURL The Data URL of the image to be converted and downloaded.
+   * @param renderer The renderer type ('svg' or other) used for the canvas.
+   * @param link The HTML link element used for image download.
+   * @param fileName The desired name for the downloaded image file.
    */
   private dataURLToImage(dataURL: string, renderer: string, link, fileName) {
     if (!dataURL || dataURL === 'data:') {
@@ -2211,8 +2222,10 @@ export default class Graph<B extends BehaviorRegistry, T extends ThemeRegistry>
     }
   }
 
-    /**
-   * 将dataUrl转换为image
+  /**
+   * Initiates the download of the graph as an image with an optional name and type.
+   * @param name The desired name for the downloaded image file (optional).
+   * @param type The type of the image to download (optional, defaults to 'image/png').
    */
   public downloadImage(name?: string, type?: DataURLType): void {
     const self = this;
@@ -2235,6 +2248,12 @@ export default class Graph<B extends BehaviorRegistry, T extends ThemeRegistry>
     });
   }
 
+  /**
+   * Initiates the download of the entire graph as an image with optional name, type, and padding configuration.
+   * @param name The desired name for the downloaded image file (optional).
+   * @param type The type of the image to download (optional, defaults to 'image/png').
+   * @param imageConfig Configuration options for the image (optional).
+   */
   public downloadFullImage(name?: string, type?: DataURLType, imageConfig?: { padding?: number | number[] }): void {
     const self = this;
     
@@ -2253,6 +2272,11 @@ export default class Graph<B extends BehaviorRegistry, T extends ThemeRegistry>
     });
   }
 
+  /**
+   * Asynchronously converts the canvas content to a Data URL of the specified type and invokes the provided callback.
+   * @param type The type of the Data URL (optional, defaults to 'image/png').
+   * @param callback A callback function to handle the Data URL (optional).
+   */
   protected asyncToDataUrl(type?: DataURLType, callback?: Function): void {
     let dataURL = '';
     if (!type) type = 'image/png';
@@ -2265,6 +2289,13 @@ export default class Graph<B extends BehaviorRegistry, T extends ThemeRegistry>
     }, 16);
   }
 
+  /**
+   * Asynchronously converts the entire canvas content to a Data URL of the specified type 
+   * with optional padding, and invokes the provided callback.
+   * @param type The type of the Data URL (optional, defaults to 'image/png').
+   * @param imageConfig Configuration options for the image (optional).
+   * @param callback A callback function to handle the Data URL (optional).
+   */
   protected asyncToFullDataUrl(type?: DataURLType, imageConfig?: { padding?: number | number[] }, callback?: Function): void {
     let dataURL = '';
     if (!type) type = 'image/png';

--- a/packages/g6/tests/index.html
+++ b/packages/g6/tests/index.html
@@ -16,6 +16,15 @@
         <option value="svg">svg</option>
         <option value="webgl">webgl</option>
       </select>
+      <label for="renderer-select">选择 Image类型 </label>
+      <select id="image-select" style="height: 40px; cursor: pointer">
+        <option value="image/png" selected>image/png</option>
+        <option value="image/jpeg">image/jpeg</option>
+        <option value="image/webp">image/webp</option>
+        <option value="image/bmp">image/bmp</option>
+      </select>
+      <button id="image-download-button">下载图片</button>
+      <button id="full-image-download-button">下载全图</button>
       <div id="container" style="height: 500px; width: 100%"></div>
     </div>
     <script type="module" src="./main.ts"></script>

--- a/packages/g6/tests/main.ts
+++ b/packages/g6/tests/main.ts
@@ -1,6 +1,8 @@
+import { DataURLType } from '@antv/g';
 import * as graphs from './demo/index';
 
 let graph: any;
+let imageType: DataURLType = "image/png"
 
 // Select for renderers.
 const $rendererSelect = document.getElementById(
@@ -9,6 +11,31 @@ const $rendererSelect = document.getElementById(
 $rendererSelect.onchange = async () => {
   graph = await render();
 };
+const $imageSelect = document.getElementById(
+  'image-select',
+) as HTMLSelectElement;
+const $imageSelectDownloadButton = document.getElementById(
+  'image-download-button',
+) as HTMLSelectElement;
+const $fullImageSelectDownloadButton = document.getElementById(
+  'full-image-download-button',
+) as HTMLSelectElement;
+$rendererSelect.onchange = async () => {
+  graph = await render();
+};
+$imageSelect.onchange = () => {
+  imageType = $imageSelect.value as DataURLType
+};
+$imageSelectDownloadButton.onclick = ()=>{
+  if(graph){
+    graph.downloadImage($demoSelect.value, imageType);
+  }
+}
+$fullImageSelectDownloadButton.onclick = ()=>{
+  if(graph){
+    graph.downloadFullImage($demoSelect.value, imageType, {padding: 10});
+  }
+}
 
 const render = async () => {
   if (graph) {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change
#### Graph API - 图片下载相关 #4916
在 v5 实现四个 API：
graph.downloadImage 画布导出图片，图片仅包含画布可见区域部分内容
graph.downloadFullImage 导出包含全图的图片(graph 内容可能超出视口范围)
graph.toDataURL 返回可见区域的图的 dataUrl，用于生成图片
graph.toFullDataURL 返回整个图（包括超出可见区域的部分）的 dataUrl，用于生成图片

在preview界面新增了下载图片选项，用于调用api下载当前图片
<img width="825" alt="微信截图_20230911163129" src="https://github.com/antvis/G6/assets/144015557/06f6cf69-68d7-42e5-b273-5a1e83388285">

<!-- Provide a description of the change below this comment. -->
