### PR TITLE
feat: add examples use G2 chart as custom node

### DIFF
--- a/packages/g6-plugin-map-view/package.json
+++ b/packages/g6-plugin-map-view/package.json
@@ -86,7 +86,7 @@
     "rollup-plugin-visualizer": "^5.6.0",
     "typedoc": "^0.25.0",
     "tslib": "^2.5.0",
-    "typescript": "^4.8.4"
+    "typescript": "5.1.6"
   },
   "limit-size": [
     {

--- a/packages/g6/package.json
+++ b/packages/g6/package.json
@@ -110,7 +110,7 @@
     "ts-jest": "^28.0.8",
     "typedoc": "^0.25.0",
     "typedoc-plugin-markdown": "^3.16.0",
-    "typescript": "^4.8.4",
+    "typescript": "5.1.6",
     "vite": "^4.2.2",
     "xmlserializer": "^0.6.1"
   },

--- a/packages/g6/src/runtime/controller/data.ts
+++ b/packages/g6/src/runtime/controller/data.ts
@@ -713,7 +713,7 @@ export class DataController {
   private isTransformActive = (config: any, changeType: DataChangeType) => {
     let activeLifecycle =
       isObject(config) && 'activeLifecycle' in config
-        ? config.activeLifecycle
+        ? (config as any).activeLifecycle
         : DEFAULT_ACTIVE_DATA_LIFECYCLE;
     activeLifecycle = Array.isArray(activeLifecycle)
       ? activeLifecycle

--- a/packages/g6/src/stdlib/plugin/hull/bubbleset.ts
+++ b/packages/g6/src/stdlib/plugin/hull/bubbleset.ts
@@ -463,7 +463,7 @@ export const genBubbleSet = (
   // eslint-disable-next-line no-redeclare
   const options = Object.assign(defaultOps, ops);
   const centroid = getPointsCenter(
-    members.map((model) => ({ x: model.data.x, y: model.data.y }) as Point),
+    members.map((model) => ({ x: model.data.x, y: model.data.y } as Point)),
   );
   // 按照到中心距离远近排序
   members = members.sort(

--- a/packages/g6/src/stdlib/plugin/hull/convexHull.ts
+++ b/packages/g6/src/stdlib/plugin/hull/convexHull.ts
@@ -21,7 +21,7 @@ export const genConvexHull = (models: (NodeModel | ComboModel)[]) => {
       ({
         x: model.data.x,
         y: model.data.y,
-      }) as Point,
+      } as Point),
   );
   points.sort((a, b) => {
     return a.x === b.x ? a.y - b.y : a.x - b.x;

--- a/packages/g6/src/types/item.ts
+++ b/packages/g6/src/types/item.ts
@@ -115,7 +115,8 @@ export type SHAPE_TYPE =
   | 'polyline'
   | 'line'
   | 'path'
-  | 'text';
+  | 'text'
+  | 'group';
 
 export type SHAPE_TYPE_3D = 'sphere' | 'cube' | 'plane';
 

--- a/packages/g6/src/util/polyline.ts
+++ b/packages/g6/src/util/polyline.ts
@@ -582,10 +582,7 @@ export class QuadTree {
   private southwest?: QuadTree;
   private southeast?: QuadTree;
 
-  constructor(
-    public boundary: AABB,
-    capacity: number,
-  ) {
+  constructor(public boundary: AABB, capacity: number) {
     this.capacity = capacity;
   }
 

--- a/packages/g6/src/util/shape.ts
+++ b/packages/g6/src/util/shape.ts
@@ -44,6 +44,7 @@ export const ShapeTagMap = {
   text: Text,
   image: Image,
   path: Path,
+  group: Group,
 };
 
 const LINE_TYPES = ['line', 'polyline', 'path'];

--- a/packages/g6/tests/index.html
+++ b/packages/g6/tests/index.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />

--- a/packages/site/.dumi/global.ts
+++ b/packages/site/.dumi/global.ts
@@ -1,17 +1,18 @@
-if (window) {
+if window {
   // window.g6 = require('@antv/g6/es'); // import the source for debugging
-  (window as any).g6 = require('@antv/g6/lib'); // import the source for debugging
+  window.g6 = require('@antv/g6/lib'); // import the source for debugging
 
-  (window as any).layoutGPU = require('@antv/layout-gpu'); // import the source for debugging
-  (window as any).Algorithm = require('@antv/algorithm');
-  (window as any).layoutWASM = require('@antv/layout-wasm'); // import the source for debugging
-  (window as any).GraphLib = require('@antv/graphlib');
+  window.layoutGPU = require('@antv/layout-gpu'); // import the source for debugging
+  window.Algorithm = require('@antv/algorithm');
+  window.layoutWASM = require('@antv/layout-wasm'); // import the source for debugging
+  window.GraphLib = require('@antv/graphlib');
 
-  (window as any).MapViewPlugin = require('@antv/g6-plugin-map-view');
-  // (window as any).g6 = require('@antv/g6/dist/g6.min.js'); // import the package for webworker
-  (window as any).insertCss = require('insert-css');
-  (window as any).Chart = require('@antv/chart-node-g6');
-  (window as any).AntVUtil = require('@antv/util');
-  (window as any).GraphLayoutPredict = require('@antv/vis-predict-engine');
-  (window as any).stats = require('stats.js');
+  window.MapViewPlugin = require('@antv/g6-plugin-map-view');
+  // window.g6 = require('@antv/g6/diFst/g6.min.js'); // import the package for webworker
+  window.insertCss = require('insert-css');
+  window.Chart = require('@antv/chart-node-g6');
+  window.AntVUtil = require('@antv/util');
+  window.GraphLayoutPredict = require('@antv/vis-predict-engine');
+  window.stats = require('stats.js');
+  window.g2 = require('@antv/g2');
 }

--- a/packages/site/.dumi/global.ts
+++ b/packages/site/.dumi/global.ts
@@ -1,4 +1,4 @@
-if window {
+if (window) {
   // window.g6 = require('@antv/g6/es'); // import the source for debugging
   window.g6 = require('@antv/g6/lib'); // import the source for debugging
 

--- a/packages/site/docs/manual/customize/nodeExtension.en.md
+++ b/packages/site/docs/manual/customize/nodeExtension.en.md
@@ -225,3 +225,52 @@ drawOtherShapes(model, shapeMap, diffData) {
   };
 }
 ```
+
+#### Use G2 chart as node
+
+`drawOtherShapes` support drawing many shapes based on `@antv/g`. For example, you can use the charts based on `@antv/g2` as the shapes of the custom nodes. Here is a simple example:
+
+```typescript
+import { stdlib, renderToMountedElement } from '@antv/g2';
+
+/** stdlib is a standard library of G2 */
+const G2Library = { ...stdlib() };
+
+// Here is the drawOtherShapes method of the custom node
+drawOtherShapes(model, shapeMap) {
+  // Create a group
+  const group = this.upsertShape(
+    'group',
+    'g2-chart-group',
+    {},
+    shapeMap,
+    model,
+  );
+  // Make the group respond to events
+  group.isMutationObserved = true;
+  // Render the G2 chart when the group is mounted to the canvas
+  group.addEventListener('DOMNodeInsertedIntoDocument', () => {
+    // Render the G2 chart to the group
+    renderToMountedElement(
+      {
+        // Here is the G2 Specification
+      },
+      {
+        group,
+        library: G2Library,
+      },
+    );
+  });
+  return {
+    'g2-chart-group': group,
+  };
+}
+```
+
+For more information on using G2 charts, you can refer to the [G2 official website] (https://g2.antv.antgroup.com/en/)。
+
+G6 5.0 also provides relevant examples:
+
+- [G2 Bar Chart Node](/en/examples/item/customNode/#g2BarChart)
+- [G2 Lattice Node](/en/examples/item/customNode/#g2LatticeChart)
+- [G2 Active Node](/en/examples/item/customNode/#g2ActiveChart)

--- a/packages/site/docs/manual/customize/nodeExtension.zh.md
+++ b/packages/site/docs/manual/customize/nodeExtension.zh.md
@@ -219,3 +219,52 @@ drawOtherShapes(model, shapeMap, diffData) {
   };
 }
 ```
+
+#### 使用 G2 图表作为自定义节点
+
+通过 `drawOtherShapes` 可以渲染许多自定义图形，这些图形底层都是基于 `@antv/g` 绘制的，因此可以将任何基于 `@antv/g` 构建的图形库的图形作为自定义节点的图形。例如，可以使用 `@antv/g2` 构建的图表作为自定义节点的图形，下面是一个简单的例子：
+
+```typescript
+import { stdlib, renderToMountedElement } from '@antv/g2';
+
+/** stdlib 是 G2 的标准工具库 */
+const G2Library = { ...stdlib() };
+
+// 下面是自定义节点的 drawOtherShapes 方法
+drawOtherShapes(model, shapeMap) {
+  // 创建一个 group
+  const group = this.upsertShape(
+    'group',
+    'g2-chart-group',
+    {},
+    shapeMap,
+    model,
+  );
+  // 让 group 响应事件
+  group.isMutationObserved = true;
+  // 当 group 挂载到画布上时，渲染 G2 图表
+  group.addEventListener('DOMNodeInsertedIntoDocument', () => {
+    // 将 G2 图表渲染到 group 里
+    renderToMountedElement(
+      {
+        // 这里填写 G2 的 Specification
+      },
+      {
+        group,
+        library: G2Library,
+      },
+    );
+  });
+  return {
+    'g2-chart-group': group,
+  };
+}
+```
+
+更多的关于 G2 图表的使用，可以参考 [G2 官网](https://g2.antv.antgroup.com/)。
+
+G6 5.0 也提供了相关案例：
+
+* [使用 G2 自定义的条形图节点](/zh/examples/item/customNode/#g2BarChart) 
+* [使用 G2 自定义的点阵图节点](/zh/examples/item/customNode/#g2LatticeChart) 
+* [使用 G2 自定义的活动图节点](/zh/examples/item/customNode/#g2ActiveChart)

--- a/packages/site/examples/item/customNode/demo/g2ActiveChart.js
+++ b/packages/site/examples/item/customNode/demo/g2ActiveChart.js
@@ -9,10 +9,6 @@ const container = document.getElementById('container');
 const width = container.scrollWidth;
 const height = container.scrollHeight || 500;
 
-const isEqual = (a, b) => {
-  return JSON.stringify(a) === JSON.stringify(b);
-};
-
 class G2BarChartNode extends Extensions.RectNode {
   drawOtherShapes(model, shapeMap) {
     const { id, data } = model;
@@ -45,8 +41,6 @@ class G2BarChartNode extends Extensions.RectNode {
     // to make group trigger DOMNodeInsertedIntoDocument event
     group.isMutationObserved = true;
     group.addEventListener('DOMNodeInsertedIntoDocument', () => {
-      if (isEqual(group.value, value)) return;
-
       const activeRadius = radius / 4;
       const activeSize = radius / 2;
       renderToMountedElement(
@@ -98,7 +92,6 @@ class G2BarChartNode extends Extensions.RectNode {
           library: G2Library,
         },
       );
-      group.value = value;
     });
 
     return {

--- a/packages/site/examples/item/customNode/demo/g2ActiveChart.js
+++ b/packages/site/examples/item/customNode/demo/g2ActiveChart.js
@@ -1,0 +1,193 @@
+/**
+ * Custom Bar chart with @antv/g2
+ */
+import { Graph, Extensions, extend } from '@antv/g6';
+import { stdlib, renderToMountedElement } from '@antv/g2';
+
+const G2Library = { ...stdlib() };
+const container = document.getElementById('container');
+const width = container.scrollWidth;
+const height = container.scrollHeight || 500;
+
+const isEqual = (a, b) => {
+  return JSON.stringify(a) === JSON.stringify(b);
+};
+
+class G2BarChartNode extends Extensions.RectNode {
+  drawOtherShapes(model, shapeMap) {
+    const { id, data } = model;
+    const { radius = 50, value } = data;
+
+    const group = this.upsertShape(
+      'circle',
+      'g2-active-chart-group',
+      {
+        r: radius,
+        fill: '#fff',
+      },
+      shapeMap,
+      model,
+    );
+
+    const title = this.upsertShape(
+      'text',
+      'g2-active-chart-title',
+      {
+        y: radius + 10,
+        fontSize: 10,
+        text: id,
+        textAlign: 'center',
+      },
+      shapeMap,
+      model,
+    );
+
+    // to make group trigger DOMNodeInsertedIntoDocument event
+    group.isMutationObserved = true;
+    group.addEventListener('DOMNodeInsertedIntoDocument', () => {
+      if (isEqual(group.value, value)) return;
+
+      const activeRadius = radius / 4;
+      const activeSize = radius / 2;
+      renderToMountedElement(
+        // @antv/g2 Specification
+        // https://g2.antv.antgroup.com/examples/general/radial/#apple-activity
+        {
+          x: -radius,
+          y: -radius,
+          width: radius * 2,
+          height: radius * 2,
+          type: 'view',
+          data: value,
+          margin: 0,
+          coordinate: { type: 'radial', innerRadius: 0.2 },
+          children: [
+            {
+              type: 'interval',
+              encode: { x: 'name', y: 1, size: activeSize, color: 'color' },
+              scale: { color: { type: 'identity' } },
+              style: { fillOpacity: 0.25 },
+              animate: false,
+              tooltip: false,
+            },
+            {
+              type: 'interval',
+              encode: { x: 'name', y: 'percent', color: 'color', size: activeSize },
+              style: {
+                radius: activeRadius,
+                shadowColor: 'rgba(0,0,0,0.45)',
+                shadowBlur: 20,
+                shadowOffsetX: -2,
+                shadowOffsetY: -5,
+              },
+              animate: {
+                enter: { type: 'fadeIn', duration: 1000 },
+              },
+              axis: false,
+              tooltip: false,
+            },
+            {
+              type: 'image',
+              encode: { x: 'name', y: 0, src: (d) => d.icon, size: 6 },
+              style: { transform: 'translateX(6)' },
+            },
+          ],
+        },
+        {
+          group,
+          library: G2Library,
+        },
+      );
+      group.value = value;
+    });
+
+    return {
+      'g2-active-chart-group': group,
+      'g2-active-chart-title': title,
+    };
+  }
+}
+
+const ExtGraph = extend(Graph, {
+  nodes: {
+    'g2-bar-chart': G2BarChartNode,
+  },
+});
+
+const generateValue = () => {
+  const getRandomPercent = () => +(Math.random() * 0.9 + 0.1).toFixed(1);
+
+  return [
+    {
+      name: 'activity1',
+      percent: getRandomPercent(),
+      color: '#1ad5de',
+      icon: 'https://gw.alipayobjects.com/zos/antfincdn/ck11Y6aRrz/shangjiantou.png',
+    },
+    {
+      name: 'activity2',
+      percent: getRandomPercent(),
+      color: '#a0ff03',
+      icon: 'https://gw.alipayobjects.com/zos/antfincdn/zY2JB7hhrO/shuangjiantou.png',
+    },
+    {
+      name: 'activity3',
+      percent: getRandomPercent(),
+      color: '#e90b3a',
+      icon: 'https://gw.alipayobjects.com/zos/antfincdn/%24qBxSxdK05/jiantou.png',
+    },
+  ];
+};
+
+const people = ['Aaron', 'Rebecca', 'Emily', 'Liam', 'Olivia', 'Ethan', 'Sophia', 'Mason'];
+const graph = new ExtGraph({
+  container: 'container',
+  width,
+  height,
+  autoFit: 'center',
+  layout: {
+    type: 'force',
+    preventOverlap: true,
+    animated: false,
+    linkDistance: (d) => {
+      if (d.source === 'node0' || d.target === 'node0') {
+        return 200;
+      }
+      return 80;
+    },
+  },
+  modes: {
+    default: [
+      {
+        type: 'drag-node',
+        // prevent hide the node when dragging
+        enableTransient: false,
+      },
+      'zoom-canvas',
+    ],
+  },
+  data: {
+    nodes: people.map((name, i) => ({
+      id: name,
+      data: { value: generateValue() },
+    })),
+    edges: people.map((_, i) => {
+      return {
+        id: `Edge${i}`,
+        source: people[i],
+        target: people[(i + 1) % 5],
+      };
+    }),
+  },
+  node: {
+    type: 'g2-bar-chart',
+    otherShapes: {},
+  },
+});
+
+if (typeof window !== 'undefined')
+  window.onresize = () => {
+    if (!graph || graph.destroyed) return;
+    if (!container || !container.scrollWidth || !container.scrollHeight) return;
+    graph.setSize([container.scrollWidth, container.scrollHeight]);
+  };

--- a/packages/site/examples/item/customNode/demo/g2BarChart.js
+++ b/packages/site/examples/item/customNode/demo/g2BarChart.js
@@ -9,10 +9,6 @@ const container = document.getElementById('container');
 const width = container.scrollWidth;
 const height = container.scrollHeight || 500;
 
-const isEqual = (a, b) => {
-  return JSON.stringify(a) === JSON.stringify(b);
-};
-
 class G2BarChartNode extends Extensions.RectNode {
   drawOtherShapes(model, shapeMap) {
     const { id, data } = model;
@@ -44,7 +40,6 @@ class G2BarChartNode extends Extensions.RectNode {
     // to make group trigger DOMNodeInsertedIntoDocument event
     group.isMutationObserved = true;
     group.addEventListener('DOMNodeInsertedIntoDocument', () => {
-      if (isEqual(group.value, value)) return;
       renderToMountedElement(
         // @antv/g2 Specification
         // https://g2.antv.antgroup.com/examples/general/interval/#column
@@ -73,7 +68,6 @@ class G2BarChartNode extends Extensions.RectNode {
           library: G2Library,
         },
       );
-      group.value = value;
     });
 
     return {

--- a/packages/site/examples/item/customNode/demo/g2BarChart.js
+++ b/packages/site/examples/item/customNode/demo/g2BarChart.js
@@ -1,0 +1,216 @@
+/**
+ * Custom Bar chart with @antv/g2
+ */
+import { Graph, Extensions, extend } from '@antv/g6';
+import { stdlib, renderToMountedElement } from '@antv/g2';
+
+const G2Library = { ...stdlib() };
+const container = document.getElementById('container');
+const width = container.scrollWidth;
+const height = container.scrollHeight || 500;
+
+const isEqual = (a, b) => {
+  return JSON.stringify(a) === JSON.stringify(b);
+};
+
+class G2BarChartNode extends Extensions.RectNode {
+  drawOtherShapes(model, shapeMap) {
+    const { id, data } = model;
+    const {
+      size: [width, height],
+      value,
+    } = data;
+
+    const group = this.upsertShape(
+      'rect',
+      'g2-bar-chart-group',
+      {
+        x: -width / 2,
+        y: -height / 2,
+        width,
+        height,
+        fill: '#fff',
+        stroke: '#697b8c',
+        radius: 10,
+        shadowColor: '#697b8c',
+        shadowBlur: 10,
+        shadowOffsetX: 5,
+        shadowOffsetY: 5,
+      },
+      shapeMap,
+      model,
+    );
+
+    // to make group trigger DOMNodeInsertedIntoDocument event
+    group.isMutationObserved = true;
+    group.addEventListener('DOMNodeInsertedIntoDocument', () => {
+      if (isEqual(group.value, value)) return;
+      renderToMountedElement(
+        // @antv/g2 Specification
+        // https://g2.antv.antgroup.com/examples/general/interval/#column
+        {
+          width,
+          height,
+          data: { value },
+          title: id,
+          type: 'interval',
+          axis: {
+            x: { title: false },
+            y: { title: false },
+          },
+          scale: {
+            y: { domain: [0, 100] },
+          },
+          encode: {
+            x: 'subject',
+            y: 'score',
+            color: 'subject',
+          },
+          legend: { color: false },
+        },
+        {
+          group,
+          library: G2Library,
+        },
+      );
+      group.value = value;
+    });
+
+    return {
+      'g2-bar-chart-group': group,
+    };
+  }
+}
+
+const ExtGraph = extend(Graph, {
+  nodes: {
+    'g2-bar-chart': G2BarChartNode,
+  },
+});
+
+const graph = new ExtGraph({
+  container: 'container',
+  width,
+  height,
+  autoFit: 'center',
+  modes: {
+    default: [
+      {
+        type: 'drag-node',
+        // prevent hide the node when dragging
+        enableTransient: false,
+      },
+    ],
+  },
+  data: {
+    nodes: [
+      {
+        id: 'Jack',
+        data: {
+          size: [250, 250],
+          value: [
+            { subject: 'Math', score: 95 },
+            { subject: 'Chinese', score: 70 },
+            { subject: 'English', score: 75 },
+            { subject: 'Geography', score: 80 },
+            { subject: 'Physics', score: 90 },
+            { subject: 'Chemistry', score: 85 },
+            { subject: 'Biology', score: 70 },
+          ],
+        },
+      },
+      {
+        id: 'Aaron',
+        data: {
+          size: [250, 250],
+          value: [
+            { subject: 'Math', score: 70 },
+            { subject: 'Chinese', score: 90 },
+            { subject: 'English', score: 90 },
+            { subject: 'Geography', score: 60 },
+            { subject: 'Physics', score: 70 },
+            { subject: 'Chemistry', score: 65 },
+            { subject: 'Biology', score: 80 },
+          ],
+        },
+      },
+      {
+        id: 'Rebecca',
+        data: {
+          size: [250, 250],
+          value: [
+            { subject: 'Math', score: 60 },
+            { subject: 'Chinese', score: 95 },
+            { subject: 'English', score: 100 },
+            { subject: 'Geography', score: 80 },
+            { subject: 'Physics', score: 60 },
+            { subject: 'Chemistry', score: 90 },
+            { subject: 'Biology', score: 85 },
+          ],
+        },
+      },
+    ],
+    edges: [],
+  },
+  node: {
+    type: 'g2-bar-chart',
+    otherShapes: {},
+    keyShape: {
+      width: {
+        fields: ['size'],
+        formatter: (model) => model.data.size[0],
+      },
+      height: {
+        fields: ['size'],
+        formatter: (model) => model.data.size[1],
+      },
+      opacity: 0,
+    },
+  },
+});
+
+if (typeof window !== 'undefined')
+  window.onresize = () => {
+    if (!graph || graph.destroyed) return;
+    if (!container || !container.scrollWidth || !container.scrollHeight) return;
+    graph.setSize([container.scrollWidth, container.scrollHeight]);
+  };
+
+const btnContainer = document.createElement('div');
+btnContainer.style.position = 'absolute';
+container.appendChild(btnContainer);
+const tip = document.createElement('span');
+tip.innerHTML = '👉 Try to:';
+btnContainer.appendChild(tip);
+
+const students = ['Emily', 'Liam', 'Olivia', 'Ethan', 'Sophia', 'Mason'];
+
+['Add Student'].forEach((name, i) => {
+  const btn = document.createElement('a');
+  btn.innerHTML = name;
+  btn.style.backgroundColor = 'rgba(255, 255, 255, 0.8)';
+  btn.style.padding = '4px';
+  btn.style.marginLeft = i > 0 ? '24px' : '8px';
+  btnContainer.appendChild(btn);
+  btn.addEventListener('click', () => {
+    const student = students.shift();
+    if (!student) return;
+    const randomScore = () => 60 + Math.floor(Math.random() * 40);
+    graph.addData('node', {
+      id: student,
+      data: {
+        size: [250, 250],
+        value: [
+          { subject: 'Math', score: randomScore() },
+          { subject: 'Chinese', score: randomScore() },
+          { subject: 'English', score: randomScore() },
+          { subject: 'Geography', score: randomScore() },
+          { subject: 'Physics', score: randomScore() },
+          { subject: 'Chemistry', score: randomScore() },
+          { subject: 'Biology', score: randomScore() },
+        ],
+      },
+    });
+    graph.layout();
+  });
+});

--- a/packages/site/examples/item/customNode/demo/g2LatticeChart.js
+++ b/packages/site/examples/item/customNode/demo/g2LatticeChart.js
@@ -9,10 +9,6 @@ const container = document.getElementById('container');
 const width = container.scrollWidth;
 const height = container.scrollHeight || 500;
 
-const isEqual = (a, b) => {
-  return JSON.stringify(a) === JSON.stringify(b);
-};
-
 class G2BarChartNode extends Extensions.RectNode {
   drawOtherShapes(model, shapeMap) {
     const { data } = model;
@@ -35,8 +31,6 @@ class G2BarChartNode extends Extensions.RectNode {
     // to make group trigger DOMNodeInsertedIntoDocument event
     group.isMutationObserved = true;
     group.addEventListener('DOMNodeInsertedIntoDocument', () => {
-      if (isEqual(group.value, value)) return;
-
       renderToMountedElement(
         // @antv/g2 Specification
         // https://g2.antv.antgroup.com/examples/animation/group/#point
@@ -79,7 +73,6 @@ class G2BarChartNode extends Extensions.RectNode {
           library: G2Library,
         },
       );
-      group.value = value;
     });
 
     return {

--- a/packages/site/examples/item/customNode/demo/g2LatticeChart.js
+++ b/packages/site/examples/item/customNode/demo/g2LatticeChart.js
@@ -1,0 +1,202 @@
+/**
+ * Custom Bar chart with @antv/g2
+ */
+import { Graph, Extensions, extend } from '@antv/g6';
+import { stdlib, renderToMountedElement } from '@antv/g2';
+
+const G2Library = { ...stdlib() };
+const container = document.getElementById('container');
+const width = container.scrollWidth;
+const height = container.scrollHeight || 500;
+
+const isEqual = (a, b) => {
+  return JSON.stringify(a) === JSON.stringify(b);
+};
+
+class G2BarChartNode extends Extensions.RectNode {
+  drawOtherShapes(model, shapeMap) {
+    const { data } = model;
+    const {
+      size: [width, height],
+      value,
+    } = data;
+    const group = this.upsertShape(
+      'group',
+      'g2-lattice-chart-group',
+      {
+        x: -width / 2,
+        y: -height / 2,
+        zIndex: 10,
+      },
+      shapeMap,
+      model,
+    );
+
+    // to make group trigger DOMNodeInsertedIntoDocument event
+    group.isMutationObserved = true;
+    group.addEventListener('DOMNodeInsertedIntoDocument', () => {
+      if (isEqual(group.value, value)) return;
+
+      renderToMountedElement(
+        // @antv/g2 Specification
+        // https://g2.antv.antgroup.com/examples/animation/group/#point
+        {
+          width,
+          height,
+          margin: 0,
+          padding: 10,
+          type: 'view',
+          autoFit: true,
+          style: { plotFill: '#000' },
+          children: [
+            {
+              type: 'point',
+              padding: 0,
+              data: { value },
+              encode: { x: 'x', y: 'y', color: 'value', shape: 'point' },
+              transform: [
+                {
+                  type: 'stackEnter',
+                  groupBy: ['x', 'y'],
+                  orderBy: 'color',
+                  duration: 10000,
+                },
+              ],
+              scale: {
+                y: { range: [0, 1] },
+                color: {
+                  type: 'sqrt',
+                  range: ['hsl(152,80%,80%)', 'hsl(228,30%,40%)'],
+                },
+              },
+              axis: false,
+              legend: { color: false },
+            },
+          ],
+        },
+        {
+          group,
+          library: G2Library,
+        },
+      );
+      group.value = value;
+    });
+
+    return {
+      'g2-lattice-chart-group': group,
+    };
+  }
+}
+
+const ExtGraph = extend(Graph, {
+  nodes: {
+    'g2-bar-chart': G2BarChartNode,
+  },
+});
+
+const generateValue = () => {
+  const xRange = [0, 100];
+  const yRange = [0, 100];
+  // create random lattice data
+  const positions = {};
+  const data = [];
+  for (let i = 0; i < 100; i++) {
+    let x = Math.round(Math.random() * (xRange[1] - xRange[0]) + xRange[0]);
+    let y = Math.round(Math.random() * (yRange[1] - yRange[0]) + yRange[0]);
+    const key = `${x}-${y}`;
+    if (positions[key]) {
+      i--;
+      continue;
+    }
+    positions[key] = true;
+    data.push({ x, y, value: Math.round(Math.random() * 10) });
+  }
+  return data;
+};
+
+const dataLength = 5;
+const graph = new ExtGraph({
+  container: 'container',
+  width,
+  height,
+  autoFit: 'center',
+  layout: {
+    type: 'force',
+    preventOverlap: true,
+    animated: true,
+    linkDistance: (d) => {
+      if (d.source === 'node0' || d.target === 'node0') {
+        return 200;
+      }
+      return 80;
+    },
+  },
+  modes: {
+    default: [
+      {
+        type: 'drag-node',
+        // prevent hide the node when dragging
+        enableTransient: false,
+      },
+      'zoom-canvas',
+    ],
+  },
+  data: {
+    nodes: Array.from({ length: dataLength }).map((_, i) => ({
+      id: `Area${i}`,
+      data: { value: generateValue(), size: [150, 100] },
+    })),
+    edges: Array.from({ length: dataLength }).map((_, i) => {
+      return {
+        id: `Edge${i}`,
+        source: `Area${i}`,
+        target: `Area${(i + 1) % 5}`,
+      };
+    }),
+  },
+  node: {
+    type: 'g2-bar-chart',
+    otherShapes: {},
+    keyShape: {
+      width: {
+        fields: ['size'],
+        formatter: (model) => model.data.size[0],
+      },
+      height: {
+        fields: ['size'],
+        formatter: (model) => model.data.size[1],
+      },
+    },
+  },
+});
+
+if (typeof window !== 'undefined')
+  window.onresize = () => {
+    if (!graph || graph.destroyed) return;
+    if (!container || !container.scrollWidth || !container.scrollHeight) return;
+    graph.setSize([container.scrollWidth, container.scrollHeight]);
+  };
+
+const btnContainer = document.createElement('div');
+btnContainer.style.position = 'absolute';
+container.appendChild(btnContainer);
+const tip = document.createElement('span');
+tip.innerHTML = '👉 Try to:';
+btnContainer.appendChild(tip);
+
+['Refresh Data'].forEach((name, i) => {
+  const btn = document.createElement('a');
+  btn.innerHTML = name;
+  btn.style.backgroundColor = 'rgba(255, 255, 255, 0.8)';
+  btn.style.padding = '4px';
+  btn.style.marginLeft = i > 0 ? '24px' : '8px';
+  btnContainer.appendChild(btn);
+  btn.addEventListener('click', () => {
+    Array.from({ length: dataLength }).forEach((_, i) => {
+      graph.updateData('node', {
+        id: `Area${i}`,
+        data: { value: generateValue() },
+      });
+    });
+  });
+});

--- a/packages/site/examples/item/customNode/demo/meta.json
+++ b/packages/site/examples/item/customNode/demo/meta.json
@@ -27,6 +27,30 @@
         "en": "Pie Chart Node"
       },
       "screenshot": "https://gw.alipayobjects.com/mdn/rms_f8c6a0/afts/img/A*idENQpnwA1sAAAAAAAAAAABkARQnAQ"
+    },
+    {
+      "filename": "g2BarChart.js",
+      "title": {
+        "zh": "使用 G2 自定义的条形图节点",
+        "en": "G2 Bar Chart Node"
+      },
+      "screenshot": "https://mdn.alipayobjects.com/huamei_qa8qxu/afts/img/A*VcCDR5myr70AAAAAAAAAAAAADmJ7AQ/original"
+    },
+    {
+      "filename": "g2LatticeChart.js",
+      "title": {
+        "zh": "使用 G2 自定义的点阵图节点",
+        "en": "G2 Lattice Node"
+      },
+      "screenshot": "https://mdn.alipayobjects.com/huamei_qa8qxu/afts/img/A*-ojrRKKxYxMAAAAAAAAAAAAADmJ7AQ/original"
+    },
+    {
+      "filename": "g2ActiveChart.js",
+      "title": {
+        "zh": "使用 G2 自定义的活动图节点",
+        "en": "G2 Active Node"
+      },
+      "screenshot": "https://mdn.alipayobjects.com/huamei_qa8qxu/afts/img/A*GVyoQKk2WIIAAAAAAAAAAAAADmJ7AQ/original"
     }
   ]
 }

--- a/packages/site/global.d.ts
+++ b/packages/site/global.d.ts
@@ -1,0 +1,18 @@
+export {};
+
+declare global {
+  interface Window {
+    g6: any;
+    layoutGPU: any;
+    Algorithm: any;
+    layoutWASM: any;
+    GraphLib: any;
+    MapViewPlugin: any;
+    insertCss: any;
+    Chart: any;
+    AntVUtil: any;
+    GraphLayoutPredict: any;
+    stats: any;
+    g2: any;
+  }
+}

--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -36,8 +36,9 @@
     "@antv/algorithm": "^0.1.26",
     "@antv/chart-node-g6": "^0.0.3",
     "@antv/dumi-theme-antv": "0.3.19-beta.1",
-    "@antv/g2": "5",
-    "@antv/g6": "5.0.0-beta.20",
+    "@antv/g6-plugin-map-view": "^0.0.1",
+    "@antv/g2": "^5.1.5",
+    "@antv/g6": "workspace:*",
     "@antv/g6-react-node": "^1.4.5",
     "@antv/graphlib": "^2.0.2",
     "@antv/layout-gpu": "^1.1.5",
@@ -46,16 +47,17 @@
     "@antv/vis-predict-engine": "^0.1.1",
     "@faker-js/faker": "^8.0.2",
     "@microsoft/api-extractor": "^7.33.6",
-    "dumi": "^2.2.4",
+    "dumi": "^2.2.12",
     "fs-extra": "latest",
     "google-translate-api-x": "^10.6.7",
     "insert-css": "^2.0.0",
     "stats.js": "^0.17.0",
     "typedoc": "^0.24.8",
     "typedoc-plugin-markdown": "^3.14.0",
-    "typescript": "^4.8.4"
+    "typescript": "5.1.6"
   },
   "devDependencies": {
+    "@types/node": "13.11.1",
     "cross-env": "^7.0.3",
     "prettier": "^2.8.8"
   }

--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -32,12 +32,11 @@
     "translate": "node translate-api-doc.mjs"
   },
   "dependencies": {
-    "fs-extra": "latest",
     "@ant-design/icons": "^4.0.6",
     "@antv/algorithm": "^0.1.26",
-    "@antv/g6-plugin-map-view": "^0.0.1",
     "@antv/chart-node-g6": "^0.0.3",
     "@antv/dumi-theme-antv": "0.3.19-beta.1",
+    "@antv/g2": "5",
     "@antv/g6": "5.0.0-beta.20",
     "@antv/g6-react-node": "^1.4.5",
     "@antv/graphlib": "^2.0.2",
@@ -48,6 +47,7 @@
     "@faker-js/faker": "^8.0.2",
     "@microsoft/api-extractor": "^7.33.6",
     "dumi": "^2.2.4",
+    "fs-extra": "latest",
     "google-translate-api-x": "^10.6.7",
     "insert-css": "^2.0.0",
     "stats.js": "^0.17.0",

--- a/packages/site/tsconfig.json
+++ b/packages/site/tsconfig.json
@@ -4,9 +4,10 @@
     "target": "ESNext",
     "jsx": "react",
     "lib": ["dom"],
+    "types": ["node"],
     "paths": {
       "@antv/g6": ["../g6/lib/index"]
-    }
+    },
   },
   "include": ["example/**/*"],
   "exclude": ["node_modules"]

--- a/packages/site/tsconfig.json
+++ b/packages/site/tsconfig.json
@@ -8,6 +8,7 @@
     "paths": {
       "@antv/g6": ["../g6/lib/index"]
     },
+    "typeRoots": ["global.d.ts"]
   },
   "include": ["example/**/*"],
   "exclude": ["node_modules"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -346,12 +346,12 @@ importers:
       '@antv/dumi-theme-antv':
         specifier: 0.3.19-beta.1
         version: 0.3.19-beta.1(@algolia/client-search@4.20.0)(@babel/core@7.23.0)(dumi@2.2.4)(jquery@3.7.1)(react-dom@16.14.0)(react@16.14.0)(search-insights@2.8.3)
+      '@antv/g2':
+        specifier: '5'
+        version: 5.0.0
       '@antv/g6':
-        specifier: workspace:*
+        specifier: 5.0.0-beta.20
         version: link:../g6
-      '@antv/g6-plugin-map-view':
-        specifier: ^0.0.1
-        version: link:../g6-plugin-map-view
       '@antv/g6-react-node':
         specifier: ^1.4.5
         version: 1.4.5
@@ -400,9 +400,6 @@ importers:
       typescript:
         specifier: ^4.8.4
         version: 4.8.4
-      umi:
-        specifier: ^4.0.83
-        version: 4.0.83(@babel/core@7.23.0)(@types/node@20.5.1)(eslint@8.48.0)(jest@28.1.3)(postcss@8.4.31)(prettier@2.8.8)(react-dom@16.14.0)(react@16.14.0)(rollup@2.33.3)(styled-components@6.0.8)(stylelint@14.16.1)(stylus@0.54.8)(typescript@4.8.4)(webpack@5.88.2)
     devDependencies:
       cross-env:
         specifier: ^7.0.3
@@ -761,6 +758,14 @@ packages:
       '@antv/matrix-util': 3.1.0-beta.3
       '@antv/util': 2.0.17
       tslib: 2.6.2
+    dev: false
+
+  /@antv/coord@0.4.6:
+    resolution: {integrity: sha512-Zu1dJkyPvJ4McUmESWkpjgIf129MsBrZttxf7Bx0rs/N9txGXuj2YZpq1M77mBCWmclxHrcTJU9v1k/iMuIv0A==}
+    dependencies:
+      '@antv/scale': 0.4.12
+      '@antv/util': 2.0.17
+      gl-matrix: 3.4.3
     dev: false
 
   /@antv/dom-util@2.0.4:
@@ -1152,6 +1157,29 @@ packages:
       tslib: 2.6.2
     dev: false
 
+  /@antv/g2@5.0.0:
+    resolution: {integrity: sha512-3IdV0tJo8WO3wCPECxTyvCk14SHOkcQjZhNPGVhgMIr3pcqQrKL6FdvPK4TTAsgbjkXMokzdioK//PddZU9r0g==}
+    dependencies:
+      '@antv/coord': 0.4.6
+      '@antv/event-emitter': 0.1.3
+      '@antv/g': 5.18.16
+      '@antv/g-canvas': 1.11.19
+      '@antv/g-plugin-dragndrop': 1.8.15
+      '@antv/gui': 0.5.0(@antv/g@5.18.16)
+      '@antv/path-util': 3.0.1
+      '@antv/scale': 0.4.12
+      '@antv/util': 3.3.5
+      d3-array: 3.2.4
+      d3-dsv: 3.0.1
+      d3-force: 3.0.0
+      d3-format: 3.1.0
+      d3-geo: 3.1.0
+      d3-hierarchy: 3.1.2
+      d3-scale-chromatic: 3.0.0
+      d3-shape: 3.2.0
+      d3-voronoi: 1.1.4
+    dev: false
+
   /@antv/g6-core@0.0.7:
     resolution: {integrity: sha512-6ixXCqxsrKgovdf14KglKT6dQFb4LbzZgQaMj9s5NsfJWgwN9aYWyU2qbsyWgHkp/AOyW+vef+w2Vlk42qXFwg==}
     dependencies:
@@ -1190,6 +1218,19 @@ packages:
     resolution: {integrity: sha512-tyTzmSRgbkkC7k3H5zAw9IpQXEC90SRr66lvVo31PDA06ilCCU/jLXR6isH92oKEgB5j2/L1aJ+MRjMUm/0MGw==}
     dependencies:
       '@antv/event-emitter': 0.1.3
+    dev: false
+
+  /@antv/gui@0.5.0(@antv/g@5.18.16):
+    resolution: {integrity: sha512-ZbKhQ3LKM0xFeTV9dU8A63ZslN3te7kD0jQ8KbSD5XfG1eaKYWNFZ4H/7kuKTQyxZZX/67nnWqrOZpKXx7zeMw==}
+    peerDependencies:
+      '@antv/g': ^5.14.1
+    dependencies:
+      '@antv/dom-util': 2.0.4
+      '@antv/g': 5.18.16
+      '@antv/scale': 0.4.12
+      '@antv/util': 3.3.5
+      d3-array: 3.2.4
+      svg-path-parser: 1.1.0
     dev: false
 
   /@antv/gui@0.5.1-alpha.1(@antv/g@5.18.16):
@@ -1482,6 +1523,14 @@ packages:
     dependencies:
       '@antv/matrix-util': 3.0.4
       '@antv/util': 2.0.17
+      tslib: 2.6.2
+    dev: false
+
+  /@antv/path-util@3.0.1:
+    resolution: {integrity: sha512-tpvAzMpF9Qm6ik2YSMqICNU5tco5POOW7S4XoxZAI/B0L26adU+Md/SmO0BBo2SpuywKvzPH3hPT3xmoyhr04Q==}
+    dependencies:
+      gl-matrix: 3.4.3
+      lodash-es: 4.17.21
       tslib: 2.6.2
     dev: false
 
@@ -10984,7 +11033,7 @@ packages:
     dependencies:
       '@babel/core': 7.23.0
       postcss: 7.0.39
-      postcss-syntax: 0.36.2(postcss@8.4.31)
+      postcss-syntax: 0.36.2(postcss-html@0.36.0)(postcss-jsx@0.36.4)(postcss-less@3.1.4)(postcss-markdown@0.36.0)(postcss-scss@2.1.1)(postcss@7.0.39)
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -11011,7 +11060,7 @@ packages:
       postcss-syntax: '>=0.36.2'
     dependencies:
       postcss: 7.0.39
-      postcss-syntax: 0.36.2(postcss@8.4.31)
+      postcss-syntax: 0.36.2(postcss-html@0.36.0)(postcss-jsx@0.36.4)(postcss-less@3.1.4)(postcss-markdown@0.36.0)(postcss-scss@2.1.1)(postcss@7.0.39)
       remark: 13.0.0
       unist-util-find-all-after: 3.0.2
     transitivePeerDependencies:
@@ -12328,7 +12377,7 @@ packages:
         optional: true
     dependencies:
       '@eslint-community/regexpp': 4.9.1
-      '@typescript-eslint/parser': 5.62.0(eslint@8.48.0)(typescript@4.8.4)
+      '@typescript-eslint/parser': 5.62.0(eslint@7.32.0)(typescript@4.8.4)
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/type-utils': 5.62.0(eslint@7.32.0)(typescript@4.8.4)
       '@typescript-eslint/utils': 5.62.0(eslint@7.32.0)(typescript@4.8.4)
@@ -12568,6 +12617,26 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: true
+
+  /@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@4.8.4):
+    resolution: {integrity: sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/scope-manager': 5.62.0
+      '@typescript-eslint/types': 5.62.0
+      '@typescript-eslint/typescript-estree': 5.62.0(typescript@4.8.4)
+      debug: 4.3.4(supports-color@5.5.0)
+      eslint: 7.32.0
+      typescript: 4.8.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
 
   /@typescript-eslint/parser@5.62.0(eslint@8.48.0)(typescript@4.8.4):
     resolution: {integrity: sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==}
@@ -12951,29 +13020,6 @@ packages:
       less: 4.1.3
       postcss-preset-env: 7.5.0(postcss@8.4.31)
       rollup-plugin-visualizer: 5.9.0(rollup@2.33.3)
-      vite: 4.3.1(@types/node@20.5.1)(less@4.1.3)(sass@1.69.0)(stylus@0.54.8)
-    transitivePeerDependencies:
-      - '@types/node'
-      - postcss
-      - rollup
-      - sass
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-    dev: false
-
-  /@umijs/bundler-vite@4.0.83(@types/node@20.5.1)(postcss@8.4.31)(rollup@2.33.3)(stylus@0.54.8):
-    resolution: {integrity: sha512-a9rYhUp5ZyHuDoOUYDnrcUAFcL0PAxcdYTXciFSB3RUmYygFqTx2teuvrR7AWnI81t9YFob48RXwzV4trUgoLw==}
-    hasBin: true
-    dependencies:
-      '@svgr/core': 6.5.1
-      '@umijs/bundler-utils': 4.0.83
-      '@umijs/utils': 4.0.83
-      '@vitejs/plugin-react': 4.0.0(vite@4.3.1)
-      less: 4.1.3
-      postcss-preset-env: 7.5.0(postcss@8.4.31)
-      rollup-plugin-visualizer: 5.9.0(rollup@2.33.3)
       vite: 4.3.1(@types/node@20.5.1)(less@3.13.1)(stylus@0.54.8)
     transitivePeerDependencies:
       - '@types/node'
@@ -13228,7 +13274,7 @@ packages:
       '@babel/preset-react': 7.22.15(@babel/core@7.23.0)
       '@babel/preset-typescript': 7.23.0(@babel/core@7.23.0)
       '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0)(eslint@7.32.0)(typescript@4.8.4)
-      '@typescript-eslint/parser': 5.62.0(eslint@8.48.0)(typescript@4.8.4)
+      '@typescript-eslint/parser': 5.62.0(eslint@7.32.0)(typescript@4.8.4)
       chalk: 4.1.2
       eslint: 7.32.0
       eslint-config-prettier: 8.10.0(eslint@7.32.0)
@@ -13320,63 +13366,6 @@ packages:
       '@umijs/bundler-esbuild': 4.0.83
       '@umijs/bundler-utils': 4.0.83
       '@umijs/bundler-vite': 4.0.83(@types/node@20.5.1)(postcss@8.4.31)(rollup@2.33.3)(sass@1.69.0)(stylus@0.54.8)
-      '@umijs/bundler-webpack': 4.0.83(styled-components@6.0.8)(typescript@4.8.4)(webpack@5.88.2)
-      '@umijs/core': 4.0.83
-      '@umijs/did-you-know': 1.0.3
-      '@umijs/es-module-parser': 0.0.7
-      '@umijs/history': 5.3.1
-      '@umijs/mfsu': 4.0.83
-      '@umijs/plugin-run': 4.0.83
-      '@umijs/renderer-react': 4.0.83(react-dom@18.1.0)(react@18.1.0)
-      '@umijs/server': 4.0.83
-      '@umijs/ui': 3.0.1
-      '@umijs/utils': 4.0.83
-      '@umijs/zod2ts': 4.0.83
-      babel-plugin-dynamic-import-node: 2.3.3
-      click-to-react-component: 1.0.8(react-dom@18.1.0)(react@18.1.0)
-      core-js: 3.28.0
-      current-script-polyfill: 1.0.0
-      enhanced-resolve: 5.9.3
-      fast-glob: 3.2.12
-      html-webpack-plugin: 5.5.0(webpack@5.88.2)
-      path-to-regexp: 1.7.0
-      postcss-prefix-selector: 1.16.0(postcss@8.4.31)
-      react: 18.1.0
-      react-dom: 18.1.0(react@18.1.0)
-      react-router: 6.3.0(react@18.1.0)
-      react-router-dom: 6.3.0(react-dom@18.1.0)(react@18.1.0)
-      regenerator-runtime: 0.13.11
-    transitivePeerDependencies:
-      - '@types/node'
-      - '@types/react'
-      - '@types/webpack'
-      - postcss
-      - rollup
-      - sass
-      - sockjs-client
-      - styled-components
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - type-fest
-      - typescript
-      - webpack
-      - webpack-dev-server
-      - webpack-hot-middleware
-      - webpack-plugin-serve
-    dev: false
-
-  /@umijs/preset-umi@4.0.83(@types/node@20.5.1)(postcss@8.4.31)(rollup@2.33.3)(styled-components@6.0.8)(stylus@0.54.8)(typescript@4.8.4)(webpack@5.88.2):
-    resolution: {integrity: sha512-aw+/7mYwjGeBFPYYb3k2Q8Jyh1aoKTWCYbFjmacgeeEmK4YUsTple15GakmPFsqh2a+ZEhO6pODNbj7HJL2nWQ==}
-    dependencies:
-      '@iconify/utils': 2.1.1
-      '@svgr/core': 6.5.1
-      '@umijs/ast': 4.0.83
-      '@umijs/babel-preset-umi': 4.0.83(styled-components@6.0.8)
-      '@umijs/bundler-esbuild': 4.0.83
-      '@umijs/bundler-utils': 4.0.83
-      '@umijs/bundler-vite': 4.0.83(@types/node@20.5.1)(postcss@8.4.31)(rollup@2.33.3)(stylus@0.54.8)
       '@umijs/bundler-webpack': 4.0.83(styled-components@6.0.8)(typescript@4.8.4)(webpack@5.88.2)
       '@umijs/core': 4.0.83
       '@umijs/did-you-know': 1.0.3
@@ -18163,6 +18152,13 @@ packages:
     resolution: {integrity: sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw==}
     dev: false
 
+  /d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+    dependencies:
+      internmap: 2.0.3
+    dev: false
+
   /d3-collection@1.0.7:
     resolution: {integrity: sha512-ii0/r5f4sjKNTfh84Di+DpztYwqKhEyUlKoPrzUFfeSkWxjW49xU2QzO9qrPrNkpdI0XJkfzvmTu8V2Zylln6A==}
     dev: false
@@ -18217,8 +18213,25 @@ packages:
     resolution: {integrity: sha512-J0piedu6Z8iB6TbIGfZgDzfXxUFN3qQRMofy2oPdXzQibYGqPB/9iMcxr/TGalU+2RsyDO+U4f33id8tbnSRMQ==}
     dev: false
 
+  /d3-format@3.1.0:
+    resolution: {integrity: sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==}
+    engines: {node: '>=12'}
+    dev: false
+
+  /d3-geo@3.1.0:
+    resolution: {integrity: sha512-JEo5HxXDdDYXCaWdwLRt79y7giK8SbhZJbFWXqbRTolCHFI5jRqteLzCsq51NKbUoX0PjBVSohxrx+NoOUujYA==}
+    engines: {node: '>=12'}
+    dependencies:
+      d3-array: 3.2.4
+    dev: false
+
   /d3-hexbin@0.2.2:
     resolution: {integrity: sha512-KS3fUT2ReD4RlGCjvCEm1RgMtp2NFZumdMu4DBzQK8AZv3fXRM6Xm8I4fSU07UXvH4xxg03NwWKWdvxfS/yc4w==}
+    dev: false
+
+  /d3-hierarchy@3.1.2:
+    resolution: {integrity: sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==}
+    engines: {node: '>=12'}
     dev: false
 
   /d3-interpolate@1.4.0:
@@ -18238,9 +18251,22 @@ packages:
     resolution: {integrity: sha512-Qxg4oirJrNXauiuC94uKMbgxwnhdda9xRLl9ihq45srlJ4Ga3CSgqGcAL8iW7N5CIv4Oz8x3E734ulxyvHPvwA==}
     dev: false
 
+  /d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+    dev: false
+
   /d3-quadtree@3.0.1:
     resolution: {integrity: sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==}
     engines: {node: '>=12'}
+    dev: false
+
+  /d3-scale-chromatic@3.0.0:
+    resolution: {integrity: sha512-Lx9thtxAKrO2Pq6OO2Ua474opeziKr279P/TKZsMAhYyNDD3EnCffdbgeSYN5O7m2ByQsxtuP2CSDczNUIZ22g==}
+    engines: {node: '>=12'}
+    dependencies:
+      d3-color: 3.1.0
+      d3-interpolate: 3.0.1
     dev: false
 
   /d3-scale@2.2.2:
@@ -18252,6 +18278,13 @@ packages:
       d3-interpolate: 1.4.0
       d3-time: 1.1.0
       d3-time-format: 2.3.0
+    dev: false
+
+  /d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+    dependencies:
+      d3-path: 3.1.0
     dev: false
 
   /d3-time-format@2.3.0:
@@ -18271,6 +18304,10 @@ packages:
   /d3-timer@3.0.1:
     resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
     engines: {node: '>=12'}
+    dev: false
+
+  /d3-voronoi@1.1.4:
+    resolution: {integrity: sha512-dArJ32hchFsrQ8uMiTBLq256MpnZjeuBtdHpaDlYuQyjU0CVzCJl/BVW+SkszaAeH95D/8gxqAhgx0ouAWAfRg==}
     dev: false
 
   /d@1.0.1:
@@ -20236,8 +20273,8 @@ packages:
       eslint: 5.16.0
       eslint-config-airbnb-base: 13.2.0(eslint-plugin-import@2.28.1)(eslint@5.16.0)
       eslint-plugin-import: 2.28.1(@typescript-eslint/parser@1.10.2)(eslint@5.16.0)
-      eslint-plugin-jsx-a11y: 6.7.1(eslint@5.16.0)
-      eslint-plugin-react: 7.33.2(eslint@5.16.0)
+      eslint-plugin-jsx-a11y: 6.7.1(eslint@8.48.0)
+      eslint-plugin-react: 7.33.2(eslint@8.48.0)
       object.assign: 4.1.4
       object.entries: 1.1.7
     dev: true
@@ -21181,7 +21218,6 @@ packages:
       resolve: 2.0.0-next.4
       semver: 6.3.1
       string.prototype.matchall: 4.0.10
-    dev: false
 
   /eslint-plugin-unicorn@20.1.0(eslint@7.32.0):
     resolution: {integrity: sha512-XQxLBJT/gnwyRR6cfYsIK1AdekQchAt5tmcsnldevGjgR2xoZsRUa5/i6e0seNHy2RoT57CkTnbVHwHF8No8LA==}
@@ -22194,10 +22230,10 @@ packages:
       eslint-plugin-eslint-comments: 3.2.0(eslint@5.16.0)
       eslint-plugin-import: 2.28.1(@typescript-eslint/parser@1.10.2)(eslint@5.16.0)
       eslint-plugin-jest: 22.21.0(eslint@5.16.0)
-      eslint-plugin-jsx-a11y: 6.7.1(eslint@5.16.0)
+      eslint-plugin-jsx-a11y: 6.7.1(eslint@8.48.0)
       eslint-plugin-markdown: 1.0.2
       eslint-plugin-promise: 4.3.1
-      eslint-plugin-react: 7.33.2(eslint@5.16.0)
+      eslint-plugin-react: 7.33.2(eslint@8.48.0)
       eslint-plugin-unicorn: 8.0.2(eslint@5.16.0)
       father-build: 1.17.1
       fs-extra: 8.1.0
@@ -24937,6 +24973,11 @@ packages:
       get-intrinsic: 1.2.1
       has: 1.0.4
       side-channel: 1.0.4
+
+  /internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
+    dev: false
 
   /interpret@1.4.0:
     resolution: {integrity: sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==}
@@ -38332,7 +38373,7 @@ packages:
       postcss-sass: 0.4.4
       postcss-scss: 2.1.1
       postcss-selector-parser: 6.0.13
-      postcss-syntax: 0.36.2(postcss@8.4.31)
+      postcss-syntax: 0.36.2(postcss-html@0.36.0)(postcss-jsx@0.36.4)(postcss-less@3.1.4)(postcss-markdown@0.36.0)(postcss-scss@2.1.1)(postcss@7.0.39)
       postcss-value-parser: 4.2.0
       resolve-from: 5.0.0
       slash: 3.0.0
@@ -39721,58 +39762,6 @@ packages:
       - webpack-plugin-serve
     dev: false
 
-  /umi@4.0.83(@babel/core@7.23.0)(@types/node@20.5.1)(eslint@8.48.0)(jest@28.1.3)(postcss@8.4.31)(prettier@2.8.8)(react-dom@16.14.0)(react@16.14.0)(rollup@2.33.3)(styled-components@6.0.8)(stylelint@14.16.1)(stylus@0.54.8)(typescript@4.8.4)(webpack@5.88.2):
-    resolution: {integrity: sha512-y1g31rWtwzN6xzujyAcsG2UyJAQ5nIp6DbNHikIImu1Xt8b+P0RIrUWncBLl6x6YS5m5w45XLdANE1JZkMef/Q==}
-    engines: {node: '>=14'}
-    hasBin: true
-    dependencies:
-      '@babel/runtime': 7.21.0
-      '@umijs/bundler-utils': 4.0.83
-      '@umijs/bundler-webpack': 4.0.83(styled-components@6.0.8)(typescript@4.8.4)(webpack@5.88.2)
-      '@umijs/core': 4.0.83
-      '@umijs/lint': 4.0.83(eslint@8.48.0)(jest@28.1.3)(styled-components@6.0.8)(stylelint@14.16.1)(typescript@4.8.4)
-      '@umijs/preset-umi': 4.0.83(@types/node@20.5.1)(postcss@8.4.31)(rollup@2.33.3)(styled-components@6.0.8)(stylus@0.54.8)(typescript@4.8.4)(webpack@5.88.2)
-      '@umijs/renderer-react': 4.0.83(react-dom@16.14.0)(react@16.14.0)
-      '@umijs/server': 4.0.83
-      '@umijs/test': 4.0.83(@babel/core@7.23.0)
-      '@umijs/utils': 4.0.83
-      prettier-plugin-organize-imports: 3.2.3(prettier@2.8.8)(typescript@4.8.4)
-      prettier-plugin-packagejson: 2.4.3(prettier@2.8.8)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@types/node'
-      - '@types/react'
-      - '@types/webpack'
-      - '@volar/vue-language-plugin-pug'
-      - '@volar/vue-typescript'
-      - eslint
-      - jest
-      - postcss
-      - postcss-html
-      - postcss-jsx
-      - postcss-less
-      - postcss-markdown
-      - postcss-scss
-      - prettier
-      - react
-      - react-dom
-      - rollup
-      - sass
-      - sockjs-client
-      - styled-components
-      - stylelint
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - type-fest
-      - typescript
-      - webpack
-      - webpack-dev-server
-      - webpack-hot-middleware
-      - webpack-plugin-serve
-    dev: false
-
   /unbox-primitive@1.0.2:
     resolution: {integrity: sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==}
     dependencies:
@@ -40609,42 +40598,6 @@ packages:
       less: 3.13.1
       postcss: 8.4.31
       rollup: 3.29.4
-      stylus: 0.54.8
-    optionalDependencies:
-      fsevents: 2.3.3
-    dev: false
-
-  /vite@4.3.1(@types/node@20.5.1)(less@4.1.3)(sass@1.69.0)(stylus@0.54.8):
-    resolution: {integrity: sha512-EPmfPLAI79Z/RofuMvkIS0Yr091T2ReUoXQqc5ppBX/sjFRhHKiPPF/R46cTdoci/XgeQpB23diiJxq5w30vdg==}
-    engines: {node: ^14.18.0 || >=16.0.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': '>= 14'
-      less: '*'
-      sass: '*'
-      stylus: '*'
-      sugarss: '*'
-      terser: ^5.4.0
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      less:
-        optional: true
-      sass:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-    dependencies:
-      '@types/node': 20.5.1
-      esbuild: 0.17.19
-      less: 4.1.3
-      postcss: 8.4.31
-      rollup: 3.29.4
-      sass: 1.69.0
       stylus: 0.54.8
     optionalDependencies:
       fsevents: 2.3.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,7 +28,7 @@ importers:
         version: 2.8.8
       react-scripts:
         specifier: 3.1.2
-        version: 3.1.2(eslint@6.8.0)(react@18.2.0)(typescript@4.8.4)
+        version: 3.1.2(eslint@6.8.0)(react@18.2.0)(typescript@5.1.6)
       stats.js:
         specifier: ^0.17.0
         version: 0.17.0
@@ -131,13 +131,13 @@ importers:
         version: 0.6.3
       '@typescript-eslint/eslint-plugin':
         specifier: ^6.5.0
-        version: 6.5.0(@typescript-eslint/parser@6.5.0)(eslint@8.48.0)(typescript@4.8.4)
+        version: 6.5.0(@typescript-eslint/parser@6.5.0)(eslint@8.48.0)(typescript@5.1.6)
       '@typescript-eslint/parser':
         specifier: ^6.5.0
-        version: 6.5.0(eslint@8.48.0)(typescript@4.8.4)
+        version: 6.5.0(eslint@8.48.0)(typescript@5.1.6)
       '@umijs/fabric':
         specifier: ^2.0.0
-        version: 2.0.0(prettier@2.8.8)(typescript@4.8.4)
+        version: 2.0.0(prettier@2.8.8)(typescript@5.1.6)
       babel-loader:
         specifier: ^8.0.6
         version: 8.0.6(@babel/core@7.23.0)(webpack@5.88.2)
@@ -200,22 +200,22 @@ importers:
         version: 0.8.0(rollup@2.79.1)
       rollup-plugin-typescript:
         specifier: ^1.0.1
-        version: 1.0.1(tslib@2.5.0)(typescript@4.8.4)
+        version: 1.0.1(tslib@2.5.0)(typescript@5.1.6)
       rollup-plugin-visualizer:
         specifier: ^5.6.0
         version: 5.6.0(rollup@2.79.1)
       ts-jest:
         specifier: ^28.0.8
-        version: 28.0.8(@babel/core@7.23.0)(jest@28.1.3)(typescript@4.8.4)
+        version: 28.0.8(@babel/core@7.23.0)(jest@28.1.3)(typescript@5.1.6)
       typedoc:
         specifier: ^0.25.0
-        version: 0.25.0(typescript@4.8.4)
+        version: 0.25.0(typescript@5.1.6)
       typedoc-plugin-markdown:
         specifier: ^3.16.0
         version: 3.16.0(typedoc@0.25.0)
       typescript:
-        specifier: ^4.8.4
-        version: 4.8.4
+        specifier: 5.1.6
+        version: 5.1.6
       vite:
         specifier: ^4.2.2
         version: 4.4.9(@types/node@13.11.1)
@@ -267,13 +267,13 @@ importers:
         version: 0.6.3
       '@typescript-eslint/eslint-plugin':
         specifier: ^6.5.0
-        version: 6.5.0(@typescript-eslint/parser@6.5.0)(eslint@8.48.0)(typescript@4.8.4)
+        version: 6.5.0(@typescript-eslint/parser@6.5.0)(eslint@8.48.0)(typescript@5.1.6)
       '@typescript-eslint/parser':
         specifier: ^6.5.0
-        version: 6.5.0(eslint@8.48.0)(typescript@4.8.4)
+        version: 6.5.0(eslint@8.48.0)(typescript@5.1.6)
       '@umijs/fabric':
         specifier: ^2.0.0
-        version: 2.0.0(prettier@2.8.8)(typescript@4.8.4)
+        version: 2.0.0(prettier@2.8.8)(typescript@5.1.6)
       babel-loader:
         specifier: ^8.0.6
         version: 8.0.6(@babel/core@7.23.0)(webpack@4.47.0)
@@ -285,7 +285,7 @@ importers:
         version: 2.28.1(@typescript-eslint/parser@6.5.0)(eslint@8.48.0)
       father:
         specifier: ^2.29.1
-        version: 2.29.1(@babel/core@7.23.0)(@storybook/source-loader@7.4.6)(jest@28.1.3)(react-dom@16.14.0)(react@16.14.0)(regenerator-runtime@0.14.0)(typescript@4.8.4)(webpack@4.47.0)
+        version: 2.29.1(@babel/core@7.23.0)(@storybook/source-loader@7.4.6)(jest@28.1.3)(react-dom@16.14.0)(react@16.14.0)(regenerator-runtime@0.14.0)(typescript@5.1.6)(webpack@4.47.0)
       gl:
         specifier: ^6.0.2
         version: 6.0.2
@@ -318,7 +318,7 @@ importers:
         version: 0.8.0(rollup@2.79.1)
       rollup-plugin-typescript:
         specifier: ^1.0.1
-        version: 1.0.1(tslib@2.5.0)(typescript@4.8.4)
+        version: 1.0.1(tslib@2.5.0)(typescript@5.1.6)
       rollup-plugin-visualizer:
         specifier: ^5.6.0
         version: 5.6.0(rollup@2.79.1)
@@ -327,10 +327,10 @@ importers:
         version: 2.5.0
       typedoc:
         specifier: ^0.25.0
-        version: 0.25.0(typescript@4.8.4)
+        version: 0.25.0(typescript@5.1.6)
       typescript:
-        specifier: ^4.8.4
-        version: 4.8.4
+        specifier: 5.1.6
+        version: 5.1.6
 
   packages/site:
     dependencies:
@@ -342,16 +342,19 @@ importers:
         version: 0.1.26
       '@antv/chart-node-g6':
         specifier: ^0.0.3
-        version: 0.0.3(@babel/core@7.23.0)(@storybook/source-loader@7.4.6)(eslint@8.48.0)(jest@28.1.3)(react-dom@16.14.0)(react@16.14.0)(regenerator-runtime@0.14.0)(typescript@4.8.4)
+        version: 0.0.3(@babel/core@7.23.0)(@storybook/source-loader@7.4.6)(eslint@8.48.0)(jest@28.1.3)(react-dom@16.14.0)(react@16.14.0)(regenerator-runtime@0.14.0)(typescript@5.1.6)
       '@antv/dumi-theme-antv':
         specifier: 0.3.19-beta.1
-        version: 0.3.19-beta.1(@algolia/client-search@4.20.0)(@babel/core@7.23.0)(dumi@2.2.4)(jquery@3.7.1)(react-dom@16.14.0)(react@16.14.0)(search-insights@2.8.3)
+        version: 0.3.19-beta.1(@algolia/client-search@4.20.0)(@babel/core@7.23.0)(dumi@2.2.12)(jquery@3.7.1)(react-dom@16.14.0)(react@16.14.0)(search-insights@2.8.3)
       '@antv/g2':
-        specifier: '5'
-        version: 5.0.0
+        specifier: ^5.1.5
+        version: 5.1.5(@antv/g2plot@2.4.31)(@antv/g6@packages+g6)
       '@antv/g6':
-        specifier: 5.0.0-beta.20
+        specifier: workspace:*
         version: link:../g6
+      '@antv/g6-plugin-map-view':
+        specifier: ^0.0.1
+        version: 0.0.1(workerize-loader@2.0.2)
       '@antv/g6-react-node':
         specifier: ^1.4.5
         version: 1.4.5
@@ -377,8 +380,8 @@ importers:
         specifier: ^7.33.6
         version: 7.33.6
       dumi:
-        specifier: ^2.2.4
-        version: 2.2.4(@babel/core@7.23.0)(@types/node@20.5.1)(eslint@8.48.0)(jest@28.1.3)(postcss@8.4.31)(prettier@2.8.8)(react-dom@16.14.0)(react@16.14.0)(rollup@2.33.3)(styled-components@6.0.8)(stylelint@14.16.1)(stylus@0.54.8)(typescript@4.8.4)(webpack@5.88.2)
+        specifier: ^2.2.12
+        version: 2.2.12(@babel/core@7.23.0)(@types/node@13.11.1)(eslint@8.48.0)(jest@28.1.3)(postcss@8.4.31)(prettier@2.8.8)(react-dom@16.14.0)(react@16.14.0)(rollup@2.33.3)(styled-components@6.0.8)(stylelint@14.16.1)(stylus@0.54.8)(typescript@5.1.6)(webpack@5.88.2)
       fs-extra:
         specifier: latest
         version: 11.1.1
@@ -393,14 +396,17 @@ importers:
         version: 0.17.0
       typedoc:
         specifier: ^0.24.8
-        version: 0.24.8(typescript@4.8.4)
+        version: 0.24.8(typescript@5.1.6)
       typedoc-plugin-markdown:
         specifier: ^3.14.0
         version: 3.16.0(typedoc@0.24.8)
       typescript:
-        specifier: ^4.8.4
-        version: 4.8.4
+        specifier: 5.1.6
+        version: 5.1.6
     devDependencies:
+      '@types/node':
+        specifier: 13.11.1
+        version: 13.11.1
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -681,6 +687,16 @@ packages:
       tslib: 2.5.0
     dev: false
 
+  /@antv/antv-spec@0.1.0-alpha.18(@antv/g2plot@2.4.31)(@antv/g6@packages+g6):
+    resolution: {integrity: sha512-30IdqLDdJFYZ/jXpaELYQEkwfR6qA0GoZ8+Wcu0ougYi5KPhM6W7OibFjofQUpPtIBIhMpW7zRcxW7gzFJVgvg==}
+    peerDependencies:
+      '@antv/g2plot': ^2.3.27
+      '@antv/g6': ^4.3.11
+    dependencies:
+      '@antv/g2plot': 2.4.31
+      '@antv/g6': link:packages/g6
+    dev: false
+
   /@antv/async-hook@2.2.9:
     resolution: {integrity: sha512-4BUp2ZUaTi2fYL67Ltkf6eV912rYJeSBokGhd5fhhnpUkMA1LEI1mg97Pqmx3yC50VEQ+LKXZxj9ePZs80ECfw==}
     dependencies:
@@ -696,12 +712,28 @@ packages:
       tslib: 2.6.2
     dev: false
 
-  /@antv/chart-node-g6@0.0.3(@babel/core@7.23.0)(@storybook/source-loader@7.4.6)(eslint@8.48.0)(jest@28.1.3)(react-dom@16.14.0)(react@16.14.0)(regenerator-runtime@0.14.0)(typescript@4.8.4):
+  /@antv/ava@3.0.7(@antv/g2plot@2.4.31)(@antv/g6@packages+g6):
+    resolution: {integrity: sha512-oRaY/FInTshQB6h4kMAPxXZVwPUTHjuwdX7MRHiQoxQvG320ZqQOvb931GA2QVfnxK08jo4zvgtxX5RdhIq6kw==}
+    dependencies:
+      '@antv/antv-spec': 0.1.0-alpha.18(@antv/g2plot@2.4.31)(@antv/g6@packages+g6)
+      '@antv/g2': 5.1.5(@antv/g2plot@2.4.31)(@antv/g6@packages+g6)
+      '@antv/smart-color': 0.2.1
+      bayesian-changepoint: 1.0.1
+      heap-js: 2.3.0
+      lodash: 4.17.21
+      regression: 2.0.1
+      tslib: 2.6.2
+    transitivePeerDependencies:
+      - '@antv/g2plot'
+      - '@antv/g6'
+    dev: false
+
+  /@antv/chart-node-g6@0.0.3(@babel/core@7.23.0)(@storybook/source-loader@7.4.6)(eslint@8.48.0)(jest@28.1.3)(react-dom@16.14.0)(react@16.14.0)(regenerator-runtime@0.14.0)(typescript@5.1.6):
     resolution: {integrity: sha512-e8R6fx2GrTViaKSt6f5puKTBC9E79Iv2yiFRazKN3FrMc0tVq6hpTsV0I7BU4lmV0EAEjynIy4VD98lEAeeqCg==}
     dependencies:
       '@antv/g-base': 0.4.7
       '@antv/g2': 4.2.10
-      father: 2.30.23(@babel/core@7.23.0)(@storybook/source-loader@7.4.6)(eslint@8.48.0)(jest@28.1.3)(react-dom@16.14.0)(react@16.14.0)(regenerator-runtime@0.14.0)(typescript@4.8.4)(webpack@4.47.0)
+      father: 2.30.23(@babel/core@7.23.0)(@storybook/source-loader@7.4.6)(eslint@8.48.0)(jest@28.1.3)(react-dom@16.14.0)(react@16.14.0)(regenerator-runtime@0.14.0)(typescript@5.1.6)(webpack@4.47.0)
       rimraf: 3.0.2
       webpack: 4.47.0
     transitivePeerDependencies:
@@ -729,6 +761,12 @@ packages:
       - vue-template-compiler
       - webpack-cli
       - webpack-command
+    dev: false
+
+  /@antv/color-schema@0.2.3:
+    resolution: {integrity: sha512-lHkN/MHQ5nnuv2fmo2jy0j9mSIddYClvDLrucH5WdXnZRNW/Y7od4iO2H0caqLoYLC7rAtzrSsoA2MD1RUvIeQ==}
+    dependencies:
+      '@types/chroma-js': 2.4.1
     dev: false
 
   /@antv/color-util@2.0.6:
@@ -774,7 +812,7 @@ packages:
       tslib: 2.5.0
     dev: false
 
-  /@antv/dumi-theme-antv@0.3.19-beta.1(@algolia/client-search@4.20.0)(@babel/core@7.23.0)(dumi@2.2.4)(jquery@3.7.1)(react-dom@16.14.0)(react@16.14.0)(search-insights@2.8.3):
+  /@antv/dumi-theme-antv@0.3.19-beta.1(@algolia/client-search@4.20.0)(@babel/core@7.23.0)(dumi@2.2.12)(jquery@3.7.1)(react-dom@16.14.0)(react@16.14.0)(search-insights@2.8.3):
     resolution: {integrity: sha512-3SDN20nxpxkPMcH3ztKyRCxhkBX/cVkrt+oT7DytQvqnebDpPOduC7ppX+qSfcIi7i6j2vs5xx/HEB0AV468Qg==}
     peerDependencies:
       dumi: ^2.0.0
@@ -793,7 +831,7 @@ packages:
       codesandbox: 2.2.3
       d3-dsv: 3.0.1
       docsearch.js: 2.6.3
-      dumi: 2.2.4(@babel/core@7.23.0)(@types/node@20.5.1)(eslint@8.48.0)(jest@28.1.3)(postcss@8.4.31)(prettier@2.8.8)(react-dom@16.14.0)(react@16.14.0)(rollup@2.33.3)(styled-components@6.0.8)(stylelint@14.16.1)(stylus@0.54.8)(typescript@4.8.4)(webpack@5.88.2)
+      dumi: 2.2.12(@babel/core@7.23.0)(@types/node@13.11.1)(eslint@8.48.0)(jest@28.1.3)(postcss@8.4.31)(prettier@2.8.8)(react-dom@16.14.0)(react@16.14.0)(rollup@2.33.3)(styled-components@6.0.8)(stylelint@14.16.1)(stylus@0.54.8)(typescript@5.1.6)(webpack@5.88.2)
       front-matter: 4.0.2
       fs-extra: 10.1.0
       glob: 8.1.0
@@ -1157,13 +1195,15 @@ packages:
       tslib: 2.6.2
     dev: false
 
-  /@antv/g2@5.0.0:
-    resolution: {integrity: sha512-3IdV0tJo8WO3wCPECxTyvCk14SHOkcQjZhNPGVhgMIr3pcqQrKL6FdvPK4TTAsgbjkXMokzdioK//PddZU9r0g==}
+  /@antv/g2@5.1.5(@antv/g2plot@2.4.31)(@antv/g6@packages+g6):
+    resolution: {integrity: sha512-5p8qawGisBQHg4W6uivjGGuN3Gx3u3mRp3AR6GJmfnE/BpTSemNT4rOhAY/IJDp4suPRX/t1/BtKIuMiwhcftA==}
     dependencies:
+      '@antv/ava': 3.0.7(@antv/g2plot@2.4.31)(@antv/g6@packages+g6)
       '@antv/coord': 0.4.6
       '@antv/event-emitter': 0.1.3
       '@antv/g': 5.18.16
       '@antv/g-canvas': 1.11.19
+      '@antv/g-plugin-3d': 1.9.22
       '@antv/g-plugin-dragndrop': 1.8.15
       '@antv/gui': 0.5.0(@antv/g@5.18.16)
       '@antv/path-util': 3.0.1
@@ -1175,9 +1215,35 @@ packages:
       d3-format: 3.1.0
       d3-geo: 3.1.0
       d3-hierarchy: 3.1.2
+      d3-path: 3.1.0
       d3-scale-chromatic: 3.0.0
       d3-shape: 3.2.0
       d3-voronoi: 1.1.4
+      flru: 1.0.2
+      fmin: 0.0.2
+      pdfast: 0.2.0
+    transitivePeerDependencies:
+      - '@antv/g2plot'
+      - '@antv/g6'
+    dev: false
+
+  /@antv/g2plot@2.4.31:
+    resolution: {integrity: sha512-SlWHYVsJgRN7E1Oe5Qk6yWBrSWmctmloknFmklaqe9vEeK+YB9ZLUffZvtAHT10mA2NZ+VjGUhlnMNgR9M1PQg==}
+    dependencies:
+      '@antv/color-util': 2.0.6
+      '@antv/event-emitter': 0.1.3
+      '@antv/g-base': 0.5.15
+      '@antv/g2': 4.2.10
+      '@antv/matrix-util': 3.1.0-beta.3
+      '@antv/path-util': 3.0.1
+      '@antv/scale': 0.3.18
+      '@antv/util': 2.0.17
+      d3-hierarchy: 2.0.0
+      d3-regression: 1.3.10
+      fmin: 0.0.2
+      pdfast: 0.2.0
+      size-sensor: 1.0.2
+      tslib: 2.6.2
     dev: false
 
   /@antv/g6-core@0.0.7:
@@ -1195,6 +1261,21 @@ packages:
       ml-matrix: 6.10.5
     dev: false
 
+  /@antv/g6-plugin-map-view@0.0.1(workerize-loader@2.0.2):
+    resolution: {integrity: sha512-MH98BFkTSNUqX2WsbuAFJ4rvKF//yXs8m+iPJ9iQERvRh5c3YkwVMXCce1t/oXnOfH6UcJpHL1au7l9d/G3pqg==}
+    dependencies:
+      '@antv/dom-util': 2.0.4
+      '@antv/g6': 5.0.0-beta.20(workerize-loader@2.0.2)
+      '@antv/graphlib': 2.0.2
+      '@antv/l7': 2.18.3
+      '@antv/l7-maps': 2.18.3
+      '@antv/util': 2.0.17
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+      - workerize-loader
+    dev: false
+
   /@antv/g6-react-node@1.4.5:
     resolution: {integrity: sha512-sYIUmYcZdqKhlGhjJAeNEJpnoJ+3zGajZjtatXBiIttsTHxFQVK3730k8048flYEaG1AweZhIydwmkqMlFf4iQ==}
     dependencies:
@@ -1203,6 +1284,34 @@ packages:
       '@types/yoga-layout': 1.9.5
       react: 16.14.0
       yoga-layout-prebuilt: 1.10.0
+    dev: false
+
+  /@antv/g6@5.0.0-beta.20(workerize-loader@2.0.2):
+    resolution: {integrity: sha512-O4yU/XwCJUjMU7WAwvdQSKlW/2JRcNvcrAH8vv02Kn3ewJZCYSNmqZ5J03VVKvIACW8RgQXwzp7Y0fr15Ujukg==}
+    dependencies:
+      '@ant-design/colors': 7.0.0
+      '@antv/algorithm': 0.1.26
+      '@antv/event-emitter': 0.1.3
+      '@antv/g': 5.18.16
+      '@antv/g-canvas': 1.11.19
+      '@antv/g-plugin-3d': 1.9.22
+      '@antv/g-plugin-control': 1.9.15
+      '@antv/g-plugin-dragndrop': 1.8.15
+      '@antv/g-svg': 1.10.17
+      '@antv/g-webgl': 1.9.25
+      '@antv/graphlib': 2.0.2
+      '@antv/gui': 0.5.1-alpha.1(@antv/g@5.18.16)
+      '@antv/hierarchy': 0.6.11
+      '@antv/layout': 1.2.11(workerize-loader@2.0.2)
+      '@antv/layout-gpu': 1.1.5(workerize-loader@2.0.2)
+      '@antv/layout-wasm': 1.3.1
+      '@antv/util': 3.3.5
+      color: 4.2.3
+      gl-matrix: 3.4.3
+      insert-css: 2.0.0
+      tslib: 2.6.2
+    transitivePeerDependencies:
+      - workerize-loader
     dev: false
 
   /@antv/g@5.18.16:
@@ -1548,6 +1657,15 @@ packages:
       '@antv/util': 2.0.17
       color-string: 1.9.1
       fecha: 4.2.3
+    dev: false
+
+  /@antv/smart-color@0.2.1:
+    resolution: {integrity: sha512-2E42oczcJtfMQCSk+Ms5pWC34aH3S8/vHBWDCiwBhuImVodzYTHDAaU1oTYN2XlJMaLSsA7lE1UUFmOG8xjOOw==}
+    dependencies:
+      '@antv/color-schema': 0.2.3
+      chroma-js: 2.4.2
+      color-blind: 0.1.3
+      quantize: 1.0.2
     dev: false
 
   /@antv/util@2.0.17:
@@ -7837,14 +7955,14 @@ packages:
       '@commitlint/types': 17.4.4
       '@types/node': 20.5.1
       chalk: 4.1.2
-      cosmiconfig: 8.3.6(typescript@4.8.4)
-      cosmiconfig-typescript-loader: 4.4.0(@types/node@20.5.1)(cosmiconfig@8.3.6)(ts-node@10.9.1)(typescript@4.8.4)
+      cosmiconfig: 8.3.6(typescript@5.1.6)
+      cosmiconfig-typescript-loader: 4.4.0(@types/node@20.5.1)(cosmiconfig@8.3.6)(ts-node@10.9.1)(typescript@5.1.6)
       lodash.isplainobject: 4.0.6
       lodash.merge: 4.6.2
       lodash.uniq: 4.5.0
       resolve-from: 5.0.0
-      ts-node: 10.9.1(@types/node@20.5.1)(typescript@4.8.4)
-      typescript: 4.8.4
+      ts-node: 10.9.1(@types/node@20.5.1)(typescript@5.1.6)
+      typescript: 5.1.6
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
@@ -8714,7 +8832,7 @@ packages:
       tslib: 2.6.2
     dev: false
 
-  /@formatjs/intl@2.9.3(typescript@4.8.4):
+  /@formatjs/intl@2.9.3(typescript@5.1.6):
     resolution: {integrity: sha512-hclPdyCF1zk2XmhgdXfl5Sd30QEdRBnIijH7Vc1AWz2K0/saVRrxuL3UYn+m3xEyfOa4yDbTWVbmXDL0XEzlsQ==}
     peerDependencies:
       typescript: ^4.7 || 5
@@ -8729,7 +8847,7 @@ packages:
       '@formatjs/intl-listformat': 7.4.2
       intl-messageformat: 10.5.3
       tslib: 2.6.2
-      typescript: 4.8.4
+      typescript: 5.1.6
     dev: false
 
   /@hapi/address@2.1.4:
@@ -9404,6 +9522,18 @@ packages:
       npmlog: 4.1.2
     dev: false
 
+  /@ljharb/resumer@0.0.1:
+    resolution: {integrity: sha512-skQiAOrCfO7vRTq53cxznMpks7wS1va95UCidALlOVWqvBAzwPVErwizDwoMqNVMEn1mDq0utxZd02eIrvF1lw==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      '@ljharb/through': 2.3.10
+    dev: false
+
+  /@ljharb/through@2.3.10:
+    resolution: {integrity: sha512-NwkQ4+jf4tMpDSlRc1wlttHnC7KfII+SjdqDEwEuQ7W0IaTK5Ab1jxCJrH6pYsLbLXiQgRn+nFQsGmKowbAKkA==}
+    engines: {node: '>= 0.4'}
+    dev: false
+
   /@loadable/component@5.15.2(react@16.14.0):
     resolution: {integrity: sha512-ryFAZOX5P2vFkUdzaAtTG88IGnr9qxSdvLRvJySXcUA4B4xVWurUNADu3AnKPksxOZajljqTrDEDcYjeL4lvLw==}
     engines: {node: '>=8'}
@@ -9993,11 +10123,11 @@ packages:
       string-argv: 0.3.2
     dev: false
 
-  /@selderee/plugin-htmlparser2@0.6.0:
-    resolution: {integrity: sha512-J3jpy002TyBjd4N/p6s+s90eX42H2eRhK3SbsZuvTDv977/E8p2U3zikdiehyJja66do7FlxLomZLPlvl2/xaA==}
+  /@selderee/plugin-htmlparser2@0.11.0:
+    resolution: {integrity: sha512-P33hHGdldxGabLFjPPpaTxVolMrzrcegejx+0GxjrIb9Zv48D8yAIA/QTDR2dFl7Uz7urX8aX6+5bCZslr+gWQ==}
     dependencies:
-      domhandler: 4.3.1
-      selderee: 0.6.0
+      domhandler: 5.0.3
+      selderee: 0.11.0
     dev: false
 
   /@sinclair/typebox@0.24.51:
@@ -10563,7 +10693,7 @@ packages:
     dependencies:
       ts-dedent: 2.2.0
 
-  /@storybook/core@5.3.21(@babel/core@7.23.0)(babel-loader@8.0.6)(eslint@5.16.0)(react-dom@16.14.0)(react@16.14.0)(typescript@4.8.4):
+  /@storybook/core@5.3.21(@babel/core@7.23.0)(babel-loader@8.0.6)(eslint@5.16.0)(react-dom@16.14.0)(react@16.14.0)(typescript@5.1.6):
     resolution: {integrity: sha512-plD47WIsn/JoyRJDOpmH7N7mEMo/jiA8ZlOitLW55zYvzUn8UrVpRFpMYo91OJxiCT6JFoaEh3XtNdhbgUwnPA==}
     peerDependencies:
       '@babel/core': '*'
@@ -10623,14 +10753,14 @@ packages:
       micromatch: 4.0.5
       node-fetch: 2.7.0
       open: 7.4.2
-      pnp-webpack-plugin: 1.5.0(typescript@4.8.4)
+      pnp-webpack-plugin: 1.5.0(typescript@5.1.6)
       postcss-flexbugs-fixes: 4.2.1
       postcss-loader: 3.0.0
       pretty-hrtime: 1.0.3
       qs: 6.11.2
       raw-loader: 3.1.0(webpack@4.47.0)
       react: 16.14.0
-      react-dev-utils: 9.1.0(eslint@5.16.0)(typescript@4.8.4)(webpack@4.47.0)
+      react-dev-utils: 9.1.0(eslint@5.16.0)(typescript@5.1.6)(webpack@4.47.0)
       react-dom: 16.14.0(react@16.14.0)
       regenerator-runtime: 0.13.11
       resolve: 1.22.6
@@ -10660,7 +10790,7 @@ packages:
       - webpack-command
     dev: true
 
-  /@storybook/core@5.3.21(@babel/core@7.23.0)(babel-loader@8.0.6)(eslint@8.48.0)(react-dom@16.14.0)(react@16.14.0)(typescript@4.8.4):
+  /@storybook/core@5.3.21(@babel/core@7.23.0)(babel-loader@8.0.6)(eslint@8.48.0)(react-dom@16.14.0)(react@16.14.0)(typescript@5.1.6):
     resolution: {integrity: sha512-plD47WIsn/JoyRJDOpmH7N7mEMo/jiA8ZlOitLW55zYvzUn8UrVpRFpMYo91OJxiCT6JFoaEh3XtNdhbgUwnPA==}
     peerDependencies:
       '@babel/core': '*'
@@ -10720,14 +10850,14 @@ packages:
       micromatch: 4.0.5
       node-fetch: 2.7.0
       open: 7.4.2
-      pnp-webpack-plugin: 1.5.0(typescript@4.8.4)
+      pnp-webpack-plugin: 1.5.0(typescript@5.1.6)
       postcss-flexbugs-fixes: 4.2.1
       postcss-loader: 3.0.0
       pretty-hrtime: 1.0.3
       qs: 6.11.2
       raw-loader: 3.1.0(webpack@4.47.0)
       react: 16.14.0
-      react-dev-utils: 9.1.0(eslint@8.48.0)(typescript@4.8.4)(webpack@4.47.0)
+      react-dev-utils: 9.1.0(eslint@8.48.0)(typescript@5.1.6)(webpack@4.47.0)
       react-dom: 16.14.0(react@16.14.0)
       regenerator-runtime: 0.13.11
       resolve: 1.22.6
@@ -10790,7 +10920,7 @@ packages:
       pretty-hrtime: 1.0.3
       regenerator-runtime: 0.13.11
 
-  /@storybook/react@5.3.21(@babel/core@7.23.0)(babel-loader@8.0.6)(eslint@5.16.0)(react-dom@16.14.0)(react@16.14.0)(typescript@4.8.4):
+  /@storybook/react@5.3.21(@babel/core@7.23.0)(babel-loader@8.0.6)(eslint@5.16.0)(react-dom@16.14.0)(react@16.14.0)(typescript@5.1.6):
     resolution: {integrity: sha512-A50F8dDZxyLGa/dE3q0Zxt7T5r9UbomoSclqw7oJTO9GI76QOu7GfsoWrEL2gTEDAmqXreLVQqGuTLQhBz0rlA==}
     engines: {node: '>=8.0.0'}
     hasBin: true
@@ -10805,7 +10935,7 @@ packages:
       '@babel/preset-flow': 7.22.15(@babel/core@7.23.0)
       '@babel/preset-react': 7.22.15(@babel/core@7.23.0)
       '@storybook/addons': 5.3.21(react-dom@16.14.0)(regenerator-runtime@0.13.11)
-      '@storybook/core': 5.3.21(@babel/core@7.23.0)(babel-loader@8.0.6)(eslint@5.16.0)(react-dom@16.14.0)(react@16.14.0)(typescript@4.8.4)
+      '@storybook/core': 5.3.21(@babel/core@7.23.0)(babel-loader@8.0.6)(eslint@5.16.0)(react-dom@16.14.0)(react@16.14.0)(typescript@5.1.6)
       '@storybook/node-logger': 5.3.21
       '@svgr/webpack': 4.3.3
       '@types/webpack-env': 1.18.2
@@ -10819,7 +10949,7 @@ packages:
       mini-css-extract-plugin: 0.7.0(webpack@4.47.0)
       prop-types: 15.8.1
       react: 16.14.0
-      react-dev-utils: 9.1.0(eslint@5.16.0)(typescript@4.8.4)(webpack@4.47.0)
+      react-dev-utils: 9.1.0(eslint@5.16.0)(typescript@5.1.6)(webpack@4.47.0)
       react-dom: 16.14.0(react@16.14.0)
       regenerator-runtime: 0.13.11
       semver: 6.3.1
@@ -10837,7 +10967,7 @@ packages:
       - webpack-command
     dev: true
 
-  /@storybook/react@5.3.21(@babel/core@7.23.0)(babel-loader@8.0.6)(eslint@8.48.0)(react-dom@16.14.0)(react@16.14.0)(typescript@4.8.4):
+  /@storybook/react@5.3.21(@babel/core@7.23.0)(babel-loader@8.0.6)(eslint@8.48.0)(react-dom@16.14.0)(react@16.14.0)(typescript@5.1.6):
     resolution: {integrity: sha512-A50F8dDZxyLGa/dE3q0Zxt7T5r9UbomoSclqw7oJTO9GI76QOu7GfsoWrEL2gTEDAmqXreLVQqGuTLQhBz0rlA==}
     engines: {node: '>=8.0.0'}
     hasBin: true
@@ -10852,7 +10982,7 @@ packages:
       '@babel/preset-flow': 7.22.15(@babel/core@7.23.0)
       '@babel/preset-react': 7.22.15(@babel/core@7.23.0)
       '@storybook/addons': 5.3.21(react-dom@16.14.0)(regenerator-runtime@0.13.11)
-      '@storybook/core': 5.3.21(@babel/core@7.23.0)(babel-loader@8.0.6)(eslint@8.48.0)(react-dom@16.14.0)(react@16.14.0)(typescript@4.8.4)
+      '@storybook/core': 5.3.21(@babel/core@7.23.0)(babel-loader@8.0.6)(eslint@8.48.0)(react-dom@16.14.0)(react@16.14.0)(typescript@5.1.6)
       '@storybook/node-logger': 5.3.21
       '@svgr/webpack': 4.3.3
       '@types/webpack-env': 1.18.2
@@ -10866,7 +10996,7 @@ packages:
       mini-css-extract-plugin: 0.7.0(webpack@4.47.0)
       prop-types: 15.8.1
       react: 16.14.0
-      react-dev-utils: 9.1.0(eslint@8.48.0)(typescript@4.8.4)(webpack@4.47.0)
+      react-dev-utils: 9.1.0(eslint@8.48.0)(typescript@5.1.6)(webpack@4.47.0)
       react-dom: 16.14.0(react@16.14.0)
       regenerator-runtime: 0.13.11
       semver: 6.3.1
@@ -11440,8 +11570,8 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@swc/core-darwin-arm64@1.3.57:
-    resolution: {integrity: sha512-lhAK9kF/ppZdNTdaxJl2gE0bXubzQXTgxB2Xojme/1sbOipaLTskBbJ3FLySChpmVOzD0QSCTiW8w/dmQxqNIQ==}
+  /@swc/core-darwin-arm64@1.3.72:
+    resolution: {integrity: sha512-oNSI5hVfZ+1xpj+dH1g4kQqA0VsGtqd8S9S+cDqkHZiOOVOevw9KN6dzVtmLOcPtlULVypVc0TVvsB55KdVZhQ==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [darwin]
@@ -11449,8 +11579,8 @@ packages:
     dev: false
     optional: true
 
-  /@swc/core-darwin-x64@1.3.57:
-    resolution: {integrity: sha512-jsTDH8Et/xdOM/ZCNvtrT6J8FT255OrMhEDvHZQZTgoky4oW/3FHUfji4J2FE97gitJqNJI8MuNuiGq81pIJRw==}
+  /@swc/core-darwin-x64@1.3.72:
+    resolution: {integrity: sha512-y5O/WQ1g0/VfTgeNahWIOutbdD5U2Gi703jaefdcoJo3FUx8WU108QQdbVGwGMgaqapo3iQB6Qs9paixYQAYsA==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [darwin]
@@ -11458,8 +11588,8 @@ packages:
     dev: false
     optional: true
 
-  /@swc/core-linux-arm-gnueabihf@1.3.57:
-    resolution: {integrity: sha512-MZv3fwcCmppbwfCWaE8cZvzbXOjX7n5SEC1hF2lgItTqp4S04dFk1iX50jKr6xS6xSLlRBPqDxwZH0sBpHaEuA==}
+  /@swc/core-linux-arm-gnueabihf@1.3.72:
+    resolution: {integrity: sha512-05JdWcso0OomHF+7bk5MBDgI8MZ9skcQ/4nhSv5gboSgSiuBmKM15Bg3lZ5iAUwGByNj7pGkSmmd3YwTrXEB+g==}
     engines: {node: '>=10'}
     cpu: [arm]
     os: [linux]
@@ -11467,8 +11597,8 @@ packages:
     dev: false
     optional: true
 
-  /@swc/core-linux-arm64-gnu@1.3.57:
-    resolution: {integrity: sha512-wUeqa/qbkOEGl6TaDQZZL7txrQXs1vL7ERjPYhi9El+ywacFY/rTW2pK5DqaNk2eulVnLhbbNjsE1OMGSEWGkQ==}
+  /@swc/core-linux-arm64-gnu@1.3.72:
+    resolution: {integrity: sha512-8qRELJaeYshhJgqvyOeXCKqBOpai+JYdWuouMbvvDUL85j3OcZhzR+bipexEbbJKcOCdRnoYB7Qg6mjqZ0t7VA==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
@@ -11477,8 +11607,8 @@ packages:
     dev: false
     optional: true
 
-  /@swc/core-linux-arm64-musl@1.3.57:
-    resolution: {integrity: sha512-pZfp1B9XfH7ZhDKFjr4qbyM093zU2Ri0IZq2M2A4W9q92+Ivy8oEIqw+gSRO3jwMDqRMEtFD49YuFhkJQakxdA==}
+  /@swc/core-linux-arm64-musl@1.3.72:
+    resolution: {integrity: sha512-tOqAGZw+Pe7YrBHFrwFVyRiKqjgjzwYbJmY+UDxLrzWrZSVtC3eO2TPrp7kWmhirg40Og81BbdfRAl8ds48w0Q==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
@@ -11487,8 +11617,8 @@ packages:
     dev: false
     optional: true
 
-  /@swc/core-linux-x64-gnu@1.3.57:
-    resolution: {integrity: sha512-dvtQnv07NikV+CJ+9PYJ3fqphSigzfvSUH6wRCmb5OzLDDLFnPLMrEO0pGeURvdIWCOhngcHF252C1Hl5uFSzA==}
+  /@swc/core-linux-x64-gnu@1.3.72:
+    resolution: {integrity: sha512-U2W2xWR3s9nplGVWz376GiBlcLTgxyYKlpZPBNZk0w3OvTcjKC62gW1Pe7PUkk4NgJUnaQDBa/mb4V4Zl+GZPA==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
@@ -11497,8 +11627,8 @@ packages:
     dev: false
     optional: true
 
-  /@swc/core-linux-x64-musl@1.3.57:
-    resolution: {integrity: sha512-1TKCSngyQxpzwBYDzF5MrEfYRDhlzt/GN1ZqlSnsJIPGkABOWZxYDvWJuMrkASdIztn3jSTPU2ih7rR7YQ8IIw==}
+  /@swc/core-linux-x64-musl@1.3.72:
+    resolution: {integrity: sha512-3+2dUiZBsifKgvnFEHWdysXjInK8K+BfPBw2tTZJmq1+fZLt0rvuErYDVMLfIJnVWLCcJMnDtTXrvkFV1y/6iA==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
@@ -11507,8 +11637,8 @@ packages:
     dev: false
     optional: true
 
-  /@swc/core-win32-arm64-msvc@1.3.57:
-    resolution: {integrity: sha512-HvBYFyf4uBua/jyTrcFLKcq8SIbKVYfz2qWsbgSAZvuQPZvDC1XhN5EDH2tPZmT97F0CJx3fltH5nli6XY1/EQ==}
+  /@swc/core-win32-arm64-msvc@1.3.72:
+    resolution: {integrity: sha512-ndI8xZ2AId806D25xgqw2SFJ9gc/jhg21+5hA8XPq9ZL+oDiaYDztaP3ijVmZ1G5xXKD9DpgB7xmylv/f6o6GA==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [win32]
@@ -11516,8 +11646,8 @@ packages:
     dev: false
     optional: true
 
-  /@swc/core-win32-ia32-msvc@1.3.57:
-    resolution: {integrity: sha512-PS8AtK9e6Rp97S0ek9W5VCZNCbDaHBUasiJUmaYqRVCq/Mn6S7eQlhd0iUDnjsagigQtoCRgMUzkVknd1tarsQ==}
+  /@swc/core-win32-ia32-msvc@1.3.72:
+    resolution: {integrity: sha512-F3TK8JHP3SRFjLRlzcRVZPnvvGm2CQ5/cwbIkaEq0Dla3kyctU8SiRqvtYwWCW4JuY10cUygIg93Ec/C9Lkk4g==}
     engines: {node: '>=10'}
     cpu: [ia32]
     os: [win32]
@@ -11525,8 +11655,8 @@ packages:
     dev: false
     optional: true
 
-  /@swc/core-win32-x64-msvc@1.3.57:
-    resolution: {integrity: sha512-A6aX/Rpp0v3g7Spf3LSwR+ivviH8x+1xla612KLZmlc0yymWt9BMd3CmBkzyRBr2e41zGCrkf6tra6wgtCbAwA==}
+  /@swc/core-win32-x64-msvc@1.3.72:
+    resolution: {integrity: sha512-FXMnIUtLl0yEmGkw+xbUg/uUPExvUxUlLSHbX7CnbSuOIHqMHzvEd9skIueLAst4bvmJ8kT1hDyAIWQcTIAJYQ==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [win32]
@@ -11534,8 +11664,8 @@ packages:
     dev: false
     optional: true
 
-  /@swc/core@1.3.57:
-    resolution: {integrity: sha512-gAT80hOVeK5qoi+BRlgXWgJYI9cbQn2oi05A09Tvb6vjFgBsr9SlQGNZB9uMlcXRXspkZFf9l3yyWRtT4we3Yw==}
+  /@swc/core@1.3.72:
+    resolution: {integrity: sha512-+AKjwLH3/STfPrd7CHzB9+NG1FVT0UKJMUChuWq9sQ8b9xlV8vUeRgZXgh/EHYvNQgl/OUTQKtL6xU2yOLuEuA==}
     engines: {node: '>=10'}
     requiresBuild: true
     peerDependencies:
@@ -11544,16 +11674,16 @@ packages:
       '@swc/helpers':
         optional: true
     optionalDependencies:
-      '@swc/core-darwin-arm64': 1.3.57
-      '@swc/core-darwin-x64': 1.3.57
-      '@swc/core-linux-arm-gnueabihf': 1.3.57
-      '@swc/core-linux-arm64-gnu': 1.3.57
-      '@swc/core-linux-arm64-musl': 1.3.57
-      '@swc/core-linux-x64-gnu': 1.3.57
-      '@swc/core-linux-x64-musl': 1.3.57
-      '@swc/core-win32-arm64-msvc': 1.3.57
-      '@swc/core-win32-ia32-msvc': 1.3.57
-      '@swc/core-win32-x64-msvc': 1.3.57
+      '@swc/core-darwin-arm64': 1.3.72
+      '@swc/core-darwin-x64': 1.3.72
+      '@swc/core-linux-arm-gnueabihf': 1.3.72
+      '@swc/core-linux-arm64-gnu': 1.3.72
+      '@swc/core-linux-arm64-musl': 1.3.72
+      '@swc/core-linux-x64-gnu': 1.3.72
+      '@swc/core-linux-x64-musl': 1.3.72
+      '@swc/core-win32-arm64-msvc': 1.3.72
+      '@swc/core-win32-ia32-msvc': 1.3.72
+      '@swc/core-win32-x64-msvc': 1.3.72
     dev: false
 
   /@szmarczak/http-timer@1.1.2:
@@ -11773,6 +11903,10 @@ packages:
     dependencies:
       '@types/connect': 3.4.36
       '@types/node': 13.11.1
+
+  /@types/chroma-js@2.4.1:
+    resolution: {integrity: sha512-YIm3RLfWdDU0/3rsNnu/Hh4uKCLQ9p/w1NvnFfBOBL/BGqOvuLNuhXwkJMUKMscmFJdan25lYqv2+qh1l7tZLg==}
+    dev: false
 
   /@types/connect@3.4.36:
     resolution: {integrity: sha512-P63Zd/JUGq+PdrM1lv0Wv5SBYeA2+CORvbrXbngriYY0jzLUWfQMQQxOhjONEz/wlHOAxOdY7CY65rgQdTjq2w==}
@@ -12020,10 +12154,6 @@ packages:
   /@types/npmlog@4.1.4:
     resolution: {integrity: sha512-WKG4gTr8przEZBiJ5r3s8ZIAoMXNbOgQ+j/d5O4X3x6kZJRLNvyUJuUK/KoG3+8BaOHPhp2m7WC6JKKeovDSzQ==}
 
-  /@types/nprogress@0.2.1:
-    resolution: {integrity: sha512-TYuyVnp+nOnimgdOydDIDYIxv2kSeuJZw4tF0p/KG7hpzcMF1WkHaREwM8O4blqfT1F7rq0nht6Ko2KVUfWzBA==}
-    dev: false
-
   /@types/offscreencanvas@2019.3.0:
     resolution: {integrity: sha512-esIJx9bQg+QYF0ra8GnvfianIY8qWB0GBx54PK5Eps6m+xTj86KLavHv6qDhzKcu5UUOgNfJ2pWaIIV7TRUd9Q==}
     dev: false
@@ -12203,7 +12333,7 @@ packages:
     resolution: {integrity: sha512-b3nLFGaGkJ9rzOcuXRfHkZMdjsawuDD0ENL9fzTophtBg8FJHSGbH7daXkEpcwy3v7Xol3pAvsmlYyFhR4pqJw==}
     dependencies:
       '@types/node': 13.11.1
-      '@types/unist': 2.0.8
+      '@types/unist': 3.0.0
       '@types/vfile-message': 2.0.0
 
   /@types/webgl-ext@0.0.30:
@@ -12267,25 +12397,25 @@ packages:
     resolution: {integrity: sha512-l+pOlH6ypLnHjtIgLhM0AKhNJhXd02ZNvCOk3INhNXsGeKR32GQlMWbcyPOiM5MRw8B89qpbHZWyU9W9xWWrOQ==}
     dev: false
 
-  /@typescript-eslint/eslint-plugin@1.10.2(@typescript-eslint/parser@1.10.2)(eslint@5.16.0)(typescript@4.8.4):
+  /@typescript-eslint/eslint-plugin@1.10.2(@typescript-eslint/parser@1.10.2)(eslint@5.16.0)(typescript@5.1.6):
     resolution: {integrity: sha512-7449RhjE1oLFIy5E/5rT4wG5+KsfPzakJuhvpzXJ3C46lq7xywY0/Rjo9ZBcwrfbk0nRZ5xmUHkk7DZ67tSBKw==}
     engines: {node: ^6.14.0 || ^8.10.0 || >=9.10.0}
     peerDependencies:
       '@typescript-eslint/parser': ^1.9.0
       eslint: ^5.0.0
     dependencies:
-      '@typescript-eslint/experimental-utils': 1.10.2(eslint@5.16.0)(typescript@4.8.4)
-      '@typescript-eslint/parser': 1.10.2(eslint@5.16.0)(typescript@4.8.4)
+      '@typescript-eslint/experimental-utils': 1.10.2(eslint@5.16.0)(typescript@5.1.6)
+      '@typescript-eslint/parser': 1.10.2(eslint@5.16.0)(typescript@5.1.6)
       eslint: 5.16.0
       eslint-utils: 1.4.3
       functional-red-black-tree: 1.0.1
       regexpp: 2.0.1
-      tsutils: 3.21.0(typescript@4.8.4)
+      tsutils: 3.21.0(typescript@5.1.6)
     transitivePeerDependencies:
       - typescript
     dev: true
 
-  /@typescript-eslint/eslint-plugin@1.13.0(@typescript-eslint/parser@2.34.0)(eslint@5.16.0)(typescript@4.8.4):
+  /@typescript-eslint/eslint-plugin@1.13.0(@typescript-eslint/parser@2.34.0)(eslint@5.16.0)(typescript@5.1.6):
     resolution: {integrity: sha512-WQHCozMnuNADiqMtsNzp96FNox5sOVpU8Xt4meaT4em8lOG1SrOv92/mUbEHQVh90sldKSfcOc/I0FOb/14G1g==}
     engines: {node: ^6.14.0 || ^8.10.0 || >=9.10.0}
     peerDependencies:
@@ -12293,17 +12423,17 @@ packages:
       eslint: ^5.0.0
     dependencies:
       '@typescript-eslint/experimental-utils': 1.13.0(eslint@5.16.0)
-      '@typescript-eslint/parser': 2.34.0(eslint@5.16.0)(typescript@4.8.4)
+      '@typescript-eslint/parser': 2.34.0(eslint@5.16.0)(typescript@5.1.6)
       eslint: 5.16.0
       eslint-utils: 1.4.3
       functional-red-black-tree: 1.0.1
       regexpp: 2.0.1
-      tsutils: 3.21.0(typescript@4.8.4)
+      tsutils: 3.21.0(typescript@5.1.6)
     transitivePeerDependencies:
       - typescript
     dev: true
 
-  /@typescript-eslint/eslint-plugin@1.13.0(@typescript-eslint/parser@2.34.0)(eslint@6.8.0)(typescript@4.8.4):
+  /@typescript-eslint/eslint-plugin@1.13.0(@typescript-eslint/parser@2.34.0)(eslint@6.8.0)(typescript@5.1.6):
     resolution: {integrity: sha512-WQHCozMnuNADiqMtsNzp96FNox5sOVpU8Xt4meaT4em8lOG1SrOv92/mUbEHQVh90sldKSfcOc/I0FOb/14G1g==}
     engines: {node: ^6.14.0 || ^8.10.0 || >=9.10.0}
     peerDependencies:
@@ -12311,17 +12441,17 @@ packages:
       eslint: ^5.0.0
     dependencies:
       '@typescript-eslint/experimental-utils': 1.13.0(eslint@6.8.0)
-      '@typescript-eslint/parser': 2.34.0(eslint@6.8.0)(typescript@4.8.4)
+      '@typescript-eslint/parser': 2.34.0(eslint@6.8.0)(typescript@5.1.6)
       eslint: 6.8.0
       eslint-utils: 1.4.3
       functional-red-black-tree: 1.0.1
       regexpp: 2.0.1
-      tsutils: 3.21.0(typescript@4.8.4)
+      tsutils: 3.21.0(typescript@5.1.6)
     transitivePeerDependencies:
       - typescript
     dev: true
 
-  /@typescript-eslint/eslint-plugin@2.34.0(@typescript-eslint/parser@2.34.0)(eslint@5.16.0)(typescript@4.8.4):
+  /@typescript-eslint/eslint-plugin@2.34.0(@typescript-eslint/parser@2.34.0)(eslint@5.16.0)(typescript@5.1.6):
     resolution: {integrity: sha512-4zY3Z88rEE99+CNvTbXSyovv2z9PNOVffTWD2W8QF5s2prBQtwN2zadqERcrHpcR7O/+KMI3fcTAmUUhK/iQcQ==}
     engines: {node: ^8.10.0 || ^10.13.0 || >=11.10.1}
     peerDependencies:
@@ -12332,18 +12462,18 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/experimental-utils': 2.34.0(eslint@5.16.0)(typescript@4.8.4)
-      '@typescript-eslint/parser': 2.34.0(eslint@5.16.0)(typescript@4.8.4)
+      '@typescript-eslint/experimental-utils': 2.34.0(eslint@5.16.0)(typescript@5.1.6)
+      '@typescript-eslint/parser': 2.34.0(eslint@5.16.0)(typescript@5.1.6)
       eslint: 5.16.0
       functional-red-black-tree: 1.0.1
       regexpp: 3.2.0
-      tsutils: 3.21.0(typescript@4.8.4)
-      typescript: 4.8.4
+      tsutils: 3.21.0(typescript@5.1.6)
+      typescript: 5.1.6
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/eslint-plugin@2.34.0(@typescript-eslint/parser@2.34.0)(eslint@6.8.0)(typescript@4.8.4):
+  /@typescript-eslint/eslint-plugin@2.34.0(@typescript-eslint/parser@2.34.0)(eslint@6.8.0)(typescript@5.1.6):
     resolution: {integrity: sha512-4zY3Z88rEE99+CNvTbXSyovv2z9PNOVffTWD2W8QF5s2prBQtwN2zadqERcrHpcR7O/+KMI3fcTAmUUhK/iQcQ==}
     engines: {node: ^8.10.0 || ^10.13.0 || >=11.10.1}
     peerDependencies:
@@ -12354,13 +12484,13 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/experimental-utils': 2.34.0(eslint@6.8.0)(typescript@4.8.4)
-      '@typescript-eslint/parser': 2.34.0(eslint@6.8.0)(typescript@4.8.4)
+      '@typescript-eslint/experimental-utils': 2.34.0(eslint@6.8.0)(typescript@5.1.6)
+      '@typescript-eslint/parser': 2.34.0(eslint@6.8.0)(typescript@5.1.6)
       eslint: 6.8.0
       functional-red-black-tree: 1.0.1
       regexpp: 3.2.0
-      tsutils: 3.21.0(typescript@4.8.4)
-      typescript: 4.8.4
+      tsutils: 3.21.0(typescript@5.1.6)
+      typescript: 5.1.6
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -12393,7 +12523,7 @@ packages:
       - supports-color
     dev: false
 
-  /@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0)(eslint@8.48.0)(typescript@4.8.4):
+  /@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0)(eslint@8.48.0)(typescript@5.1.6):
     resolution: {integrity: sha512-TiZzBSJja/LbhNPvk6yc0JrX9XqhQ0hdh6M2svYfsHGejaKFIAGd9MQ+ERIMzLGlN/kZoYIgdxFV0PuljTKXag==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -12405,23 +12535,23 @@ packages:
         optional: true
     dependencies:
       '@eslint-community/regexpp': 4.9.1
-      '@typescript-eslint/parser': 5.62.0(eslint@8.48.0)(typescript@4.8.4)
+      '@typescript-eslint/parser': 5.62.0(eslint@8.48.0)(typescript@5.1.6)
       '@typescript-eslint/scope-manager': 5.62.0
-      '@typescript-eslint/type-utils': 5.62.0(eslint@8.48.0)(typescript@4.8.4)
-      '@typescript-eslint/utils': 5.62.0(eslint@8.48.0)(typescript@4.8.4)
+      '@typescript-eslint/type-utils': 5.62.0(eslint@8.48.0)(typescript@5.1.6)
+      '@typescript-eslint/utils': 5.62.0(eslint@8.48.0)(typescript@5.1.6)
       debug: 4.3.4(supports-color@5.5.0)
       eslint: 8.48.0
       graphemer: 1.4.0
       ignore: 5.2.4
       natural-compare-lite: 1.4.0
       semver: 7.5.4
-      tsutils: 3.21.0(typescript@4.8.4)
-      typescript: 4.8.4
+      tsutils: 3.21.0(typescript@5.1.6)
+      typescript: 5.1.6
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@typescript-eslint/eslint-plugin@6.5.0(@typescript-eslint/parser@6.5.0)(eslint@8.48.0)(typescript@4.8.4):
+  /@typescript-eslint/eslint-plugin@6.5.0(@typescript-eslint/parser@6.5.0)(eslint@8.48.0)(typescript@5.1.6):
     resolution: {integrity: sha512-2pktILyjvMaScU6iK3925uvGU87E+N9rh372uGZgiMYwafaw9SXq86U04XPq3UH6tzRvNgBsub6x2DacHc33lw==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -12433,10 +12563,10 @@ packages:
         optional: true
     dependencies:
       '@eslint-community/regexpp': 4.9.1
-      '@typescript-eslint/parser': 6.5.0(eslint@8.48.0)(typescript@4.8.4)
+      '@typescript-eslint/parser': 6.5.0(eslint@8.48.0)(typescript@5.1.6)
       '@typescript-eslint/scope-manager': 6.5.0
-      '@typescript-eslint/type-utils': 6.5.0(eslint@8.48.0)(typescript@4.8.4)
-      '@typescript-eslint/utils': 6.5.0(eslint@8.48.0)(typescript@4.8.4)
+      '@typescript-eslint/type-utils': 6.5.0(eslint@8.48.0)(typescript@5.1.6)
+      '@typescript-eslint/utils': 6.5.0(eslint@8.48.0)(typescript@5.1.6)
       '@typescript-eslint/visitor-keys': 6.5.0
       debug: 4.3.4(supports-color@5.5.0)
       eslint: 8.48.0
@@ -12444,13 +12574,13 @@ packages:
       ignore: 5.2.4
       natural-compare: 1.4.0
       semver: 7.5.4
-      ts-api-utils: 1.0.3(typescript@4.8.4)
-      typescript: 4.8.4
+      ts-api-utils: 1.0.3(typescript@5.1.6)
+      typescript: 5.1.6
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/experimental-utils@1.10.2(eslint@5.16.0)(typescript@4.8.4):
+  /@typescript-eslint/experimental-utils@1.10.2(eslint@5.16.0)(typescript@5.1.6):
     resolution: {integrity: sha512-Hf5lYcrnTH5Oc67SRrQUA7KuHErMvCf5RlZsyxXPIT6AXa8fKTyfFO6vaEnUmlz48RpbxO4f0fY3QtWkuHZNjg==}
     engines: {node: ^6.14.0 || ^8.10.0 || >=9.10.0}
     peerDependencies:
@@ -12460,7 +12590,7 @@ packages:
       '@typescript-eslint/typescript-estree': 1.10.2
       eslint: 5.16.0
       eslint-scope: 4.0.3
-      typescript: 4.8.4
+      typescript: 5.1.6
     dev: true
 
   /@typescript-eslint/experimental-utils@1.13.0(eslint@5.16.0):
@@ -12487,14 +12617,14 @@ packages:
       eslint-scope: 4.0.3
     dev: true
 
-  /@typescript-eslint/experimental-utils@2.34.0(eslint@5.16.0)(typescript@4.8.4):
+  /@typescript-eslint/experimental-utils@2.34.0(eslint@5.16.0)(typescript@5.1.6):
     resolution: {integrity: sha512-eS6FTkq+wuMJ+sgtuNTtcqavWXqsflWcfBnlYhg/nS4aZ1leewkXGbvBhaapn1q6qf4M71bsR1tez5JTRMuqwA==}
     engines: {node: ^8.10.0 || ^10.13.0 || >=11.10.1}
     peerDependencies:
       eslint: '*'
     dependencies:
       '@types/json-schema': 7.0.13
-      '@typescript-eslint/typescript-estree': 2.34.0(typescript@4.8.4)
+      '@typescript-eslint/typescript-estree': 2.34.0(typescript@5.1.6)
       eslint: 5.16.0
       eslint-scope: 5.1.1
       eslint-utils: 2.1.0
@@ -12503,14 +12633,14 @@ packages:
       - typescript
     dev: true
 
-  /@typescript-eslint/experimental-utils@2.34.0(eslint@6.8.0)(typescript@4.8.4):
+  /@typescript-eslint/experimental-utils@2.34.0(eslint@6.8.0)(typescript@5.1.6):
     resolution: {integrity: sha512-eS6FTkq+wuMJ+sgtuNTtcqavWXqsflWcfBnlYhg/nS4aZ1leewkXGbvBhaapn1q6qf4M71bsR1tez5JTRMuqwA==}
     engines: {node: ^8.10.0 || ^10.13.0 || >=11.10.1}
     peerDependencies:
       eslint: '*'
     dependencies:
       '@types/json-schema': 7.0.13
-      '@typescript-eslint/typescript-estree': 2.34.0(typescript@4.8.4)
+      '@typescript-eslint/typescript-estree': 2.34.0(typescript@5.1.6)
       eslint: 6.8.0
       eslint-scope: 5.1.1
       eslint-utils: 2.1.0
@@ -12537,14 +12667,14 @@ packages:
       - typescript
     dev: false
 
-  /@typescript-eslint/parser@1.10.2(eslint@5.16.0)(typescript@4.8.4):
+  /@typescript-eslint/parser@1.10.2(eslint@5.16.0)(typescript@5.1.6):
     resolution: {integrity: sha512-xWDWPfZfV0ENU17ermIUVEVSseBBJxKfqBcRCMZ8nAjJbfA5R7NWMZmFFHYnars5MjK4fPjhu4gwQv526oZIPQ==}
     engines: {node: ^6.14.0 || ^8.10.0 || >=9.10.0}
     peerDependencies:
       eslint: ^5.0.0
     dependencies:
       '@types/eslint-visitor-keys': 1.0.0
-      '@typescript-eslint/experimental-utils': 1.10.2(eslint@5.16.0)(typescript@4.8.4)
+      '@typescript-eslint/experimental-utils': 1.10.2(eslint@5.16.0)(typescript@5.1.6)
       '@typescript-eslint/typescript-estree': 1.10.2
       eslint: 5.16.0
       eslint-visitor-keys: 1.3.0
@@ -12578,7 +12708,7 @@ packages:
       eslint-visitor-keys: 1.3.0
     dev: true
 
-  /@typescript-eslint/parser@2.34.0(eslint@5.16.0)(typescript@4.8.4):
+  /@typescript-eslint/parser@2.34.0(eslint@5.16.0)(typescript@5.1.6):
     resolution: {integrity: sha512-03ilO0ucSD0EPTw2X4PntSIRFtDPWjrVq7C3/Z3VQHRC7+13YB55rcJI3Jt+YgeHbjUdJPcPa7b23rXCBokuyA==}
     engines: {node: ^8.10.0 || ^10.13.0 || >=11.10.1}
     peerDependencies:
@@ -12589,16 +12719,16 @@ packages:
         optional: true
     dependencies:
       '@types/eslint-visitor-keys': 1.0.0
-      '@typescript-eslint/experimental-utils': 2.34.0(eslint@5.16.0)(typescript@4.8.4)
-      '@typescript-eslint/typescript-estree': 2.34.0(typescript@4.8.4)
+      '@typescript-eslint/experimental-utils': 2.34.0(eslint@5.16.0)(typescript@5.1.6)
+      '@typescript-eslint/typescript-estree': 2.34.0(typescript@5.1.6)
       eslint: 5.16.0
       eslint-visitor-keys: 1.3.0
-      typescript: 4.8.4
+      typescript: 5.1.6
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser@2.34.0(eslint@6.8.0)(typescript@4.8.4):
+  /@typescript-eslint/parser@2.34.0(eslint@6.8.0)(typescript@5.1.6):
     resolution: {integrity: sha512-03ilO0ucSD0EPTw2X4PntSIRFtDPWjrVq7C3/Z3VQHRC7+13YB55rcJI3Jt+YgeHbjUdJPcPa7b23rXCBokuyA==}
     engines: {node: ^8.10.0 || ^10.13.0 || >=11.10.1}
     peerDependencies:
@@ -12609,11 +12739,11 @@ packages:
         optional: true
     dependencies:
       '@types/eslint-visitor-keys': 1.0.0
-      '@typescript-eslint/experimental-utils': 2.34.0(eslint@6.8.0)(typescript@4.8.4)
-      '@typescript-eslint/typescript-estree': 2.34.0(typescript@4.8.4)
+      '@typescript-eslint/experimental-utils': 2.34.0(eslint@6.8.0)(typescript@5.1.6)
+      '@typescript-eslint/typescript-estree': 2.34.0(typescript@5.1.6)
       eslint: 6.8.0
       eslint-visitor-keys: 1.3.0
-      typescript: 4.8.4
+      typescript: 5.1.6
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -12638,7 +12768,7 @@ packages:
       - supports-color
     dev: false
 
-  /@typescript-eslint/parser@5.62.0(eslint@8.48.0)(typescript@4.8.4):
+  /@typescript-eslint/parser@5.62.0(eslint@8.48.0)(typescript@5.1.6):
     resolution: {integrity: sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -12650,15 +12780,15 @@ packages:
     dependencies:
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@4.8.4)
+      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.1.6)
       debug: 4.3.4(supports-color@5.5.0)
       eslint: 8.48.0
-      typescript: 4.8.4
+      typescript: 5.1.6
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@typescript-eslint/parser@6.5.0(eslint@8.48.0)(typescript@4.8.4):
+  /@typescript-eslint/parser@6.5.0(eslint@8.48.0)(typescript@5.1.6):
     resolution: {integrity: sha512-LMAVtR5GN8nY0G0BadkG0XIe4AcNMeyEy3DyhKGAh9k4pLSMBO7rF29JvDBpZGCmp5Pgz5RLHP6eCpSYZJQDuQ==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -12670,11 +12800,11 @@ packages:
     dependencies:
       '@typescript-eslint/scope-manager': 6.5.0
       '@typescript-eslint/types': 6.5.0
-      '@typescript-eslint/typescript-estree': 6.5.0(typescript@4.8.4)
+      '@typescript-eslint/typescript-estree': 6.5.0(typescript@5.1.6)
       '@typescript-eslint/visitor-keys': 6.5.0
       debug: 4.3.4(supports-color@5.5.0)
       eslint: 8.48.0
-      typescript: 4.8.4
+      typescript: 5.1.6
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -12723,7 +12853,7 @@ packages:
       - supports-color
     dev: false
 
-  /@typescript-eslint/type-utils@5.62.0(eslint@8.48.0)(typescript@4.8.4):
+  /@typescript-eslint/type-utils@5.62.0(eslint@8.48.0)(typescript@5.1.6):
     resolution: {integrity: sha512-xsSQreu+VnfbqQpW5vnCJdq1Z3Q0U31qiWmRhr98ONQmcp/yhiPJFPq8MXiJVLiksmOKSjIldZzkebzHuCGzew==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -12733,17 +12863,17 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@4.8.4)
-      '@typescript-eslint/utils': 5.62.0(eslint@8.48.0)(typescript@4.8.4)
+      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.1.6)
+      '@typescript-eslint/utils': 5.62.0(eslint@8.48.0)(typescript@5.1.6)
       debug: 4.3.4(supports-color@5.5.0)
       eslint: 8.48.0
-      tsutils: 3.21.0(typescript@4.8.4)
-      typescript: 4.8.4
+      tsutils: 3.21.0(typescript@5.1.6)
+      typescript: 5.1.6
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@typescript-eslint/type-utils@6.5.0(eslint@8.48.0)(typescript@4.8.4):
+  /@typescript-eslint/type-utils@6.5.0(eslint@8.48.0)(typescript@5.1.6):
     resolution: {integrity: sha512-f7OcZOkRivtujIBQ4yrJNIuwyCQO1OjocVqntl9dgSIZAdKqicj3xFDqDOzHDlGCZX990LqhLQXWRnQvsapq8A==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -12753,12 +12883,12 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/typescript-estree': 6.5.0(typescript@4.8.4)
-      '@typescript-eslint/utils': 6.5.0(eslint@8.48.0)(typescript@4.8.4)
+      '@typescript-eslint/typescript-estree': 6.5.0(typescript@5.1.6)
+      '@typescript-eslint/utils': 6.5.0(eslint@8.48.0)(typescript@5.1.6)
       debug: 4.3.4(supports-color@5.5.0)
       eslint: 8.48.0
-      ts-api-utils: 1.0.3(typescript@4.8.4)
-      typescript: 4.8.4
+      ts-api-utils: 1.0.3(typescript@5.1.6)
+      typescript: 5.1.6
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -12794,7 +12924,7 @@ packages:
       semver: 5.5.0
     dev: true
 
-  /@typescript-eslint/typescript-estree@2.34.0(typescript@4.8.4):
+  /@typescript-eslint/typescript-estree@2.34.0(typescript@5.1.6):
     resolution: {integrity: sha512-OMAr+nJWKdlVM9LOqCqh3pQQPwxHAN7Du8DR6dmwCrAmxtiXQnhHJ6tBNtf+cggqfo51SG/FCwnKhXCIM7hnVg==}
     engines: {node: ^8.10.0 || ^10.13.0 || >=11.10.1}
     peerDependencies:
@@ -12809,8 +12939,8 @@ packages:
       is-glob: 4.0.3
       lodash: 4.17.21
       semver: 7.5.4
-      tsutils: 3.21.0(typescript@4.8.4)
-      typescript: 4.8.4
+      tsutils: 3.21.0(typescript@5.1.6)
+      typescript: 5.1.6
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -12857,7 +12987,28 @@ packages:
       - supports-color
     dev: false
 
-  /@typescript-eslint/typescript-estree@6.5.0(typescript@4.8.4):
+  /@typescript-eslint/typescript-estree@5.62.0(typescript@5.1.6):
+    resolution: {integrity: sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/types': 5.62.0
+      '@typescript-eslint/visitor-keys': 5.62.0
+      debug: 4.3.4(supports-color@5.5.0)
+      globby: 11.1.0
+      is-glob: 4.0.3
+      semver: 7.5.4
+      tsutils: 3.21.0(typescript@5.1.6)
+      typescript: 5.1.6
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@typescript-eslint/typescript-estree@6.5.0(typescript@5.1.6):
     resolution: {integrity: sha512-q0rGwSe9e5Kk/XzliB9h2LBc9tmXX25G0833r7kffbl5437FPWb2tbpIV9wAATebC/018pGa9fwPDuvGN+LxWQ==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -12872,8 +13023,8 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.5.4
-      ts-api-utils: 1.0.3(typescript@4.8.4)
-      typescript: 4.8.4
+      ts-api-utils: 1.0.3(typescript@5.1.6)
+      typescript: 5.1.6
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -12898,7 +13049,7 @@ packages:
       - typescript
     dev: false
 
-  /@typescript-eslint/utils@5.62.0(eslint@8.48.0)(typescript@4.8.4):
+  /@typescript-eslint/utils@5.62.0(eslint@8.48.0)(typescript@5.1.6):
     resolution: {integrity: sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -12909,7 +13060,7 @@ packages:
       '@types/semver': 7.5.3
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@4.8.4)
+      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.1.6)
       eslint: 8.48.0
       eslint-scope: 5.1.1
       semver: 7.5.4
@@ -12918,7 +13069,7 @@ packages:
       - typescript
     dev: false
 
-  /@typescript-eslint/utils@6.5.0(eslint@8.48.0)(typescript@4.8.4):
+  /@typescript-eslint/utils@6.5.0(eslint@8.48.0)(typescript@5.1.6):
     resolution: {integrity: sha512-9nqtjkNykFzeVtt9Pj6lyR9WEdd8npPhhIPM992FWVkZuS6tmxHfGVnlUcjpUP2hv8r4w35nT33mlxd+Be1ACQ==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -12929,7 +13080,7 @@ packages:
       '@types/semver': 7.5.3
       '@typescript-eslint/scope-manager': 6.5.0
       '@typescript-eslint/types': 6.5.0
-      '@typescript-eslint/typescript-estree': 6.5.0(typescript@4.8.4)
+      '@typescript-eslint/typescript-estree': 6.5.0(typescript@5.1.6)
       eslint: 8.48.0
       semver: 7.5.4
     transitivePeerDependencies:
@@ -13009,7 +13160,7 @@ packages:
       - supports-color
     dev: false
 
-  /@umijs/bundler-vite@4.0.83(@types/node@20.5.1)(postcss@8.4.31)(rollup@2.33.3)(sass@1.69.0)(stylus@0.54.8):
+  /@umijs/bundler-vite@4.0.83(@types/node@13.11.1)(postcss@8.4.31)(rollup@2.33.3)(sass@1.69.0)(stylus@0.54.8):
     resolution: {integrity: sha512-a9rYhUp5ZyHuDoOUYDnrcUAFcL0PAxcdYTXciFSB3RUmYygFqTx2teuvrR7AWnI81t9YFob48RXwzV4trUgoLw==}
     hasBin: true
     dependencies:
@@ -13020,7 +13171,7 @@ packages:
       less: 4.1.3
       postcss-preset-env: 7.5.0(postcss@8.4.31)
       rollup-plugin-visualizer: 5.9.0(rollup@2.33.3)
-      vite: 4.3.1(@types/node@20.5.1)(less@3.13.1)(stylus@0.54.8)
+      vite: 4.3.1(@types/node@13.11.1)(less@3.13.1)(stylus@0.54.8)
     transitivePeerDependencies:
       - '@types/node'
       - postcss
@@ -13032,7 +13183,7 @@ packages:
       - terser
     dev: false
 
-  /@umijs/bundler-webpack@4.0.83(styled-components@6.0.8)(typescript@4.8.4)(webpack@5.88.2):
+  /@umijs/bundler-webpack@4.0.83(styled-components@6.0.8)(typescript@5.1.6)(webpack@5.88.2):
     resolution: {integrity: sha512-7Z1hUuUQTp5cB3sFnKCHclpBpWjpSNeezYDqxa2me/wGi+zZEMXagSFvt8GTIjGuA8OGenUdG8fLb3umHlO5Bg==}
     hasBin: true
     dependencies:
@@ -13049,7 +13200,7 @@ packages:
       cors: 2.8.5
       css-loader: 6.7.1(webpack@5.88.2)
       es5-imcompatible-versions: 0.1.86
-      fork-ts-checker-webpack-plugin: 8.0.0(typescript@4.8.4)(webpack@5.88.2)
+      fork-ts-checker-webpack-plugin: 8.0.0(typescript@5.1.6)(webpack@5.88.2)
       jest-worker: 29.4.3
       lightningcss: 1.19.0
       node-libs-browser: 2.2.1
@@ -13187,11 +13338,11 @@ packages:
       '@umijs/es-module-parser-win32-x64-msvc': 0.0.7
     dev: false
 
-  /@umijs/fabric@1.2.14(typescript@4.8.4):
+  /@umijs/fabric@1.2.14(typescript@5.1.6):
     resolution: {integrity: sha512-GsGOdsFhCtrW6LuWczs+7WLs4E+KYxK+xriDM2jNcuxw0Fozp46PynFZ2pYszueyTdN2NQx/xbhWp0vF6XSYiQ==}
     dependencies:
-      '@typescript-eslint/eslint-plugin': 1.13.0(@typescript-eslint/parser@2.34.0)(eslint@5.16.0)(typescript@4.8.4)
-      '@typescript-eslint/parser': 2.34.0(eslint@5.16.0)(typescript@4.8.4)
+      '@typescript-eslint/eslint-plugin': 1.13.0(@typescript-eslint/parser@2.34.0)(eslint@5.16.0)(typescript@5.1.6)
+      '@typescript-eslint/parser': 2.34.0(eslint@5.16.0)(typescript@5.1.6)
       eslint: 5.16.0
       eslint-config-airbnb: 17.1.1(eslint-plugin-import@2.28.1)(eslint-plugin-jsx-a11y@6.7.1)(eslint-plugin-react@7.13.0)(eslint@5.16.0)
       eslint-config-airbnb-base: 13.2.0(eslint-plugin-import@2.28.1)(eslint@5.16.0)
@@ -13223,16 +13374,16 @@ packages:
       - typescript
     dev: true
 
-  /@umijs/fabric@2.0.0(prettier@2.8.8)(typescript@4.8.4):
+  /@umijs/fabric@2.0.0(prettier@2.8.8)(typescript@5.1.6):
     resolution: {integrity: sha512-M63Pbp7vwbGXO5h4rakCZGhhZzQD+g0ELGKb9Xibnfsbw+a0PkL9sfYahJROETm3gNBB6YT9Z/EgtEVgKPktgg==}
     dependencies:
-      '@typescript-eslint/eslint-plugin': 1.13.0(@typescript-eslint/parser@2.34.0)(eslint@6.8.0)(typescript@4.8.4)
-      '@typescript-eslint/parser': 2.34.0(eslint@6.8.0)(typescript@4.8.4)
+      '@typescript-eslint/eslint-plugin': 1.13.0(@typescript-eslint/parser@2.34.0)(eslint@6.8.0)(typescript@5.1.6)
+      '@typescript-eslint/parser': 2.34.0(eslint@6.8.0)(typescript@5.1.6)
       eslint: 6.8.0
       eslint-config-airbnb: 17.1.1(eslint-plugin-import@2.28.1)(eslint-plugin-jsx-a11y@6.7.1)(eslint-plugin-react@7.13.0)(eslint@6.8.0)
       eslint-config-airbnb-base: 13.2.0(eslint-plugin-import@2.28.1)(eslint@6.8.0)
       eslint-config-airbnb-typescript: 4.0.1(eslint-plugin-import@2.28.1)(eslint-plugin-jsx-a11y@6.7.1)(eslint-plugin-react@7.13.0)(eslint@6.8.0)
-      eslint-config-egg: 7.5.1(eslint@6.8.0)(typescript@4.8.4)
+      eslint-config-egg: 7.5.1(eslint@6.8.0)(typescript@5.1.6)
       eslint-config-prettier: 4.3.0(eslint@6.8.0)
       eslint-formatter-pretty: 2.1.1
       eslint-plugin-babel: 5.3.1(eslint@6.8.0)
@@ -13309,16 +13460,16 @@ packages:
       query-string: 6.14.1
     dev: false
 
-  /@umijs/lint@4.0.83(eslint@8.48.0)(jest@28.1.3)(styled-components@6.0.8)(stylelint@14.16.1)(typescript@4.8.4):
+  /@umijs/lint@4.0.83(eslint@8.48.0)(jest@28.1.3)(styled-components@6.0.8)(stylelint@14.16.1)(typescript@5.1.6):
     resolution: {integrity: sha512-6Io0b2pdMJ1BBPkwFgUT0smE1CCVr4yoV3rSUwaAOB6tjhbSVDCjAJfRzXwswiwgEcb3VuVAGYE7vLa83IMQ+Q==}
     dependencies:
       '@babel/core': 7.21.0
       '@babel/eslint-parser': 7.22.11(@babel/core@7.21.0)(eslint@8.48.0)
       '@stylelint/postcss-css-in-js': 0.38.0(postcss-syntax@0.36.2)(postcss@8.4.31)
-      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0)(eslint@8.48.0)(typescript@4.8.4)
-      '@typescript-eslint/parser': 5.62.0(eslint@8.48.0)(typescript@4.8.4)
+      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0)(eslint@8.48.0)(typescript@5.1.6)
+      '@typescript-eslint/parser': 5.62.0(eslint@8.48.0)(typescript@5.1.6)
       '@umijs/babel-preset-umi': 4.0.83(styled-components@6.0.8)
-      eslint-plugin-jest: 27.2.3(@typescript-eslint/eslint-plugin@5.62.0)(eslint@8.48.0)(jest@28.1.3)(typescript@4.8.4)
+      eslint-plugin-jest: 27.2.3(@typescript-eslint/eslint-plugin@5.62.0)(eslint@8.48.0)(jest@28.1.3)(typescript@5.1.6)
       eslint-plugin-react: 7.33.2(eslint@8.48.0)
       eslint-plugin-react-hooks: 4.6.0(eslint@8.48.0)
       postcss: 8.4.31
@@ -13356,7 +13507,7 @@ packages:
       tsx: 3.13.0
     dev: false
 
-  /@umijs/preset-umi@4.0.83(@types/node@20.5.1)(postcss@8.4.31)(rollup@2.33.3)(sass@1.69.0)(styled-components@6.0.8)(stylus@0.54.8)(typescript@4.8.4)(webpack@5.88.2):
+  /@umijs/preset-umi@4.0.83(@types/node@13.11.1)(postcss@8.4.31)(rollup@2.33.3)(sass@1.69.0)(styled-components@6.0.8)(stylus@0.54.8)(typescript@5.1.6)(webpack@5.88.2):
     resolution: {integrity: sha512-aw+/7mYwjGeBFPYYb3k2Q8Jyh1aoKTWCYbFjmacgeeEmK4YUsTple15GakmPFsqh2a+ZEhO6pODNbj7HJL2nWQ==}
     dependencies:
       '@iconify/utils': 2.1.1
@@ -13365,8 +13516,8 @@ packages:
       '@umijs/babel-preset-umi': 4.0.83(styled-components@6.0.8)
       '@umijs/bundler-esbuild': 4.0.83
       '@umijs/bundler-utils': 4.0.83
-      '@umijs/bundler-vite': 4.0.83(@types/node@20.5.1)(postcss@8.4.31)(rollup@2.33.3)(sass@1.69.0)(stylus@0.54.8)
-      '@umijs/bundler-webpack': 4.0.83(styled-components@6.0.8)(typescript@4.8.4)(webpack@5.88.2)
+      '@umijs/bundler-vite': 4.0.83(@types/node@13.11.1)(postcss@8.4.31)(rollup@2.33.3)(sass@1.69.0)(stylus@0.54.8)
+      '@umijs/bundler-webpack': 4.0.83(styled-components@6.0.8)(typescript@5.1.6)(webpack@5.88.2)
       '@umijs/core': 4.0.83
       '@umijs/did-you-know': 1.0.3
       '@umijs/es-module-parser': 0.0.7
@@ -13535,7 +13686,7 @@ packages:
       '@babel/plugin-transform-react-jsx-self': 7.22.5(@babel/core@7.23.0)
       '@babel/plugin-transform-react-jsx-source': 7.22.5(@babel/core@7.23.0)
       react-refresh: 0.14.0
-      vite: 4.3.1(@types/node@20.5.1)(less@3.13.1)(stylus@0.54.8)
+      vite: 4.3.1(@types/node@13.11.1)(less@3.13.1)(stylus@0.54.8)
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -14239,6 +14390,11 @@ packages:
 
   /alphanum-sort@1.0.2:
     resolution: {integrity: sha512-0FcBfdcmaumGPQ0qPn7Q5qTgz/ooXgIyp1rf8ik5bGX8mpE2YHjC0P/eyQvxu1GURYQgq9ozf2mteQ5ZD9YiyQ==}
+
+  /amdefine@1.0.1:
+    resolution: {integrity: sha512-S2Hw0TtNkMJhIabBwIojKL9YHO5T0n5eNqWJ7Lrlel/zDbftQpxpapi8tZs3X1HWa+u+QeydGmzzNU0m09+Rcg==}
+    engines: {node: '>=0.4.2'}
+    dev: false
 
   /animated-scroll-to@2.3.0:
     resolution: {integrity: sha512-PT/5MSKCWQaK2kuOl2HT2KJMuJEvUS4/TgMhWy82c2EmF74/CIkvPBPKOvd8nMYP6Higo7xCn49/iSW9BccMoQ==}
@@ -15884,6 +16040,10 @@ packages:
   /batch@0.6.1:
     resolution: {integrity: sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw==}
 
+  /bayesian-changepoint@1.0.1:
+    resolution: {integrity: sha512-OhSHWfGiEcBtI46b5guJGmj6pJEjvyaXsRPCAQy5MPoVaDZ38poXmzVZLSIuw6VLQmZs58+uf5F9iFA4NVmTTA==}
+    dev: false
+
   /bcrypt-pbkdf@1.0.2:
     resolution: {integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==}
     dependencies:
@@ -16769,6 +16929,10 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
+  /chroma-js@2.4.2:
+    resolution: {integrity: sha512-U9eDw6+wt7V8z5NncY2jJfZa+hUH8XEj8FQHgFJTrUFnJfXYf4Ml4adI2vXZOjqRDpFWtYVWypDfZwnJ+HIR4A==}
+    dev: false
+
   /chrome-trace-event@1.0.3:
     resolution: {integrity: sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==}
     engines: {node: '>=6.0'}
@@ -16807,7 +16971,6 @@ packages:
 
   /classnames@2.3.2:
     resolution: {integrity: sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw==}
-    dev: false
 
   /clean-css@4.2.4:
     resolution: {integrity: sha512-EJUDT7nDVFDvaQgAo2G/PJvxmp1o/c6iXLbswsBbUFXi1Nr+AjA2cKmfbKDMjMvzEe75g3P6JkaDDAKk96A85A==}
@@ -17137,6 +17300,13 @@ packages:
       map-visit: 1.0.0
       object-visit: 1.0.1
 
+  /color-blind@0.1.3:
+    resolution: {integrity: sha512-n65+lsZBF7UvN7Vpml2NmlH4zYppxRwZCRUg21BmTn1uV39+Tv6Dap8KdPZ2uRe7KybOe0jEalvfdvY9zJJlJw==}
+    engines: {node: '>= 14'}
+    dependencies:
+      onecolor: 3.1.0
+    dev: false
+
   /color-convert@1.9.3:
     resolution: {integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==}
     dependencies:
@@ -17415,6 +17585,10 @@ packages:
     resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
     engines: {node: '>= 0.6'}
 
+  /contour_plot@0.0.1:
+    resolution: {integrity: sha512-Nil2HI76Xux6sVGORvhSS8v66m+/h5CwFkBJDO+U5vWaMdNC0yXNCsGDPbzPhvqOEU5koebhdEvD372LI+IyLw==}
+    dev: false
+
   /conventional-changelog-angular@6.0.0:
     resolution: {integrity: sha512-6qLgrBF4gueoC7AFVHu51nHL9pF9FRjXrH+ceVf7WmAfH3gs+gEYOkvxhjMPjZu57I4AGUGoNTY8V7Hrgf1uqg==}
     engines: {node: '>=14'}
@@ -17547,7 +17721,7 @@ packages:
       vary: 1.1.2
     dev: false
 
-  /cosmiconfig-typescript-loader@4.4.0(@types/node@20.5.1)(cosmiconfig@8.3.6)(ts-node@10.9.1)(typescript@4.8.4):
+  /cosmiconfig-typescript-loader@4.4.0(@types/node@20.5.1)(cosmiconfig@8.3.6)(ts-node@10.9.1)(typescript@5.1.6):
     resolution: {integrity: sha512-BabizFdC3wBHhbI4kJh0VkQP9GkBfoHPydD0COMce1nJ1kJAB3F2TmJ/I7diULBKtmEWSwEbuN/KDtgnmUUVmw==}
     engines: {node: '>=v14.21.3'}
     peerDependencies:
@@ -17557,9 +17731,9 @@ packages:
       typescript: '>=4'
     dependencies:
       '@types/node': 20.5.1
-      cosmiconfig: 8.3.6(typescript@4.8.4)
-      ts-node: 10.9.1(@types/node@20.5.1)(typescript@4.8.4)
-      typescript: 4.8.4
+      cosmiconfig: 8.3.6(typescript@5.1.6)
+      ts-node: 10.9.1(@types/node@20.5.1)(typescript@5.1.6)
+      typescript: 5.1.6
     dev: true
 
   /cosmiconfig@5.2.1:
@@ -17591,7 +17765,7 @@ packages:
       path-type: 4.0.0
       yaml: 1.10.2
 
-  /cosmiconfig@8.3.6(typescript@4.8.4):
+  /cosmiconfig@8.3.6(typescript@5.1.6):
     resolution: {integrity: sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==}
     engines: {node: '>=14'}
     peerDependencies:
@@ -17604,7 +17778,7 @@ packages:
       js-yaml: 4.1.0
       parse-json: 5.2.0
       path-type: 4.0.0
-      typescript: 4.8.4
+      typescript: 5.1.6
     dev: true
 
   /cp-file@6.2.0:
@@ -18229,6 +18403,10 @@ packages:
     resolution: {integrity: sha512-KS3fUT2ReD4RlGCjvCEm1RgMtp2NFZumdMu4DBzQK8AZv3fXRM6Xm8I4fSU07UXvH4xxg03NwWKWdvxfS/yc4w==}
     dev: false
 
+  /d3-hierarchy@2.0.0:
+    resolution: {integrity: sha512-SwIdqM3HxQX2214EG9GTjgmCc/mbSx4mQBn+DuEETubhOw6/U3fmnji4uCVrmzOydMHSO1nZle5gh6HB/wdOzw==}
+    dev: false
+
   /d3-hierarchy@3.1.2:
     resolution: {integrity: sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==}
     engines: {node: '>=12'}
@@ -18259,6 +18437,10 @@ packages:
   /d3-quadtree@3.0.1:
     resolution: {integrity: sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==}
     engines: {node: '>=12'}
+    dev: false
+
+  /d3-regression@1.3.10:
+    resolution: {integrity: sha512-PF8GWEL70cHHWpx2jUQXc68r1pyPHIA+St16muk/XRokETzlegj5LriNKg7o4LR0TySug4nHYPJNNRz/W+/Niw==}
     dev: false
 
   /d3-scale-chromatic@3.0.0:
@@ -18614,6 +18796,10 @@ packages:
       is-descriptor: 1.0.2
       isobject: 3.0.1
 
+  /defined@1.0.1:
+    resolution: {integrity: sha512-hsBd2qSVCRE+5PmNdHt1uzyrFu5d3RwmFDKzyNZMFq/EwDNJF7Ee5+D5oEKF0hU6LhtoUF1macFvOe4AskQC1Q==}
+    dev: false
+
   /del@3.0.0:
     resolution: {integrity: sha512-7yjqSoVSlJzA4t/VUwazuEagGeANEKB3f/aNI//06pfKgwoCb7f6Q1gETN1sZzYaj6chTQ0AhIwDiPdfOjko4A==}
     engines: {node: '>=4'}
@@ -18847,7 +19033,7 @@ packages:
     dependencies:
       esutils: 2.0.3
 
-  /docz-core@0.13.7(react-dom@16.14.0)(react@16.14.0)(typescript@4.8.4):
+  /docz-core@0.13.7(react-dom@16.14.0)(react@16.14.0)(typescript@5.1.6):
     resolution: {integrity: sha512-VPQJj8yKepZMCTX/u/dxq3iW/1i8WkKaY1Aiet4NGz/pcvRHFHu1Pcwsp/3QM1wGNqbXw+96DJBOO7OpRVECXg==}
     dependencies:
       '@babel/core': 7.2.2
@@ -18889,8 +19075,8 @@ packages:
       mini-html-webpack-plugin: 0.2.3
       p-reduce: 1.0.0
       progress-estimator: 0.2.2
-      react-dev-utils: 7.0.5(typescript@4.8.4)(webpack@4.47.0)
-      react-docgen-typescript-loader: 3.7.2(typescript@4.8.4)(webpack@4.47.0)
+      react-dev-utils: 7.0.5(typescript@5.1.6)(webpack@4.47.0)
+      react-docgen-typescript-loader: 3.7.2(typescript@5.1.6)(webpack@4.47.0)
       react-hot-loader: 4.13.1(react-dom@16.14.0)(react@16.14.0)
       rehype-docz: 0.13.6
       rehype-slug: 2.0.3
@@ -19082,13 +19268,13 @@ packages:
       - webpack-command
     dev: false
 
-  /docz-plugin-umi-css@0.14.1(react-dom@16.14.0)(react@16.14.0)(typescript@4.8.4):
+  /docz-plugin-umi-css@0.14.1(react-dom@16.14.0)(react@16.14.0)(typescript@5.1.6):
     resolution: {integrity: sha512-LvwEMz2a5I7OLDrgW9T8arJes5uMAVvaUCXesN9sP65OOl021Wu6B4a+BL+xJQXd1HpYXxrRl5dHdn0hFeAKCA==}
     dependencies:
       autoprefixer: 9.8.8
       css-loader: 1.0.1(webpack@4.47.0)
       deepmerge: 2.2.1
-      docz-core: 0.13.7(react-dom@16.14.0)(react@16.14.0)(typescript@4.8.4)
+      docz-core: 0.13.7(react-dom@16.14.0)(react@16.14.0)(typescript@5.1.6)
       less: 3.13.1
       less-loader: 4.1.0(less@3.13.1)(webpack@4.47.0)
       loader-utils: 1.4.2
@@ -19489,6 +19675,13 @@ packages:
     resolution: {integrity: sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==}
     engines: {node: '>=10'}
 
+  /dotignore@0.1.2:
+    resolution: {integrity: sha512-UGGGWfSauusaVJC+8fgV+NVvBXkCTmVv7sk6nojDZZvuOUNGUy0Zk4UpHQD6EDjS0jpBwcACvH4eofvyzBcRDw==}
+    hasBin: true
+    dependencies:
+      minimatch: 3.1.2
+    dev: false
+
   /draft-js@0.10.5(react-dom@16.14.0)(react@16.14.0):
     resolution: {integrity: sha512-LE6jSCV9nkPhfVX2ggcRLA4FKs6zWq9ceuO/88BpXdNCS7mjRTgs0NsV6piUCJX9YxMsB9An33wnkMmU2sD2Zg==}
     peerDependencies:
@@ -19509,8 +19702,8 @@ packages:
     resolution: {integrity: sha512-a/Y5lf0G6gwsEQ9hop/n03CcjmHsGBk384Cz/AEX6mRYrfSpUx/lQvP9HLoXkCzScl9PL1sSmLPnMkgaXDCZLA==}
     dev: false
 
-  /dumi@2.2.4(@babel/core@7.23.0)(@types/node@20.5.1)(eslint@8.48.0)(jest@28.1.3)(postcss@8.4.31)(prettier@2.8.8)(react-dom@16.14.0)(react@16.14.0)(rollup@2.33.3)(styled-components@6.0.8)(stylelint@14.16.1)(stylus@0.54.8)(typescript@4.8.4)(webpack@5.88.2):
-    resolution: {integrity: sha512-sfEhFDZTqUFDBqRNcULpefexMTu2IY1un0GhZZ6cFti74kJgEaFCQ1Xr+8/L+2d54U5+z4pByoZPjIS4aee36w==}
+  /dumi@2.2.12(@babel/core@7.23.0)(@types/node@13.11.1)(eslint@8.48.0)(jest@28.1.3)(postcss@8.4.31)(prettier@2.8.8)(react-dom@16.14.0)(react@16.14.0)(rollup@2.33.3)(styled-components@6.0.8)(stylelint@14.16.1)(stylus@0.54.8)(typescript@5.1.6)(webpack@5.88.2):
+    resolution: {integrity: sha512-HAazT2+3C23fCVpG57ksXJkqkbI9KIaacfw40Odv4Dr0UvXHHRqT1b4091O6Ylu5L1FKcltEW6/h3aQjofz8MA==}
     hasBin: true
     peerDependencies:
       react: '>=16.8'
@@ -19519,12 +19712,12 @@ packages:
       '@ant-design/icons-svg': 4.3.1
       '@makotot/ghostui': 2.0.0(react@16.14.0)
       '@stackblitz/sdk': 1.9.0
-      '@swc/core': 1.3.57
+      '@swc/core': 1.3.72
       '@types/hast': 2.3.6
       '@types/mdast': 3.0.13
-      '@types/nprogress': 0.2.1
       '@umijs/bundler-utils': 4.0.83
       '@umijs/core': 4.0.83
+      '@umijs/utils': 4.0.83
       animated-scroll-to: 2.3.0
       classnames: 2.3.2
       codesandbox: 2.2.3
@@ -19538,12 +19731,12 @@ packages:
       file-system-cache: 2.4.4
       github-slugger: 1.5.0
       hast-util-is-element: 2.1.3
-      hast-util-raw: 7.2.3
+      hast-util-raw: 8.0.0
       hast-util-to-estree: 2.3.3
       hast-util-to-string: 2.0.0
       heti: 0.9.4
       hosted-git-info: 6.1.1
-      html-to-text: 8.2.1
+      html-to-text: 9.0.5
       html2sketch: 1.0.2
       js-yaml: 4.1.0
       lodash.throttle: 4.1.1
@@ -19561,8 +19754,8 @@ packages:
       react: 16.14.0
       react-copy-to-clipboard: 5.1.0(react@16.14.0)
       react-dom: 16.14.0(react@16.14.0)
-      react-error-boundary: 3.1.4(react@16.14.0)
-      react-intl: 6.4.7(react@16.14.0)(typescript@4.8.4)
+      react-error-boundary: 4.0.11(react@16.14.0)
+      react-intl: 6.4.7(react@16.14.0)(typescript@5.1.6)
       rehype-autolink-headings: 6.1.1
       rehype-remove-comments: 5.0.0
       rehype-stringify: 9.0.4
@@ -19573,7 +19766,7 @@ packages:
       remark-rehype: 10.1.0
       sass: 1.69.0
       sitemap: 7.1.1
-      umi: 4.0.83(@babel/core@7.23.0)(@types/node@20.5.1)(eslint@8.48.0)(jest@28.1.3)(postcss@8.4.31)(prettier@2.8.8)(react-dom@16.14.0)(react@16.14.0)(rollup@2.33.3)(sass@1.69.0)(styled-components@6.0.8)(stylelint@14.16.1)(stylus@0.54.8)(typescript@4.8.4)(webpack@5.88.2)
+      umi: 4.0.83(@babel/core@7.23.0)(@types/node@13.11.1)(eslint@8.48.0)(jest@28.1.3)(postcss@8.4.31)(prettier@2.8.8)(react-dom@16.14.0)(react@16.14.0)(rollup@2.33.3)(sass@1.69.0)(styled-components@6.0.8)(stylelint@14.16.1)(stylus@0.54.8)(typescript@5.1.6)(webpack@5.88.2)
       unified: 10.1.2
       unist-util-visit: 4.1.2
       unist-util-visit-parents: 5.1.3
@@ -20273,18 +20466,18 @@ packages:
       eslint: 5.16.0
       eslint-config-airbnb-base: 13.2.0(eslint-plugin-import@2.28.1)(eslint@5.16.0)
       eslint-plugin-import: 2.28.1(@typescript-eslint/parser@1.10.2)(eslint@5.16.0)
-      eslint-plugin-jsx-a11y: 6.7.1(eslint@8.48.0)
-      eslint-plugin-react: 7.33.2(eslint@8.48.0)
+      eslint-plugin-jsx-a11y: 6.7.1(eslint@5.16.0)
+      eslint-plugin-react: 7.33.2(eslint@5.16.0)
       object.assign: 4.1.4
       object.entries: 1.1.7
     dev: true
 
-  /eslint-config-egg@7.5.1(eslint@5.16.0)(typescript@4.8.4):
+  /eslint-config-egg@7.5.1(eslint@5.16.0)(typescript@5.1.6):
     resolution: {integrity: sha512-HNu+M0Od4HH7SMqo17oFe2n2mwMcKaNA52SQuCXIb3i0KazBxvaaa9DmNvoymQXlbxsZYtSN1J1eKmfZJiISkg==}
     engines: {node: '>=8.0.0'}
     dependencies:
-      '@typescript-eslint/eslint-plugin': 2.34.0(@typescript-eslint/parser@2.34.0)(eslint@5.16.0)(typescript@4.8.4)
-      '@typescript-eslint/parser': 2.34.0(eslint@5.16.0)(typescript@4.8.4)
+      '@typescript-eslint/eslint-plugin': 2.34.0(@typescript-eslint/parser@2.34.0)(eslint@5.16.0)(typescript@5.1.6)
+      '@typescript-eslint/parser': 2.34.0(eslint@5.16.0)(typescript@5.1.6)
       babel-eslint: 8.2.6
       eslint-plugin-eggache: 1.0.0
       eslint-plugin-import: 2.28.1(@typescript-eslint/parser@2.34.0)(eslint@5.16.0)
@@ -20299,12 +20492,12 @@ packages:
       - typescript
     dev: true
 
-  /eslint-config-egg@7.5.1(eslint@6.8.0)(typescript@4.8.4):
+  /eslint-config-egg@7.5.1(eslint@6.8.0)(typescript@5.1.6):
     resolution: {integrity: sha512-HNu+M0Od4HH7SMqo17oFe2n2mwMcKaNA52SQuCXIb3i0KazBxvaaa9DmNvoymQXlbxsZYtSN1J1eKmfZJiISkg==}
     engines: {node: '>=8.0.0'}
     dependencies:
-      '@typescript-eslint/eslint-plugin': 2.34.0(@typescript-eslint/parser@2.34.0)(eslint@6.8.0)(typescript@4.8.4)
-      '@typescript-eslint/parser': 2.34.0(eslint@6.8.0)(typescript@4.8.4)
+      '@typescript-eslint/eslint-plugin': 2.34.0(@typescript-eslint/parser@2.34.0)(eslint@6.8.0)(typescript@5.1.6)
+      '@typescript-eslint/parser': 2.34.0(eslint@6.8.0)(typescript@5.1.6)
       babel-eslint: 8.2.6
       eslint-plugin-eggache: 1.0.0
       eslint-plugin-import: 2.28.1(@typescript-eslint/parser@2.34.0)(eslint@6.8.0)
@@ -20348,7 +20541,7 @@ packages:
       eslint: 7.32.0
     dev: false
 
-  /eslint-config-react-app@5.2.1(@typescript-eslint/eslint-plugin@2.34.0)(@typescript-eslint/parser@2.34.0)(babel-eslint@10.0.3)(eslint-plugin-flowtype@3.13.0)(eslint-plugin-import@2.18.2)(eslint-plugin-jsx-a11y@6.2.3)(eslint-plugin-react-hooks@1.7.0)(eslint-plugin-react@7.14.3)(eslint@6.8.0)(typescript@4.8.4):
+  /eslint-config-react-app@5.2.1(@typescript-eslint/eslint-plugin@2.34.0)(@typescript-eslint/parser@2.34.0)(babel-eslint@10.0.3)(eslint-plugin-flowtype@3.13.0)(eslint-plugin-import@2.18.2)(eslint-plugin-jsx-a11y@6.2.3)(eslint-plugin-react-hooks@1.7.0)(eslint-plugin-react@7.14.3)(eslint@6.8.0)(typescript@5.1.6):
     resolution: {integrity: sha512-pGIZ8t0mFLcV+6ZirRgYK6RVqUIKRIi9MmgzUEmrIknsn3AdO0I32asO86dJgloHq+9ZPl8UIg8mYrvgP5u2wQ==}
     peerDependencies:
       '@typescript-eslint/eslint-plugin': 2.x
@@ -20365,8 +20558,8 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/eslint-plugin': 2.34.0(@typescript-eslint/parser@2.34.0)(eslint@6.8.0)(typescript@4.8.4)
-      '@typescript-eslint/parser': 2.34.0(eslint@6.8.0)(typescript@4.8.4)
+      '@typescript-eslint/eslint-plugin': 2.34.0(@typescript-eslint/parser@2.34.0)(eslint@6.8.0)(typescript@5.1.6)
+      '@typescript-eslint/parser': 2.34.0(eslint@6.8.0)(typescript@5.1.6)
       babel-eslint: 10.0.3(eslint@6.8.0)
       confusing-browser-globals: 1.0.11
       eslint: 6.8.0
@@ -20375,7 +20568,7 @@ packages:
       eslint-plugin-jsx-a11y: 6.2.3(eslint@6.8.0)
       eslint-plugin-react: 7.14.3(eslint@6.8.0)
       eslint-plugin-react-hooks: 1.7.0(eslint@6.8.0)
-      typescript: 4.8.4
+      typescript: 5.1.6
     dev: true
 
   /eslint-formatter-pretty@2.1.1:
@@ -20452,7 +20645,7 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 1.10.2(eslint@5.16.0)(typescript@4.8.4)
+      '@typescript-eslint/parser': 1.10.2(eslint@5.16.0)(typescript@5.1.6)
       debug: 3.2.7(supports-color@6.1.0)
       eslint: 5.16.0
       eslint-import-resolver-node: 0.3.9
@@ -20481,7 +20674,7 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 2.34.0(eslint@5.16.0)(typescript@4.8.4)
+      '@typescript-eslint/parser': 2.34.0(eslint@5.16.0)(typescript@5.1.6)
       debug: 3.2.7(supports-color@6.1.0)
       eslint: 5.16.0
       eslint-import-resolver-node: 0.3.9
@@ -20510,7 +20703,7 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 2.34.0(eslint@6.8.0)(typescript@4.8.4)
+      '@typescript-eslint/parser': 2.34.0(eslint@6.8.0)(typescript@5.1.6)
       debug: 3.2.7(supports-color@6.1.0)
       eslint: 6.8.0
       eslint-import-resolver-node: 0.3.9
@@ -20539,7 +20732,7 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 6.5.0(eslint@8.48.0)(typescript@4.8.4)
+      '@typescript-eslint/parser': 6.5.0(eslint@8.48.0)(typescript@5.1.6)
       debug: 3.2.7(supports-color@6.1.0)
       eslint: 8.48.0
       eslint-import-resolver-node: 0.3.9
@@ -20658,7 +20851,7 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 2.34.0(eslint@6.8.0)(typescript@4.8.4)
+      '@typescript-eslint/parser': 2.34.0(eslint@6.8.0)(typescript@5.1.6)
       array-includes: 3.1.7
       contains-path: 0.1.0
       debug: 2.6.9(supports-color@6.1.0)
@@ -20687,7 +20880,7 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 1.10.2(eslint@5.16.0)(typescript@4.8.4)
+      '@typescript-eslint/parser': 1.10.2(eslint@5.16.0)(typescript@5.1.6)
       array-includes: 3.1.7
       array.prototype.findlastindex: 1.2.3
       array.prototype.flat: 1.3.2
@@ -20722,7 +20915,7 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 2.34.0(eslint@5.16.0)(typescript@4.8.4)
+      '@typescript-eslint/parser': 2.34.0(eslint@5.16.0)(typescript@5.1.6)
       array-includes: 3.1.7
       array.prototype.findlastindex: 1.2.3
       array.prototype.flat: 1.3.2
@@ -20757,7 +20950,7 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 2.34.0(eslint@6.8.0)(typescript@4.8.4)
+      '@typescript-eslint/parser': 2.34.0(eslint@6.8.0)(typescript@5.1.6)
       array-includes: 3.1.7
       array.prototype.findlastindex: 1.2.3
       array.prototype.flat: 1.3.2
@@ -20792,7 +20985,7 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 6.5.0(eslint@8.48.0)(typescript@4.8.4)
+      '@typescript-eslint/parser': 6.5.0(eslint@8.48.0)(typescript@5.1.6)
       array-includes: 3.1.7
       array.prototype.findlastindex: 1.2.3
       array.prototype.flat: 1.3.2
@@ -20855,7 +21048,7 @@ packages:
       - typescript
     dev: false
 
-  /eslint-plugin-jest@27.2.3(@typescript-eslint/eslint-plugin@5.62.0)(eslint@8.48.0)(jest@28.1.3)(typescript@4.8.4):
+  /eslint-plugin-jest@27.2.3(@typescript-eslint/eslint-plugin@5.62.0)(eslint@8.48.0)(jest@28.1.3)(typescript@5.1.6):
     resolution: {integrity: sha512-sRLlSCpICzWuje66Gl9zvdF6mwD5X86I4u55hJyFBsxYOsBCmT5+kSUjf+fkFWVMMgpzNEupjW8WzUqi83hJAQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
@@ -20868,10 +21061,10 @@ packages:
       jest:
         optional: true
     dependencies:
-      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0)(eslint@8.48.0)(typescript@4.8.4)
-      '@typescript-eslint/utils': 5.62.0(eslint@8.48.0)(typescript@4.8.4)
+      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0)(eslint@8.48.0)(typescript@5.1.6)
+      '@typescript-eslint/utils': 5.62.0(eslint@8.48.0)(typescript@5.1.6)
       eslint: 8.48.0
-      jest: 28.1.3(@types/node@20.5.1)(ts-node@10.9.1)
+      jest: 28.1.3(@types/node@13.11.1)(ts-node@10.9.1)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -21218,6 +21411,7 @@ packages:
       resolve: 2.0.0-next.4
       semver: 6.3.1
       string.prototype.matchall: 4.0.10
+    dev: false
 
   /eslint-plugin-unicorn@20.1.0(eslint@7.32.0):
     resolution: {integrity: sha512-XQxLBJT/gnwyRR6cfYsIK1AdekQchAt5tmcsnldevGjgR2xoZsRUa5/i6e0seNHy2RoT57CkTnbVHwHF8No8LA==}
@@ -22193,7 +22387,7 @@ packages:
       - webpack
     dev: false
 
-  /father@2.29.1(@babel/core@7.23.0)(@storybook/source-loader@7.4.6)(jest@28.1.3)(react-dom@16.14.0)(react@16.14.0)(regenerator-runtime@0.14.0)(typescript@4.8.4)(webpack@4.47.0):
+  /father@2.29.1(@babel/core@7.23.0)(@storybook/source-loader@7.4.6)(jest@28.1.3)(react-dom@16.14.0)(react@16.14.0)(regenerator-runtime@0.14.0)(typescript@5.1.6)(webpack@4.47.0):
     resolution: {integrity: sha512-H8DNbIlhwn7nH7TGpWwVMkE4se62tWCM2NZWTZ6teZ9ronZV+esNJIyMySjxUlU3eNUeXK1p9qO+cffC17aNpA==}
     hasBin: true
     dependencies:
@@ -22208,21 +22402,21 @@ packages:
       '@storybook/addon-storysource': 5.3.21(@storybook/source-loader@7.4.6)(react-dom@16.14.0)(react@16.14.0)
       '@storybook/addons': 5.3.22(react-dom@16.14.0)(regenerator-runtime@0.14.0)
       '@storybook/cli': 5.3.22(jest@28.1.3)
-      '@storybook/react': 5.3.21(@babel/core@7.23.0)(babel-loader@8.0.6)(eslint@5.16.0)(react-dom@16.14.0)(react@16.14.0)(typescript@4.8.4)
+      '@storybook/react': 5.3.21(@babel/core@7.23.0)(babel-loader@8.0.6)(eslint@5.16.0)(react-dom@16.14.0)(react@16.14.0)(typescript@5.1.6)
       '@storybook/theming': 5.3.22(react-dom@16.14.0)(react@16.14.0)
-      '@typescript-eslint/eslint-plugin': 1.10.2(@typescript-eslint/parser@1.10.2)(eslint@5.16.0)(typescript@4.8.4)
-      '@typescript-eslint/parser': 1.10.2(eslint@5.16.0)(typescript@4.8.4)
-      '@umijs/fabric': 1.2.14(typescript@4.8.4)
+      '@typescript-eslint/eslint-plugin': 1.10.2(@typescript-eslint/parser@1.10.2)(eslint@5.16.0)(typescript@5.1.6)
+      '@typescript-eslint/parser': 1.10.2(eslint@5.16.0)(typescript@5.1.6)
+      '@umijs/fabric': 1.2.14(typescript@5.1.6)
       babel-loader: 8.0.6(@babel/core@7.23.0)(webpack@4.47.0)
       docz: 1.2.0(eslint@5.16.0)(react-dom@16.14.0)(react@16.14.0)
       docz-core: 1.2.0(eslint@5.16.0)(react-dom@16.14.0)(react@16.14.0)
-      docz-plugin-umi-css: 0.14.1(react-dom@16.14.0)(react@16.14.0)(typescript@4.8.4)
+      docz-plugin-umi-css: 0.14.1(react-dom@16.14.0)(react@16.14.0)(typescript@5.1.6)
       docz-theme-umi: 2.1.1(@babel/core@7.23.0)(eslint@5.16.0)(react-dom@16.14.0)(react@16.14.0)
       eslint: 5.16.0
       eslint-config-airbnb: 17.1.1(eslint-plugin-import@2.28.1)(eslint-plugin-jsx-a11y@6.7.1)(eslint-plugin-react@7.33.2)(eslint@5.16.0)
       eslint-config-airbnb-base: 13.2.0(eslint-plugin-import@2.28.1)(eslint@5.16.0)
       eslint-config-airbnb-typescript: 4.0.1(eslint-plugin-import@2.28.1)(eslint-plugin-jsx-a11y@6.7.1)(eslint-plugin-react@7.33.2)(eslint@5.16.0)
-      eslint-config-egg: 7.5.1(eslint@5.16.0)(typescript@4.8.4)
+      eslint-config-egg: 7.5.1(eslint@5.16.0)(typescript@5.1.6)
       eslint-config-prettier: 4.3.0(eslint@5.16.0)
       eslint-formatter-pretty: 2.1.1
       eslint-plugin-babel: 5.3.1(eslint@5.16.0)
@@ -22230,10 +22424,10 @@ packages:
       eslint-plugin-eslint-comments: 3.2.0(eslint@5.16.0)
       eslint-plugin-import: 2.28.1(@typescript-eslint/parser@1.10.2)(eslint@5.16.0)
       eslint-plugin-jest: 22.21.0(eslint@5.16.0)
-      eslint-plugin-jsx-a11y: 6.7.1(eslint@8.48.0)
+      eslint-plugin-jsx-a11y: 6.7.1(eslint@5.16.0)
       eslint-plugin-markdown: 1.0.2
       eslint-plugin-promise: 4.3.1
-      eslint-plugin-react: 7.33.2(eslint@8.48.0)
+      eslint-plugin-react: 7.33.2(eslint@5.16.0)
       eslint-plugin-unicorn: 8.0.2(eslint@5.16.0)
       father-build: 1.17.1
       fs-extra: 8.1.0
@@ -22276,7 +22470,7 @@ packages:
       - webpack-command
     dev: true
 
-  /father@2.30.23(@babel/core@7.23.0)(@storybook/source-loader@7.4.6)(eslint@8.48.0)(jest@28.1.3)(react-dom@16.14.0)(react@16.14.0)(regenerator-runtime@0.14.0)(typescript@4.8.4)(webpack@4.47.0):
+  /father@2.30.23(@babel/core@7.23.0)(@storybook/source-loader@7.4.6)(eslint@8.48.0)(jest@28.1.3)(react-dom@16.14.0)(react@16.14.0)(regenerator-runtime@0.14.0)(typescript@5.1.6)(webpack@4.47.0):
     resolution: {integrity: sha512-6VX1UL2urtmM4b4Wh9xAulSsC9a4G4pOpPR7bqfpCqFxw4zflrrskktg398jqag2HFFbu0uvFq4z78vVqO46Gg==}
     hasBin: true
     dependencies:
@@ -22291,13 +22485,13 @@ packages:
       '@storybook/addon-storysource': 5.3.21(@storybook/source-loader@7.4.6)(react-dom@16.14.0)(react@16.14.0)
       '@storybook/addons': 5.3.22(react-dom@16.14.0)(regenerator-runtime@0.14.0)
       '@storybook/cli': 5.3.22(jest@28.1.3)
-      '@storybook/react': 5.3.21(@babel/core@7.23.0)(babel-loader@8.0.6)(eslint@8.48.0)(react-dom@16.14.0)(react@16.14.0)(typescript@4.8.4)
+      '@storybook/react': 5.3.21(@babel/core@7.23.0)(babel-loader@8.0.6)(eslint@8.48.0)(react-dom@16.14.0)(react@16.14.0)(typescript@5.1.6)
       '@storybook/theming': 5.3.22(react-dom@16.14.0)(react@16.14.0)
       '@umijs/fabric': 2.14.1
       babel-loader: 8.0.6(@babel/core@7.23.0)(webpack@5.88.2)
       docz: 1.2.0(eslint@8.48.0)(react-dom@16.14.0)(react@16.14.0)
       docz-core: 1.2.0(eslint@8.48.0)(react-dom@16.14.0)(react@16.14.0)
-      docz-plugin-umi-css: 0.14.1(react-dom@16.14.0)(react@16.14.0)(typescript@4.8.4)
+      docz-plugin-umi-css: 0.14.1(react-dom@16.14.0)(react@16.14.0)(typescript@5.1.6)
       docz-theme-umi: 2.1.1(@babel/core@7.23.0)(eslint@8.48.0)(react-dom@16.14.0)(react@16.14.0)
       father-build: 1.22.5(webpack@4.47.0)
       fs-extra: 8.1.0
@@ -22677,6 +22871,16 @@ packages:
       inherits: 2.0.4
       readable-stream: 2.3.8
 
+  /fmin@0.0.2:
+    resolution: {integrity: sha512-sSi6DzInhl9d8yqssDfGZejChO8d2bAGIpysPsvYsxFe898z89XhCZg6CPNV3nhUhFefeC/AXZK2bAJxlBjN6A==}
+    dependencies:
+      contour_plot: 0.0.1
+      json2module: 0.0.3
+      rollup: 0.25.8
+      tape: 4.17.0
+      uglify-js: 2.8.29
+    dev: false
+
   /focus-lock@0.11.6:
     resolution: {integrity: sha512-KSuV3ur4gf2KqMNoZx3nXNVhqCkn42GuTYCX4tXPEwf0MjpFQmNMiN6m7dXaUXgIoivL6/65agoUMg4RLS0Vbg==}
     engines: {node: '>=10'}
@@ -22776,7 +22980,7 @@ packages:
       - supports-color
     dev: true
 
-  /fork-ts-checker-webpack-plugin@1.5.0(eslint@5.16.0)(typescript@4.8.4)(webpack@4.47.0):
+  /fork-ts-checker-webpack-plugin@1.5.0(eslint@5.16.0)(typescript@5.1.6)(webpack@4.47.0):
     resolution: {integrity: sha512-zEhg7Hz+KhZlBhILYpXy+Beu96gwvkROWJiTXOCyOOMMrdBIRPvsBpBqgTI4jfJGrJXcqGwJR8zsBGDmzY0jsA==}
     engines: {node: '>=6.11.5', yarn: '>=1.0.0'}
     peerDependencies:
@@ -22798,14 +23002,14 @@ packages:
       minimatch: 3.1.2
       semver: 5.7.2
       tapable: 1.1.3
-      typescript: 4.8.4
+      typescript: 5.1.6
       webpack: 4.47.0
       worker-rpc: 0.1.1
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /fork-ts-checker-webpack-plugin@1.5.0(eslint@6.8.0)(typescript@4.8.4)(webpack@4.40.2):
+  /fork-ts-checker-webpack-plugin@1.5.0(eslint@6.8.0)(typescript@5.1.6)(webpack@4.40.2):
     resolution: {integrity: sha512-zEhg7Hz+KhZlBhILYpXy+Beu96gwvkROWJiTXOCyOOMMrdBIRPvsBpBqgTI4jfJGrJXcqGwJR8zsBGDmzY0jsA==}
     engines: {node: '>=6.11.5', yarn: '>=1.0.0'}
     peerDependencies:
@@ -22827,7 +23031,7 @@ packages:
       minimatch: 3.1.2
       semver: 5.7.2
       tapable: 1.1.3
-      typescript: 4.8.4
+      typescript: 5.1.6
       webpack: 4.40.2
       worker-rpc: 0.1.1
     transitivePeerDependencies:
@@ -22863,7 +23067,7 @@ packages:
       - supports-color
     dev: false
 
-  /fork-ts-checker-webpack-plugin@1.5.0(eslint@8.48.0)(typescript@4.8.4)(webpack@4.47.0):
+  /fork-ts-checker-webpack-plugin@1.5.0(eslint@8.48.0)(typescript@5.1.6)(webpack@4.47.0):
     resolution: {integrity: sha512-zEhg7Hz+KhZlBhILYpXy+Beu96gwvkROWJiTXOCyOOMMrdBIRPvsBpBqgTI4jfJGrJXcqGwJR8zsBGDmzY0jsA==}
     engines: {node: '>=6.11.5', yarn: '>=1.0.0'}
     peerDependencies:
@@ -22885,14 +23089,14 @@ packages:
       minimatch: 3.1.2
       semver: 5.7.2
       tapable: 1.1.3
-      typescript: 4.8.4
+      typescript: 5.1.6
       webpack: 4.47.0
       worker-rpc: 0.1.1
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /fork-ts-checker-webpack-plugin@8.0.0(typescript@4.8.4)(webpack@5.88.2):
+  /fork-ts-checker-webpack-plugin@8.0.0(typescript@5.1.6)(webpack@5.88.2):
     resolution: {integrity: sha512-mX3qW3idpueT2klaQXBzrIM/pHw+T0B/V9KHEvNrqijTq9NFnMZU6oreVxDYcf33P8a5cW+67PjodNHthGnNVg==}
     engines: {node: '>=12.13.0', yarn: '>=1.0.0'}
     peerDependencies:
@@ -22911,7 +23115,7 @@ packages:
       schema-utils: 3.3.0
       semver: 7.5.4
       tapable: 2.2.1
-      typescript: 4.8.4
+      typescript: 5.1.6
       webpack: 5.88.2
     dev: false
 
@@ -24060,6 +24264,23 @@ packages:
       zwitch: 2.0.4
     dev: false
 
+  /hast-util-raw@8.0.0:
+    resolution: {integrity: sha512-bKbaUxMNLjZMMowgcrc4l3aQSPiMLiceZD+mp+AKF8Si0mtyR2DYVdxzS2XBxXYDeW/VvfZy40lNxHRiY6MMTg==}
+    dependencies:
+      '@types/hast': 2.3.6
+      extend: 3.0.2
+      hast-util-from-parse5: 7.1.2
+      hast-util-to-parse5: 7.1.0
+      html-void-elements: 2.0.1
+      mdast-util-to-hast: 12.3.0
+      parse5: 7.1.2
+      unist-util-position: 4.0.4
+      unist-util-visit: 4.1.2
+      vfile: 5.3.7
+      web-namespaces: 2.0.1
+      zwitch: 2.0.4
+    dev: false
+
   /hast-util-to-estree@2.3.3:
     resolution: {integrity: sha512-ihhPIUPxN0v0w6M5+IiAZZrn0LH2uZomeWwhn7uP7avZC6TE7lIiEh2yBMPr5+zi1aUCXq6VoYRgs2Bw9xmycQ==}
     dependencies:
@@ -24172,6 +24393,11 @@ packages:
     dependencies:
       no-case: 2.3.2
       upper-case: 1.1.3
+
+  /heap-js@2.3.0:
+    resolution: {integrity: sha512-E5303mzwQ+4j/n2J0rDvEPBN7GKjhis10oHiYOgjxsmxYgqG++hz9NyLLOXttzH8as/DyiBHYpUrJTZWYaMo8Q==}
+    engines: {node: '>=10.0.0'}
+    dev: false
 
   /heti-findandreplacedomtext@0.5.0:
     resolution: {integrity: sha512-GFZjqU8LAdu1uR72GqrReI+lzNLMlcWtvdz1TKNJiofyo1mfTecFYSZEoEbcLcRMl+KwEldnNQoS4BwO8wtg0A==}
@@ -24371,17 +24597,15 @@ packages:
       lodash.camelcase: 4.3.0
       react: 16.14.0
 
-  /html-to-text@8.2.1:
-    resolution: {integrity: sha512-aN/3JvAk8qFsWVeE9InWAWueLXrbkoVZy0TkzaGhoRBC2gCFEeRLDDJN3/ijIGHohy6H+SZzUQWN/hcYtaPK8w==}
-    engines: {node: '>=10.23.2'}
-    hasBin: true
+  /html-to-text@9.0.5:
+    resolution: {integrity: sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg==}
+    engines: {node: '>=14'}
     dependencies:
-      '@selderee/plugin-htmlparser2': 0.6.0
+      '@selderee/plugin-htmlparser2': 0.11.0
       deepmerge: 4.3.1
-      he: 1.2.0
-      htmlparser2: 6.1.0
-      minimist: 1.2.8
-      selderee: 0.6.0
+      dom-serializer: 2.0.0
+      htmlparser2: 8.0.2
+      selderee: 0.11.0
     dev: false
 
   /html-void-elements@1.0.5:
@@ -25961,34 +26185,6 @@ packages:
       - supports-color
       - ts-node
 
-  /jest-cli@28.1.3(@types/node@20.5.1)(ts-node@10.9.1):
-    resolution: {integrity: sha512-roY3kvrv57Azn1yPgdTebPAXvdR2xfezaKKYzVxZ6It/5NCxzJym6tUI5P1zkdWhfUYkxEI9uZWcQdaFLo8mJQ==}
-    engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
-    hasBin: true
-    peerDependencies:
-      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
-    peerDependenciesMeta:
-      node-notifier:
-        optional: true
-    dependencies:
-      '@jest/core': 28.1.3(ts-node@10.9.1)
-      '@jest/test-result': 28.1.3
-      '@jest/types': 28.1.3
-      chalk: 4.1.2
-      exit: 0.1.2
-      graceful-fs: 4.2.11
-      import-local: 3.1.0
-      jest-config: 28.1.3(@types/node@20.5.1)(ts-node@10.9.1)
-      jest-util: 28.1.3
-      jest-validate: 28.1.3
-      prompts: 2.4.2
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - supports-color
-      - ts-node
-    dev: false
-
   /jest-config@24.9.0:
     resolution: {integrity: sha512-RATtQJtVYQrp7fvWg6f5y3pEFj9I+H8sWw4aKxnDZ96mob5i5SD6ZEGWgMLXQ4LE8UurrjbdlLWdUeo+28QpfQ==}
     engines: {node: '>= 6'}
@@ -26050,49 +26246,9 @@ packages:
       pretty-format: 28.1.3
       slash: 3.0.0
       strip-json-comments: 3.1.1
-      ts-node: 10.9.1(@types/node@20.5.1)(typescript@4.8.4)
+      ts-node: 10.9.1(@types/node@20.5.1)(typescript@5.1.6)
     transitivePeerDependencies:
       - supports-color
-
-  /jest-config@28.1.3(@types/node@20.5.1)(ts-node@10.9.1):
-    resolution: {integrity: sha512-MG3INjByJ0J4AsNBm7T3hsuxKQqFIiRo/AUqb1q9LRKI5UU6Aar9JHbr9Ivn1TVwfUD9KirRoM/T6u8XlcQPHQ==}
-    engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
-    peerDependencies:
-      '@types/node': '*'
-      ts-node: '>=9.0.0'
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      ts-node:
-        optional: true
-    dependencies:
-      '@babel/core': 7.23.0
-      '@jest/test-sequencer': 28.1.3
-      '@jest/types': 28.1.3
-      '@types/node': 20.5.1
-      babel-jest: 28.1.3(@babel/core@7.23.0)
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      deepmerge: 4.3.1
-      glob: 7.2.3
-      graceful-fs: 4.2.11
-      jest-circus: 28.1.3
-      jest-environment-node: 28.1.3
-      jest-get-type: 28.0.2
-      jest-regex-util: 28.0.2
-      jest-resolve: 28.1.3
-      jest-runner: 28.1.3
-      jest-util: 28.1.3
-      jest-validate: 28.1.3
-      micromatch: 4.0.5
-      parse-json: 5.2.0
-      pretty-format: 28.1.3
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-      ts-node: 10.9.1(@types/node@20.5.1)(typescript@4.8.4)
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
 
   /jest-diff@24.9.0:
     resolution: {integrity: sha512-qMfrTs8AdJE2iqrTp0hzh7kTd2PQWrsFyj9tORoKmu32xjPjeE4NyjVRDz8ybYwqS2ik8N4hsIpiVTyFeo2lBQ==}
@@ -26906,26 +27062,6 @@ packages:
       - supports-color
       - ts-node
 
-  /jest@28.1.3(@types/node@20.5.1)(ts-node@10.9.1):
-    resolution: {integrity: sha512-N4GT5on8UkZgH0O5LUavMRV1EDEhNTL0KEfRmDIeZHSV7p2XgLoY9t9VDUgL6o+yfdgYHVxuz81G8oB9VG5uyA==}
-    engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
-    hasBin: true
-    peerDependencies:
-      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
-    peerDependenciesMeta:
-      node-notifier:
-        optional: true
-    dependencies:
-      '@jest/core': 28.1.3(ts-node@10.9.1)
-      '@jest/types': 28.1.3
-      import-local: 3.1.0
-      jest-cli: 28.1.3(@types/node@20.5.1)(ts-node@10.9.1)
-    transitivePeerDependencies:
-      - '@types/node'
-      - supports-color
-      - ts-node
-    dev: false
-
   /jju@1.4.0:
     resolution: {integrity: sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==}
     dev: false
@@ -27218,6 +27354,13 @@ packages:
   /json-stringify-safe@5.0.1:
     resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
 
+  /json2module@0.0.3:
+    resolution: {integrity: sha512-qYGxqrRrt4GbB8IEOy1jJGypkNsjWoIMlZt4bAsmUScCA507Hbc2p1JOhBzqn45u3PWafUgH2OnzyNU7udO/GA==}
+    hasBin: true
+    dependencies:
+      rw: 1.3.3
+    dev: false
+
   /json2mq@0.2.0:
     resolution: {integrity: sha512-SzoRg7ux5DWTII9J2qkrZrqV1gt+rTaoufMxEzXbS26Uid0NwaJd123HcoB80TgubEppxxIGdNxCx50fEoEWQA==}
     dependencies:
@@ -27440,6 +27583,10 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       invert-kv: 3.0.1
+    dev: false
+
+  /leac@0.6.0:
+    resolution: {integrity: sha512-y+SqErxb8h7nE/fiEX07jsbuhrpO9lL8eca7/Y1nuWV2moNlXhyd59iDGcRf6moVyDMbmTNzL40SUyrFU/yDpg==}
     dev: false
 
   /lead@1.0.0:
@@ -29529,6 +29676,15 @@ packages:
       ml-array-rescale: 1.3.7
     dev: false
 
+  /mock-property@1.0.0:
+    resolution: {integrity: sha512-imC60k5A55GPUU43PqczbubOyyxCudIgneACKzL3PKfsBk08dc1HgNNU8siQbEIAPPjVUhc+gb0v0ypZ/iP9pw==}
+    dependencies:
+      functions-have-names: 1.2.3
+      has: 1.0.4
+      has-property-descriptors: 1.0.0
+      isarray: 2.0.5
+    dev: false
+
   /moment@2.29.4:
     resolution: {integrity: sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==}
 
@@ -30312,6 +30468,11 @@ packages:
     dependencies:
       wrappy: 1.0.2
 
+  /onecolor@3.1.0:
+    resolution: {integrity: sha512-YZSypViXzu3ul5LMu/m6XjJ9ol8qAy9S2VjHl5E6UlhUH1KGKWabyEJifn0Jjpw23bYDzC2ucKMPGiH5kfwSGQ==}
+    engines: {node: '>=0.4.8'}
+    dev: false
+
   /onetime@2.0.1:
     resolution: {integrity: sha512-oyyPpiMaKARvvcgip+JV+7zci5L8D1W9RZIz2l1o08AM3pfspitVWnPt3mzHcBPp12oYMTy0pqrFs/C+m3EwsQ==}
     engines: {node: '>=4'}
@@ -30829,11 +30990,11 @@ packages:
     dependencies:
       entities: 4.5.0
 
-  /parseley@0.7.0:
-    resolution: {integrity: sha512-xyOytsdDu077M3/46Am+2cGXEKM9U9QclBDv7fimY7e+BBlxh2JcBp2mgNsmkyA9uvgyTjVzDi7cP1v4hcFxbw==}
+  /parseley@0.12.1:
+    resolution: {integrity: sha512-e6qHKe3a9HWr0oMRVDTRhKce+bRO8VGQR3NyVwcjwrbhMmFCX9KszEV35+rn4AdilFAq9VPxP/Fe1wC9Qjd2lw==}
     dependencies:
-      moo: 0.5.2
-      nearley: 2.20.1
+      leac: 0.6.0
+      peberminta: 0.9.0
     dev: false
 
   /parseurl@1.3.3:
@@ -30962,6 +31123,14 @@ packages:
       ripemd160: 2.0.2
       safe-buffer: 5.2.1
       sha.js: 2.4.11
+
+  /pdfast@0.2.0:
+    resolution: {integrity: sha512-cq6TTu6qKSFUHwEahi68k/kqN2mfepjkGrG9Un70cgdRRKLKY6Rf8P8uvP2NvZktaQZNF3YE7agEkLj0vGK9bA==}
+    dev: false
+
+  /peberminta@0.9.0:
+    resolution: {integrity: sha512-XIxfHpEuSJbITd1H3EeQwpcZbTLHc+VVr8ANI9t5sit565tsI4/xK3KWTUFE2e6QiangUkh3B0jihzmGnNrRsQ==}
+    dev: false
 
   /perfect-scrollbar@1.5.5:
     resolution: {integrity: sha512-dzalfutyP3e/FOpdlhVryN4AJ5XDVauVWxybSkLZmakFE2sS3y3pc4JnSprw8tGmHvkaG5Edr5T7LBTZ+WWU2g==}
@@ -31160,11 +31329,11 @@ packages:
     engines: {node: '>=12.13.0'}
     dev: true
 
-  /pnp-webpack-plugin@1.5.0(typescript@4.8.4):
+  /pnp-webpack-plugin@1.5.0(typescript@5.1.6):
     resolution: {integrity: sha512-jd9olUr9D7do+RN8Wspzhpxhgp1n6Vd0NtQ4SFkmIACZoEL1nkyAdW9Ygrinjec0vgDcWjscFQQ1gDW8rsfKTg==}
     engines: {node: '>=6'}
     dependencies:
-      ts-pnp: 1.1.4(typescript@4.8.4)
+      ts-pnp: 1.1.4(typescript@5.1.6)
     transitivePeerDependencies:
       - typescript
 
@@ -32511,7 +32680,7 @@ packages:
       fast-diff: 1.3.0
     dev: true
 
-  /prettier-plugin-organize-imports@3.2.3(prettier@2.8.8)(typescript@4.8.4):
+  /prettier-plugin-organize-imports@3.2.3(prettier@2.8.8)(typescript@5.1.6):
     resolution: {integrity: sha512-KFvk8C/zGyvUaE3RvxN2MhCLwzV6OBbFSkwZ2OamCrs9ZY4i5L77jQ/w4UmUr+lqX8qbaqVq6bZZkApn+IgJSg==}
     peerDependencies:
       '@volar/vue-language-plugin-pug': ^1.0.4
@@ -32525,7 +32694,7 @@ packages:
         optional: true
     dependencies:
       prettier: 2.8.8
-      typescript: 4.8.4
+      typescript: 5.1.6
     dev: false
 
   /prettier-plugin-packagejson@2.3.0(prettier@2.8.8):
@@ -32888,6 +33057,11 @@ packages:
     resolution: {integrity: sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==}
     engines: {node: '>=0.6'}
 
+  /quantize@1.0.2:
+    resolution: {integrity: sha512-25P7wI2UoDbIQsQp50ARkt+5pwPsOq7G/BqvT5xAbapnRoNWMN8/p55H9TXd5MuENiJnm5XICB2H2aDZGwts7w==}
+    engines: {node: '>=0.10.21'}
+    dev: false
+
   /query-string@4.3.4:
     resolution: {integrity: sha512-O2XLNDBIg1DnTOa+2XrIwSiXEV8h2KImXUnjhhn2+UsvZ+Es2uyd5CCRTNQlDGbzUQOW3aYCBx9rVA6dzsiY7Q==}
     engines: {node: '>=0.10.0'}
@@ -33043,7 +33217,7 @@ packages:
       react-dom: '>=16.9.0'
     dependencies:
       babel-runtime: 6.26.0
-      classnames: 2.2.6
+      classnames: 2.3.2
       css-animation: 1.6.1
       prop-types: 15.8.1
       raf: 3.4.1
@@ -33059,7 +33233,7 @@ packages:
       react-dom: '>=16.9.0'
     dependencies:
       '@ant-design/css-animation': 1.7.3
-      classnames: 2.2.6
+      classnames: 2.3.2
       raf: 3.4.1
       rc-util: 4.21.1
       react: 16.14.0
@@ -33069,7 +33243,7 @@ packages:
     resolution: {integrity: sha512-qv0VXfAAnysMWJigxaP6se4bJHvr17D9qsLbi8BOpdgEocsS0RkgY1IUiFaOVYKJDy/EyLC447O02sV/y5YYBg==}
     dependencies:
       babel-runtime: 6.26.0
-      classnames: 2.2.6
+      classnames: 2.3.2
       moment: 2.29.4
       prop-types: 15.8.1
       rc-trigger: 2.6.5(react-dom@16.14.0)(react@16.14.0)
@@ -33113,7 +33287,7 @@ packages:
     resolution: {integrity: sha512-6qOgh0/by0nVNASx6LZnhRTy17Etcgav+IrI7kL9V9kcDZ/g7K14JFlqrtJ3NjDq/Kyn+BPI1st1XvbkhfaJeg==}
     dependencies:
       babel-runtime: 6.26.0
-      classnames: 2.2.6
+      classnames: 2.3.2
       prop-types: 15.8.1
       react-lifecycles-compat: 3.0.4
 
@@ -33133,7 +33307,7 @@ packages:
   /rc-collapse@1.11.8(react-dom@16.14.0)(react@16.14.0):
     resolution: {integrity: sha512-8EhfPyScTYljkbRuIoHniSwZagD5UPpZ3CToYgoNYWC85L2qCbPYF7+OaC713FOrIkp6NbfNqXsITNxmDAmxog==}
     dependencies:
-      classnames: 2.2.6
+      classnames: 2.3.2
       css-animation: 1.6.1
       prop-types: 15.8.1
       rc-animate: 2.11.1(react-dom@16.14.0)(react@16.14.0)
@@ -33189,7 +33363,7 @@ packages:
     peerDependencies:
       react: '*'
     dependencies:
-      classnames: 2.2.6
+      classnames: 2.3.2
       rc-util: 4.21.1
       react: 16.14.0
       react-lifecycles-compat: 3.0.4
@@ -33226,7 +33400,7 @@ packages:
     resolution: {integrity: sha512-p0XYn0wrOpAZ2fUGE6YJ6U8JBNc5ASijznZ6dkojdaEfQJAeZtV9KMEewhxkVlxGSbbdXe10ptjBlTEW9vEwEg==}
     dependencies:
       babel-runtime: 6.26.0
-      classnames: 2.2.6
+      classnames: 2.3.2
       prop-types: 15.8.1
       rc-trigger: 2.6.5(react-dom@16.14.0)(react@16.14.0)
       react-lifecycles-compat: 3.0.4
@@ -33269,7 +33443,7 @@ packages:
       react-dom: '>=15.0.0'
     dependencies:
       babel-runtime: 6.26.0
-      classnames: 2.2.6
+      classnames: 2.3.2
       draft-js: 0.10.5(react-dom@16.14.0)(react@16.14.0)
       immutable: 3.7.6
       lodash: 4.17.21
@@ -33285,7 +33459,7 @@ packages:
       react-dom: '>=15.x'
     dependencies:
       babel-runtime: 6.26.0
-      classnames: 2.2.6
+      classnames: 2.3.2
       dom-scroll-into-view: 1.2.1
       draft-js: 0.10.5(react-dom@16.14.0)(react@16.14.0)
       immutable: 3.7.6
@@ -33364,7 +33538,7 @@ packages:
     resolution: {integrity: sha512-wAT4EBpLDW4+27c935k4F1JLk+gnhyGBkpzBmtkNvIHLG8yTndZSJ2bFfSYfkA6C82IxmAztXs3ffCeUd/rkbg==}
     dependencies:
       babel-runtime: 6.26.0
-      classnames: 2.2.6
+      classnames: 2.3.2
       prop-types: 15.8.1
       rc-util: 4.21.1
       rmc-feedback: 2.0.0
@@ -33401,7 +33575,7 @@ packages:
       react: '*'
     dependencies:
       '@ant-design/create-react-context': 0.2.6(prop-types@15.8.1)(react@16.14.0)
-      classnames: 2.2.6
+      classnames: 2.3.2
       rc-menu: 7.5.5(react-dom@16.14.0)(react@16.14.0)
       rc-trigger: 2.6.5(react-dom@16.14.0)(react@16.14.0)
       rc-util: 4.21.1
@@ -33433,7 +33607,7 @@ packages:
       react: '*'
       react-dom: '*'
     dependencies:
-      classnames: 2.2.6
+      classnames: 2.3.2
       dom-scroll-into-view: 1.2.1
       mini-store: 2.0.0
       mutationobserver-shim: 0.3.7
@@ -33494,7 +33668,7 @@ packages:
     resolution: {integrity: sha512-U5+f4BmBVfMSf3OHSLyRagsJ74yKwlrQAtbbL5ijoA0F2C60BufwnOcHG18tVprd7iaIjzZt1TKMmQSYSvgrig==}
     dependencies:
       babel-runtime: 6.26.0
-      classnames: 2.2.6
+      classnames: 2.3.2
       prop-types: 15.8.1
       rc-animate: 2.11.1(react-dom@16.14.0)(react@16.14.0)
       rc-util: 4.21.1
@@ -33535,7 +33709,7 @@ packages:
     resolution: {integrity: sha512-/Xr4/3GOa1DtL8iCYl7qRUroEMrRDhZiiuHwcVFfSiwa9LYloMlUWcOJsnr8LN6A7rLPdm3/CHStUNeYd+2pKw==}
     dependencies:
       babel-runtime: 6.26.0
-      classnames: 2.2.6
+      classnames: 2.3.2
       prop-types: 15.8.1
       react-lifecycles-compat: 3.0.4
 
@@ -33592,7 +33766,7 @@ packages:
   /rc-rate@2.5.1:
     resolution: {integrity: sha512-3iJkNJT8xlHklPCdeZtUZmJmRVUbr6AHRlfSsztfYTXVlHrv2TcPn3XkHsH+12j812WVB7gvilS2j3+ffjUHXg==}
     dependencies:
-      classnames: 2.2.6
+      classnames: 2.3.2
       prop-types: 15.8.1
       rc-util: 4.21.1
       react-lifecycles-compat: 3.0.4
@@ -33617,7 +33791,7 @@ packages:
       react: ^16.0.0
       react-dom: ^16.0.0
     dependencies:
-      classnames: 2.2.6
+      classnames: 2.3.2
       rc-util: 4.21.1
       react: 16.14.0
       react-dom: 16.14.0(react@16.14.0)
@@ -33673,7 +33847,7 @@ packages:
     resolution: {integrity: sha512-WhswxOMWiNnkXRbxyrj0kiIvyCfo/BaRPaYbsDetSIAU2yEDwKHF798blCP5u86KLOBKBvtxWLFCkSsQw1so5w==}
     dependencies:
       babel-runtime: 6.26.0
-      classnames: 2.2.6
+      classnames: 2.3.2
       component-classes: 1.2.6
       dom-scroll-into-view: 1.2.1
       prop-types: 15.8.1
@@ -33707,7 +33881,7 @@ packages:
     resolution: {integrity: sha512-WMT5mRFUEcrLWwTxsyS8jYmlaMsTVCZIGENLikHsNv+tE8ThU2lCoPfi/xFNUfJFNFSBFP3MwPez9ZsJmNp13g==}
     dependencies:
       babel-runtime: 6.26.0
-      classnames: 2.2.6
+      classnames: 2.3.2
       prop-types: 15.8.1
       rc-tooltip: 3.7.3(react-dom@16.14.0)(react@16.14.0)
       rc-util: 4.21.1
@@ -33731,7 +33905,7 @@ packages:
     resolution: {integrity: sha512-2Vkkrpa7PZbg7qPsqTNzVDov4u78cmxofjjnIHiGB9+9rqKS8oTLPzbW2uiWDr3Lk+yGwh8rbpGO1E6VAgBCOg==}
     dependencies:
       babel-runtime: 6.26.0
-      classnames: 2.2.6
+      classnames: 2.3.2
       lodash: 4.17.21
       prop-types: 15.8.1
 
@@ -33755,7 +33929,7 @@ packages:
       react: ^16.0.0
       react-dom: ^16.0.0
     dependencies:
-      classnames: 2.2.6
+      classnames: 2.3.2
       prop-types: 15.8.1
       react: 16.14.0
       react-dom: 16.14.0(react@16.14.0)
@@ -33780,7 +33954,7 @@ packages:
       react: ^16.0.0
       react-dom: ^16.0.0
     dependencies:
-      classnames: 2.2.6
+      classnames: 2.3.2
       component-classes: 1.2.6
       lodash: 4.17.21
       mini-store: 2.0.0
@@ -33850,7 +34024,7 @@ packages:
     dependencies:
       '@ant-design/create-react-context': 0.2.6(prop-types@15.8.1)(react@16.14.0)
       babel-runtime: 6.26.0
-      classnames: 2.2.6
+      classnames: 2.3.2
       lodash: 4.17.21
       prop-types: 15.8.1
       raf: 3.4.1
@@ -33879,7 +34053,7 @@ packages:
   /rc-time-picker@3.7.3(react-dom@16.14.0)(react@16.14.0):
     resolution: {integrity: sha512-Lv1Mvzp9fRXhXEnRLO4nW6GLNxUkfAZ3RsiIBsWjGjXXvMNjdr4BX/ayElHAFK0DoJqOhm7c5tjmIYpEOwcUXg==}
     dependencies:
-      classnames: 2.2.6
+      classnames: 2.3.2
       moment: 2.29.4
       prop-types: 15.8.1
       raf: 3.4.1
@@ -33915,7 +34089,7 @@ packages:
   /rc-tree-select@2.9.4(react-dom@16.14.0)(react@16.14.0):
     resolution: {integrity: sha512-0HQkXAN4XbfBW20CZYh3G+V+VMrjX42XRtDCpyv6PDUm5vikC0Ob682ZBCVS97Ww2a5Hf6Ajmu0ahWEdIEpwhg==}
     dependencies:
-      classnames: 2.2.6
+      classnames: 2.3.2
       dom-scroll-into-view: 1.2.1
       prop-types: 15.8.1
       raf: 3.4.1
@@ -33952,7 +34126,7 @@ packages:
       react-dom: '*'
     dependencies:
       '@ant-design/create-react-context': 0.2.6(prop-types@15.8.1)(react@16.14.0)
-      classnames: 2.2.6
+      classnames: 2.3.2
       prop-types: 15.8.1
       rc-animate: 2.11.1(react-dom@16.14.0)(react@16.14.0)
       rc-util: 4.21.1
@@ -33981,7 +34155,7 @@ packages:
     resolution: {integrity: sha512-m6Cts9hLeZWsTvWnuMm7oElhf+03GOjOLfTuU0QmdB9ZrW7jR2IpI5rpNM7i9MvAAlMAmTx5Zr7g3uu/aMvZAw==}
     dependencies:
       babel-runtime: 6.26.0
-      classnames: 2.2.6
+      classnames: 2.3.2
       prop-types: 15.8.1
       rc-align: 2.4.5
       rc-animate: 2.11.1(react-dom@16.14.0)(react@16.14.0)
@@ -33995,7 +34169,7 @@ packages:
     resolution: {integrity: sha512-hQxbbJpo23E2QnYczfq3Ec5J5tVl2mUDhkqxrEsQAqk16HfADQg+iKNWzEYXyERSncdxfnzYuaBgy764mNRzTA==}
     dependencies:
       babel-runtime: 6.26.0
-      classnames: 2.2.6
+      classnames: 2.3.2
       prop-types: 15.8.1
       raf: 3.4.1
       rc-align: 2.4.5
@@ -34025,7 +34199,7 @@ packages:
     resolution: {integrity: sha512-WXt0HGxXyzLrPV6iec/96Rbl/6dyrAW8pKuY6wwD7yFYwfU5bjgKjv7vC8KNMJ6wzitFrZjnoiogNL3dF9dj3Q==}
     dependencies:
       babel-runtime: 6.26.0
-      classnames: 2.2.6
+      classnames: 2.3.2
       prop-types: 15.8.1
       warning: 4.0.3
 
@@ -34143,7 +34317,7 @@ packages:
       react: 16.14.0
     dev: false
 
-  /react-dev-utils@7.0.5(typescript@4.8.4)(webpack@4.47.0):
+  /react-dev-utils@7.0.5(typescript@5.1.6)(webpack@4.47.0):
     resolution: {integrity: sha512-zJnqqb0x6gd63E3xoz5pXAxBPNaW75Hyz7GgQp0qPhMroBCRQtRvG67AoTZZY1z4yCYVJQZAfQJFdnea0Ujbug==}
     engines: {node: '>=6'}
     peerDependencies:
@@ -34177,7 +34351,7 @@ packages:
       sockjs-client: 1.3.0(supports-color@6.1.0)
       strip-ansi: 5.0.0
       text-table: 0.2.0
-      typescript: 4.8.4
+      typescript: 5.1.6
       webpack: 4.47.0
     transitivePeerDependencies:
       - supports-color
@@ -34225,7 +34399,7 @@ packages:
       - vue-template-compiler
     dev: true
 
-  /react-dev-utils@9.1.0(eslint@5.16.0)(typescript@4.8.4)(webpack@4.47.0):
+  /react-dev-utils@9.1.0(eslint@5.16.0)(typescript@5.1.6)(webpack@4.47.0):
     resolution: {integrity: sha512-X2KYF/lIGyGwP/F/oXgGDF24nxDA2KC4b7AFto+eqzc/t838gpSGiaU8trTqHXOohuLxxc5qi1eDzsl9ucPDpg==}
     engines: {node: '>=8.10'}
     peerDependencies:
@@ -34244,7 +34418,7 @@ packages:
       escape-string-regexp: 1.0.5
       filesize: 3.6.1
       find-up: 3.0.0
-      fork-ts-checker-webpack-plugin: 1.5.0(eslint@5.16.0)(typescript@4.8.4)(webpack@4.47.0)
+      fork-ts-checker-webpack-plugin: 1.5.0(eslint@5.16.0)(typescript@5.1.6)(webpack@4.47.0)
       global-modules: 2.0.0
       globby: 8.0.2
       gzip-size: 5.1.1
@@ -34260,7 +34434,7 @@ packages:
       sockjs-client: 1.4.0
       strip-ansi: 5.2.0
       text-table: 0.2.0
-      typescript: 4.8.4
+      typescript: 5.1.6
       webpack: 4.47.0
     transitivePeerDependencies:
       - eslint
@@ -34268,7 +34442,7 @@ packages:
       - vue-template-compiler
     dev: true
 
-  /react-dev-utils@9.1.0(eslint@6.8.0)(typescript@4.8.4)(webpack@4.40.2):
+  /react-dev-utils@9.1.0(eslint@6.8.0)(typescript@5.1.6)(webpack@4.40.2):
     resolution: {integrity: sha512-X2KYF/lIGyGwP/F/oXgGDF24nxDA2KC4b7AFto+eqzc/t838gpSGiaU8trTqHXOohuLxxc5qi1eDzsl9ucPDpg==}
     engines: {node: '>=8.10'}
     peerDependencies:
@@ -34287,7 +34461,7 @@ packages:
       escape-string-regexp: 1.0.5
       filesize: 3.6.1
       find-up: 3.0.0
-      fork-ts-checker-webpack-plugin: 1.5.0(eslint@6.8.0)(typescript@4.8.4)(webpack@4.40.2)
+      fork-ts-checker-webpack-plugin: 1.5.0(eslint@6.8.0)(typescript@5.1.6)(webpack@4.40.2)
       global-modules: 2.0.0
       globby: 8.0.2
       gzip-size: 5.1.1
@@ -34303,7 +34477,7 @@ packages:
       sockjs-client: 1.4.0
       strip-ansi: 5.2.0
       text-table: 0.2.0
-      typescript: 4.8.4
+      typescript: 5.1.6
       webpack: 4.40.2
     transitivePeerDependencies:
       - eslint
@@ -34354,7 +34528,7 @@ packages:
       - vue-template-compiler
     dev: false
 
-  /react-dev-utils@9.1.0(eslint@8.48.0)(typescript@4.8.4)(webpack@4.47.0):
+  /react-dev-utils@9.1.0(eslint@8.48.0)(typescript@5.1.6)(webpack@4.47.0):
     resolution: {integrity: sha512-X2KYF/lIGyGwP/F/oXgGDF24nxDA2KC4b7AFto+eqzc/t838gpSGiaU8trTqHXOohuLxxc5qi1eDzsl9ucPDpg==}
     engines: {node: '>=8.10'}
     peerDependencies:
@@ -34373,7 +34547,7 @@ packages:
       escape-string-regexp: 1.0.5
       filesize: 3.6.1
       find-up: 3.0.0
-      fork-ts-checker-webpack-plugin: 1.5.0(eslint@8.48.0)(typescript@4.8.4)(webpack@4.47.0)
+      fork-ts-checker-webpack-plugin: 1.5.0(eslint@8.48.0)(typescript@5.1.6)(webpack@4.47.0)
       global-modules: 2.0.0
       globby: 8.0.2
       gzip-size: 5.1.1
@@ -34389,7 +34563,7 @@ packages:
       sockjs-client: 1.4.0
       strip-ansi: 5.2.0
       text-table: 0.2.0
-      typescript: 4.8.4
+      typescript: 5.1.6
       webpack: 4.47.0
     transitivePeerDependencies:
       - eslint
@@ -34408,15 +34582,15 @@ packages:
   /react-docgen-external-proptypes-handler@1.0.3:
     resolution: {integrity: sha512-jWFA7NCdSnNs9Yr7xAhcUJEwH7qhIKxsyXF5yzzriFiBBfGIlkdzslGWRW4GFD5B8Fu24MTDM1G5q8M3L8+Qdw==}
 
-  /react-docgen-typescript-loader@3.7.2(typescript@4.8.4)(webpack@4.47.0):
+  /react-docgen-typescript-loader@3.7.2(typescript@5.1.6)(webpack@4.47.0):
     resolution: {integrity: sha512-fNzUayyUGzSyoOl7E89VaPKJk9dpvdSgyXg81cUkwy0u+NBvkzQG3FC5WBIlXda0k/iaxS+PWi+OC+tUiGxzPA==}
     peerDependencies:
       typescript: '*'
     dependencies:
       '@webpack-contrib/schema-utils': 1.0.0-beta.0(webpack@4.47.0)
       loader-utils: 1.4.2
-      react-docgen-typescript: 1.22.0(typescript@4.8.4)
-      typescript: 4.8.4
+      react-docgen-typescript: 1.22.0(typescript@5.1.6)
+      typescript: 5.1.6
     transitivePeerDependencies:
       - webpack
 
@@ -34427,12 +34601,12 @@ packages:
     dependencies:
       typescript: 3.3.4000
 
-  /react-docgen-typescript@1.22.0(typescript@4.8.4):
+  /react-docgen-typescript@1.22.0(typescript@5.1.6):
     resolution: {integrity: sha512-MPLbF8vzRwAG3GcjdL+OHQlhgtWsLTXs+7uJiHfEeT3Ur7IsZaNYqRTLQ9sj2nB6M6jylcPCeCmH7qbszJmecg==}
     peerDependencies:
       typescript: '>= 3.x'
     dependencies:
-      typescript: 4.8.4
+      typescript: 5.1.6
 
   /react-docgen@3.0.0:
     resolution: {integrity: sha512-2UseoLWabFNXuk1Foz4VDPSIAkxz+1Hmmq4qijzUmYHDq0ZSloKDLXtGLpQRcAi/M76hRpPtH1rV4BI5jNAOnQ==}
@@ -34515,6 +34689,15 @@ packages:
   /react-error-boundary@3.1.4(react@16.14.0):
     resolution: {integrity: sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==}
     engines: {node: '>=10', npm: '>=6'}
+    peerDependencies:
+      react: '>=16.13.1'
+    dependencies:
+      '@babel/runtime': 7.23.1
+      react: 16.14.0
+    dev: false
+
+  /react-error-boundary@4.0.11(react@16.14.0):
+    resolution: {integrity: sha512-U13ul67aP5DOSPNSCWQ/eO0AQEYzEFkVljULQIjMV0KlffTAhxuDoBKdO0pb/JZ8mDhMKFZ9NZi0BmLGUiNphw==}
     peerDependencies:
       react: '>=16.13.1'
     dependencies:
@@ -34656,7 +34839,7 @@ packages:
       prop-types: 15.8.1
       react: 16.14.0
 
-  /react-intl@6.4.7(react@16.14.0)(typescript@4.8.4):
+  /react-intl@6.4.7(react@16.14.0)(typescript@5.1.6):
     resolution: {integrity: sha512-0hnOHAZhxTFqD1hGTxrF40qNyZJPPYiGhWIIxIz0Udz+3e3c7sdN80qlxArR+AbJ+jb5ALXZkJYH20+GPFCM0Q==}
     peerDependencies:
       react: ^16.6.0 || 17 || 18
@@ -34667,7 +34850,7 @@ packages:
     dependencies:
       '@formatjs/ecma402-abstract': 1.17.2
       '@formatjs/icu-messageformat-parser': 2.6.2
-      '@formatjs/intl': 2.9.3(typescript@4.8.4)
+      '@formatjs/intl': 2.9.3(typescript@5.1.6)
       '@formatjs/intl-displaynames': 6.5.2
       '@formatjs/intl-listformat': 7.4.2
       '@types/hoist-non-react-statics': 3.3.2
@@ -34676,7 +34859,7 @@ packages:
       intl-messageformat: 10.5.3
       react: 16.14.0
       tslib: 2.6.2
-      typescript: 4.8.4
+      typescript: 5.1.6
     dev: false
 
   /react-is@16.13.1:
@@ -34867,7 +35050,7 @@ packages:
       react: 18.1.0
     dev: false
 
-  /react-scripts@3.1.2(eslint@6.8.0)(react@18.2.0)(typescript@4.8.4):
+  /react-scripts@3.1.2(eslint@6.8.0)(react@18.2.0)(typescript@5.1.6):
     resolution: {integrity: sha512-aN9E1jn+Qii45/uLUzS7Hjfd/DXbcaAiRkoMwnJXAXShbpJiP2xwmr7yuVF0kR0cnvt0SI+IPZjsOH8MziSYQQ==}
     engines: {node: '>=8.10'}
     hasBin: true
@@ -34877,8 +35060,8 @@ packages:
     dependencies:
       '@babel/core': 7.6.0
       '@svgr/webpack': 4.3.2
-      '@typescript-eslint/eslint-plugin': 2.34.0(@typescript-eslint/parser@2.34.0)(eslint@6.8.0)(typescript@4.8.4)
-      '@typescript-eslint/parser': 2.34.0(eslint@6.8.0)(typescript@4.8.4)
+      '@typescript-eslint/eslint-plugin': 2.34.0(@typescript-eslint/parser@2.34.0)(eslint@6.8.0)(typescript@5.1.6)
+      '@typescript-eslint/parser': 2.34.0(eslint@6.8.0)(typescript@5.1.6)
       babel-eslint: 10.0.3(eslint@6.8.0)
       babel-jest: 24.9.0(@babel/core@7.6.0)
       babel-loader: 8.0.6(@babel/core@7.6.0)(webpack@4.40.2)
@@ -34890,7 +35073,7 @@ packages:
       dotenv: 6.2.0
       dotenv-expand: 5.1.0
       eslint: 6.8.0
-      eslint-config-react-app: 5.2.1(@typescript-eslint/eslint-plugin@2.34.0)(@typescript-eslint/parser@2.34.0)(babel-eslint@10.0.3)(eslint-plugin-flowtype@3.13.0)(eslint-plugin-import@2.18.2)(eslint-plugin-jsx-a11y@6.2.3)(eslint-plugin-react-hooks@1.7.0)(eslint-plugin-react@7.14.3)(eslint@6.8.0)(typescript@4.8.4)
+      eslint-config-react-app: 5.2.1(@typescript-eslint/eslint-plugin@2.34.0)(@typescript-eslint/parser@2.34.0)(babel-eslint@10.0.3)(eslint-plugin-flowtype@3.13.0)(eslint-plugin-import@2.18.2)(eslint-plugin-jsx-a11y@6.2.3)(eslint-plugin-react-hooks@1.7.0)(eslint-plugin-react@7.14.3)(eslint@6.8.0)(typescript@5.1.6)
       eslint-loader: 3.0.0(eslint@6.8.0)(webpack@4.40.2)
       eslint-plugin-flowtype: 3.13.0(eslint@6.8.0)
       eslint-plugin-import: 2.18.2(@typescript-eslint/parser@2.34.0)(eslint@6.8.0)
@@ -34908,7 +35091,7 @@ packages:
       jest-watch-typeahead: 0.4.0
       mini-css-extract-plugin: 0.8.0(webpack@4.40.2)
       optimize-css-assets-webpack-plugin: 5.0.3(webpack@4.40.2)
-      pnp-webpack-plugin: 1.5.0(typescript@4.8.4)
+      pnp-webpack-plugin: 1.5.0(typescript@5.1.6)
       postcss-flexbugs-fixes: 4.1.0
       postcss-loader: 3.0.0
       postcss-normalize: 7.0.1
@@ -34916,14 +35099,14 @@ packages:
       postcss-safe-parser: 4.0.1
       react: 18.2.0
       react-app-polyfill: 1.0.6
-      react-dev-utils: 9.1.0(eslint@6.8.0)(typescript@4.8.4)(webpack@4.40.2)
+      react-dev-utils: 9.1.0(eslint@6.8.0)(typescript@5.1.6)(webpack@4.40.2)
       resolve: 1.12.0
       resolve-url-loader: 3.1.0
       sass-loader: 7.2.0(webpack@4.40.2)
       semver: 6.3.0
       style-loader: 1.0.0(webpack@4.40.2)
       terser-webpack-plugin: 1.4.1(webpack@4.40.2)
-      ts-pnp: 1.1.4(typescript@4.8.4)
+      ts-pnp: 1.1.4(typescript@5.1.6)
       url-loader: 2.1.0(webpack@4.40.2)
       webpack: 4.40.2
       webpack-dev-server: 3.2.1(webpack@4.40.2)
@@ -34987,7 +35170,7 @@ packages:
       react: ^0.14.0 || ^15.0.1 || ^16.0.0
       react-dom: ^0.14.0 || ^15.0.1 || ^16.0.0
     dependencies:
-      classnames: 2.2.6
+      classnames: 2.3.2
       enquire.js: 2.1.6
       json2mq: 0.2.0
       lodash.debounce: 4.0.8
@@ -35528,6 +35711,10 @@ packages:
 
   /regl@1.7.0:
     resolution: {integrity: sha512-bEAtp/qrtKucxXSJkD4ebopFZYP0q1+3Vb2WECWv/T8yQEgKxDxJ7ztO285tAMaYZVR6mM1GgI6CCn8FROtL1w==}
+    dev: false
+
+  /regression@2.0.1:
+    resolution: {integrity: sha512-A4XYsc37dsBaNOgEjkJKzfJlE394IMmUPlI/p3TTI9u3T+2a+eox5Pr/CPUqF0eszeWZJPAc6QkroAhuUpWDJQ==}
     dev: false
 
   /rehype-autolink-headings@6.1.1:
@@ -36180,7 +36367,7 @@ packages:
     resolution: {integrity: sha512-5PWOGOW7VXks/l3JzlOU9NIxRpuaSS8d9zA3UULUCuTKnpwBHNvv1jSJzxgbbCQeYzROWUpgKI4za3X4C/mKmQ==}
     dependencies:
       babel-runtime: 6.26.0
-      classnames: 2.2.6
+      classnames: 2.3.2
 
   /rollup-plugin-babel@4.3.3(@babel/core@7.4.5)(rollup@1.27.8):
     resolution: {integrity: sha512-tKzWOCmIJD/6aKNz0H1GMM+lW1q9KyFubbWzGiOG540zxPPifnEAHTZwjo0g991Y+DyOZcLqBgqOdqazYE5fkw==}
@@ -36367,7 +36554,7 @@ packages:
       typescript: 4.8.4
     dev: false
 
-  /rollup-plugin-typescript@1.0.1(tslib@2.5.0)(typescript@4.8.4):
+  /rollup-plugin-typescript@1.0.1(tslib@2.5.0)(typescript@5.1.6):
     resolution: {integrity: sha512-rwJDNn9jv/NsKZuyBb/h0jsclP4CJ58qbvZt2Q9zDIGILF2LtdtvCqMOL+Gq9IVq5MTrTlHZNrn8h7VjQgd8tw==}
     deprecated: This package has been deprecated and is no longer maintained. Please use @rollup/plugin-typescript.
     peerDependencies:
@@ -36377,7 +36564,7 @@ packages:
       resolve: 1.22.6
       rollup-pluginutils: 2.8.2
       tslib: 2.5.0
-      typescript: 4.8.4
+      typescript: 5.1.6
     dev: true
 
   /rollup-plugin-url@2.2.4(rollup@1.27.8):
@@ -36433,6 +36620,15 @@ packages:
     resolution: {integrity: sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==}
     dependencies:
       estree-walker: 0.6.1
+
+  /rollup@0.25.8:
+    resolution: {integrity: sha512-a2S4Bh3bgrdO4BhKr2E4nZkjTvrJ2m2bWjMTzVYtoqSCn0HnuxosXnaJUHrMEziOWr3CzL9GjilQQKcyCQpJoA==}
+    hasBin: true
+    dependencies:
+      chalk: 1.1.3
+      minimist: 1.2.8
+      source-map-support: 0.3.3
+    dev: false
 
   /rollup@1.27.8:
     resolution: {integrity: sha512-EVoEV5rAWl+5clnGznt1KY8PeVkzVQh/R0d2s3gHEkN7gfoyC4JmvIVuCtPbYE8NM5Ep/g+nAmvKXBjzaqTsHA==}
@@ -36727,10 +36923,10 @@ packages:
     resolution: {integrity: sha512-9A+PDmgm+2du77B5i0Ip2cxOqqHjgNxnBgglxLcX78A2D6c2rTo61z4jnVABpF4cKeDMDG+cmXXvdnqse2VqMA==}
     dev: false
 
-  /selderee@0.6.0:
-    resolution: {integrity: sha512-ibqWGV5aChDvfVdqNYuaJP/HnVBhlRGSRrlbttmlMpHcLuTqqbMH36QkSs9GEgj5M88JDYLI8eyP94JaQ8xRlg==}
+  /selderee@0.11.0:
+    resolution: {integrity: sha512-5TF+l7p4+OsnP8BCCvSyZiSPc4x4//p5uPwK8TCnVPJYRmU2aYKMpOXvw8zM5a5JvuuCGN1jmsMwuU2W02ukfA==}
     dependencies:
-      parseley: 0.7.0
+      parseley: 0.12.1
     dev: false
 
   /select-hose@2.0.0:
@@ -37426,6 +37622,12 @@ packages:
       decode-uri-component: 0.2.2
     dev: false
 
+  /source-map-support@0.3.3:
+    resolution: {integrity: sha512-9O4+y9n64RewmFoKUZ/5Tx9IHIcXM6Q+RTSw6ehnqybUz4a7iwR3Eaw80uLtqqQ5D0C+5H03D4KKGo9PdP33Gg==}
+    dependencies:
+      source-map: 0.1.32
+    dev: false
+
   /source-map-support@0.5.13:
     resolution: {integrity: sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==}
     dependencies:
@@ -37441,6 +37643,13 @@ packages:
   /source-map-url@0.4.1:
     resolution: {integrity: sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw==}
     deprecated: See https://github.com/lydell/source-map-url#deprecated
+
+  /source-map@0.1.32:
+    resolution: {integrity: sha512-htQyLrrRLkQ87Zfrir4/yN+vAUd6DNjVayEjTSHXu29AYQJw57I4/xEL/M6p6E/woPNJwvZt6rVlzc7gFEJccQ==}
+    engines: {node: '>=0.8.0'}
+    dependencies:
+      amdefine: 1.0.1
+    dev: false
 
   /source-map@0.5.6:
     resolution: {integrity: sha512-MjZkVp0NHr5+TPihLcadqnlVoGIoWo4IBHptutGh9wI3ttUYvCG26HkSuDi+K6lsZ25syXJXcctwgyVCt//xqA==}
@@ -38729,6 +38938,28 @@ packages:
     resolution: {integrity: sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==}
     engines: {node: '>=6'}
 
+  /tape@4.17.0:
+    resolution: {integrity: sha512-KCuXjYxCZ3ru40dmND+oCLsXyuA8hoseu2SS404Px5ouyS0A99v8X/mdiLqsR5MTAyamMBN7PRwt2Dv3+xGIxw==}
+    hasBin: true
+    dependencies:
+      '@ljharb/resumer': 0.0.1
+      '@ljharb/through': 2.3.10
+      call-bind: 1.0.2
+      deep-equal: 1.1.1
+      defined: 1.0.1
+      dotignore: 0.1.2
+      for-each: 0.3.3
+      glob: 7.2.3
+      has: 1.0.4
+      inherits: 2.0.4
+      is-regex: 1.1.4
+      minimist: 1.2.8
+      mock-property: 1.0.0
+      object-inspect: 1.12.3
+      resolve: 1.22.6
+      string.prototype.trim: 1.2.8
+    dev: false
+
   /tar-fs@1.16.3:
     resolution: {integrity: sha512-NvCeXpYx7OsmOh8zIOP/ebG55zZmxLE0etfWRbWok+q2Qo8x/vOR/IJT1taADXPe+jsiu9axDb3X4B+iIgNlKw==}
     dependencies:
@@ -39271,13 +39502,13 @@ packages:
   /tryer@1.0.1:
     resolution: {integrity: sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA==}
 
-  /ts-api-utils@1.0.3(typescript@4.8.4):
+  /ts-api-utils@1.0.3(typescript@5.1.6):
     resolution: {integrity: sha512-wNMeqtMz5NtwpT/UZGY5alT+VoKdSsOOP/kqHFcUW1P/VRhH2wJ48+DN2WwUliNbQ976ETwDL0Ifd2VVvgonvg==}
     engines: {node: '>=16.13.0'}
     peerDependencies:
       typescript: '>=4.2.0'
     dependencies:
-      typescript: 4.8.4
+      typescript: 5.1.6
     dev: true
 
   /ts-dedent@1.2.0:
@@ -39292,7 +39523,7 @@ packages:
     resolution: {integrity: sha512-Z86EW+fFFh/IFB1fqQ3/+7Zpf9t2ebOAxNI/V6Wo7r5gqiqtxmgTlQ1qbqQcjLKYeSHPTsEmvlJUDg/EuL0uHQ==}
     dev: false
 
-  /ts-jest@28.0.8(@babel/core@7.23.0)(jest@28.1.3)(typescript@4.8.4):
+  /ts-jest@28.0.8(@babel/core@7.23.0)(jest@28.1.3)(typescript@5.1.6):
     resolution: {integrity: sha512-5FaG0lXmRPzApix8oFG8RKjAz4ehtm8yMKOTy5HX3fY6W8kmvOrmcY0hKDElW52FJov+clhUbrKAqofnj4mXTg==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     hasBin: true
@@ -39322,7 +39553,7 @@ packages:
       lodash.memoize: 4.1.2
       make-error: 1.3.6
       semver: 7.5.4
-      typescript: 4.8.4
+      typescript: 5.1.6
       yargs-parser: 21.1.1
     dev: true
 
@@ -39356,7 +39587,7 @@ packages:
       webpack: 4.47.0
     dev: false
 
-  /ts-node@10.9.1(@types/node@20.5.1)(typescript@4.8.4):
+  /ts-node@10.9.1(@types/node@20.5.1)(typescript@5.1.6):
     resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
     hasBin: true
     peerDependencies:
@@ -39382,11 +39613,11 @@ packages:
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
-      typescript: 4.8.4
+      typescript: 5.1.6
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
-  /ts-pnp@1.1.4(typescript@4.8.4):
+  /ts-pnp@1.1.4(typescript@5.1.6):
     resolution: {integrity: sha512-1J/vefLC+BWSo+qe8OnJQfWTYRS6ingxjwqmHMqaMxXMj7kFtKLgAaYW3JeX3mktjgUL+etlU8/B4VUAUI9QGw==}
     engines: {node: '>=6'}
     peerDependencies:
@@ -39395,7 +39626,7 @@ packages:
       typescript:
         optional: true
     dependencies:
-      typescript: 4.8.4
+      typescript: 5.1.6
 
   /ts-toolbelt@9.6.0:
     resolution: {integrity: sha512-nsZd8ZeNUzukXPlJmTBwUAuABDe/9qtVDelJeT/qW0ow3ZS3BsQJtNkan1802aM9Uf68/Y8ljw86Hu0h5IUW3w==}
@@ -39431,6 +39662,16 @@ packages:
     dependencies:
       tslib: 1.14.1
       typescript: 4.8.4
+    dev: false
+
+  /tsutils@3.21.0(typescript@5.1.6):
+    resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
+    engines: {node: '>= 6'}
+    peerDependencies:
+      typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
+    dependencies:
+      tslib: 1.14.1
+      typescript: 5.1.6
 
   /tsx@3.13.0:
     resolution: {integrity: sha512-rjmRpTu3as/5fjNq/kOkOtihgLxuIz6pbKdj9xwP4J5jOLkBxw/rjN5ANw+KyrrOXV5uB7HC8+SrrSJxT65y+A==}
@@ -39568,7 +39809,7 @@ packages:
       typedoc: '>=0.24.0'
     dependencies:
       handlebars: 4.7.8
-      typedoc: 0.24.8(typescript@4.8.4)
+      typedoc: 0.24.8(typescript@5.1.6)
     dev: false
 
   /typedoc-plugin-markdown@3.16.0(typedoc@0.25.0):
@@ -39577,10 +39818,10 @@ packages:
       typedoc: '>=0.24.0'
     dependencies:
       handlebars: 4.7.8
-      typedoc: 0.25.0(typescript@4.8.4)
+      typedoc: 0.25.0(typescript@5.1.6)
     dev: true
 
-  /typedoc@0.24.8(typescript@4.8.4):
+  /typedoc@0.24.8(typescript@5.1.6):
     resolution: {integrity: sha512-ahJ6Cpcvxwaxfu4KtjA8qZNqS43wYt6JL27wYiIgl1vd38WW/KWX11YuAeZhuz9v+ttrutSsgK+XO1CjL1kA3w==}
     engines: {node: '>= 14.14'}
     hasBin: true
@@ -39591,10 +39832,10 @@ packages:
       marked: 4.3.0
       minimatch: 9.0.3
       shiki: 0.14.4
-      typescript: 4.8.4
+      typescript: 5.1.6
     dev: false
 
-  /typedoc@0.25.0(typescript@4.8.4):
+  /typedoc@0.25.0(typescript@5.1.6):
     resolution: {integrity: sha512-FvCYWhO1n5jACE0C32qg6b3dSfQ8f2VzExnnRboowHtqUD6ARzM2r8YJeZFYXhcm2hI4C2oCRDgNPk/yaQUN9g==}
     engines: {node: '>= 16'}
     hasBin: true
@@ -39605,7 +39846,7 @@ packages:
       marked: 4.3.0
       minimatch: 9.0.3
       shiki: 0.14.4
-      typescript: 4.8.4
+      typescript: 5.1.6
     dev: true
 
   /types-ramda@0.29.5:
@@ -39627,6 +39868,12 @@ packages:
   /typescript@4.8.4:
     resolution: {integrity: sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==}
     engines: {node: '>=4.2.0'}
+    hasBin: true
+    dev: false
+
+  /typescript@5.1.6:
+    resolution: {integrity: sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==}
+    engines: {node: '>=14.17'}
     hasBin: true
 
   /ua-parser-js@0.7.36:
@@ -39710,22 +39957,22 @@ packages:
       prettier: 2.8.8
       slash2: 2.0.0
 
-  /umi@4.0.83(@babel/core@7.23.0)(@types/node@20.5.1)(eslint@8.48.0)(jest@28.1.3)(postcss@8.4.31)(prettier@2.8.8)(react-dom@16.14.0)(react@16.14.0)(rollup@2.33.3)(sass@1.69.0)(styled-components@6.0.8)(stylelint@14.16.1)(stylus@0.54.8)(typescript@4.8.4)(webpack@5.88.2):
+  /umi@4.0.83(@babel/core@7.23.0)(@types/node@13.11.1)(eslint@8.48.0)(jest@28.1.3)(postcss@8.4.31)(prettier@2.8.8)(react-dom@16.14.0)(react@16.14.0)(rollup@2.33.3)(sass@1.69.0)(styled-components@6.0.8)(stylelint@14.16.1)(stylus@0.54.8)(typescript@5.1.6)(webpack@5.88.2):
     resolution: {integrity: sha512-y1g31rWtwzN6xzujyAcsG2UyJAQ5nIp6DbNHikIImu1Xt8b+P0RIrUWncBLl6x6YS5m5w45XLdANE1JZkMef/Q==}
     engines: {node: '>=14'}
     hasBin: true
     dependencies:
       '@babel/runtime': 7.21.0
       '@umijs/bundler-utils': 4.0.83
-      '@umijs/bundler-webpack': 4.0.83(styled-components@6.0.8)(typescript@4.8.4)(webpack@5.88.2)
+      '@umijs/bundler-webpack': 4.0.83(styled-components@6.0.8)(typescript@5.1.6)(webpack@5.88.2)
       '@umijs/core': 4.0.83
-      '@umijs/lint': 4.0.83(eslint@8.48.0)(jest@28.1.3)(styled-components@6.0.8)(stylelint@14.16.1)(typescript@4.8.4)
-      '@umijs/preset-umi': 4.0.83(@types/node@20.5.1)(postcss@8.4.31)(rollup@2.33.3)(sass@1.69.0)(styled-components@6.0.8)(stylus@0.54.8)(typescript@4.8.4)(webpack@5.88.2)
+      '@umijs/lint': 4.0.83(eslint@8.48.0)(jest@28.1.3)(styled-components@6.0.8)(stylelint@14.16.1)(typescript@5.1.6)
+      '@umijs/preset-umi': 4.0.83(@types/node@13.11.1)(postcss@8.4.31)(rollup@2.33.3)(sass@1.69.0)(styled-components@6.0.8)(stylus@0.54.8)(typescript@5.1.6)(webpack@5.88.2)
       '@umijs/renderer-react': 4.0.83(react-dom@16.14.0)(react@16.14.0)
       '@umijs/server': 4.0.83
       '@umijs/test': 4.0.83(@babel/core@7.23.0)
       '@umijs/utils': 4.0.83
-      prettier-plugin-organize-imports: 3.2.3(prettier@2.8.8)(typescript@4.8.4)
+      prettier-plugin-organize-imports: 3.2.3(prettier@2.8.8)(typescript@5.1.6)
       prettier-plugin-packagejson: 2.4.3(prettier@2.8.8)
     transitivePeerDependencies:
       - '@babel/core'
@@ -40568,7 +40815,7 @@ packages:
       remove-trailing-separator: 1.1.0
       replace-ext: 1.0.1
 
-  /vite@4.3.1(@types/node@20.5.1)(less@3.13.1)(stylus@0.54.8):
+  /vite@4.3.1(@types/node@13.11.1)(less@3.13.1)(stylus@0.54.8):
     resolution: {integrity: sha512-EPmfPLAI79Z/RofuMvkIS0Yr091T2ReUoXQqc5ppBX/sjFRhHKiPPF/R46cTdoci/XgeQpB23diiJxq5w30vdg==}
     engines: {node: ^14.18.0 || >=16.0.0}
     hasBin: true
@@ -40593,7 +40840,7 @@ packages:
       terser:
         optional: true
     dependencies:
-      '@types/node': 20.5.1
+      '@types/node': 13.11.1
       esbuild: 0.17.19
       less: 3.13.1
       postcss: 8.4.31


### PR DESCRIPTION
通过 `drawOtherShapes` 可以渲染许多自定义图形，这些图形底层都是基于 `@antv/g` 绘制的，因此可以将任何基于 `@antv/g` 构建的图形库的图形作为自定义节点的图形。例如，可以使用 `@antv/g2` 构建的图表作为自定义节点的图形，下面是一个简单的例子：

```typescript
import { stdlib, renderToMountedElement } from '@antv/g2';

/** stdlib 是 G2 的标准工具库 */
const G2Library = { ...stdlib() };

// 下面是自定义节点的 drawOtherShapes 方法
drawOtherShapes(model, shapeMap) {
  // 创建一个 group
  const group = this.upsertShape(
    'group',
    'g2-chart-group',
    {},
    shapeMap,
    model,
  );
  // 让 group 响应事件
  group.isMutationObserved = true;
  // 当 group 挂载到画布上时，渲染 G2 图表
  group.addEventListener('DOMNodeInsertedIntoDocument', () => {
    // 将 G2 图表渲染到 group 里
    renderToMountedElement(
      {
        // 这里填写 G2 的 Specification
      },
      {
        group,
        library: G2Library,
      },
    );
  });
  return {
    'g2-chart-group': group,
  };
}
```

添加的例子：

![Oct-11-2023 13-29-21](https://github.com/antvis/G6/assets/25787943/82a98e53-f5f7-47fa-8ab8-63bbd37669cd)

![Oct-11-2023 13-30-37](https://github.com/antvis/G6/assets/25787943/106f2108-08de-4df8-baf9-0164afa475fd)

<img width="561" alt="image" src="https://github.com/antvis/G6/assets/25787943/e72d49f0-ad81-4805-b5c4-005c4f3e1ad1">

## 其他

typescirpt 版本 -> 5.1.6
dumi 版本 -> ^2.2.12
修复一些类型问题
