### PR TITLE
fix: fix incorrect label position on edges

### DIFF
--- a/packages/g6/src/item/edge.ts
+++ b/packages/g6/src/item/edge.ts
@@ -146,6 +146,11 @@ export default class Edge extends Item {
       this.hide(false);
     }
     this.changedStates = [];
+
+    this.labelGroup.children
+      .filter((element) => element.attributes.dataIsLabel)
+      .forEach((shape) => (shape.attributes.dataOriginPosition = ''));
+
     this.updateLabelPosition(true);
   }
 


### PR DESCRIPTION
修复官网元素 demo 边标签错位的问题

画布加载时，若元素未设置默认位置而是采用 layout，dataOriginPosition 为 `{x: 0, y: 0}` 会聚集在左上角

修复前
![image](https://github.com/antvis/G6/assets/55794321/8d178254-5f6b-4e79-85c5-0558223d58b6)
修复后
![image](https://github.com/antvis/G6/assets/55794321/3a611f91-ff3a-4aa1-aaa6-a7596fdd9d1b)
