### PR TITLE
fix: scrollNode demo crash

### DIFF
--- a/packages/site/examples/item/customNode/demo/scrollNode.js
+++ b/packages/site/examples/item/customNode/demo/scrollNode.js
@@ -204,13 +204,13 @@ registerBehavior("dice-er-scroll", {
     }
   },
   mousedown(e) {
-    this.mousedown = true;
+    this.isMousedown = true;
   },
   mouseup(e) {
-    this.mousedown = false;
+    this.isMousedown = false;
   },
   move(e) {
-    if (this.mousedown) return;
+    if (this.isMousedown) return;
     const name = e.shape.get("name");
     const item = e.item;
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

1. `npm test` failed on the latest master due to `tests/unit/shape/combo-collapsed-pos-spec.ts`.
2. The site doesn't have any existing tests, so I cannot add test case for the fix.

##### Description of change
In the demo page https://g6.antv.antgroup.com/en/examples/item/customNode#scrollNode, it will crash after you drag the node.
<img width="1472" alt="image" src="https://github.com/antvis/G6/assets/29599723/e2ec7b19-27d8-4e59-a3d2-77557d6d34ef">

This pr fixed it.