### PR TITLE
feat(spec): init spec definition

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+  "cSpell.words": [
+    "Fruchterman",
+    "gforce",
+    "graphlib"
+  ]
+}

--- a/packages/g6/__tests__/unit/spec/behavior.spec.ts
+++ b/packages/g6/__tests__/unit/spec/behavior.spec.ts
@@ -1,0 +1,9 @@
+import type { BehaviorOptions } from '../../../src';
+
+describe('spec behavior', () => {
+  it('behavior', () => {
+    const behavior: BehaviorOptions = ['drag-canvas', 'zoom-canvas', { type: 'unset' }, { type: 'any', anyProps: 1 }];
+
+    expect(behavior).toBeTruthy();
+  });
+});

--- a/packages/g6/__tests__/unit/spec/canvas.spec.ts
+++ b/packages/g6/__tests__/unit/spec/canvas.spec.ts
@@ -1,0 +1,15 @@
+import { Renderer } from '@antv/g-canvas';
+import type { CanvasOptions } from '../../../src';
+
+describe('spec canvas', () => {
+  it('canvas', () => {
+    const canvas: CanvasOptions = {
+      width: 100,
+      height: 100,
+      renderer: () => new Renderer(),
+      autoResize: true,
+    };
+
+    expect(canvas).toBeTruthy();
+  });
+});

--- a/packages/g6/__tests__/unit/spec/data.spec.ts
+++ b/packages/g6/__tests__/unit/spec/data.spec.ts
@@ -1,0 +1,91 @@
+import type { DataOptions } from '../../../src';
+
+describe('spec data', () => {
+  it('empty data', () => {
+    const data: DataOptions = {
+      nodes: [],
+      edges: [],
+    };
+
+    expect(data).toBeTruthy();
+  });
+
+  it('data', () => {
+    const data: DataOptions = {
+      nodes: [
+        {
+          id: 'node1',
+          data: {
+            value: 1,
+          },
+          style: {
+            collapsed: true,
+            parentId: 'combo-1',
+            fill: 'red',
+          },
+        },
+      ],
+    };
+
+    expect(data).toBeTruthy();
+  });
+
+  it('data with combo', () => {
+    const data: DataOptions = {
+      nodes: [
+        {
+          id: 'node1',
+          data: {
+            value: 1,
+          },
+          style: {
+            collapsed: true,
+            parentId: 'combo-1',
+            fill: 'red',
+          },
+        },
+      ],
+      combos: [
+        {
+          id: 'combo-1',
+          data: {
+            value: 1,
+          },
+          style: {
+            collapsed: true,
+            fill: 'red',
+          },
+        },
+      ],
+    };
+
+    expect(data).toBeTruthy();
+  });
+
+  it('normal data', () => {
+    const data: DataOptions = {
+      nodes: [
+        { id: 'node-1' },
+        { id: 'node-2', data: { value: 1, field: 'A' } },
+        { id: 'node-3', data: { value: 2 }, style: { x: 1, fill: 'red', y: 1, opacity: 0.1 } },
+      ],
+      edges: [
+        {
+          id: 'edge-1',
+          source: 'node-1',
+          target: 'node-2',
+          data: { value: 1, field: 'A' },
+          style: { stroke: 'red' },
+        },
+        { id: 'edge-2', source: 'node-1', target: 'node-3' },
+      ],
+      combos: [
+        { id: 'combo-1' },
+        { id: 'combo-2', data: { value: 1, field: 'A' } },
+        { id: 'combo-3', data: { value: 2 }, style: { x: 1, fill: 'red' } },
+      ],
+    };
+
+    expect(data).toBeTruthy();
+  });
+});

--- a/packages/g6/__tests__/unit/spec/element/combo.spec.ts
+++ b/packages/g6/__tests__/unit/spec/element/combo.spec.ts
@@ -1,0 +1,52 @@
+import type { ComboOptions } from '../../../../src';
+
+describe('spec element combo', () => {
+  it('combo 1', () => {
+    const combo: ComboOptions = {
+      style: {
+        comboStyle: (model) => model.style?.comboStyle || 'white',
+      },
+      state: {
+        state1: {
+          comboStyle: 'red',
+        },
+      },
+      animation: {
+        enter: {
+          type: 'fade-in',
+          delay: 100,
+        },
+        show: {
+          type: 'wave-in',
+          duration: 100,
+        },
+      },
+    };
+
+    expect(combo).toBeTruthy();
+  });
+
+  it('combo 2', () => {
+    const combo: ComboOptions = {
+      style: {
+        opacity: (data) => data.style?.opacity || 1,
+      },
+      state: {
+        activate: {
+          opacity: 1,
+        },
+      },
+      animation: {
+        enter: [
+          {
+            fields: ['lineWidth'],
+            shape: 'keyShape',
+            duration: 1000,
+          },
+        ],
+      },
+    };
+
+    expect(combo).toBeTruthy();
+  });
+});

