### PR TITLE
perf: lazy load non-rendered graphics when first screen

### DIFF
--- a/packages/g6/src/item/edge.ts
+++ b/packages/g6/src/item/edge.ts
@@ -96,10 +96,22 @@ export default class Edge extends Item {
         true;
     }
 
+    const newShapeMap = { ...shapeMap, ...this.afterDrawShapeMap };
+    const actualRenderedShapeMap = {};
+
+    Object.keys(newShapeMap).forEach((id) => {
+      const shape = newShapeMap[id];
+      if (this.renderExt.shouldRenderShape(shape)) {
+        actualRenderedShapeMap[id] = shape;
+      } else {
+        this.renderExt.cacheShapeMap[id] = true;
+      }
+    });
+
     // add shapes to group, and update shapeMap
     this.shapeMap = updateShapes(
       this.shapeMap,
-      { ...shapeMap, ...this.afterDrawShapeMap },
+      actualRenderedShapeMap,
       this.group,
       this.labelGroup,
     );
@@ -404,7 +416,9 @@ export default class Edge extends Item {
     });
     if (visible) return clonedEdge;
     Object.keys(this.shapeMap).forEach((shapeId) => {
-      if (!this.shapeMap[shapeId].isVisible()) {
+      const shape = this.shapeMap[shapeId];
+      if (!this.renderExt.shouldRenderShape(shape)) return;
+      if (!shape.isVisible()) {
         clonedEdge.shapeMap[shapeId].hide();
       } else {
         clonedEdge.shapeMap[shapeId].show();

--- a/packages/g6/src/item/edge.ts
+++ b/packages/g6/src/item/edge.ts
@@ -99,12 +99,12 @@ export default class Edge extends Item {
     const newShapeMap = { ...shapeMap, ...this.afterDrawShapeMap };
     const actualRenderedShapeMap = {};
 
-    Object.keys(newShapeMap).forEach((id) => {
-      const shape = newShapeMap[id];
-      if (this.renderExt.shouldRenderShape(shape)) {
-        actualRenderedShapeMap[id] = shape;
+    Object.keys(newShapeMap).forEach((shapeId) => {
+      const shape = newShapeMap[shapeId];
+      if (this.renderExt.shouldRenderShape(shapeId, shape)) {
+        actualRenderedShapeMap[shapeId] = shape;
       } else {
-        this.renderExt.cacheShapeMap[id] = true;
+        this.renderExt.cacheShapeMap[shapeId] = true;
       }
     });
 
@@ -417,11 +417,12 @@ export default class Edge extends Item {
     if (visible) return clonedEdge;
     Object.keys(this.shapeMap).forEach((shapeId) => {
       const shape = this.shapeMap[shapeId];
-      if (!this.renderExt.shouldRenderShape(shape)) return;
-      if (!shape.isVisible()) {
-        clonedEdge.shapeMap[shapeId].hide();
-      } else {
-        clonedEdge.shapeMap[shapeId].show();
+      if (this.renderExt.shouldRenderShape(shapeId, shape)) {
+        if (!shape.isVisible()) {
+          clonedEdge.shapeMap[shapeId].hide();
+        } else {
+          clonedEdge.shapeMap[shapeId].show();
+        }
       }
     });
     return clonedEdge;

--- a/packages/g6/src/item/item.ts
+++ b/packages/g6/src/item/item.ts
@@ -545,7 +545,7 @@ export default abstract class Item implements IItem {
   public hide(animate = true, keepKeyShape = false, shapeIds = undefined) {
     const shapeIdsToHide =
       shapeIds?.filter((id) => {
-        const shape = this.shapeMap[id] || this.loadCacheShape(id);
+        const shape = this.shapeMap[id];
         return (
           shape &&
           (shape.attributes.visibility !== 'hidden' ||

--- a/packages/g6/src/item/node.ts
+++ b/packages/g6/src/item/node.ts
@@ -92,12 +92,12 @@ export default class Node extends Item {
 
     const actualRenderedShapeMap = {};
 
-    Object.keys(shapeMap).forEach((id) => {
-      const shape = shapeMap[id];
-      if (this.renderExt.shouldRenderShape(shape)) {
-        actualRenderedShapeMap[id] = shape;
+    Object.keys(shapeMap).forEach((shapeId) => {
+      const shape = shapeMap[shapeId];
+      if (this.renderExt.shouldRenderShape(shapeId, shape)) {
+        actualRenderedShapeMap[shapeId] = shape;
       } else {
-        this.renderExt.cacheShapeMap[id] = true;
+        this.renderExt.cacheShapeMap[shapeId] = true;
       }
     });
 
@@ -323,11 +323,12 @@ export default class Node extends Item {
     });
     Object.keys(this.shapeMap).forEach((shapeId) => {
       const shape = this.shapeMap[shapeId];
-      if (!this.renderExt.shouldRenderShape(shape)) return;
-      if (!shape.isVisible()) {
-        clonedNode.shapeMap[shapeId].hide();
-      } else {
-        clonedNode.shapeMap[shapeId]?.show();
+      if (this.renderExt.shouldRenderShape(shapeId, shape)) {
+        if (!shape.isVisible()) {
+          clonedNode.shapeMap[shapeId].hide();
+        } else {
+          clonedNode.shapeMap[shapeId]?.show();
+        }
       }
     });
     return clonedNode;

--- a/packages/g6/src/stdlib/item/edge/base.ts
+++ b/packages/g6/src/stdlib/item/edge/base.ts
@@ -83,16 +83,13 @@ export abstract class BaseEdge {
   public getMergedStyles(model: EdgeDisplayModel) {
     const { data } = model;
     const dataStyles = {} as EdgeShapeStyles;
-    Object.keys(data).forEach((fieldName) => {
+    for (const fieldName in data) {
       if (RESERVED_SHAPE_IDS.includes(fieldName)) {
-        dataStyles[fieldName] = data[fieldName] as ShapeStyle;
+        dataStyles[fieldName] = data[fieldName];
       } else if (fieldName === OTHER_SHAPES_FIELD_NAME) {
-        Object.keys(data[fieldName]).forEach(
-          (otherShapeId) =>
-            (dataStyles[otherShapeId] = data[fieldName][otherShapeId]),
-        );
+        Object.assign(dataStyles, data[fieldName]);
       }
-    });
+    }
     const merged = mergeStyles([
       this.themeStyles,
       this.defaultStyles,
@@ -608,15 +605,16 @@ export abstract class BaseEdge {
       model,
     );
 
-    if (this.shouldRenderShape(newShape)) {
+    if (this.shouldRenderShape(id, newShape)) {
       shapeMap[id] = newShape;
     }
 
     return newShape;
   }
 
-  public shouldRenderShape(shape) {
+  public shouldRenderShape(id: ID, shape: DisplayObject) {
     if (!shape) return false;
+    if (id === 'keyShape') return true;
     return shape.attributes.visibility !== 'hidden';
   }
 }

--- a/packages/g6/src/stdlib/plugin/lodController/index.ts
+++ b/packages/g6/src/stdlib/plugin/lodController/index.ts
@@ -224,9 +224,15 @@ export class LodController extends Base {
           graph.hideItem(id, { shapeIds: invisibleShapeIds, disableAnimate });
         }
         const item = graph.itemController.itemMap.get(id);
+
+        const existLabel =
+          item.labelGroup.children.length ||
+          item.cacheShapeMap.labelShape ||
+          item.cacheShapeMap.labelBackgroundShape;
+
         if (
           disableLod ||
-          (item.labelGroup.children.length &&
+          (existLabel &&
             (rest > 0 || (zoomRatio >= 1 && this.shownIds.has(id))))
         ) {
           const shapeIdsToShow = lodVisibleShapeIds.concat(autoVisibleShapeIds);

--- a/packages/g6/src/util/shape.ts
+++ b/packages/g6/src/util/shape.ts
@@ -196,14 +196,14 @@ export const updateShapes = (
   removeDiff = true,
   shouldUpdate: (id: string) => boolean = () => true,
 ): NodeShapeMap | EdgeShapeMap => {
-  const tolalMap = {
+  const totalMap = {
     ...prevShapeMap,
     ...newShapeMap,
   };
   const finalShapeMap = {
     ...prevShapeMap,
   };
-  Object.keys(tolalMap).forEach((id) => {
+  for (const id in totalMap) {
     const prevShape = prevShapeMap[id];
     const newShape = newShapeMap[id];
     if (newShape && !shouldUpdate(id)) return;
@@ -242,7 +242,8 @@ export const updateShapes = (
       delete finalShapeMap[id];
       prevShape.remove();
     }
-  });
+  }
+
   return finalShapeMap as NodeShapeMap;
 };
 
@@ -299,16 +300,14 @@ const merge2Styles = (
 ) => {
   if (!styleMap1) return { ...styleMap2 };
   else if (!styleMap2) return { ...styleMap1 };
-  const mergedStyle = styleMap1;
-  Object.keys(styleMap2).forEach((shapeId) => {
-    const style = styleMap2[shapeId];
-    if (!style) return;
-    mergedStyle[shapeId] = {
-      ...mergedStyle[shapeId],
-      ...style,
-    };
-  });
-  return mergedStyle;
+  for (const shapeId in styleMap2) {
+    if (!styleMap1[shapeId]) {
+      styleMap1[shapeId] = { ...styleMap2[shapeId] };
+    } else {
+      Object.assign(styleMap1[shapeId], styleMap2[shapeId]);
+    }
+  }
+  return styleMap1;
 };
 
 /**

--- a/packages/g6/src/util/shape.ts
+++ b/packages/g6/src/util/shape.ts
@@ -164,7 +164,6 @@ export const upsertShape = (
     if (style.interactive === false) shape.interactive = false;
     else shape.interactive = true;
   }
-  shapeMap[id] = shape;
   return shape;
 };
 
@@ -231,7 +230,6 @@ export const updateShapes = (
       ) {
         parentGroup.appendChild(newShape);
         if (newShape.style.lod === 'auto') {
-          newShape.style.visibility = 'hidden';
           if (newShape.id === 'labelShape' && parentGroup === labelGroup) {
             labelGroup.attributes.visibility = 'hidden';
           }

--- a/packages/g6/src/util/string.ts
+++ b/packages/g6/src/util/string.ts
@@ -1,0 +1,7 @@
+export const camelCase = (str) => {
+  return str
+    .replace(/(?:^\w|[A-Z]|\b\w)/g, function (word, index) {
+      return index === 0 ? word.toLowerCase() : word.toUpperCase();
+    })
+    .replace(/\s+/g, '');
+};

--- a/packages/g6/src/util/zoom.ts
+++ b/packages/g6/src/util/zoom.ts
@@ -26,9 +26,7 @@ export const formatLodLevels = (
  * @returns
  */
 export const getZoomLevel = (levels: LodLevelRanges, zoom: number) => {
-  const keys = Object.keys(levels);
-  for (let i = 0; i < keys.length; i++) {
-    const idx = keys[i];
+  for (const idx in levels) {
     const zoomRange = levels[idx];
     if (zoom >= zoomRange[0] && zoom < zoomRange[1]) {
       return Number(idx);


### PR DESCRIPTION
性能优化：创建时不展示的图形不真正创建

文本创建消耗大，可能创建时 G 层需要计算包围盒等。在创建时发现其 visibility 是 hidden 不真正创建，而在第一次显示时展示。

Demo 中 renderNodes 耗时 949ms -> 743ms

<img width="1440" alt="image" src="https://github.com/antvis/G6/assets/55794321/1b589c31-505c-4ca8-8186-584950d96418">
