### PR TITLE
fix: use position absolute instead of fixed to make canvases overlap each other

### DIFF
--- a/packages/g6/src/runtime/graph.ts
+++ b/packages/g6/src/runtime/graph.ts
@@ -236,7 +236,8 @@ export default class Graph<B extends BehaviorRegistry, T extends ThemeRegistry>
             .getContextService()
             .getDomElement() as unknown as HTMLElement;
           if ($domElement && $domElement.style) {
-            $domElement.style.position = 'fixed';
+            // Make all these 3 canvas doms overlap each other. The container already has `position: relative` style.
+            $domElement.style.position = 'absolute';
             $domElement.style.outline = 'none';
             $domElement.tabIndex = 1; // Enable keyboard events
             // Transient canvas should let interactive events go through.


### PR DESCRIPTION
`position: fixed` will make a lot of problems especially when page gets scrolled, so `absolute` is a better choice.
<img width="630" alt="position absolute" src="https://github.com/antvis/G6/assets/3608471/3ea724f3-b81d-4acc-af00-c98592b2289d">

Sigma.js also arrange canvases like this:
<img width="462" alt="sigma.js" src="https://github.com/antvis/G6/assets/3608471/2336ebe3-89fd-46a7-91a3-235f63cfdf41">
