### PR TITLE
fix: avoid reappending exited shape

### DIFF
--- a/packages/g6/src/util/shape.ts
+++ b/packages/g6/src/util/shape.ts
@@ -211,22 +211,27 @@ export const updateShapes = (
     const prevShape = prevShapeMap[id];
     const newShape = newShapeMap[id];
     if (newShape && !shouldUpdate(id)) return;
-    if (prevShape && newShape) {
-      // update intersaction
-      finalShapeMap[id] = newShape;
-      if (prevShape !== newShape) {
+
+    if (newShape) {
+      // Remove dirty shape first.
+      if (prevShape && prevShape !== newShape) {
         prevShape.remove();
       }
-      if (!newShape.destroyed && newShape.style.display !== 'none') {
-        group.appendChild(newShape);
-      }
-    } else if (!prevShape && newShape) {
-      // add newShapeMap - prevShapeMap
       finalShapeMap[id] = newShape;
-      if (!newShape.destroyed && newShape.style.display !== 'none') {
+      if (
+        // NewShape is already in the group, no need to reappend.
+        // Note: If the given child is a reference to an existing node in the document,
+        // appendChild() moves it from its current position to the new position.
+        // @see https://developer.mozilla.org/en-US/docs/Web/API/Node/appendChild
+        newShape.parentElement !== group &&
+        !newShape.destroyed &&
+        newShape.style.display !== 'none'
+      ) {
         group.appendChild(newShape);
       }
-    } else if (prevShape && !newShape && removeDiff) {
+    }
+
+    if (prevShape && !newShape && removeDiff) {
       // remove prevShapeMap - newShapeMap
       delete finalShapeMap[id];
       prevShape.remove();

--- a/packages/g6/src/util/shape3d.ts
+++ b/packages/g6/src/util/shape3d.ts
@@ -182,18 +182,27 @@ export const updateShapes3D = (
     const prevShape = prevShapeMap[id];
     const newShape = newShapeMap[id];
     if (newShape && !shouldUpdate(id)) return;
-    if (prevShape && newShape) {
-      // update intersaction
-      finalShapeMap[id] = newShape;
-      if (prevShape !== newShape) {
+
+    if (newShape) {
+      // Remove dirty shape first.
+      if (prevShape && prevShape !== newShape) {
         prevShape.remove();
       }
-      group.appendChild(newShape);
-    } else if (!prevShape && newShape) {
-      // add newShapeMap - prevShapeMap
       finalShapeMap[id] = newShape;
-      group.appendChild(newShape);
-    } else if (prevShape && !newShape && removeDiff) {
+      if (
+        // NewShape is already in the group, no need to reappend.
+        // Note: If the given child is a reference to an existing node in the document,
+        // appendChild() moves it from its current position to the new position.
+        // @see https://developer.mozilla.org/en-US/docs/Web/API/Node/appendChild
+        newShape.parentElement !== group &&
+        !newShape.destroyed &&
+        newShape.style.display !== 'none'
+      ) {
+        group.appendChild(newShape);
+      }
+    }
+
+    if (prevShape && !newShape && removeDiff) {
       // remove prevShapeMap - newShapeMap
       delete finalShapeMap[id];
       prevShape.remove();


### PR DESCRIPTION
dagre 例子中切换布局，在 Canvas 渲染器下会出现已失效的边又被渲染出来的情况。

按照 DOM API 的说明，对于一个已有父节点的子节点，appendChild 会首先从父节点上移除它，再添加。
updateShapes 方法中会重复 appendChild 子节点到同一个父节点上，此时会造成多余的移除和添加，即使父子关系都没有发生改变。
修改方式在 G6 这边需要判断下 newShape 当前的父节点是不是已经为 group 了，此时也不需要调用 appendChild 了。但这个逻辑不能实现在 appendChild 方法内部，基于以上说明。

修复后效果如下，切换布局后也不会出现多余的边了：
![Oct-07-2023 17-55-10](https://github.com/antvis/G6/assets/3608471/10d8347c-d1a8-4ae0-a339-779f675ba634)