--- a/packages/g6/__tests__/unit/spec/element/edge.spec.ts
+++ b/packages/g6/__tests__/unit/spec/element/edge.spec.ts
@@ -1,0 +1,62 @@
+import type { EdgeOptions } from '../../../../src';
+
+describe('spec element edge', () => {
+  it('edge 1', () => {
+    const edge: EdgeOptions = {
+      style: {
+        edgeStyle: (model) => model.style?.edgeStyle || 'white',
+      },
+      state: {
+        state1: {
+          edgeStyle: 'red',
+        },
+      },
+      animation: {
+        enter: {
+          type: 'fade-in',
+          delay: 100,
+        },
+        show: {
+          type: 'wave-in',
+          duration: 100,
+        },
+      },
+      palette: {
+        type: 'group',
+        color: 'my-palette',
+        invert: true,
+      },
+    };
+
+    expect(edge).toBeTruthy();
+  });
+
+  it('edge 2', () => {
+    const edge: EdgeOptions = {
+      style: {
+        opacity: (data) => data.style?.opacity || 1,
+      },
+      state: {
+        activate: {
+          opacity: 1,
+        },
+      },
+      animation: {
+        enter: [
+          {
+            fields: ['lineWidth'],
+            shape: 'keyShape',
+            duration: 1000,
+          },
+        ],
+      },
+      palette: {
+        type: 'group',
+        color: 'my-palette',
+        invert: true,
+      },
+    };
+
+    expect(edge).toBeTruthy();
+  });
+});

--- a/packages/g6/__tests__/unit/spec/element/node.spec.ts
+++ b/packages/g6/__tests__/unit/spec/element/node.spec.ts
@@ -1,0 +1,58 @@
+import type { NodeOptions } from '../../../../src';
+
+describe('spec element node', () => {
+  it('node 1', () => {
+    const node: NodeOptions = {
+      animation: {
+        enter: [
+          {
+            shape: 'keyShape',
+            fields: ['opacity'],
+            duration: 1000,
+          },
+        ],
+      },
+      style: {
+        collapsed: (data) => data.style?.collapsed || false,
+        parentId: '1',
+        x: 1,
+        y: 1,
+      },
+      palette: 'category10',
+      state: {
+        selected: {
+          any: 1,
+          x: 1,
+        },
+      },
+    };
+
+    expect(node).toBeTruthy();
+  });
+
+  it('node 2', () => {
+    const node: NodeOptions = {
+      style: {
+        nodeStyle: (model) => model.style?.nodeStyle || 'white',
+      },
+      state: {
+        state1: {
+          nodeStyle: (data) => data.style?.nodeStyle || 'white',
+        },
+      },
+      animation: {
+        enter: {
+          type: 'fade-in',
+          delay: 100,
+        },
+        show: {
+          type: 'wave-in',
+          duration: 100,
+        },
+      },
+      palette: 'spectral',
+    };
+
+    expect(node).toBeTruthy();
+  });
+});

--- a/packages/g6/__tests__/unit/spec/index.spec.ts
+++ b/packages/g6/__tests__/unit/spec/index.spec.ts
@@ -1,0 +1,69 @@
+import { Renderer } from '@antv/g-canvas';
+import type { G6Spec } from '../../../src';
+
+describe('spec', () => {
+  it('spec', () => {
+    const options: G6Spec = {
+      width: 800,
+      height: 600,
+      renderer: () => new Renderer(),
+      devicePixelRatio: 2,
+      autoResize: true,
+      autoFit: {
+        type: 'view',
+        rule: {},
+      },
+      padding: [10, 10],
+      zoom: 1.2,
+      zoomRange: [0.5, 2],
+      data: {
+        nodes: [
+          {
+            id: 'node-1',
+            data: {
+              value: 1,
+            },
+            style: {
+              nodeStyle: 'red',
+            },
+          },
+        ],
+        edges: [],
+        combos: [],
+      },
+      node: {
+        style: {
+          nodeStyle: 'blue',
+        },
+        state: {
+          state1: {
+            nodeStyle: 'green',
+          },
+        },
+        animation: {
+          enter: {
+            type: 'fade-in',
+          },
+        },
+        palette: {
+          type: 'group',
+          field: 'field',
+          color: 'brBG',
+        },
+      },
+      edge: {
+        animation: {
+          enter: [{ fields: ['opacity'], duration: 500, shape: 'keyShape' }],
+        },
+      },
+      theme: 'light',
+      behaviors: ['drag-canvas', 'my-behavior', { type: 'drag-node' }],
+      widgets: ['my-widget', { type: 'another-widget', text: 'text', value: 1 }],
+      optimize: {
+        tileFirstRender: true,
+      },
+    };
+
+    expect(options).toBeTruthy();
+  });
+});

--- a/packages/g6/__tests__/unit/spec/layout.spec.ts
+++ b/packages/g6/__tests__/unit/spec/layout.spec.ts
@@ -1,0 +1,68 @@
+import type { LayoutOptions } from '../../../src';
+
+describe('spec layout', () => {
+  it('layout 1', () => {
+    const layout: LayoutOptions = {
+      type: 'force',
+      linkDistance: 50,
+      maxSpeed: 100,
+      animated: true,
+      clustering: true,
+      nodeClusterBy: 'cluster',
+      clusterNodeStrength: 70,
+    };
+
+    expect(layout).toBeTruthy();
+  });
+
+  it('layout 2', () => {
+    const layout: LayoutOptions = {
+      type: 'dagre',
+      nodesep: 100,
+      ranksep: 70,
+      controlPoints: true,
+    };
+
+    expect(layout).toBeTruthy();
+  });
+
+  it('custom layout', () => {
+    const layout: LayoutOptions = {
+      type: 'any',
+      value: 1,
+    };
+
+    expect(layout).toBeTruthy();
+  });
+
+  it('register', () => {
+    const builtInLayout: LayoutOptions = {
+      type: 'concentric',
+      clockwise: true,
+      height: 100,
+    };
+    expect(builtInLayout).toBeTruthy();
+
+    type RegisterLayout = LayoutOptions;
+
+    const registerLayout1: RegisterLayout = {
+      type: 'layout1',
+      param: 1,
+    };
+    expect(registerLayout1).toBeTruthy();
+
+    const registerLayout2: RegisterLayout = {
+      type: 'layout2',
+      args: true,
+    };
+    expect(registerLayout2).toBeTruthy();
+
+    const pipeLayout: LayoutOptions = [
+      {
+        type: 'force',
+        nodesFilter: (node) => (node.data as { value: number }).value > 1,
+      },
+    ];
+    expect(pipeLayout).toBeTruthy();
+  });
+});

