### PR TITLE
chore: remove userGraphCore

### DIFF
--- a/packages/g6/src/item/edge.ts
+++ b/packages/g6/src/item/edge.ts
@@ -1,6 +1,6 @@
 import { Circle, Group } from '@antv/g';
 import { clone, throttle } from '@antv/util';
-import { EdgeDisplayModel, EdgeModel, ID } from '../types';
+import { EdgeDisplayModel, EdgeModel, ID, Point } from '../types';
 import { EdgeModelData } from '../types/edge';
 import { DisplayMapper, State, LodStrategyObj } from '../types/item';
 import { updateShapes } from '../util/shape';
@@ -43,6 +43,13 @@ export default class Edge extends Item {
   public sourceItem: Node | Combo;
   public targetItem: Node | Combo;
 
+  /** Caches to avoid unnecessary calculations. */
+  private sourcePositionCache: Point;
+  private targetPositionCache: Point;
+  private controlPointsCache: Point;
+  private sourcePointCache: Point;
+  private targetPointCache: Point;
+
   constructor(props: IProps) {
     super(props);
     this.init({ ...props, type: 'edge' });
@@ -68,40 +75,7 @@ export default class Edge extends Item {
     animate = true,
     onfinish: Function = () => {},
   ) {
-    // get the point near the other end
-    const { sourceAnchor, targetAnchor, keyShape } = displayModel.data;
-    const sourcePosition = this.sourceItem.getPosition();
-    const targetPosition = this.targetItem.getPosition();
-
-    let targetPrevious = sourcePosition;
-    let sourcePrevious = targetPosition;
-
-    // TODO: type
-    // @ts-ignore
-    if (keyShape?.controlPoints?.length) {
-      // @ts-ignore
-      const controlPointsBesideEnds = keyShape.controlPoints.filter(
-        (point) =>
-          !isSamePoint(point, sourcePosition) &&
-          !isSamePoint(point, targetPosition),
-      );
-      sourcePrevious = getNearestPoint(
-        controlPointsBesideEnds,
-        sourcePosition,
-      ).nearestPoint;
-      targetPrevious = getNearestPoint(
-        controlPointsBesideEnds,
-        targetPosition,
-      ).nearestPoint;
-    }
-    const sourcePoint = this.sourceItem.getAnchorPoint(
-      sourcePrevious,
-      sourceAnchor,
-    );
-    const targetPoint = this.targetItem.getAnchorPoint(
-      targetPrevious,
-      targetAnchor,
-    );
+    const { sourcePoint, targetPoint } = this.getEndPoints(displayModel);
     this.renderExt.mergeStyles(displayModel);
     const firstRendering = !this.shapeMap?.keyShape;
     this.renderExt.setSourcePoint(sourcePoint);
@@ -164,16 +138,23 @@ export default class Edge extends Item {
    * Sometimes no changes on edge data, but need to re-draw it
    * e.g. source and target nodes' position changed
    */
-  public forceUpdate = throttle(
-    () => {
-      if (!this.destroyed) this.draw(this.displayModel);
-    },
-    16,
-    {
-      leading: true,
-      trailing: true,
-    },
-  );
+  public forceUpdate() {
+    if (this.destroyed) return;
+    const { sourcePoint, targetPoint, changed } = this.getEndPoints(
+      this.displayModel,
+    );
+    if (!changed) return;
+    this.renderExt.setSourcePoint(sourcePoint);
+    this.renderExt.setTargetPoint(targetPoint);
+    const shapeMap = this.renderExt.draw(
+      this.displayModel,
+      sourcePoint,
+      targetPoint,
+      this.shapeMap,
+    );
+    // add shapes to group, and update shapeMap
+    this.shapeMap = updateShapes(this.shapeMap, shapeMap, this.group);
+  }
 
   /**
    * Update end item for item and re-draw the edge
@@ -186,9 +167,88 @@ export default class Edge extends Item {
     this.draw(this.displayModel);
   }
 
-  // public update(model: EdgeModel) {
-  //   super.update(model);
-  // }
+  /**
+   * Calculate the source and target points according to the source and target nodes and the anchorPoints and controlPoints.
+   * @param displayModel
+   * @returns
+   */
+  private getEndPoints(displayModel: EdgeDisplayModel) {
+    // get the point near the other end
+    const { sourceAnchor, targetAnchor, keyShape } = displayModel.data;
+    const sourcePosition = this.sourceItem.getPosition();
+    const targetPosition = this.targetItem.getPosition();
+
+    if (
+      !this.shouldUpdatePoints(
+        sourcePosition,
+        targetPosition,
+        // @ts-ignore
+        keyShape?.controlPoints,
+      )
+    ) {
+      return {
+        sourcePoint: this.sourcePointCache,
+        targetPoint: this.targetPointCache,
+        changed: false,
+      };
+    }
+
+    let targetPrevious = sourcePosition;
+    let sourcePrevious = targetPosition;
+
+    // TODO: type
+    // @ts-ignore
+    if (keyShape?.controlPoints?.length) {
+      // @ts-ignore
+      const controlPointsBesideEnds = keyShape.controlPoints.filter(
+        (point) =>
+          !isSamePoint(point, sourcePosition) &&
+          !isSamePoint(point, targetPosition),
+      );
+      sourcePrevious = getNearestPoint(
+        controlPointsBesideEnds,
+        sourcePosition,
+      ).nearestPoint;
+      targetPrevious = getNearestPoint(
+        controlPointsBesideEnds,
+        targetPosition,
+      ).nearestPoint;
+    }
+    this.sourcePointCache = this.sourceItem.getAnchorPoint(
+      sourcePrevious,
+      sourceAnchor,
+    );
+    this.targetPointCache = this.targetItem.getAnchorPoint(
+      targetPrevious,
+      targetAnchor,
+    );
+    return {
+      sourcePoint: this.sourcePointCache,
+      targetPoint: this.targetPointCache,
+      changed: true,
+    };
+  }
+
+  /**
+   * Returns false if the source, target, controlPoints are not changed, avoiding unnecessary computations.
+   * @param sourcePosition
+   * @param targetPosition
+   * @param controlPoints
+   * @returns
+   */
+  private shouldUpdatePoints(sourcePosition, targetPosition, controlPoints) {
+    const changed = !(
+      isSamePoint(sourcePosition, this.sourcePositionCache) &&
+      isSamePoint(targetPosition, this.targetPositionCache) &&
+      controlPoints === this.controlPointsCache
+    );
+    if (changed) {
+      this.sourcePositionCache = sourcePosition;
+      this.targetPositionCache = targetPosition;
+      this.controlPointsCache = controlPoints;
+    }
+    return changed;
+  }
 
   public clone(
     containerGroup: Group,

--- a/packages/g6/src/item/node.ts
+++ b/packages/g6/src/item/node.ts
@@ -79,7 +79,9 @@ export default class Node extends Item {
     const { animates, disableAnimate, x = 0, y = 0, z = 0 } = displayModel.data;
     if (firstRendering) {
       // first rendering, move the group
-      group.setLocalPosition(x, y, z);
+      group.style.x = x;
+      group.style.y = y;
+      group.style.z = z;
     } else {
       // terminate previous animations
       this.stopAnimations();
@@ -195,11 +197,9 @@ export default class Node extends Item {
         return;
       }
     }
-    group.setLocalPosition([
-      position.x as number,
-      position.y as number,
-      position.z,
-    ]);
+    group.style.x = position.x;
+    group.style.y = position.y;
+    group.style.z = position.z;
     onfinish(displayModel.id, !animate);
   }
 

--- a/packages/g6/src/runtime/controller/data.ts
+++ b/packages/g6/src/runtime/controller/data.ts
@@ -45,10 +45,6 @@ export class DataController {
   public graph: IGraph;
   public extensions = [];
   /**
-   * User input data.
-   */
-  public userGraphCore: GraphCore;
-  /**
    * Inner data stored in graphCore structure.
    */
   public graphCore: GraphCore;
@@ -57,6 +53,11 @@ export class DataController {
    * A flag to note whether the tree data structure should be recalculated and establish.
    */
   private treeDirtyFlag: boolean;
+
+  /**
+   * Cache the current data type;
+   */
+  private dataType: 'treeData' | 'graphData' | 'fetch';
 
   constructor(graph: IGraph<any, any>) {
     this.graph = graph;
@@ -181,7 +182,7 @@ export class DataController {
    */
   private onDataChange(param: { data: DataConfig; type: DataChangeType }) {
     const { data, type: changeType } = param;
-    const { userGraphCore } = this;
+    const { graphCore } = this;
     const change = () => {
       switch (changeType) {
         case 'remove':
@@ -202,8 +203,8 @@ export class DataController {
           break;
       }
     };
-    if (userGraphCore) {
-      userGraphCore.batch(change);
+    if (graphCore) {
+      graphCore.batch(change);
     } else {
       change();
     }
@@ -215,7 +216,7 @@ export class DataController {
   }) {
     const { ids, action } = params;
     ids.forEach((id) => {
-      this.userGraphCore.mergeNodeData(id, {
+      this.graphCore.mergeNodeData(id, {
         collapsed: action === 'collapse',
       });
     });
@@ -223,7 +224,7 @@ export class DataController {
 
   private onLayout({ options }) {
     if (this.treeDirtyFlag && isTreeLayout(options)) {
-      this.establishUserGraphCoreTree();
+      this.establishGraphCoreTree();
     }
   }
 
@@ -231,7 +232,7 @@ export class DataController {
     const { modes = {} } = this.graph.getSpecification();
     const mode = this.graph.getMode() || 'default';
     if (hasTreeBehaviors(modes[mode])) {
-      this.establishUserGraphCoreTree();
+      this.establishGraphCoreTree();
     }
   }
 
@@ -244,31 +245,29 @@ export class DataController {
     const mode = this.graph.getMode() || 'default';
     if (action !== 'add' || !modes.includes(mode)) return;
     if (hasTreeBehaviors(behaviors)) {
-      this.establishUserGraphCoreTree();
+      this.establishGraphCoreTree();
     }
   }
 
   private onModeChange(param: { mode: string }) {
     const { modes = {} } = this.graph.getSpecification();
     if (hasTreeBehaviors(modes[param.mode])) {
-      this.establishUserGraphCoreTree();
+      this.establishGraphCoreTree();
     }
   }
 
-  private establishUserGraphCoreTree() {
+  private establishGraphCoreTree() {
     if (!this.treeDirtyFlag) return;
-    const nodes = this.userGraphCore.getAllNodes();
-    const edges = this.userGraphCore.getAllEdges();
-    this.userGraphCore.batch(() => {
-      // graph data to tree structure and storing
-      const rootIds = nodes
-        .filter((node) => node.data.isRoot)
-        .map((node) => node.id);
-      graphData2TreeData({}, { nodes, edges }, rootIds).forEach((tree) => {
-        traverse(tree, (node) => {
-          node.children?.forEach((child) => {
-            this.userGraphCore.setParent(child.id, node.id, 'tree');
-          });
+    const nodes = this.graphCore.getAllNodes();
+    const edges = this.graphCore.getAllEdges();
+    // graph data to tree structure and storing
+    const rootIds = nodes
+      .filter((node) => node.data.isRoot)
+      .map((node) => node.id);
+    graphData2TreeData({}, { nodes, edges }, rootIds).forEach((tree) => {
+      traverse(tree, (node) => {
+        node.children?.forEach((child) => {
+          this.graphCore.setParent(child.id, node.id, 'tree');
         });
       });
     });
@@ -286,20 +285,11 @@ export class DataController {
   ) {
     const { type: dataType, data } = this.formatData(dataConfig) || {};
     if (!dataType) return;
+    this.dataType = dataType;
 
     const { nodes = [], edges = [], combos = [] } = this.transformData(data);
 
     if (changeType === 'replace') {
-      this.userGraphCore = new GraphLib<NodeUserModelData, EdgeUserModelData>({
-        nodes: nodes.concat(
-          combos?.map((combo) => ({
-            id: combo.id,
-            data: { ...combo.data, _isCombo: true },
-          })) || [],
-        ),
-        edges,
-        onChanged: (event) => this.updateGraphCore(event),
-      });
       this.graphCore = new GraphLib<NodeModelData, EdgeModelData>(
         clone({
           nodes: nodes.concat(
@@ -341,9 +331,9 @@ export class DataController {
         });
       }
     } else {
-      const { userGraphCore } = this;
+      const { graphCore } = this;
       const prevData = deconstructData({
-        nodes: userGraphCore.getAllNodes(),
+        nodes: graphCore.getAllNodes(),
         edges: [],
       });
       const nodesAndCombos = nodes.concat(
@@ -355,62 +345,108 @@ export class DataController {
 
       // =========== node & combos ============
       if (!prevData.nodes.length) {
-        userGraphCore.addNodes(nodesAndCombos);
+        graphCore.addNodes(nodesAndCombos);
       } else {
         if (changeType === 'mergeReplace') {
-          // remove the nodes which are not in data but in userGraphCore
+          // remove the nodes which are not in incoming data but in graphCore
           const nodeAndComboIds = nodesAndCombos.map((node) => node.id);
           prevData.nodes.forEach((prevNode) => {
-            if (!nodeAndComboIds.includes(prevNode.id))
-              userGraphCore.removeNode(prevNode.id);
+            if (!nodeAndComboIds.includes(prevNode.id)) {
+              this.removeNode(prevNode);
+            }
           });
         }
         // add or update node
         nodesAndCombos.forEach((item) => {
-          if (userGraphCore.hasNode(item.id)) {
+          if (graphCore.hasNode(item.id)) {
             // update node which is in the graphCore
-            userGraphCore.mergeNodeData(item.id, item.data);
+            graphCore.mergeNodeData(item.id, item.data);
           } else {
             // add node which is in data but not in graphCore
-            userGraphCore.addNode(item);
+            graphCore.addNode(item);
           }
         });
       }
 
       // =========== edge ============
-      prevData.edges = userGraphCore.getAllEdges();
+      prevData.edges = graphCore.getAllEdges();
       if (!prevData.edges.length) {
-        userGraphCore.addEdges(edges);
+        graphCore.addEdges(edges);
       } else {
         if (changeType === 'mergeReplace') {
-          // remove the edges which are not in data but in userGraphCore
+          // remove the edges which are not in incoming data but in graphCore
           const edgeIds = edges.map((edge) => edge.id);
           prevData.edges.forEach((prevEdge) => {
             if (!edgeIds.includes(prevEdge.id))
-              userGraphCore.removeEdge(prevEdge.id);
+              graphCore.removeEdge(prevEdge.id);
           });
         }
         // add or update edge
         edges.forEach((edge) => {
-          if (userGraphCore.hasEdge(edge.id)) {
+          if (graphCore.hasEdge(edge.id)) {
             // update edge which is in the graphCore
-            userGraphCore.mergeEdgeData(edge.id, edge.data);
+            graphCore.mergeEdgeData(edge.id, edge.data);
           } else {
             // add edge which is in data but not in graphCore
-            userGraphCore.addEdge(edge);
+            graphCore.addEdge(edge);
           }
         });
       }
     }
 
     if (data.edges?.length) {
-      const { userGraphCore } = this;
+      const { graphCore } = this;
       // convert and store tree structure to graphCore
       this.updateTreeGraph(dataType, {
-        nodes: userGraphCore.getAllNodes(),
-        edges: userGraphCore.getAllEdges(),
+        nodes: graphCore.getAllNodes(),
+        edges: graphCore.getAllEdges(),
       });
     }
+  }
+
+  private removeNode(nodeModel: NodeModel) {
+    const { id, data } = nodeModel;
+    const { graphCore } = this;
+    if (graphCore.hasTreeStructure('combo')) {
+      // remove from its parent's children list
+      graphCore.setParent(id, undefined, 'combo');
+      const { parentId } = data;
+      // move the children to the grandparent's children list
+      graphCore.getChildren(id, 'combo').forEach((child) => {
+        graphCore.setParent(child.id, parentId, 'combo');
+        graphCore.mergeNodeData(child.id, { parentId });
+      });
+    }
+    if (graphCore.hasTreeStructure('tree')) {
+      const succeedIds = [];
+      graphCore.dfsTree(
+        id,
+        (child) => {
+          succeedIds.push(child.id);
+        },
+        'tree',
+      );
+      const succeedEdgeIds = graphCore
+        .getAllEdges()
+        .filter(
+          ({ source, target }) =>
+            succeedIds.includes(source) && succeedIds.includes(target),
+        )
+        .map((edge) => edge.id);
+      this.graph.showItem(
+        succeedIds
+          .filter((succeedId) => succeedId !== id)
+          .concat(succeedEdgeIds),
+      );
+
+      // for tree graph view, remove the node from the parent's children list
+      graphCore.setParent(id, undefined, 'tree');
+      // for tree graph view, make the its children to be roots
+      graphCore
+        .getChildren(id, 'tree')
+        .forEach((child) => graphCore.setParent(child.id, undefined, 'tree'));
+    }
+    graphCore.removeNode(id);
   }
 
   /**
@@ -418,30 +454,25 @@ export class DataController {
    * @param data data to be removed which is part of old one
    */
   private removeData(data: GraphData) {
-    const { userGraphCore } = this;
+    const { graphCore } = this;
     const { nodes = [], edges = [], combos = [] } = data;
     const nodesAndCombos = nodes.concat(combos);
-    const prevNodesAndCombos = userGraphCore.getAllNodes();
-    const prevEdges = userGraphCore.getAllEdges();
+    const prevNodesAndCombos = graphCore.getAllNodes();
+    const prevEdges = graphCore.getAllEdges();
     if (prevNodesAndCombos.length && nodesAndCombos.length) {
-      // update the parentId
-      if (this.graphCore.hasTreeStructure('combo')) {
-        nodesAndCombos.forEach((item) => {
-          const { parentId } = item.data;
-          this.graphCore.getChildren(item.id, 'combo').forEach((child) => {
-            userGraphCore.mergeNodeData(child.id, { parentId });
-          });
-        });
-      }
+      // update combo tree view and tree graph view
+      nodesAndCombos.forEach((item) => {
+        this.removeNode(item);
+      });
       // remove the node
-      userGraphCore.removeNodes(nodesAndCombos.map((node) => node.id));
+      // graphCore.removeNodes(nodesAndCombos.map((node) => node.id));
     }
     if (prevEdges.length && edges.length) {
       // add or update edge
       const ids = edges
         .map((edge) => edge.id)
-        .filter((id) => userGraphCore.hasEdge(id));
-      userGraphCore.removeEdges(ids);
+        .filter((id) => graphCore.hasEdge(id));
+      graphCore.removeEdges(ids);
     }
   }
 
@@ -450,7 +481,7 @@ export class DataController {
    * @param data data to be updated which is part of old one
    */
   private updateData(dataConfig: DataConfig) {
-    const { userGraphCore } = this;
+    const { graphCore } = this;
     const { type: dataType, data } = this.formatData(dataConfig);
     if (!dataType) return;
     const { nodes = [], edges = [], combos = [] } = data; //this.transformData(data as GraphData);
@@ -459,38 +490,35 @@ export class DataController {
       edges: prevEdges,
       combos: prevCombos,
     } = deconstructData({
-      nodes: userGraphCore.getAllNodes(),
-      edges: userGraphCore.getAllEdges(),
+      nodes: graphCore.getAllNodes(),
+      edges: graphCore.getAllEdges(),
     });
     if (prevNodes.length) {
       // update node
       nodes.forEach((newModel) => {
         const { id, data } = newModel;
         if (data) {
-          const mergedData = mergeOneLevelData(
-            userGraphCore.getNode(id),
-            newModel,
-          );
-          userGraphCore.mergeNodeData(id, mergedData);
+          const mergedData = mergeOneLevelData(graphCore.getNode(id), newModel);
+          graphCore.mergeNodeData(id, mergedData);
+        }
+        if (data.hasOwnProperty('parentId')) {
+          graphCore.setParent(id, data.parentId, 'combo');
         }
       });
     }
     if (prevEdges.length) {
       // update edge
       edges.forEach((newModel) => {
-        const oldModel = userGraphCore.getEdge(newModel.id);
+        const oldModel = graphCore.getEdge(newModel.id);
         if (!oldModel) return;
         const { id, source, target, data } = newModel;
         if (source && oldModel.source !== source)
-          userGraphCore.updateEdgeSource(id, source);
+          graphCore.updateEdgeSource(id, source);
         if (target && oldModel.target !== target)
-          userGraphCore.updateEdgeTarget(id, target);
+          graphCore.updateEdgeTarget(id, target);
         if (data) {
-          const mergedData = mergeOneLevelData(
-            userGraphCore.getEdge(id),
-            newModel,
-          );
-          userGraphCore.mergeEdgeData(id, mergedData);
+          const mergedData = mergeOneLevelData(graphCore.getEdge(id), newModel);
+          graphCore.mergeEdgeData(id, mergedData);
         }
       });
     }
@@ -538,17 +566,20 @@ export class DataController {
         }
         // update other properties
         if (Object.keys(others).length) {
-          const mergedData = mergeOneLevelData(userGraphCore.getNode(id), {
+          const mergedData = mergeOneLevelData(graphCore.getNode(id), {
             id,
             data: others,
           });
-          userGraphCore.mergeNodeData(id, mergedData);
+          graphCore.mergeNodeData(id, mergedData);
+          if (others.hasOwnProperty('parentId')) {
+            graphCore.setParent(id, others.parentId, 'combo');
+          }
         }
       });
       // update succeed nodes
       modelsToMove.forEach((newModel) => {
         const { id, data } = newModel;
-        userGraphCore.mergeNodeData(id, data);
+        graphCore.mergeNodeData(id, data);
       });
     }
 
@@ -560,8 +591,8 @@ export class DataController {
     ) {
       // convert and store tree structure to graphCore
       this.updateTreeGraph(dataType, {
-        nodes: this.userGraphCore.getAllNodes(),
-        edges: this.userGraphCore.getAllEdges(),
+        nodes: this.graphCore.getAllNodes(),
+        edges: this.graphCore.getAllEdges(),
       });
     }
   }
@@ -589,7 +620,7 @@ export class DataController {
     }
 
     return {
-      type: type || 'graphData',
+      type: type || this.dataType || 'graphData',
       data: data as GraphData,
     };
   }
@@ -640,15 +671,12 @@ export class DataController {
       }
     });
     // update succeed nodes
-    const { userGraphCore } = this;
+    const { graphCore } = this;
     succeedNodesModels.forEach((newModel) => {
       const { id, data } = newModel;
       if (data) {
-        const mergedData = mergeOneLevelData(
-          userGraphCore.getNode(id),
-          newModel,
-        );
-        userGraphCore.mergeNodeData(id, mergedData);
+        const mergedData = mergeOneLevelData(graphCore.getNode(id), newModel);
+        graphCore.mergeNodeData(id, mergedData);
       }
     });
   }
@@ -656,17 +684,21 @@ export class DataController {
   private addCombo(data: GraphData) {
     const { combos = [] } = data;
     if (!combos?.length) return;
-    const { userGraphCore } = this;
+    const { graphCore } = this;
     const { id, data: comboData } = combos[0];
     const { _children = [], ...others } = comboData;
 
+    if (!graphCore.hasTreeStructure('combo')) {
+      graphCore.attachTreeStructure('combo');
+    }
+
     // add or update combo
-    if (userGraphCore.hasNode(id)) {
+    if (graphCore.hasNode(id)) {
       // update node which is in the graphCore
-      userGraphCore.mergeNodeData(id, { ...others, _isCombo: true });
+      graphCore.mergeNodeData(id, { ...others, _isCombo: true });
     } else {
       // add node which is in data but not in graphCore
-      userGraphCore.addNode({ id, data: { ...others, _isCombo: true } });
+      graphCore.addNode({ id, data: { ...others, _isCombo: true } });
     }
 
     // update strucutre
@@ -677,252 +709,20 @@ export class DataController {
         );
         return;
       }
-      userGraphCore.mergeNodeData(childId, { parentId: id });
+      graphCore.setParent(childId, id, 'combo');
+      graphCore.mergeNodeData(childId, { parentId: id });
     });
   }
 
   /**
-   * Update graphCore with transformed userGraphCore data.
-   */
-  private updateGraphCore(event) {
-    const { graphCore } = this;
-
-    const {
-      nodes = [],
-      edges = [],
-      combos = [],
-    } = deconstructData({
-      nodes: this.userGraphCore.getAllNodes(),
-      edges: this.userGraphCore.getAllEdges(),
-    });
-
-    const prevNodesAndCombos = graphCore.getAllNodes();
-
-    // function to update one data in graphCore with different model type ('node' or 'edge')
-    const syncUpdateToGraphCore = (
-      id,
-      newValue,
-      oldValue,
-      isNodeOrCombo,
-      diff = [],
-    ) => {
-      if (isNodeOrCombo) {
-        if (newValue.data) graphCore.updateNodeData(id, { ...newValue.data });
-      } else {
-        if (diff.includes('data'))
-          graphCore.updateEdgeData(id, { ...newValue.data });
-        // source and target may be changed
-        if (diff.includes('source'))
-          graphCore.updateEdgeSource(id, newValue.source);
-        if (diff.includes('target'))
-          graphCore.updateEdgeTarget(id, newValue.target);
-      }
-    };
-
-    graphCore.batch(() => {
-      // === step 3: sync to graphCore according to the changes in userGraphCore ==
-      const newModelMap: {
-        [id: string]: {
-          type: 'node' | 'edge' | 'combo';
-          model: NodeModel | EdgeModel | ComboModel;
-        };
-      } = {};
-      const parentMap: {
-        [id: string]: {
-          new: ID;
-          old?: ID;
-        };
-      } = {};
-      const changeMap: {
-        [id: string]: boolean;
-      } = {};
-      const treeChanges = [];
-      event.changes.forEach((change) => {
-        const id = change.id || change.value?.id;
-        if (id !== undefined) {
-          changeMap[id] = true;
-          return;
-        }
-        if (
-          [
-            'TreeStructureAttached',
-            'TreeStructureChanged',
-            'TreeStructureChanged',
-          ].includes(change.type)
-        ) {
-          treeChanges.push(change);
-        }
-      });
-      nodes.forEach((model) => {
-        newModelMap[model.id] = { type: 'node', model };
-        if (model.data.hasOwnProperty('parentId')) {
-          parentMap[model.id] = {
-            new: model.data.parentId,
-            old: undefined,
-          };
-        }
-      });
-      edges.forEach(
-        (model) => (newModelMap[model.id] = { type: 'edge', model }),
-      );
-      combos.forEach((model) => {
-        newModelMap[model.id] = { type: 'combo', model };
-        if (model.data.hasOwnProperty('parentId')) {
-          parentMap[model.id] = {
-            new: model.data.parentId,
-            old: undefined,
-          };
-        }
-      });
-      prevNodesAndCombos.forEach((prevModel) => {
-        const { id } = prevModel;
-        if (
-          parentMap[id]?.new !== undefined ||
-          prevModel.data.parentId !== undefined
-        ) {
-          parentMap[id] = {
-            new: parentMap[id]?.new,
-            old: prevModel.data.parentId,
-          };
-        } else {
-          delete parentMap[id];
-        }
-        const { model: newModel } = newModelMap[id] || {};
-        // remove
-        if (!newModel) {
-          // remove a combo, put the children to upper parent
-          if (prevModel.data._isCombo) {
-            graphCore.getChildren(id, 'combo').forEach((child) => {
-              parentMap[child.id] = {
-                ...parentMap[child.id],
-                new: prevModel.data.parentId,
-              };
-            });
-          }
-          // if it has combo parent, remove it from the parent's children list
-          if (prevModel.data.parentId) {
-            graphCore.setParent(id, undefined, 'combo');
-          }
-
-          // for tree graph view, show the succeed nodes and edges
-          const succeedIds = [];
-          if (graphCore.hasTreeStructure('tree')) {
-            graphCore.dfsTree(
-              id,
-              (child) => {
-                succeedIds.push(child.id);
-              },
-              'tree',
-            );
-            const succeedEdgeIds = graphCore
-              .getAllEdges()
-              .filter(
-                ({ source, target }) =>
-                  succeedIds.includes(source) && succeedIds.includes(target),
-              )
-              .map((edge) => edge.id);
-            this.graph.showItem(
-              succeedIds
-                .filter((succeedId) => succeedId !== id)
-                .concat(succeedEdgeIds),
-            );
-
-            // for tree graph view, remove the node from the parent's children list
-            graphCore.setParent(id, undefined, 'tree');
-            // for tree graph view, make the its children to be roots
-            graphCore
-              .getChildren(id, 'tree')
-              .forEach((child) =>
-                graphCore.setParent(child.id, undefined, 'tree'),
-              );
-          }
-          // remove the node data
-          graphCore.removeNode(id);
-          delete parentMap[prevModel.id];
-        }
-        // update
-        //  || diffAt(newModel, prevModel, true)?.length
-        else if (changeMap[id])
-          syncUpdateToGraphCore(id, newModel, prevModel, true);
-        // delete from the map indicates this model is visited
-        delete newModelMap[id];
-      });
-      graphCore.getAllEdges().forEach((prevEdge) => {
-        const { id } = prevEdge;
-        const { model: newModel } = newModelMap[id] || {};
-        // remove
-        if (!newModel) graphCore.removeEdge(id);
-        // update
-        else {
-          const diff = diffAt(newModel, prevEdge, false);
-          if (diff?.length)
-            syncUpdateToGraphCore(id, newModel, prevEdge, false, diff);
-        }
-        // delete from the map indicates this model is visited
-        delete newModelMap[id];
-      });
-      // add
-      Object.values(newModelMap).forEach(({ type, model }) => {
-        if (type === 'node' || type === 'combo') graphCore.addNode(model);
-        else if (type === 'edge') graphCore.addEdge(model as EdgeModel);
-      });
-      // update parents after adding all items
-      Object.keys(parentMap).forEach((id) => {
-        if (parentMap[id].new === parentMap[id].old) return;
-        if (!validateComboStrucutre(this.graph, id, parentMap[id].new)) {
-          graphCore.mergeNodeData(id, { parentId: parentMap[id].old });
-          return;
-        }
-        graphCore.mergeNodeData(id, { parentId: parentMap[id].new });
-        graphCore.setParent(id, parentMap[id].new, 'combo');
-        // after remove from parent's children list, check whether the parent is empty
-        // if so, update parent's position to be the child's
-        if (parentMap[id].old !== undefined) {
-          const parentChildren = graphCore.getChildren(
-            parentMap[id].old,
-            'combo',
-          );
-          const {
-            x = 0,
-            y = 0,
-            z = 0,
-          } = this.graph.getDisplayModel(parentMap[id].old)?.data || {};
-          if (!parentChildren.length) {
-            graphCore.mergeNodeData(parentMap[id].old, {
-              x: convertToNumber(x),
-              y: convertToNumber(y),
-              z: convertToNumber(z),
-            });
-          }
-        }
-      });
-
-      // update tree structure
-      treeChanges.forEach((change) => {
-        const { type, treeKey, nodeId, newParentId } = change;
-        if (type === 'TreeStructureAttached') {
-          graphCore.attachTreeStructure(treeKey);
-          return;
-        } else if (type === 'TreeStructureChanged') {
-          graphCore.setParent(nodeId, newParentId, treeKey);
-          return;
-        } else if (type === 'TreeStructureDetached') {
-          graphCore.detachTreeStructure(treeKey);
-          return;
-        }
-      });
-    });
-  }
-
-  /**
-   * Clone data from userGraphCore, and run transforms
+   * Clone data from graphCore, and run transforms
    * @returns transformed data and the id map list
    */
   private transformData(data): GraphData {
     let dataCloned: GraphData = clone(data);
     //  transform the data with transform extensions, output innerData and idMaps ===
     this.extensions.forEach(({ func, config }) => {
-      dataCloned = func(dataCloned, config, this.userGraphCore);
+      dataCloned = func(dataCloned, config, this.graphCore);
     });
     return dataCloned;
   }
@@ -933,12 +733,12 @@ export class DataController {
    * @param data
    */
   private updateTreeGraph(dataType, data) {
-    this.userGraphCore.attachTreeStructure('tree');
+    this.graphCore.attachTreeStructure('tree');
     if (dataType === 'treeData') {
       // tree structure storing
       data.edges.forEach((edge) => {
         const { source, target } = edge;
-        this.userGraphCore.setParent(target, source, 'tree');
+        this.graphCore.setParent(target, source, 'tree');
       });
     } else {
       this.treeDirtyFlag = true;

--- a/packages/g6/src/runtime/controller/item.ts
+++ b/packages/g6/src/runtime/controller/item.ts
@@ -428,10 +428,6 @@ export class ItemController {
         });
       };
       const debounceUpdateRelates = debounce(updateRelates, 16, false);
-      const throttleUpdateRelates = throttle(updateRelates, 16, {
-        leading: true,
-        trailing: true,
-      });
 
       Object.values(nodeComboUpdate).forEach((updateObj: any) => {
         const { isReplace, previous, current, id } = updateObj;
@@ -527,7 +523,7 @@ export class ItemController {
           nodeRelatedIdsToUpdate.add(edge.id);
         });
 
-        item.onframe = () => throttleUpdateRelates(nodeRelatedIdsToUpdate);
+        item.onframe = () => updateRelates(nodeRelatedIdsToUpdate);
         let statesCache;
         if (
           innerModel.data._isCombo &&
@@ -557,7 +553,7 @@ export class ItemController {
             },
             500,
             {
-              leading: false,
+              leading: true,
               trailing: true,
             },
           ),
@@ -1641,6 +1637,7 @@ export class ItemController {
       undefined,
       !animate,
       (model, canceled) => {
+        console.log('position finish');
         this.graph.hideItem(model.id, canceled);
       },
       undefined,

--- a/packages/g6/src/runtime/controller/item.ts
+++ b/packages/g6/src/runtime/controller/item.ts
@@ -542,7 +542,6 @@ export class ItemController {
           // call after updating finished
           throttle(
             (_, canceled) => {
-              item.onframe?.(true);
               item.onframe = undefined;
               if (statesCache) {
                 statesCache.forEach((state) =>
@@ -1637,7 +1636,6 @@ export class ItemController {
       undefined,
       !animate,
       (model, canceled) => {
-        console.log('position finish');
         this.graph.hideItem(model.id, canceled);
       },
       undefined,

--- a/packages/g6/src/runtime/graph.ts
+++ b/packages/g6/src/runtime/graph.ts
@@ -1126,11 +1126,17 @@ export default class Graph<B extends BehaviorRegistry, T extends ThemeRegistry>
   public removeData(itemType: ITEM_TYPE, ids: ID | ID[]) {
     const idArr = isArray(ids) ? ids : [ids];
     const data = { nodes: [], edges: [], combos: [] };
-    const { userGraphCore, graphCore } = this.dataController;
+    const { graphCore } = this.dataController;
     const { specification } = this.themeController;
-    const getItem =
-      itemType === 'edge' ? userGraphCore.getEdge : userGraphCore.getNode;
-    data[`${itemType}s`] = idArr.map((id) => getItem.bind(userGraphCore)(id));
+    const getItem = itemType === 'edge' ? graphCore.getEdge : graphCore.getNode;
+    const hasItem = itemType === 'edge' ? graphCore.hasEdge : graphCore.hasNode;
+    data[`${itemType}s`] = idArr.map((id) => {
+      if (!hasItem.bind(graphCore)(id)) {
+        console.warn(`The ${itemType} data with id ${id} does not exist. It will be ignored`);
+        return;
+      }
+      return getItem.bind(graphCore)(id);
+    }).filter(Boolean);
     graphCore.once('changed', (event) => {
       if (!event.changes.length) return;
       const changes = event.changes;

--- a/packages/g6/src/runtime/graph.ts
+++ b/packages/g6/src/runtime/graph.ts
@@ -7,7 +7,7 @@ import {
   PointLike,
   Rect,
   Cursor,
-} from '@antv/g'
+} from '@antv/g';
 import { GraphChange, ID } from '@antv/graphlib';
 import {
   clone,

--- a/packages/g6/src/stdlib/behavior/index.ts
+++ b/packages/g6/src/stdlib/behavior/index.ts
@@ -13,6 +13,6 @@ export * from './orbit-canvas-3d';
 export * from './rotate-canvas-3d';
 export * from './track-canvas-3d';
 export * from './zoom-canvas-3d';
-export * from './create-edge'
+export * from './create-edge';
 export * from './shortcuts-call';
 export * from './scroll-canvas';

--- a/packages/g6/src/stdlib/behavior/zoom-canvas.ts
+++ b/packages/g6/src/stdlib/behavior/zoom-canvas.ts
@@ -76,6 +76,7 @@ export class ZoomCanvas extends Behavior {
   private hiddenEdgeIds: ID[];
   private hiddenNodeIds: ID[];
   private zoomTimer: ReturnType<typeof setTimeout>;
+  private tileRequestId?: number;
 
   constructor(options: Partial<ZoomCanvasOptions>) {
     const finalOptions = Object.assign({}, DEFAULT_OPTIONS, options);
@@ -117,11 +118,14 @@ export class ZoomCanvas extends Behavior {
     const { graph } = this;
     const { tileBehavior: graphBehaviorOptimize, tileBehaviorSize = 1000 } =
       graph.getSpecification().optimize || {};
-    const optimize = this.options.enableOptimize || graphBehaviorOptimize;
-    const shouldOptimzie = isNumber(optimize)
+    const optimize =
+      this.options.enableOptimize !== undefined
+        ? this.options.enableOptimize
+        : graphBehaviorOptimize;
+    const shouldOptimze = isNumber(optimize)
       ? graph.getAllNodesData().length > optimize
       : optimize;
-    if (shouldOptimzie) {
+    if (shouldOptimze) {
       this.hiddenEdgeIds = graph
         .getAllEdgesData()
         .map((edge) => edge.id)
@@ -131,7 +135,6 @@ export class ZoomCanvas extends Behavior {
         .map((node) => node.id)
         .filter((id) => graph.getItemVisible(id) === true);
 
-      let requestId;
       const hiddenIds = [...this.hiddenNodeIds];
       const sectionNum = Math.ceil(hiddenIds.length / tileBehaviorSize);
       const sections = Array.from({ length: sectionNum }, (v, i) =>
@@ -141,17 +144,26 @@ export class ZoomCanvas extends Behavior {
         ),
       );
       const update = () => {
-        if (!sections.length) {
-          cancelAnimationFrame(requestId);
+        if (!sections.length && this.tileRequestId) {
+          cancelAnimationFrame(this.tileRequestId);
+          this.tileRequestId = undefined;
           return;
         }
         const section = sections.shift();
         graph.startHistoryBatch();
         graph.hideItem(section, false, true);
+<<<<<<< HEAD
         graph.stopHistoryBatch();
         requestId = requestAnimationFrame(update);
       };
       requestId = requestAnimationFrame(update);
+=======
+        this.tileRequestId = requestAnimationFrame(update);
+      };
+      graph.startHistoryBatch();
+      this.tileRequestId = requestAnimationFrame(update);
+      graph.stopHistoryBatch();
+>>>>>>> 1f9ef72a9b (fix: edge update problem; fix: autoFit at first render and layout;)
     }
   }
 
@@ -159,14 +171,20 @@ export class ZoomCanvas extends Behavior {
     const { graph, hiddenEdgeIds = [], hiddenNodeIds } = this;
     const { tileBehavior: graphBehaviorOptimize, tileBehaviorSize = 1000 } =
       graph.getSpecification().optimize || {};
-    const optimize = this.options.enableOptimize || graphBehaviorOptimize;
-    const shouldOptimzie = isNumber(optimize)
+    const optimize =
+      this.options.enableOptimize !== undefined
+        ? this.options.enableOptimize
+        : graphBehaviorOptimize;
+    const shouldOptimze = isNumber(optimize)
       ? graph.getAllNodesData().length > optimize
       : optimize;
     this.zooming = false;
-    if (shouldOptimzie) {
+    if (shouldOptimze) {
+      if (this.tileRequestId) {
+        cancelAnimationFrame(this.tileRequestId);
+        this.tileRequestId = undefined;
+      }
       if (hiddenNodeIds) {
-        let requestId;
         const hiddenIds = [...hiddenNodeIds, ...hiddenEdgeIds];
         const sectionNum = Math.ceil(hiddenIds.length / tileBehaviorSize);
         const sections = Array.from({ length: sectionNum }, (v, i) =>
@@ -176,16 +194,26 @@ export class ZoomCanvas extends Behavior {
           ),
         );
         const update = () => {
-          if (!sections.length) {
-            cancelAnimationFrame(requestId);
+          if (!sections.length && this.tileRequestId) {
+            cancelAnimationFrame(this.tileRequestId);
+            this.tileRequestId = undefined;
             return;
           }
+<<<<<<< HEAD
           graph.executeWithNoStack(() => {
             graph.showItem(sections.shift(), false);
           });
           requestId = requestAnimationFrame(update);
         };
         requestId = requestAnimationFrame(update);
+=======
+          graph.showItem(sections.shift(), false);
+          this.tileRequestId = requestAnimationFrame(update);
+        };
+        graph.executeWithNoStack(() => {
+          this.tileRequestId = requestAnimationFrame(update);
+        });
+>>>>>>> 1f9ef72a9b (fix: edge update problem; fix: autoFit at first render and layout;)
       }
     }
     this.hiddenEdgeIds = [];

--- a/packages/g6/src/stdlib/behavior/zoom-canvas.ts
+++ b/packages/g6/src/stdlib/behavior/zoom-canvas.ts
@@ -152,18 +152,10 @@ export class ZoomCanvas extends Behavior {
         const section = sections.shift();
         graph.startHistoryBatch();
         graph.hideItem(section, false, true);
-<<<<<<< HEAD
         graph.stopHistoryBatch();
-        requestId = requestAnimationFrame(update);
-      };
-      requestId = requestAnimationFrame(update);
-=======
         this.tileRequestId = requestAnimationFrame(update);
       };
-      graph.startHistoryBatch();
       this.tileRequestId = requestAnimationFrame(update);
-      graph.stopHistoryBatch();
->>>>>>> 1f9ef72a9b (fix: edge update problem; fix: autoFit at first render and layout;)
     }
   }
 
@@ -199,21 +191,12 @@ export class ZoomCanvas extends Behavior {
             this.tileRequestId = undefined;
             return;
           }
-<<<<<<< HEAD
           graph.executeWithNoStack(() => {
             graph.showItem(sections.shift(), false);
           });
-          requestId = requestAnimationFrame(update);
-        };
-        requestId = requestAnimationFrame(update);
-=======
-          graph.showItem(sections.shift(), false);
           this.tileRequestId = requestAnimationFrame(update);
         };
-        graph.executeWithNoStack(() => {
-          this.tileRequestId = requestAnimationFrame(update);
-        });
->>>>>>> 1f9ef72a9b (fix: edge update problem; fix: autoFit at first render and layout;)
+        this.tileRequestId = requestAnimationFrame(update);
       }
     }
     this.hiddenEdgeIds = [];

--- a/packages/g6/src/stdlib/data/mapNodeSize.ts
+++ b/packages/g6/src/stdlib/data/mapNodeSize.ts
@@ -9,7 +9,7 @@ import {
 /**
  * Validate and format the graph data.
  * @param data input user data.
- * @param userGraphCore the graph core stores the previous data.
+ * @param graphCore the graph core stores the previous data.
  * @returns formatted data.
  */
 export const MapNodeSize = (
@@ -18,7 +18,7 @@ export const MapNodeSize = (
     field?: string;
     range?: [number, number];
   } = {},
-  userGraphCore?: GraphCore,
+  graphCore?: GraphCore,
 ): GraphData => {
   const { field, range = [8, 40] } = options;
   if (!field) return data;

--- a/packages/g6/src/stdlib/data/transformV4Data.ts
+++ b/packages/g6/src/stdlib/data/transformV4Data.ts
@@ -10,13 +10,13 @@ import {
 /**
  * Validate and format the graph data.
  * @param data input user data.
- * @param userGraphCore the graph core stores the previous data.
+ * @param graphCore the graph core stores the previous data.
  * @returns formatted data.
  */
 export const TransformV4Data = (
   data: GraphData,
   options = {},
-  userGraphCore?: GraphCore,
+  graphCore?: GraphCore,
 ): GraphData => {
   const { nodes = [], edges = [], combos = [] } = data;
   const formattedNodes = nodes.map((node: any) => {

--- a/packages/g6/src/stdlib/data/validateData.ts
+++ b/packages/g6/src/stdlib/data/validateData.ts
@@ -10,13 +10,13 @@ import {
 /**
  * Validate and format the graph data.
  * @param data input user data.
- * @param userGraphCore the graph core stores the previous data.
+ * @param graphCore the graph core stores the previous data.
  * @returns formatted data.
  */
 export const ValidateData = (
   data: GraphData,
   options = {},
-  userGraphCore?: GraphCore,
+  graphCore?: GraphCore,
 ): GraphData => {
   const { nodes, edges, combos } = data;
   const idMap = new Map();
@@ -64,7 +64,7 @@ export const ValidateData = (
     if (
       parentId !== undefined &&
       !comboIdMap.has(parentId) &&
-      (!userGraphCore || !userGraphCore.hasNode(parentId))
+      (!graphCore || !graphCore.hasNode(parentId))
     ) {
       console.error(
         `The parentId of combo with id ${combo.id} will be removed since it is not exist in combos.`,
@@ -80,9 +80,9 @@ export const ValidateData = (
       if (
         parentId !== undefined &&
         !comboIdMap.has(parentId) &&
-        (!userGraphCore || !userGraphCore.hasNode(parentId))
+        (!graphCore || !graphCore.hasNode(parentId))
       ) {
-        // TODO: parentId is a node in userGraphCore
+        // TODO: parentId is a node in graphCore
         console.error(
           `The parentId of node with id ${node.id} will be removed since it is not exist in combos.`,
         );
@@ -100,8 +100,8 @@ export const ValidateData = (
       let { source, target } = edge;
       if (!idAndDataCheck(edge, 'edge', true)) return false;
 
-      if (userGraphCore?.hasEdge(id)) {
-        const existEdge = userGraphCore?.getEdge(id);
+      if (graphCore?.hasEdge(id)) {
+        const existEdge = graphCore?.getEdge(id);
         if (source === undefined) source = existEdge.source;
         if (target === undefined) target = existEdge.target;
       }
@@ -121,7 +121,7 @@ export const ValidateData = (
       if (
         !nodeIdMap.has(source) &&
         !comboIdMap.has(source) &&
-        (!userGraphCore || !userGraphCore.hasNode(source))
+        (!graphCore || !graphCore.hasNode(source))
       ) {
         console.error(
           `The edge with id ${id} will be ignored since its source ${source} is not existed in nodes and combos.`,
@@ -131,7 +131,7 @@ export const ValidateData = (
       if (
         !nodeIdMap.has(target) &&
         !comboIdMap.has(target) &&
-        (!userGraphCore || !userGraphCore.hasNode(target))
+        (!graphCore || !graphCore.hasNode(target))
       ) {
         console.error(
           `The edge with id ${id} will be ignored since its target ${target} is not existed in nodes and combos.`,

--- a/packages/g6/src/stdlib/item/edge/base.ts
+++ b/packages/g6/src/stdlib/item/edge/base.ts
@@ -686,12 +686,9 @@ export abstract class BaseEdge {
       resultStyle[`${markerField}Offset`] = 0;
       return;
     }
-    let arrowStyle = {} as ArrowStyle;
-    if (isBoolean(arrowConfig)) {
-      arrowStyle = { ...DEFAULT_ARROW_CONFIG } as ArrowStyle;
-    } else {
-      arrowStyle = arrowConfig;
-    }
+    const arrowStyle = isBoolean(arrowConfig)
+      ? ({ ...DEFAULT_ARROW_CONFIG } as ArrowStyle)
+      : arrowConfig;
     const {
       type = 'triangle',
       width = 10,
@@ -700,14 +697,13 @@ export abstract class BaseEdge {
       offset = 0,
       ...others
     } = arrowStyle;
-    const path = propPath ? propPath : getArrowPath(type, width, height);
     resultStyle[markerField] = this.upsertShape(
       'path',
       `${markerField}Shape`,
       {
         ...bodyStyle,
         fill: type === 'simple' ? '' : bodyStyle.stroke,
-        path,
+        path: propPath || getArrowPath(type, width, height),
         anchor: '0.5 0.5',
         transformOrigin: 'center',
         ...others,

--- a/packages/g6/src/types/graph.ts
+++ b/packages/g6/src/types/graph.ts
@@ -406,7 +406,10 @@ export interface IGraph<
    * @returns
    * @group View
    */
-  fitCenter: (effectTiming?: CameraAnimationOptions) => Promise<void>;
+  fitCenter: (
+    boundsType?: 'render' | 'layout',
+    effectTiming?: CameraAnimationOptions,
+  ) => Promise<void>;
   /**
    * Move the graph to make the item align the view center.
    * @param item node/edge/combo item or its id

--- a/packages/g6/src/types/graph.ts
+++ b/packages/g6/src/types/graph.ts
@@ -395,8 +395,8 @@ export interface IGraph<
    */
   fitView: (
     options?: {
-      padding: Padding;
-      rules: FitViewRules;
+      padding?: Padding;
+      rules?: FitViewRules;
     },
     effectTiming?: CameraAnimationOptions,
   ) => Promise<void>;

--- a/packages/g6/src/types/view.ts
+++ b/packages/g6/src/types/view.ts
@@ -1,7 +1,12 @@
 export interface FitViewRules {
-  onlyOutOfViewPort?: boolean; // Whehter fit it only when the graph is out of the view.
-  direction?: 'x' | 'y' | 'both'; // Axis to fit.
-  ratioRule?: 'max' | 'min'; // Ratio rule to fit.
+  /** Whehter fit it only when the graph is out of the view.  */
+  onlyOutOfViewPort?: boolean;
+  /** Axis to fit.  */
+  direction?: 'x' | 'y' | 'both';
+  /** Ratio rule to fit. */
+  ratioRule?: 'max' | 'min';
+  /** Bounds type. 'render' means calculate the bounds by get rendering bounds. 'layout' for the situation that layout algorithm is done but the positions are not animated rendered. */
+  boundsType?: 'render' | 'layout';
 }
 
 export type GraphAlignment =

--- a/packages/g6/src/util/event.ts
+++ b/packages/g6/src/util/event.ts
@@ -9,6 +9,8 @@ import {
   NodeDataUpdated,
   NodeRemoved,
   TreeStructureChanged,
+  TreeStructureAttached,
+  TreeStructureDetached,
 } from '@antv/graphlib';
 import { IG6GraphEvent, IGraph, NodeModelData } from '../types';
 import { GraphCore } from '../types/data';
@@ -84,6 +86,8 @@ export type GroupedChanges = {
   EdgeDataUpdated: EdgeDataUpdated<EdgeModelData>[];
   TreeStructureChanged: TreeStructureChanged[];
   ComboStructureChanged: TreeStructureChanged[];
+  TreeStructureAttached: TreeStructureAttached[];
+  TreeStructureDetached: TreeStructureDetached[];
 };
 
 /**
@@ -106,6 +110,8 @@ export const getGroupedChanges = (
     EdgeDataUpdated: [],
     TreeStructureChanged: [],
     ComboStructureChanged: [],
+    TreeStructureAttached: [],
+    TreeStructureDetached: [],
   };
   changes.forEach((change) => {
     const { type: changeType } = change;
@@ -126,7 +132,14 @@ export const getGroupedChanges = (
       else if (change.treeKey === 'tree')
         groupedChanges.TreeStructureChanged.push(change);
       return;
-    } else if (['NodeRemoved', 'EdgeRemoved'].includes(changeType)) {
+    } else if (
+      [
+        'NodeRemoved',
+        'EdgeRemoved',
+        'TreeStructureAttached',
+        'TreeStructureDetached',
+      ].includes(changeType)
+    ) {
       groupedChanges[changeType].push(change);
     } else {
       const { id: oid } = change.value;

--- a/packages/g6/src/util/layout.ts
+++ b/packages/g6/src/util/layout.ts
@@ -163,3 +163,48 @@ export const radialLayout = (
   });
   return;
 };
+
+/**
+ * Get the layout (nodes' positions) bounds of a graph.
+ * @param {Graph} graph - The graph object.
+ * @returns {Object} - The layout bounds object containing the minimum, maximum, center, and halfExtents values.
+ */
+export const getLayoutBounds = (graph) => {
+  const min = [Infinity, Infinity];
+  const max = [-Infinity, -Infinity];
+  const borderIds = { min: [], max: [] };
+  graph.getAllNodesData().forEach((model) => {
+    const { x, y } = model.data;
+    if (isNaN(x) || isNaN(y)) return;
+    if (min[0] > x) {
+      min[0] = x;
+      borderIds.min[0] = model.id;
+    }
+    if (min[1] > y) {
+      min[1] = y;
+      borderIds.min[1] = model.id;
+    }
+    if (max[0] < x) {
+      max[0] = x;
+      borderIds.max[0] = model.id;
+    }
+    if (max[1] < y) {
+      max[1] = y;
+      borderIds.max[1] = model.id;
+    }
+  });
+  borderIds.min.forEach((id, i) => {
+    const { halfExtents: nodeHalfSize } = graph.getRenderBBox(id);
+    min[i] -= nodeHalfSize[i];
+  });
+  borderIds.max.forEach((id, i) => {
+    const { halfExtents: nodeHalfSize } = graph.getRenderBBox(id);
+    max[i] += nodeHalfSize[i];
+  });
+  return {
+    min,
+    max,
+    center: min.map((val, i) => (max[i] + val) / 2),
+    halfExtents: min.map((val, i) => (max[i] - val) / 2),
+  };
+};

--- a/packages/g6/src/util/point.ts
+++ b/packages/g6/src/util/point.ts
@@ -61,8 +61,10 @@ export const distance = (p1: Point, p2: Point): number => {
  * @param p2
  * @returns
  */
-export const isSamePoint = (p1: Point, p2: Point): boolean =>
-  p1.x === p2.x && p1.y === p2.y && p1.z === p2.z;
+export const isSamePoint = (p1: Point, p2: Point): boolean => {
+  if (!p1 || !p2) return false;
+  return p1.x === p2.x && p1.y === p2.y && p1.z === p2.z;
+};
 
 /**
  * Get point and circle intersect point.

--- a/packages/g6/src/util/shape.ts
+++ b/packages/g6/src/util/shape.ts
@@ -272,7 +272,7 @@ export const formatPadding = (
 export const mergeStyles = (styleMaps: ItemShapeStyles[]) => {
   let currentResult = styleMaps[0];
   styleMaps.forEach((styleMap, i) => {
-    if (i > 0) currentResult = merge2Styles(currentResult, styleMap);
+    if (i > 0) currentResult = merge2Styles(currentResult, styleMap, i === 1);
   });
   return currentResult;
 };
@@ -286,18 +286,18 @@ export const mergeStyles = (styleMaps: ItemShapeStyles[]) => {
 const merge2Styles = (
   styleMap1: ItemShapeStyles,
   styleMap2: ItemShapeStyles,
+  needClone?: boolean,
 ) => {
   if (!styleMap1) return { ...styleMap2 };
   else if (!styleMap2) return { ...styleMap1 };
-  const mergedStyle = clone(styleMap1);
+  const mergedStyle = needClone ? clone(styleMap1) : styleMap1;
   Object.keys(styleMap2).forEach((shapeId) => {
     const style = styleMap2[shapeId];
-    mergedStyle[shapeId] = mergedStyle[shapeId] || {};
     if (!style) return;
-    Object.keys(style).forEach((styleName) => {
-      const value = style[styleName];
-      mergedStyle[shapeId][styleName] = value;
-    });
+    mergedStyle[shapeId] = {
+      ...mergedStyle[shapeId],
+      ...style,
+    };
   });
   return mergedStyle;
 };

--- a/packages/g6/src/util/shape.ts
+++ b/packages/g6/src/util/shape.ts
@@ -270,9 +270,9 @@ export const formatPadding = (
  * @returns
  */
 export const mergeStyles = (styleMaps: ItemShapeStyles[]) => {
-  let currentResult = styleMaps[0];
+  let currentResult = clone(styleMaps[0]);
   styleMaps.forEach((styleMap, i) => {
-    if (i > 0) currentResult = merge2Styles(currentResult, styleMap, i === 1);
+    if (i > 0) currentResult = merge2Styles(currentResult, styleMap);
   });
   return currentResult;
 };
@@ -286,11 +286,10 @@ export const mergeStyles = (styleMaps: ItemShapeStyles[]) => {
 const merge2Styles = (
   styleMap1: ItemShapeStyles,
   styleMap2: ItemShapeStyles,
-  needClone?: boolean,
 ) => {
   if (!styleMap1) return { ...styleMap2 };
   else if (!styleMap2) return { ...styleMap1 };
-  const mergedStyle = needClone ? clone(styleMap1) : styleMap1;
+  const mergedStyle = styleMap1;
   Object.keys(styleMap2).forEach((shapeId) => {
     const style = styleMap2[shapeId];
     if (!style) return;

--- a/packages/g6/tests/demo/combo/combo-basic.ts
+++ b/packages/g6/tests/demo/combo/combo-basic.ts
@@ -132,5 +132,14 @@ export default (
       ],
     },
   });
+  graph.on('canvas:click', (e) => {
+    // graph.removeData('combo', 'combo1');
+    graph.updateData('node', {
+      id: 'node5',
+      data: {
+        parentId: 'combo3',
+      },
+    });
+  });
   return graph;
 };

--- a/packages/g6/tests/demo/data/graphCore.ts
+++ b/packages/g6/tests/demo/data/graphCore.ts
@@ -1,0 +1,1422 @@
+import { Layout, LayoutMapping } from '@antv/layout';
+import { Graph, extend, stdLib } from '../../../src/index';
+import { TestCaseContext } from '../interface';
+
+const data = {
+  nodes: [
+    {
+      id: '0',
+      name: 'analytics.cluster',
+      cluster: 'analytics',
+      value: 21,
+    },
+    {
+      id: '1',
+      name: 'analytics.graph',
+      cluster: 'analytics',
+      value: 34,
+    },
+    {
+      id: '2',
+      name: 'analytics.optimization',
+      cluster: 'analytics',
+      value: 8,
+    },
+    {
+      id: '3',
+      name: 'animate',
+      cluster: 'animate',
+      value: 40,
+    },
+    {
+      id: '4',
+      name: 'animate.interpolate',
+      cluster: 'animate',
+      value: 18,
+    },
+    {
+      id: '5',
+      name: 'data.converters',
+      cluster: 'data',
+      value: 25,
+    },
+    {
+      id: '6',
+      name: 'data',
+      cluster: 'data',
+      value: 10,
+    },
+    {
+      id: '7',
+      name: 'display',
+      cluster: 'display',
+      value: 4,
+    },
+    {
+      id: '8',
+      name: 'flex',
+      cluster: 'flex',
+      value: 6,
+    },
+    {
+      id: '9',
+      name: 'physics',
+      cluster: 'physics',
+      value: 22,
+    },
+    {
+      id: '10',
+      name: 'query',
+      cluster: 'query',
+      value: 67,
+    },
+    {
+      id: '11',
+      name: 'query.methods',
+      cluster: 'query',
+      value: 71,
+    },
+    {
+      id: '12',
+      name: 'scale',
+      cluster: 'scale',
+      value: 33,
+    },
+    {
+      id: '13',
+      name: 'util',
+      cluster: 'util',
+      value: 23,
+    },
+    {
+      id: '14',
+      name: 'util.heap',
+      cluster: 'util',
+      value: 2,
+    },
+    {
+      id: '15',
+      cluster: 'util',
+      name: 'util.math',
+      value: 2,
+    },
+    {
+      id: '16',
+      name: 'util.palette',
+      cluster: 'util',
+      value: 5,
+    },
+    {
+      id: '17',
+      name: 'vis.axis',
+      cluster: 'vis',
+      value: 24,
+    },
+    {
+      id: '18',
+      name: 'vis.controls',
+      cluster: 'vis',
+      value: 28,
+    },
+    {
+      id: '19',
+      name: 'vis.data',
+      cluster: 'vis',
+      value: 70,
+    },
+    {
+      id: '20',
+      name: 'vis.data.render',
+      cluster: 'vis',
+      value: 11,
+    },
+    {
+      id: '21',
+      name: 'vis.events',
+      cluster: 'vis',
+      value: 8,
+    },
+    {
+      id: '22',
+      name: 'vis.legend',
+      cluster: 'vis',
+      value: 27,
+    },
+    {
+      id: '23',
+      name: 'vis.operator.distortion',
+      cluster: 'vis',
+      value: 9,
+    },
+    {
+      id: '24',
+      name: 'vis.operator.encoder',
+      cluster: 'vis',
+      value: 30,
+    },
+    {
+      id: '25',
+      name: 'vis.operator.filter',
+      cluster: 'vis',
+      value: 17,
+    },
+    {
+      id: '26',
+      name: 'vis.operator',
+      cluster: 'vis',
+      value: 27,
+    },
+    {
+      id: '27',
+      name: 'vis.operator.label',
+      cluster: 'vis',
+      value: 18,
+    },
+    {
+      id: '28',
+      name: 'vis.operator.layout',
+      cluster: 'vis',
+      value: 91,
+    },
+    {
+      id: '29',
+      name: 'vis',
+      cluster: 'vis',
+      value: 13,
+    },
+  ],
+  edges: [
+    {
+      source: '10',
+      target: '10',
+      sourceWeight: 61,
+      targetWeight: 61,
+    },
+    {
+      source: '11',
+      target: '11',
+      sourceWeight: 39,
+      targetWeight: 39,
+    },
+    {
+      source: '3',
+      target: '3',
+      sourceWeight: 30,
+      targetWeight: 30,
+    },
+    {
+      source: '19',
+      target: '19',
+      sourceWeight: 26,
+      targetWeight: 26,
+    },
+    {
+      source: '13',
+      target: '13',
+      sourceWeight: 23,
+      targetWeight: 23,
+    },
+    {
+      source: '9',
+      target: '9',
+      sourceWeight: 22,
+      targetWeight: 22,
+    },
+    {
+      source: '12',
+      target: '12',
+      sourceWeight: 19,
+      targetWeight: 19,
+    },
+    {
+      id: 'edge-1',
+      source: '28',
+      target: '19',
+      sourceWeight: 34,
+      targetWeight: 0,
+    },
+    {
+      source: '4',
+      target: '4',
+      sourceWeight: 16,
+      targetWeight: 16,
+    },
+    {
+      source: '11',
+      target: '10',
+      sourceWeight: 32,
+      targetWeight: 0,
+    },
+    {
+      source: '28',
+      target: '28',
+      sourceWeight: 14,
+      targetWeight: 14,
+    },
+    {
+      source: '18',
+      target: '18',
+      sourceWeight: 12,
+      targetWeight: 12,
+    },
+    {
+      source: '26',
+      target: '26',
+      sourceWeight: 11,
+      targetWeight: 11,
+    },
+    {
+      source: '28',
+      target: '13',
+      sourceWeight: 20,
+      targetWeight: 0,
+    },
+    {
+      source: '5',
+      target: '6',
+      sourceWeight: 17,
+      targetWeight: 2,
+    },
+    {
+      source: '19',
+      target: '13',
+      sourceWeight: 17,
+      targetWeight: 0,
+    },
+    {
+      source: '17',
+      target: '17',
+      sourceWeight: 7,
+      targetWeight: 7,
+    },
+    {
+      source: '6',
+      target: '6',
+      sourceWeight: 7,
+      targetWeight: 7,
+    },
+    {
+      source: '12',
+      target: '13',
+      sourceWeight: 14,
+      targetWeight: 0,
+    },
+    {
+      source: '1',
+      target: '19',
+      sourceWeight: 14,
+      targetWeight: 0,
+    },
+    {
+      source: '5',
+      target: '5',
+      sourceWeight: 7,
+      targetWeight: 7,
+    },
+    {
+      source: '21',
+      target: '19',
+      sourceWeight: 6,
+      targetWeight: 4,
+    },
+    {
+      source: '25',
+      target: '19',
+      sourceWeight: 10,
+      targetWeight: 0,
+    },
+    {
+      source: '0',
+      target: '0',
+      sourceWeight: 5,
+      targetWeight: 5,
+    },
+    {
+      source: '3',
+      target: '13',
+      sourceWeight: 9,
+      targetWeight: 0,
+    },
+    {
+      source: '20',
+      target: '19',
+      sourceWeight: 5,
+      targetWeight: 4,
+    },
+    {
+      source: '19',
+      target: '12',
+      sourceWeight: 9,
+      targetWeight: 0,
+    },
+    {
+      source: '0',
+      target: '19',
+      sourceWeight: 8,
+      targetWeight: 0,
+    },
+    {
+      source: '24',
+      target: '19',
+      sourceWeight: 8,
+      targetWeight: 0,
+    },
+    {
+      source: '22',
+      target: '22',
+      sourceWeight: 4,
+      targetWeight: 4,
+    },
+    {
+      source: '24',
+      target: '24',
+      sourceWeight: 4,
+      targetWeight: 4,
+    },
+    {
+      source: '26',
+      target: '3',
+      sourceWeight: 7,
+      targetWeight: 0,
+    },
+    {
+      source: '24',
+      target: '16',
+      sourceWeight: 7,
+      targetWeight: 0,
+    },
+    {
+      source: '16',
+      target: '16',
+      sourceWeight: 3,
+      targetWeight: 3,
+    },
+    {
+      source: '10',
+      target: '13',
+      sourceWeight: 6,
+      targetWeight: 0,
+    },
+    {
+      source: '7',
+      target: '7',
+      sourceWeight: 3,
+      targetWeight: 3,
+    },
+    {
+      source: '22',
+      target: '13',
+      sourceWeight: 6,
+      targetWeight: 0,
+    },
+    {
+      source: '20',
+      target: '20',
+      sourceWeight: 3,
+      targetWeight: 3,
+    },
+    {
+      source: '1',
+      target: '26',
+      sourceWeight: 6,
+      targetWeight: 0,
+    },
+    {
+      source: '27',
+      target: '19',
+      sourceWeight: 6,
+      targetWeight: 0,
+    },
+    {
+      source: '28',
+      target: '12',
+      sourceWeight: 6,
+      targetWeight: 0,
+    },
+    {
+      source: '22',
+      target: '7',
+      sourceWeight: 6,
+      targetWeight: 0,
+    },
+    {
+      source: '28',
+      target: '3',
+      sourceWeight: 6,
+      targetWeight: 0,
+    },
+    {
+      source: '17',
+      target: '7',
+      sourceWeight: 5,
+      targetWeight: 0,
+    },
+    {
+      source: '26',
+      target: '13',
+      sourceWeight: 5,
+      targetWeight: 0,
+    },
+    {
+      source: '27',
+      target: '13',
+      sourceWeight: 5,
+      targetWeight: 0,
+    },
+    {
+      source: '1',
+      target: '13',
+      sourceWeight: 5,
+      targetWeight: 0,
+    },
+    {
+      source: '1',
+      target: '3',
+      sourceWeight: 5,
+      targetWeight: 0,
+    },
+    {
+      source: '26',
+      target: '29',
+      sourceWeight: 3,
+      targetWeight: 2,
+    },
+    {
+      source: '22',
+      target: '16',
+      sourceWeight: 5,
+      targetWeight: 0,
+    },
+    {
+      source: '18',
+      target: '21',
+      sourceWeight: 4,
+      targetWeight: 0,
+    },
+    {
+      source: '22',
+      target: '12',
+      sourceWeight: 4,
+      targetWeight: 0,
+    },
+    {
+      source: '23',
+      target: '23',
+      sourceWeight: 2,
+      targetWeight: 2,
+    },
+    {
+      source: '17',
+      target: '29',
+      sourceWeight: 2,
+      targetWeight: 2,
+    },
+    {
+      source: '28',
+      target: '17',
+      sourceWeight: 4,
+      targetWeight: 0,
+    },
+    {
+      source: '15',
+      target: '15',
+      sourceWeight: 2,
+      targetWeight: 2,
+    },
+    {
+      source: '17',
+      target: '12',
+      sourceWeight: 4,
+      targetWeight: 0,
+    },
+    {
+      source: '27',
+      target: '27',
+      sourceWeight: 2,
+      targetWeight: 2,
+    },
+    {
+      source: '14',
+      target: '14',
+      sourceWeight: 2,
+      targetWeight: 2,
+    },
+    {
+      source: '18',
+      target: '29',
+      sourceWeight: 3,
+      targetWeight: 1,
+    },
+    {
+      source: '25',
+      target: '26',
+      sourceWeight: 3,
+      targetWeight: 0,
+    },
+    {
+      source: '28',
+      target: '9',
+      sourceWeight: 3,
+      targetWeight: 0,
+    },
+    {
+      source: '27',
+      target: '7',
+      sourceWeight: 3,
+      targetWeight: 0,
+    },
+    {
+      source: '24',
+      target: '12',
+      sourceWeight: 3,
+      targetWeight: 0,
+    },
+    {
+      source: '17',
+      target: '13',
+      sourceWeight: 3,
+      targetWeight: 0,
+    },
+    {
+      source: '18',
+      target: '13',
+      sourceWeight: 3,
+      targetWeight: 0,
+    },
+    {
+      source: '20',
+      target: '13',
+      sourceWeight: 3,
+      targetWeight: 0,
+    },
+    {
+      source: '0',
+      target: '13',
+      sourceWeight: 3,
+      targetWeight: 0,
+    },
+    {
+      source: '24',
+      target: '13',
+      sourceWeight: 3,
+      targetWeight: 0,
+    },
+    {
+      source: '19',
+      target: '6',
+      sourceWeight: 3,
+      targetWeight: 0,
+    },
+    {
+      source: '29',
+      target: '3',
+      sourceWeight: 3,
+      targetWeight: 0,
+    },
+    {
+      source: '25',
+      target: '3',
+      sourceWeight: 3,
+      targetWeight: 0,
+    },
+    {
+      source: '24',
+      target: '3',
+      sourceWeight: 3,
+      targetWeight: 0,
+    },
+    {
+      source: '17',
+      target: '3',
+      sourceWeight: 3,
+      targetWeight: 0,
+    },
+    {
+      source: '0',
+      target: '15',
+      sourceWeight: 2,
+      targetWeight: 0,
+    },
+    {
+      source: '28',
+      target: '26',
+      sourceWeight: 2,
+      targetWeight: 0,
+    },
+    {
+      source: '24',
+      target: '26',
+      sourceWeight: 2,
+      targetWeight: 0,
+    },
+    {
+      source: '16',
+      target: '13',
+      sourceWeight: 2,
+      targetWeight: 0,
+    },
+    {
+      source: '1',
+      target: '14',
+      sourceWeight: 2,
+      targetWeight: 0,
+    },
+    {
+      source: '29',
+      target: '21',
+      sourceWeight: 2,
+      targetWeight: 0,
+    },
+    {
+      source: '21',
+      target: '21',
+      sourceWeight: 1,
+      targetWeight: 1,
+    },
+    {
+      source: '29',
+      target: '19',
+      sourceWeight: 2,
+      targetWeight: 0,
+    },
+    {
+      source: '19',
+      target: '14',
+      sourceWeight: 2,
+      targetWeight: 0,
+    },
+    {
+      source: '4',
+      target: '13',
+      sourceWeight: 2,
+      targetWeight: 0,
+    },
+    {
+      source: '19',
+      target: '15',
+      sourceWeight: 2,
+      targetWeight: 0,
+    },
+    {
+      source: '8',
+      target: '17',
+      sourceWeight: 2,
+      targetWeight: 0,
+    },
+    {
+      source: '2',
+      target: '13',
+      sourceWeight: 2,
+      targetWeight: 0,
+    },
+    {
+      source: '18',
+      target: '19',
+      sourceWeight: 2,
+      targetWeight: 0,
+    },
+    {
+      source: '1',
+      target: '1',
+      sourceWeight: 1,
+      targetWeight: 1,
+    },
+    {
+      source: '23',
+      target: '17',
+      sourceWeight: 2,
+      targetWeight: 0,
+    },
+    {
+      source: '23',
+      target: '19',
+      sourceWeight: 2,
+      targetWeight: 0,
+    },
+    {
+      source: '0',
+      target: '3',
+      sourceWeight: 2,
+      targetWeight: 0,
+    },
+    {
+      source: '18',
+      target: '3',
+      sourceWeight: 2,
+      targetWeight: 0,
+    },
+    {
+      source: '19',
+      target: '3',
+      sourceWeight: 2,
+      targetWeight: 0,
+    },
+    {
+      source: '29',
+      target: '13',
+      sourceWeight: 1,
+      targetWeight: 0,
+    },
+    {
+      source: '8',
+      target: '29',
+      sourceWeight: 1,
+      targetWeight: 0,
+    },
+    {
+      source: '21',
+      target: '3',
+      sourceWeight: 1,
+      targetWeight: 0,
+    },
+    {
+      source: '22',
+      target: '3',
+      sourceWeight: 1,
+      targetWeight: 0,
+    },
+    {
+      source: '3',
+      target: '4',
+      sourceWeight: 1,
+      targetWeight: 0,
+    },
+    {
+      source: '2',
+      target: '29',
+      sourceWeight: 1,
+      targetWeight: 0,
+    },
+    {
+      source: '22',
+      target: '19',
+      sourceWeight: 1,
+      targetWeight: 0,
+    },
+    {
+      source: '23',
+      target: '3',
+      sourceWeight: 1,
+      targetWeight: 0,
+    },
+    {
+      source: '2',
+      target: '26',
+      sourceWeight: 1,
+      targetWeight: 0,
+    },
+    {
+      source: '2',
+      target: '19',
+      sourceWeight: 1,
+      targetWeight: 0,
+    },
+    {
+      source: '26',
+      target: '19',
+      sourceWeight: 1,
+      targetWeight: 0,
+    },
+    {
+      source: '2',
+      target: '17',
+      sourceWeight: 1,
+      targetWeight: 0,
+    },
+    {
+      source: '27',
+      target: '3',
+      sourceWeight: 1,
+      targetWeight: 0,
+    },
+    {
+      source: '5',
+      target: '13',
+      sourceWeight: 1,
+      targetWeight: 0,
+    },
+    {
+      source: '2',
+      target: '12',
+      sourceWeight: 1,
+      targetWeight: 0,
+    },
+    {
+      source: '28',
+      target: '20',
+      sourceWeight: 1,
+      targetWeight: 0,
+    },
+    {
+      source: '18',
+      target: '28',
+      sourceWeight: 1,
+      targetWeight: 0,
+    },
+    {
+      source: '23',
+      target: '21',
+      sourceWeight: 1,
+      targetWeight: 0,
+    },
+    {
+      source: '8',
+      target: '6',
+      sourceWeight: 1,
+      targetWeight: 0,
+    },
+    {
+      source: '2',
+      target: '3',
+      sourceWeight: 1,
+      targetWeight: 0,
+    },
+    {
+      source: '1',
+      target: '29',
+      sourceWeight: 1,
+      targetWeight: 0,
+    },
+    {
+      source: '23',
+      target: '28',
+      sourceWeight: 1,
+      targetWeight: 0,
+    },
+    {
+      source: '6',
+      target: '13',
+      sourceWeight: 1,
+      targetWeight: 0,
+    },
+    {
+      source: '25',
+      target: '13',
+      sourceWeight: 1,
+      targetWeight: 0,
+    },
+    {
+      source: '8',
+      target: '7',
+      sourceWeight: 1,
+      targetWeight: 0,
+    },
+    {
+      source: '7',
+      target: '13',
+      sourceWeight: 1,
+      targetWeight: 0,
+    },
+    {
+      source: '27',
+      target: '26',
+      sourceWeight: 1,
+      targetWeight: 0,
+    },
+    {
+      source: '18',
+      target: '7',
+      sourceWeight: 1,
+      targetWeight: 0,
+    },
+    {
+      source: '0',
+      target: '26',
+      sourceWeight: 1,
+      targetWeight: 0,
+    },
+    {
+      source: '19',
+      target: '7',
+      sourceWeight: 1,
+      targetWeight: 0,
+    },
+    {
+      source: '8',
+      target: '19',
+      sourceWeight: 1,
+      targetWeight: 0,
+    },
+    {
+      source: '28',
+      target: '29',
+      sourceWeight: 1,
+      targetWeight: 0,
+    },
+  ],
+};
+
+const data2 = {
+  nodes: [
+    {
+      id: '0',
+      label: '0',
+    },
+    {
+      id: '1',
+      label: '1',
+    },
+    {
+      id: '2',
+      label: '2',
+    },
+    {
+      id: '3',
+      label: '3',
+    },
+    {
+      id: '4',
+      label: '4',
+    },
+    {
+      id: '5',
+      label: '5',
+    },
+    {
+      id: '6',
+      label: '6',
+    },
+    {
+      id: '7',
+      label: '7',
+    },
+    {
+      id: '8',
+      label: '8',
+    },
+    {
+      id: '9',
+      label: '9',
+    },
+    {
+      id: '10',
+      label: '10',
+    },
+    {
+      id: '11',
+      label: '11',
+    },
+    {
+      id: '12',
+      label: '12',
+    },
+    {
+      id: '13',
+      label: '13',
+    },
+    {
+      id: '14',
+      label: '14',
+    },
+    {
+      id: '15',
+      label: '15',
+    },
+    {
+      id: '16',
+      label: '16',
+    },
+    {
+      id: '17',
+      label: '17',
+    },
+    {
+      id: '18',
+      label: '18',
+    },
+    {
+      id: '19',
+      label: '19',
+    },
+    {
+      id: '20',
+      label: '20',
+    },
+    {
+      id: '21',
+      label: '21',
+    },
+    {
+      id: '22',
+      label: '22',
+    },
+    {
+      id: '23',
+      label: '23',
+    },
+    {
+      id: '24',
+      label: '24',
+    },
+    {
+      id: '25',
+      label: '25',
+    },
+    {
+      id: '26',
+      label: '26',
+    },
+    {
+      id: '27',
+      label: '27',
+    },
+    {
+      id: '28',
+      label: '28',
+    },
+    {
+      id: '29',
+      label: '29',
+    },
+    {
+      id: '30',
+      label: '30',
+    },
+    {
+      id: '31',
+      label: '31',
+    },
+    {
+      id: '32',
+      label: '32',
+    },
+    {
+      id: '33',
+      label: '33',
+    },
+  ],
+  edges: [
+    {
+      source: '0',
+      target: '1',
+    },
+    {
+      source: '0',
+      target: '2',
+    },
+    {
+      source: '0',
+      target: '3',
+    },
+    {
+      source: '0',
+      target: '4',
+    },
+    {
+      source: '0',
+      target: '5',
+    },
+    {
+      source: '0',
+      target: '7',
+    },
+    {
+      source: '0',
+      target: '8',
+    },
+    {
+      source: '0',
+      target: '9',
+    },
+    {
+      source: '0',
+      target: '10',
+    },
+    {
+      source: '0',
+      target: '11',
+    },
+    {
+      source: '0',
+      target: '13',
+    },
+    {
+      source: '0',
+      target: '14',
+    },
+    {
+      source: '0',
+      target: '15',
+    },
+    {
+      source: '0',
+      target: '16',
+    },
+    {
+      source: '2',
+      target: '3',
+    },
+    {
+      source: '4',
+      target: '5',
+    },
+    {
+      source: '4',
+      target: '6',
+    },
+    {
+      source: '5',
+      target: '6',
+    },
+    {
+      source: '7',
+      target: '13',
+    },
+    {
+      source: '8',
+      target: '14',
+    },
+    {
+      source: '9',
+      target: '10',
+    },
+    {
+      source: '10',
+      target: '22',
+    },
+    {
+      source: '10',
+      target: '14',
+    },
+    {
+      source: '10',
+      target: '12',
+    },
+    {
+      source: '10',
+      target: '24',
+    },
+    {
+      source: '10',
+      target: '21',
+    },
+    {
+      source: '10',
+      target: '20',
+    },
+    {
+      source: '11',
+      target: '24',
+    },
+    {
+      source: '11',
+      target: '22',
+    },
+    {
+      source: '11',
+      target: '14',
+    },
+    {
+      source: '12',
+      target: '13',
+    },
+    {
+      source: '16',
+      target: '17',
+    },
+    {
+      source: '16',
+      target: '18',
+    },
+    {
+      source: '16',
+      target: '21',
+    },
+    {
+      source: '16',
+      target: '22',
+    },
+    {
+      source: '17',
+      target: '18',
+    },
+    {
+      source: '17',
+      target: '20',
+    },
+    {
+      source: '18',
+      target: '19',
+    },
+    {
+      source: '19',
+      target: '20',
+    },
+    {
+      source: '19',
+      target: '33',
+    },
+    {
+      source: '19',
+      target: '22',
+    },
+    {
+      source: '19',
+      target: '23',
+    },
+    {
+      source: '20',
+      target: '21',
+    },
+    {
+      source: '21',
+      target: '22',
+    },
+    {
+      source: '22',
+      target: '24',
+    },
+    {
+      source: '22',
+      target: '25',
+    },
+    {
+      source: '22',
+      target: '26',
+    },
+    {
+      source: '22',
+      target: '23',
+    },
+    {
+      source: '22',
+      target: '28',
+    },
+    {
+      source: '22',
+      target: '30',
+    },
+    {
+      source: '22',
+      target: '31',
+    },
+    {
+      source: '22',
+      target: '32',
+    },
+    {
+      source: '22',
+      target: '33',
+    },
+    {
+      source: '23',
+      target: '28',
+    },
+    {
+      source: '23',
+      target: '27',
+    },
+    {
+      source: '23',
+      target: '29',
+    },
+    {
+      source: '23',
+      target: '30',
+    },
+    {
+      source: '23',
+      target: '31',
+    },
+    {
+      source: '23',
+      target: '33',
+    },
+    {
+      source: '32',
+      target: '33',
+    },
+  ],
+};
+
+export default (context: TestCaseContext, options?: {}) => {
+  const { width, height } = context;
+  const graph = new Graph({
+    ...context,
+    transforms: ['transform-v4-data'],
+    layout: {
+      type: 'circular',
+    },
+    theme: {
+      type: 'spec',
+      specification: {
+        node: {
+          dataTypeField: 'cluster',
+        },
+        edge: {
+          dataTypeField: 'cluster',
+        },
+      },
+    },
+    node: (model) => {
+      return {
+        id: model.id,
+        data: {
+          ...model.data,
+          labelShape: {
+            position: 'right',
+            textAlign: 'left',
+            offsetX: 0,
+            offsetY: 0,
+            ...model.data.labelShape,
+            text: model.data.name,
+            maxWidth: 100,
+          },
+          animates: {
+            update: [
+              {
+                fields: ['opacity'],
+                shapeId: 'haloShape',
+              },
+              {
+                fields: ['lineWidth'],
+                shapeId: 'keyShape',
+              },
+            ],
+          },
+        },
+      };
+    },
+    edge: {
+      keyShape: {
+        opacity: 0.4,
+      },
+    },
+    modes: {
+      default: [
+        'drag-node',
+        'click-select',
+        'zoom-canvas',
+        'drag-canvas',
+        'drag-combo',
+      ],
+    },
+    data,
+  });
+  graph.on('node:click', (e) => {
+    graph.removeData('node', e.itemId);
+  });
+  graph.on('edge:click', (e) => {
+    graph.removeData('edge', e.itemId);
+  });
+
+  graph.on('canvas:click', (e) => {
+    // graph.updateData('node', {
+    //   id: '10',
+    //   data: {
+    //     cluster: `c${Math.random()}`,
+    //   },
+    // });
+
+    // const combo = graph.addCombo(
+    //   {
+    //     id: 'combo1',
+    //     data: {},
+    //   },
+    //   ['1', '2', '3'],
+    // );
+
+    graph.changeData(data2);
+  });
+  return graph;
+};

--- a/packages/g6/tests/demo/index.ts
+++ b/packages/g6/tests/demo/index.ts
@@ -64,6 +64,8 @@ import legend from './plugins/legend';
 import snapline from './plugins/snapline';
 import mapper from './visual/mapper';
 import minimap from './plugins/minimap';
+import graphCore from './data/graphCore';
+import dagreUpdate from './layouts/dagre-update';
 
 export { default as timebar_time } from './plugins/timebar-time';
 export { default as timebar_chart } from './plugins/timebar-chart';
@@ -134,4 +136,6 @@ export {
   hull,
   legend,
   snapline,
+  graphCore,
+  dagreUpdate,
 };

--- a/packages/g6/tests/demo/layouts/circular.ts
+++ b/packages/g6/tests/demo/layouts/circular.ts
@@ -4,7 +4,7 @@ import { TestCaseContext } from '../interface';
 
 export default (context: TestCaseContext) => {
   const { width, height } = context;
-  return new G6.Graph({
+  const graph = new G6.Graph({
     ...context,
     type: 'graph',
     data: JSON.parse(JSON.stringify(data)),
@@ -13,5 +13,9 @@ export default (context: TestCaseContext) => {
       center: [width! / 2, height! / 2],
       radius: 200,
     },
+    modes: {
+      default: ['drag-canvas', 'zoom-canvas'],
+    },
   });
+  return graph;
 };

--- a/packages/g6/tests/demo/layouts/dagre-update.ts
+++ b/packages/g6/tests/demo/layouts/dagre-update.ts
@@ -1,0 +1,149 @@
+import { extend, Graph, Extensions } from '../../../src/index';
+import { TestCaseContext } from '../interface';
+
+export default (context: TestCaseContext) => {
+  const ExtGraph = extend(Graph, {
+    layouts: {
+      dagre: Extensions.DagreLayout,
+    },
+    edges: {
+      'cubic-edge': Extensions.CubicEdge,
+      'quadratic-edge': Extensions.QuadraticEdge,
+      'polyline-edge': Extensions.PolylineEdge,
+    },
+  });
+
+  const data = {
+    nodes: [
+      {
+        id: '0',
+        data: {
+          label: '0',
+        },
+      },
+      {
+        id: '1',
+        data: {
+          label: '1',
+        },
+      },
+    ],
+    edges: [
+      {
+        id: 'edge-395',
+        source: '0',
+        target: '1',
+        data: {},
+      },
+    ],
+  };
+
+  const layoutConfigs = {
+    Default: {
+      type: 'dagre',
+      nodesep: 100,
+      ranksep: 70,
+      controlPoints: true,
+    },
+    // TODO: 换个数据
+    LR: {
+      type: 'dagre',
+      rankdir: 'LR',
+      align: 'DL',
+      nodesep: 50,
+      ranksep: 70,
+      controlPoints: true,
+    },
+    'LR&UL': {
+      type: 'dagre',
+      rankdir: 'LR',
+      align: 'UL',
+      controlPoints: true,
+      nodesep: 50,
+      ranksep: 70,
+    },
+  };
+
+  const container = context.container;
+  const graph = new ExtGraph({
+    ...context,
+    layout: layoutConfigs.Default,
+    node: (node) => {
+      return {
+        id: node.id,
+        data: {
+          ...node.data,
+          type: 'rect-node',
+          lodStrategy: {},
+          keyShape: {
+            width: 60,
+            height: 30,
+            radius: 8,
+          },
+          labelShape: {
+            position: 'center',
+            maxWidth: '80%',
+            text: `node-${node.data.label}`,
+          },
+          // animates: {
+          //   update: [
+          //     {
+          //       fields: ['x', 'y'],
+          //     },
+          //   ],
+          // },
+        },
+      };
+    },
+    edge: {
+      type: 'polyline-edge',
+      keyShape: {
+        // radius: 20,
+        // offset: 45,
+        // endArrow: true,
+        // lineWidth: 2,
+        // stroke: '#C2C8D5',
+        // routeCfg: {
+        //   obstacleAvoidance: true,
+        // },
+      },
+    },
+    modes: {
+      default: ['drag-node', 'drag-canvas', 'zoom-canvas', 'click-select'],
+    },
+    autoFit: 'view',
+    data,
+  });
+
+  graph.on('edge:click', (e) => {
+    console.log('clickedge', e.itemId, graph.canvas, graph);
+  });
+
+  if (typeof window !== 'undefined')
+    window.onresize = () => {
+      if (!graph || graph.destroyed) return;
+      if (!container || !container.scrollWidth || !container.scrollHeight)
+        return;
+      graph.setSize([container.scrollWidth, container.scrollHeight]);
+    };
+
+  const btnContainer = document.createElement('div');
+  btnContainer.style.position = 'absolute';
+  container.appendChild(btnContainer);
+  const tip = document.createElement('span');
+  tip.innerHTML = '👉 Change configs:';
+  btnContainer.appendChild(tip);
+
+  Object.keys(layoutConfigs).forEach((name, i) => {
+    const btn = document.createElement('a');
+    btn.innerHTML = name;
+    btn.style.backgroundColor = 'rgba(255, 255, 255, 0.8)';
+    btn.style.padding = '4px';
+    btn.style.marginLeft = i > 0 ? '24px' : '8px';
+    btnContainer.appendChild(btn);
+    btn.addEventListener('click', () => {
+      graph.layout(layoutConfigs[name]);
+    });
+  });
+  return graph;
+};

--- a/packages/g6/tests/demo/performance/performance.ts
+++ b/packages/g6/tests/demo/performance/performance.ts
@@ -1759,11 +1759,6 @@ const nodes = data.nodes.map((node) => {
     // @ts-ignore
     node.data.cluster = 0;
   }
-  node.data.layout = {
-    id: node.id,
-    x: node.data.x,
-    y: node.data.y,
-  };
   return node;
 });
 
@@ -2116,7 +2111,7 @@ const createGraph = async () => {
             ],
             show: [
               {
-                fields: ['size'],
+                fields: ['transform'],
                 duration: 200,
               },
               {
@@ -2238,5 +2233,6 @@ export default async () => {
       graph.destroy();
     }
   });
+
   return graph;
 };

--- a/packages/g6/tests/demo/tree/treeGraph.ts
+++ b/packages/g6/tests/demo/tree/treeGraph.ts
@@ -32,6 +32,9 @@ export default (
     layout: {
       type: layoutType,
     },
+    modes: {
+      default: ['drag-canvas', 'drag-node'],
+    },
     node: (innerModel) => {
       const { x, y, labelShape } = innerModel.data;
       return {
@@ -190,5 +193,8 @@ export default (
 
   graph.translateTo({ x: 100, y: 100 });
 
+  graph.on('edge:click', (e) => {
+    console.log('clickedge', e.itemId);
+  });
   return graph;
 };

--- a/packages/g6/tests/demo/tree/treeGraph.ts
+++ b/packages/g6/tests/demo/tree/treeGraph.ts
@@ -33,7 +33,7 @@ export default (
       type: layoutType,
     },
     modes: {
-      default: ['drag-canvas', 'drag-node'],
+      default: ['drag-canvas', 'drag-node', 'collapse-expand-tree'],
     },
     node: (innerModel) => {
       const { x, y, labelShape } = innerModel.data;

--- a/packages/g6/tests/integration/behaviors-create-edge.spec.ts
+++ b/packages/g6/tests/integration/behaviors-create-edge.spec.ts
@@ -1,6 +1,6 @@
 import { resetEntityCounter } from '@antv/g';
-import { createContext } from './utils';
 import createEdge from '../demo/behaviors/create-edge';
+import { createContext } from './utils';
 import './utils/useSnapshotMatchers';
 
 describe('Create edge behavior', () => {

--- a/packages/g6/tests/unit/view-spec.ts
+++ b/packages/g6/tests/unit/view-spec.ts
@@ -439,7 +439,7 @@ describe('viewport', () => {
         expect(py).toBeCloseTo(250, 1);
       });
 
-      await graph.fitCenter({
+      await graph.fitCenter('render', {
         duration: 2000,
         easing: 'ease-in',
       });

--- a/packages/site/examples/feature/features/demo/itemAnimates.js
+++ b/packages/site/examples/feature/features/demo/itemAnimates.js
@@ -251,7 +251,7 @@ const viewPortActions = {
     graph.fitView({}, { duration: 500 });
   },
   'Fit Center': () => {
-    graph.fitCenter({}, { duration: 500 });
+    graph.fitCenter('render', { duration: 500 });
   },
   'Zoom In': () => {
     const currentZoom = graph.getZoom();

--- a/packages/site/examples/scatter/changePosition/demo/viewAnimates.js
+++ b/packages/site/examples/scatter/changePosition/demo/viewAnimates.js
@@ -65,7 +65,7 @@ const actions = {
     graph.fitView({}, { duration: 500 });
   },
   'Fit Center': () => {
-    graph.fitCenter({}, { duration: 500 });
+    graph.fitCenter('render', { duration: 500 });
   },
   'Zoom In': () => {
     const currentZoom = graph.getZoom();


### PR DESCRIPTION
- chore: remove userGraphCore
之前已经将数据处理流程（transform）提前到 userGraphCore 读取数据前，目的是保证 userGraphCore 读取到的是正确的数据格式。这样一来，userGraphCore 没有存在的必要，数据流程可简化为：

用户输入数据 - transformers -> graphCore - mapper -> display data

简化数据流，便于维护和问题定位，减少不必要的数据存储和计算开销。

- fix: edge update problems;

- fix: autoFit at first render and layout
布局完成后的屏幕适配，此时可能因为有动画，还没有完成图的更新。应当根据布局完成后节点的位置范围，进行图适配的计算；

- fix: nodes visibility problem while tree graph collapse and expand
树图收起后快速展开，可能出现子节点未正确显示的问题