### PR TITLE
fix: remove duplicated dragend case

### DIFF
--- a/packages/pc/src/graph/controller/event.ts
+++ b/packages/pc/src/graph/controller/event.ts
@@ -95,7 +95,6 @@ export default class EventController extends AbstractEvent {
       case  'mousedown':
         this.mousedown = true;
         break;
-      case 'dragend':
       case 'mouseup':
         // mouseup happend before click, so setTimeout to reset the tag for reference in click event
         setTimeout(() => this.mousedown = false);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->

`case "dragend"` already exists above:
https://github.com/antvis/G6/blob/304db350dcb05e4a6e1b341a1465e3c27facc699/packages/pc/src/graph/controller/event.ts#L91

this extra line will result to esbuild warning:
```
(esbuild plugin) [esbuild] (.nuxt/dist/server/_nuxt/electronic-372bd534.js:31248:13) This case clause will never be evaluated because it duplicates an earlier case clause
```