--- a/packages/g6/__tests__/unit/spec/optimize.spec.ts
+++ b/packages/g6/__tests__/unit/spec/optimize.spec.ts
@@ -1,0 +1,11 @@
+import type { OptimizeOptions } from '../../../src';
+
+describe('spec optimize', () => {
+  it('optimize 1', () => {
+    const optimize: OptimizeOptions = {
+      tileFirstRender: true,
+    };
+
+    expect(optimize).toBeTruthy();
+  });
+});

--- a/packages/g6/__tests__/unit/spec/theme.spec.ts
+++ b/packages/g6/__tests__/unit/spec/theme.spec.ts
@@ -1,0 +1,9 @@
+import type { ThemeOptions } from '../../../src';
+
+describe('spec theme', () => {
+  it('theme', () => {
+    const theme: ThemeOptions = 'light';
+
+    expect(theme).toBeTruthy();
+  });
+});

--- a/packages/g6/__tests__/unit/spec/viewport.spec.ts
+++ b/packages/g6/__tests__/unit/spec/viewport.spec.ts
@@ -1,0 +1,29 @@
+import type { ViewportOptions } from '../../../src';
+
+describe('spec viewport', () => {
+  it('viewport 1', () => {
+    const viewport: ViewportOptions = {
+      autoFit: 'view',
+      padding: 0,
+      zoom: 1,
+      zoomRange: [0.5, 2],
+    };
+
+    expect(viewport).toBeTruthy();
+  });
+
+  it('viewport 2', () => {
+    const viewport: ViewportOptions = {
+      autoFit: {
+        type: 'center',
+        effectTiming: {
+          duration: 1000,
+        },
+      },
+      padding: [10, 10],
+      zoom: 0.5,
+    };
+
+    expect(viewport).toBeTruthy();
+  });
+});

--- a/packages/g6/__tests__/unit/spec/widget.spec.ts
+++ b/packages/g6/__tests__/unit/spec/widget.spec.ts
@@ -1,0 +1,9 @@
+import type { WidgetOptions } from '../../../src';
+
+describe('spec widget', () => {
+  it('widget', () => {
+    const widget: WidgetOptions = ['minimap', { type: 'unset', key: '1' }];
+
+    expect(widget).toBeTruthy();
+  });
+});

--- a/packages/g6/src/animations/types.ts
+++ b/packages/g6/src/animations/types.ts
@@ -1,0 +1,5 @@
+import type { IAnimationEffectTiming } from '@antv/g';
+
+export type AnimationEffectTiming = Partial<
+  Pick<IAnimationEffectTiming, 'duration' | 'delay' | 'easing' | 'iterations'>
+>;

--- a/packages/g6/src/behaviors/types.ts
+++ b/packages/g6/src/behaviors/types.ts
@@ -1,0 +1,1 @@
+export type BuiltInBehaviorOptions = { type: 'unset' };

--- a/packages/g6/src/index.ts
+++ b/packages/g6/src/index.ts
@@ -1,3 +1,18 @@
 import './preset';
 
 export const version = '5.0.0';
+
+export type { G6Spec } from './spec';
+export type { BehaviorOptions } from './spec/behavior';
+export type { CanvasOptions } from './spec/canvas';
+export type { DataOptions } from './spec/data';
+export type { AnimationOptions } from './spec/element/animation';
+export type { ComboOptions } from './spec/element/combo';
+export type { EdgeOptions } from './spec/element/edge';
+export type { NodeOptions } from './spec/element/node';
+export type { PaletteOptions } from './spec/element/palette';
+export type { LayoutOptions } from './spec/layout';
+export type { OptimizeOptions } from './spec/optimize';
+export type { ThemeOptions } from './spec/theme';
+export type { ViewportOptions } from './spec/viewport';
+export type { WidgetOptions } from './spec/widget';

