### PR TITLE
refactor(register): adjust getPlugins returns type

### DIFF
--- a/packages/g6/src/item/item.ts
+++ b/packages/g6/src/item/item.ts
@@ -135,7 +135,7 @@ export default abstract class Item implements IItem {
       lodLevels: modelLodLevels,
       enableBalanceShape,
     } = this.displayModel.data;
-    const RenderExtension = renderExtensions.find((ext) => ext.type === type);
+    const RenderExtension = renderExtensions[type];
     this.themeStyles = theme.styles;
     this.lodLevels = modelLodLevels ? formatLodLevels(modelLodLevels) : theme.lodLevels;
     if (!RenderExtension) {
@@ -270,7 +270,7 @@ export default abstract class Item implements IItem {
       Object.values(this.shapeMap).forEach((child) => child.destroy());
       this.shapeMap = { keyShape: undefined };
       const { type = this.type === 'node' ? 'circle-node' : 'line-edge' } = displayModel.data;
-      const RenderExtension = this.renderExtensions.find((ext) => ext.type === type);
+      const RenderExtension = this.renderExtensions[type];
       this.renderExt = new RenderExtension({
         themeStyles: this.themeStyles.default,
         lodLevels: this.lodLevels,

--- a/packages/g6/src/plugin/register.ts
+++ b/packages/g6/src/plugin/register.ts
@@ -65,7 +65,6 @@ function register<T extends PluginCategory>(category: T, type: string, pluginCla
     );
   }
 
-  pluginClass.type = type;
   pluginRegistry[category].set(type, pluginClass);
 }
 
@@ -83,15 +82,15 @@ function getPlugin<T extends PluginCategory>(category: T, type: string): PluginR
 }
 
 /**
- * <zh/> 根据类别获取所有的插件类列表。
+ * <zh/> 根据类别获取所有的插件类。
  *
- * <en/> Retrieves a list of all plugin classes for a given category.
+ * <en/> Retrieves all plugin classes for a given category.
  * @param category - <zh/> 要检索的插件分类 | <en/> Plugin category to retrieve
- * @returns <zh/> 返回指定类别下所有插件类的数组 | <en/> Returns an array of all plugin classes for the specified category
+ * @returns <zh/> 返回指定类别下所有插件类 | <en/> Returns all plugin classes for the specified category
  * @internal
  */
-function getPlugins<T extends PluginCategory>(category: T): PluginRegistry[T][string][] {
-  return Array.from(pluginRegistry[category]?.values() || []);
+function getPlugins<T extends PluginCategory>(category: T) {
+  return Object.fromEntries(pluginRegistry[category]) as PluginRegistry[T];
 }
 
 export { getPlugin, getPlugins, register };

--- a/packages/g6/src/runtime/controller/item.ts
+++ b/packages/g6/src/runtime/controller/item.ts
@@ -87,9 +87,9 @@ const getWarnMsg = {
  */
 export class ItemController {
   public graph: Graph;
-  public nodeExtensions: NodeRegistry[string][] = [];
-  public edgeExtensions: EdgeRegistry[string][] = [];
-  public comboExtensions: NodeRegistry[string][] = [];
+  public nodeExtensions: NodeRegistry = {};
+  public edgeExtensions: EdgeRegistry = {};
+  public comboExtensions: NodeRegistry = {};
 
   public zoom: number;
 

--- a/packages/g6/src/runtime/controller/theme.ts
+++ b/packages/g6/src/runtime/controller/theme.ts
@@ -42,10 +42,7 @@ export class ThemeController {
   }
 
   private getThemes(): ThemeRegistry {
-    return getPlugins('theme').reduce((res, acc) => {
-      res[acc.type] = acc;
-      return res;
-    }, {}) as ThemeRegistry;
+    return getPlugins('theme');
   }
 
   /**

--- a/packages/g6/tests/unit/register.spec.ts
+++ b/packages/g6/tests/unit/register.spec.ts
@@ -47,7 +47,7 @@ describe('Plugin Registration', () => {
     it('should retrieve all plugins for a given category', () => {
       register(category, type, CustomBehavior);
       const plugins = getPlugins(category);
-      expect(plugins).toContain(CustomBehavior);
+      expect(plugins[type]).toBe(CustomBehavior);
     });
   });
 });


### PR DESCRIPTION
调整了 getPlugins 的返回值类型，调整前返回的是一个数据，需要遍历查找，调整后是一个 object，可以直接通过 `key` 取到对应的插件

> Adjusted the return value type of getPlugins. Before adjustment, the returned value is a data, which needs to be searched through traversal; after adjustment, it is an object, which can be directly obtained from the corresponding plug-in through the key