--- a/packages/g6/src/layouts/types.ts
+++ b/packages/g6/src/layouts/types.ts
@@ -1,0 +1,109 @@
+import type {
+  CircularLayoutOptions,
+  ConcentricLayoutOptions,
+  D3ForceLayoutOptions,
+  ForceAtlas2LayoutOptions,
+  ForceLayoutOptions,
+  FruchtermanLayoutOptions,
+  GridLayoutOptions,
+  MDSLayoutOptions,
+  RadialLayoutOptions,
+  RandomLayoutOptions,
+} from '@antv/layout';
+import type { AnimationEffectTiming } from '../animations/types';
+
+export type BuiltInLayoutOptions =
+  | CircularLayout
+  | RandomLayout
+  | ConcentricLayout
+  | GridLayout
+  | MDSLayout
+  | RadialLayout
+  | FruchtermanLayout
+  | D3ForceLayout
+  | ForceLayout
+  | ForceAtlas2;
+
+interface CircularLayout extends CircularLayoutOptions, AnimationOptions, WebWorkerLayoutOptions, PresetLayoutOptions {
+  type: 'circular';
+}
+
+interface RandomLayout extends RandomLayoutOptions, AnimationOptions, WebWorkerLayoutOptions, PresetLayoutOptions {
+  type: 'random';
+}
+
+interface GridLayout extends GridLayoutOptions, AnimationOptions, WebWorkerLayoutOptions, PresetLayoutOptions {
+  type: 'grid';
+}
+
+interface MDSLayout extends MDSLayoutOptions, AnimationOptions, WebWorkerLayoutOptions, PresetLayoutOptions {
+  type: 'mds';
+}
+
+interface ConcentricLayout
+  extends ConcentricLayoutOptions,
+    AnimationOptions,
+    WebWorkerLayoutOptions,
+    PresetLayoutOptions {
+  type: 'concentric';
+}
+
+interface RadialLayout extends RadialLayoutOptions, AnimationOptions, WebWorkerLayoutOptions, PresetLayoutOptions {
+  type: 'radial';
+}
+
+interface FruchtermanLayout
+  extends FruchtermanLayoutOptions,
+    AnimationOptions,
+    WebWorkerLayoutOptions,
+    PresetLayoutOptions {
+  type: 'fruchterman' | 'fruchtermanGPU';
+}
+
+interface D3ForceLayout extends D3ForceLayoutOptions, AnimationOptions, WebWorkerLayoutOptions, PresetLayoutOptions {
+  type: 'd3force';
+}
+
+interface ForceLayout extends ForceLayoutOptions, AnimationOptions, WebWorkerLayoutOptions, PresetLayoutOptions {
+  type: 'force' | 'gforce';
+}
+
+interface ForceAtlas2 extends ForceAtlas2LayoutOptions, AnimationOptions, WebWorkerLayoutOptions, PresetLayoutOptions {
+  type: 'forceAtlas2';
+}
+
+interface PresetLayoutOptions {
+  presetLayout?: Partial<BuiltInLayoutOptions>;
+}
+
+interface AnimationOptions {
+  /**
+   * <zh/> 启用布局动画，对于迭代布局，会在两次迭代之间进行动画过渡
+   *
+   * <en/> Enable layout animation, for iterative layout, animation transition will be performed between two iterations
+   */
+  animated?: boolean;
+
+  /**
+   * <zh/> 布局动画的配置项
+   *
+   * <en/> Layout animation options
+   */
+  animationEffectTiming?: AnimationEffectTiming;
+}
+
+export interface WebWorkerLayoutOptions {
+  /**
+   * <zh/> 是否在 WebWorker 中运行布局
+   *
+   * <en/> Whether to run the layout in WebWorker
+   */
+  workerEnabled?: boolean;
+
+  /**
+   * <zh/> 迭代布局的迭代次数
+   *
+   * <en/> Iterations for iterable layouts
+   */
+  iterations?: number;
+}

--- a/packages/g6/src/palettes/types.ts
+++ b/packages/g6/src/palettes/types.ts
@@ -1,0 +1,7 @@
+export type Palette = string | BuiltInPalette | CategoricalPalette | ContinuousPalette;
+
+export type BuiltInPalette = 'category10' | 'category20';
+
+export type CategoricalPalette = string[];
+
+export type ContinuousPalette = (ratio: number) => string;

--- a/packages/g6/src/spec/behavior.ts
+++ b/packages/g6/src/spec/behavior.ts
@@ -1,0 +1,12 @@
+import type { BuiltInBehaviorOptions } from '../behaviors/types';
+
+export type BehaviorOptions = Abbr<BuiltInBehaviorOptions | CustomBehaviorOptions>[];
+
+type CustomBehaviorOptions = STDBehaviorOptions;
+
+export interface STDBehaviorOptions {
+  type: string;
+  [key: string]: unknown;
+}
+
+type Abbr<R extends STDBehaviorOptions> = (R & { key?: string }) | R['type'];

--- a/packages/g6/src/spec/canvas.ts
+++ b/packages/g6/src/spec/canvas.ts
@@ -1,0 +1,35 @@
+import type { CanvasConfig, IRenderer } from '@antv/g';
+import type { CanvasLayer } from '../types/canvas';
+
+/**
+ * <zh/> 画布配置项
+ *
+ * <en/> Canvas spec
+ * @public
+ */
+export type CanvasOptions = Pick<CanvasConfig, 'container' | 'devicePixelRatio'> & {
+  /**
+   * <zh/> 画布宽度
+   *
+   * <en/> canvas width
+   */
+  width?: number;
+  /**
+   * <zh/> 画布高度
+   *
+   * <en/> canvas height
+   */
+  height?: number;
+  /**
+   * <zh/> 获取渲染器
+   *
+   * <en/> get renderer
+   */
+  renderer?: (layer: CanvasLayer) => IRenderer;
+  /**
+   * <zh/> 是否自动调整画布大小
+   *
+   * <en/> whether to auto resize canvas
+   */
+  autoResize?: boolean;
+};

--- a/packages/g6/src/spec/data.ts
+++ b/packages/g6/src/spec/data.ts
@@ -1,0 +1,60 @@
+import type { ID } from '@antv/graphlib';
+import type { EdgeStyle } from './element/edge';
+import type { NodeLikeStyle } from './element/node';
+
+export type DataOptions = {
+  /**
+   * <zh/> 节点数据
+   *
+   * <en/> node data
+   */
+  nodes?: NodeData[];
+  /**
+   * <zh/> 边数据
+   *
+   * <en/> edge data
+   */
+  edges?: EdgeData[];
+  /**
+   * <zh/> Combo 数据
+   *
+   * <en/> combo data
+   */
+  combos?: ComboData[];
+};
+
+export type NodeData = {
+  id: ID;
+  data?: Record<string, unknown>;
+  style?: NodeLikeDataStyle;
+};
+
+export type ComboData = {
+  id: ID;
+  data?: Record<string, unknown>;
+  style?: NodeLikeDataStyle;
+};
+
+export type EdgeData = {
+  id: ID;
+  source: ID;
+  target: ID;
+  data?: Record<string, unknown>;
+  style?: EdgeDataStyle;
+};
+
+interface NodeLikeDataStyle extends BaseElementStyle, NodeLikeStyle {
+  collapsed?: boolean;
+  parentId?: ID;
+}
+
+interface EdgeDataStyle extends BaseElementStyle, EdgeStyle {}
+
+interface BaseElementStyle {
+  /**
+   * <zh/> 默认状态
+   *
+   * <en/> Default state
+   */
+  states?: string[];
+}

--- a/packages/g6/src/spec/element/animation.ts
+++ b/packages/g6/src/spec/element/animation.ts
@@ -1,0 +1,36 @@
+import type { AnimationEffectTiming } from '../../animations/types';
+
+export type AnimationOptions = {
+  [STAGE in AnimationStage]?: StageAnimationOptions;
+} & {
+  [key: string]: StageAnimationOptions;
+};
+
+/**
+ * <zh/> 动画阶段
+ *
+ * <en/> Animation stage
+ */
+export type AnimationStage = 'enter' | 'exit' | 'update' | 'show' | 'hide' | 'transform';
+
+export type StageAnimationOptions = ComponentAnimationOptions | ConfigurableAnimationOptions[];
+
+/**
+ * <zh/> 注册动画的配置项
+ *
+ * <en/> Animation options
+ */
+export interface ComponentAnimationOptions extends AnimationEffectTiming {
+  type: string;
+}
+
+/**
+ * <zh/> 手动配置动画配置项（G6 5.0 初版方案）
+ *
+ * <en/> Manually configure animation options (G6 5.0 first edition plan)
+ */
+export interface ConfigurableAnimationOptions extends AnimationEffectTiming {
+  fields: string[];
+  shape?: string;
+  states?: string[];
+}

--- a/packages/g6/src/spec/element/combo.ts
+++ b/packages/g6/src/spec/element/combo.ts
@@ -1,0 +1,44 @@
+import type { CallableObject } from '../../types/callable';
+import type { NodeData } from '../data';
+import type { AnimationOptions } from './animation';
+import type { NodeLikeStyle } from './node';
+import type { PaletteOptions } from './palette';
+
+/**
+ * <zh/> Combo 配置项
+ *
+ * <en/> Combo spec
+ */
+export type ComboOptions = {
+  /**
+   * <zh/> Combo 样式
+   *
+   * <en/> Combo style
+   */
+  style?: CallableObject<NodeLikeStyle, NodeData>;
+  /**
+   * <zh/> Combo 状态样式
+   *
+   * <en/> Combo state style
+   */
+  state?: Record<string, CallableObject<NodeLikeStyle, NodeData>>;
+  /**
+   * <zh/> Combo 动画
+   *
+   * <en/> Combo animation
+   */
+  animation?: AnimationOptions;
+  /**
+   * <zh/> 色板
+   *
+   * <en/> Palette
+   */
+  palette?: PaletteOptions;
+};
+
+export type StaticComboOptions = {
+  style?: NodeLikeStyle;
+  state?: Record<string, NodeLikeStyle>;
+  animation?: AnimationOptions;
+  palette?: PaletteOptions;
+};

--- a/packages/g6/src/spec/element/edge.ts
+++ b/packages/g6/src/spec/element/edge.ts
@@ -1,0 +1,54 @@
+import type { BaseStyleProps } from '@antv/g';
+import type { CallableObject } from '../../types/callable';
+import type { EdgeData } from '../data';
+import type { AnimationOptions } from './animation';
+import type { PaletteOptions } from './palette';
+
+/**
+ * <zh/> 边配置项
+ *
+ * <en/> Edge spec
+ */
+export type EdgeOptions = {
+  /**
+   * <zh/> 边样式
+   *
+   * <en/> Edge style
+   */
+  style?: CallableObject<EdgeStyle, EdgeData>;
+  /**
+   * <zh/> 边状态样式
+   *
+   * <en/> Edge state style
+   */
+  state?: Record<string, CallableObject<EdgeStyle, EdgeData>>;
+  /**
+   * <zh/> 边动画
+   *
+   * <en/> Edge animation
+   */
+  animation?: AnimationOptions;
+  /**
+   * <zh/> 色板
+   *
+   * <en/> Palette
+   */
+  palette?: PaletteOptions;
+};
+
+export type StaticEdgeOptions = {
+  style?: EdgeStyle;
+  state?: Record<string, EdgeStyle>;
+  animation?: PaletteOptions;
+  palette?: PaletteOptions;
+};
+
+/**
+ * <zh/> 边样式
+ *
+ * <en/> Edge style
+ */
+export type EdgeStyle = Pick<BaseStyleProps, 'cursor' | 'opacity' | 'pointerEvents' | 'visibility' | 'zIndex'> & {
+  states?: string[];
+  type?: string;
+} & Record<string, unknown>;

--- a/packages/g6/src/spec/element/node.ts
+++ b/packages/g6/src/spec/element/node.ts
@@ -1,0 +1,56 @@
+import type { BaseStyleProps } from '@antv/g';
+import type { CallableObject } from '../../types/callable';
+import type { NodeData } from '../data';
+import type { AnimationOptions } from './animation';
+import type { PaletteOptions } from './palette';
+
+/**
+ * <zh/> 节点配置项
+ *
+ * <en/> Node spec
+ */
+export type NodeOptions = {
+  /**
+   * <zh/> 节点样式
+   *
+   * <en/> Node style
+   */
+  style?: CallableObject<NodeLikeStyle, NodeData>;
+  /**
+   * <zh/> 节点状态样式
+   *
+   * <en/> Node state style
+   */
+  state?: Record<string, CallableObject<NodeLikeStyle, NodeData>>;
+  /**
+   * <zh/> 节点动画
+   *
+   * <en/> Node animation
+   */
+  animation?: AnimationOptions;
+  /**
+   * <zh/> 色板
+   *
+   * <en/> Palette
+   */
+  palette?: PaletteOptions;
+};
+
+export type StaticNodeOptions = {
+  style?: NodeLikeStyle;
+  state?: Record<string, NodeLikeStyle>;
+  animation?: AnimationOptions;
+  palette?: PaletteOptions;
+};
+
+/**
+ * <zh/> 节点或 combo 样式
+ *
+ * <en/> Node or combo style
+ */
+export type NodeLikeStyle = Pick<BaseStyleProps, 'cursor' | 'opacity' | 'pointerEvents' | 'visibility' | 'zIndex'> & {
+  type?: string;
+  x?: number;
+  y?: number;
+  z?: number;
+} & Record<string, unknown>;

--- a/packages/g6/src/spec/element/palette.ts
+++ b/packages/g6/src/spec/element/palette.ts
@@ -1,0 +1,56 @@
+import type { Palette } from '../../palettes/types';
+
+/**
+ * <zh/> 色板配置项
+ *
+ * <en/> Palette options
+ * @public
+ */
+export type PaletteOptions = Palette | CategoricalPaletteOptions | ContinuousPaletteOptions;
+
+export type STDPaletteOptions = CategoricalPaletteOptions | ContinuousPaletteOptions;
+
+interface CategoricalPaletteOptions extends BasePaletteOptions {
+  /**
+   * <zh/> 分组取色
+   *
+   * <en/> Coloring by group
+   */
+  type: 'group';
+  /**
+   * <zh/> 分组字段，未指定时基于节点 id 分组
+   *
+   * <en/> Group field, when not specified, group by node id
+   */
+  field?: string;
+}
+
+interface ContinuousPaletteOptions extends BasePaletteOptions {
+  /**
+   * <zh/> 基于字段值取色
+   *
+   * <en/> Coloring based on field value
+   */
+  type: 'value';
+  /**
+   * <zh/> 取值字段
+   *
+   * <en/> Value field
+   */
+  field: string;
+}
+
+export interface BasePaletteOptions {
+  /**
+   * <zh/> 色板颜色
+   *
+   * <en/> Palette color
+   */
+  color: Palette;
+  /**
+   * <zh/> 倒序取色
+   *
+   * <en/> Color in reverse order
+   */
+  invert?: boolean;
+}

--- a/packages/g6/src/spec/index.ts
+++ b/packages/g6/src/spec/index.ts
@@ -1,7 +1,75 @@
+import type { BehaviorOptions } from './behavior';
+import type { CanvasOptions } from './canvas';
+import type { DataOptions } from './data';
+import type { ComboOptions } from './element/combo';
+import type { EdgeOptions } from './element/edge';
+import type { NodeOptions } from './element/node';
+import type { LayoutOptions } from './layout';
+import type { OptimizeOptions } from './optimize';
+import type { ThemeOptions } from './theme';
+import type { ViewportOptions } from './viewport';
+import type { WidgetOptions } from './widget';
+
 /**
  * <zh/> Spec 定义
  *
  * <en/> Specification definition
  */
 
-export {};
+export type G6Spec = CanvasOptions &
+  ViewportOptions & {
+    /**
+     * <zh/> 数据
+     *
+     * <en/> Data
+     */
+    data?: DataOptions;
+    /**
+     * <zh/> 布局
+     *
+     * <en/> Layout
+     */
+    layout?: LayoutOptions;
+    /**
+     * <zh/> 节点
+     *
+     * <en/> Node
+     */
+    node?: NodeOptions;
+    /**
+     * <zh/> 边
+     *
+     * <en/> Edge
+     */
+    edge?: EdgeOptions;
+    /**
+     * <zh/> Combo
+     *
+     * <en/> Combo
+     */
+    combo?: ComboOptions;
+    /**
+     * <zh/> 主题
+     *
+     * <en/> Theme
+     */
+    theme?: ThemeOptions;
+    /**
+     * <zh/> 交互
+     *
+     * <en/> Behaviors
+     */
+    behaviors?: BehaviorOptions;
+    /**
+     * <zh/> 画布插件
+     *
+     * <en/> Canvas widget
+     */
+    widgets?: WidgetOptions;
+    /**
+     * <zh/> 优化选项
+     *
+     * <en/> Optimize options
+     */
+    optimize?: OptimizeOptions;
+  };

--- a/packages/g6/src/spec/layout.ts
+++ b/packages/g6/src/spec/layout.ts
@@ -1,0 +1,22 @@
+import type { BuiltInLayoutOptions } from '../layouts/types';
+import type { NodeData } from './data';
+
+export type LayoutOptions = BuiltInLayoutOptions | CustomLayoutOptions | PipeLayoutOptions[];
+
+type CustomLayoutOptions = STDLayoutOptions;
+
+export interface STDLayoutOptions {
+  type: string;
+  [key: string]: unknown;
+}
+
+export type PipeLayoutOptions = (BuiltInLayoutOptions | CustomLayoutOptions) & {
+  /**
+   * <zh/> 参与该布局的节点
+   *
+   * <en/> Nodes involved in the layout
+   * @param node - <zh/> 节点数据 | <en/> node data
+   * @returns <zh/> 是否参与布局 | <en/> Whether to participate in the layout
+   */
+  nodesFilter: (node: NodeData) => boolean;
+};

--- a/packages/g6/src/spec/optimize.ts
+++ b/packages/g6/src/spec/optimize.ts
@@ -1,0 +1,32 @@
+export type OptimizeOptions = {
+  /**
+   * <zh/> 是否开启首次渲染时的分片渲染，若为 number，则表示开启分片渲染的元素数量上限
+   *
+   * <en/> Whether enable tile rendering for first time. If it is a number, it means the maximum number of elements for tile rendering.
+   */
+  tileFirstRender?: boolean | number;
+  /**
+   * <zh/> 首次渲染时的分片渲染的元素数量上限
+   *
+   * <en/> Tile size for first rendering.
+   */
+  tileFirstRenderSize?: number;
+  /**
+   * <zh/> 是否在 drag-canvas, zoom-canvas 显示/隐藏图形过程中，启用分片渲染。若指定 number，则表示开启分片渲染的元素数量上限。
+   *
+   * <en/> Whether enable tile hiding / showing for behaviors, e.g. hiding shapes while drag-canvas, zoom-canvas.
+   */
+  tileBehavior?: boolean | number;
+  /**
+   * <zh/> 交互的分片渲染单片/一帧渲染的元素数量
+   *
+   * <en/> Tile size for shape optimizing by behaviors, e.g. hiding shapes while drag-canvas, zoom-canvas.  The enableOptimize in behavior configuration has higher priority.
+   */
+  tileBehaviorSize?: number;
+  /**
+   * <zh/> 层级渲染的分片渲染单片/一帧渲染的元素数量
+   *
+   * <en/> Tile size for level of detail changing.
+   */
+  tileLodSize?: number;
+};

--- a/packages/g6/src/spec/theme.ts
+++ b/packages/g6/src/spec/theme.ts
@@ -1,0 +1,11 @@
+import type { BuiltInTheme } from '../themes/types';
+
+/**
+ * <zh/> 主题配置项
+ *
+ * <en/> Theme Options
+ * @public
+ */
+export type ThemeOptions = BuiltInTheme | CustomTheme;
+
+type CustomTheme = string;

--- a/packages/g6/src/spec/viewport.ts
+++ b/packages/g6/src/spec/viewport.ts
@@ -1,0 +1,117 @@
+import type { AnimationEffectTiming } from '../animations/types';
+import type { Padding, STDPadding } from '../types/padding';
+import type { Point } from '../types/point';
+
+/**
+ * <zh/> 视口配置项
+ *
+ * <en/> Viewport
+ * @public
+ */
+export type ViewportOptions = {
+  /**
+   * <zh/> 是否自动适应
+   *
+   * <en/> whether to auto fit
+   */
+  autoFit?: AutoFit;
+  /**
+   * <zh/> 画布内边距
+   *
+   * <en/> canvas padding
+   */
+  padding?: Padding;
+  /**
+   * <zh/> 缩放比例
+   *
+   * <en/> zoom ratio
+   */
+  zoom?: number;
+  /**
+   * <zh/> 缩放范围
+   *
+   * <en/> zoom range
+   */
+  zoomRange?: [number, number];
+};
+
+/**
+ * @internal
+ */
+export type STDViewportOptions = {
+  autoFit?: STDAutoFit;
+  padding?: STDPadding;
+  zoom?: number;
+  zoomRange?: [number, number];
+};
+
+/**
+ * <zh/> 视口自适应规则
+ *
+ * <en/> Viewport auto fit rules
+ * @public
+ */
+export type AutoFit = STDAutoFit | 'view' | 'center';
+
+/**
+ * <zh/> 视口自适应规则(标准属性)
+ *
+ * <en/> Viewport auto fit rules(STD)
+ * @public
+ */
+export type STDAutoFit =
+  | { type: 'view'; padding?: Padding; rule?: FitViewRule; effectTiming?: AnimationEffectTiming }
+  | { type: 'center'; effectTiming?: AnimationEffectTiming }
+  | { type: 'position'; position: Point; alignment?: AlignmentPosition; effectTiming?: AnimationEffectTiming };
+
+export type FitViewRule = {
+  /**
+   * <zh/> 是否仅当图内容超出视窗时，进行适配
+   *
+   * <en/> Whether to fit the view only when the graph content exceeds the viewport
+   */
+  onlyOutOfViewport?: boolean;
+  /**
+   * <zh/> 是否仅当图内容大于视窗时，进行适配
+   *
+   * <en/> Whether to fit the view only when the graph content is larger than the viewport
+   */
+  onlyZoomAtLargerThanViewport?: boolean;
+  /**
+   * <zh/> 适配时限制缩放的方向，默认为 'both'
+   *
+   * <en/> Limit the direction of zoom when fitting, default is 'both'
+   */
+  direction?: 'x' | 'y' | 'both';
+  /**
+   * <zh/> 缩放比例应当根据横、纵方向上的较大者还是较小者
+   *
+   * <en/> Whether the zoom ratio should be based on the larger or smaller of the horizontal and vertical directions
+   */
+  ratioRule?: 'max' | 'min';
+  /**
+   * <zh/> 根据渲染的包围盒进行适配，还是根据节点布局的位置进行适配。默认为 'current'
+   *
+   * - `current` 直接获取当前包围盒
+   *
+   * - `final` 计算布局后的包围盒，适用于当前正在执行布局动画的情况
+   *
+   * <en/> Whether to fit according to the rendered bounding box or the layout position of the node. Default is 'current'
+   *
+   * - `current` Get the current bounds directly.
+   *
+   * - `final` Calculate the bounds after layout, which is suitable for the situation where the layout animation is currently being executed.
+   */
+  boundsType?: 'current' | 'final';
+};
+
+type AlignmentPosition =
+  | 'top'
+  | 'bottom'
+  | 'left'
+  | 'right'
+  | 'center'
+  | 'top-left'
+  | 'top-right'
+  | 'bottom-left'
+  | 'bottom-right';

--- a/packages/g6/src/spec/widget.ts
+++ b/packages/g6/src/spec/widget.ts
@@ -1,0 +1,12 @@
+import type { BuiltInWidgetOptions } from '../widgets/types';
+
+export type WidgetOptions = Abbr<BuiltInWidgetOptions | CustomWidgetOptions>[];
+
+type CustomWidgetOptions = STDWidgetOptions;
+
+export interface STDWidgetOptions {
+  type: string;
+  [key: string]: unknown;
+}
+
+type Abbr<R extends STDWidgetOptions> = (R & { key?: string }) | R['type'];

--- a/packages/g6/src/themes/types.ts
+++ b/packages/g6/src/themes/types.ts
@@ -1,0 +1,1 @@
+export type BuiltInTheme = 'light' | 'dark';

--- a/packages/g6/src/types/callable.ts
+++ b/packages/g6/src/types/callable.ts
@@ -1,0 +1,31 @@
+/**
+ * <zh/> 可回调值
+ *
+ * <en/> Callable value
+ * @example
+ * type Prop = number;
+ * type CallableProp = Callable<Prop>;
+ * const prop1: CallableProp = 1;
+ * const prop2: CallableProp = (value) => value;
+ */
+export type CallableValue<Returns, Param = Returns> = Returns | ((args: Param) => Returns);
+
+/**
+ * <zh/> 可回调对象
+ *
+ * <en/> Callable object
+ * @example
+ * type Style = {
+ *  fill?: string;
+ * }
+ * type CallableObjectStyle = CallableObject<Style, { model: { value: string } }>;
+ * const style1: CallableObjectStyle = {
+ *  fill: 'red',
+ * }
+ * const style2: CallableObjectStyle = {
+ *  fill: ({ model }) => model.value,
+ * }
+ */
+export type CallableObject<Obj extends Record<string, unknown>, Param = never> = {
+  [K in keyof Obj]: CallableValue<Obj[K], Param>;
+};

--- a/packages/g6/src/types/canvas.ts
+++ b/packages/g6/src/types/canvas.ts
@@ -1,0 +1,1 @@
+export type CanvasLayer = 'background' | 'main' | 'label' | 'transient' | 'transientLabel';

--- a/packages/g6/src/types/padding.ts
+++ b/packages/g6/src/types/padding.ts
@@ -1,0 +1,3 @@
+export type Padding = number | number[];
+
+export type STDPadding = [number, number, number, number];

--- a/packages/g6/src/types/point.ts
+++ b/packages/g6/src/types/point.ts
@@ -1,0 +1,3 @@
+import type { Vector2, Vector3 } from './vector';
+
+export type Point = Vector2 | Vector3;

--- a/packages/g6/src/types/vector.ts
+++ b/packages/g6/src/types/vector.ts
@@ -1,0 +1,3 @@
+export type Vector2 = [number, number] | Float32Array;
+
+export type Vector3 = [number, number, number] | Float32Array;

--- a/packages/g6/src/widgets/types.ts
+++ b/packages/g6/src/widgets/types.ts
@@ -1,0 +1,1 @@
+export type BuiltInWidgetOptions = { type: 'unset' };


### PR DESCRIPTION
基于当前 Spec 定义迁移至临时分支，并做了以下调整：
* `data.[element].style` 属性新增 `states`、`collapsed`、`parentId` 支持，用于设置元素默认状态值、展开/收起状态、父节点ID
* `[element].style` 和 `[element].state` 属性中移除 `collapsed` 与 `parentId` 支持
* `[element].animate` 变更为 `[element].animation`，并提供以下写法支持：
```js
const animation = [
  {
    fields: ['opacity'],
    shape: 'keyShape',
    states: ['selected'],
  },
];
```

除此之外还进行了以下类型调整：
* 移除了 `ImmediatelyInvokedLayout` 的支持，可以通过更新数据实现

---

Migrated to a temporary branch based on the current Spec definition, and made the following adjustments:
* The `data.[element].style` property adds `states`, `collapsed`, and `parentId` support to set the default state value, expand/collapse state, and parent node ID of the element
* Remove `collapsed` and `parentId` support in `[element].style` and `[element].state` properties
* `[element].animate` changed to `[element].animation`, and the following writing support is provided:
```js
const animation = [
  {
    fields: ['opacity'],
    shape: 'keyShape',
    states: ['selected'],
  },
];
```

In addition, the following type adjustments have been made:
* Removed support for `ImmediatelyInvokedLayout`, which can be achieved by updating the data
