### PR TITLE
feat: add circle node element

### DIFF
--- a/packages/g6/__tests__/demo/static/index.ts
+++ b/packages/g6/__tests__/demo/static/index.ts
@@ -1,3 +1,4 @@
 export * from './layered-canvas';
+export * from './node-circle';
 export * from './shape-badge';
 export * from './shape-label';

--- a/packages/g6/__tests__/demo/static/index.ts
+++ b/packages/g6/__tests__/demo/static/index.ts
@@ -1,4 +1,5 @@
 export * from './layered-canvas';
 export * from './node-circle';
 export * from './shape-badge';
+export * from './shape-icon';
 export * from './shape-label';

--- a/packages/g6/__tests__/demo/static/node-circle.ts
+++ b/packages/g6/__tests__/demo/static/node-circle.ts
@@ -45,6 +45,9 @@ export const nodeCircle: StaticTestCase = async (context) => {
       iconHeight: 32,
       // halo
       haloOpacity: 0.4,
+      haloStroke: 'grey',
+      haloLineWidth: 12,
+      haloPointerEvents: 'none',
     },
   });
 

--- a/packages/g6/__tests__/demo/static/node-circle.ts
+++ b/packages/g6/__tests__/demo/static/node-circle.ts
@@ -18,7 +18,7 @@ export const nodeCircle: StaticTestCase = async (context) => {
     style: {
       // key
       cx: 300,
-      cy: 300,
+      cy: 100,
       fill: 'red',
       r: 40,
       // label
@@ -48,8 +48,23 @@ export const nodeCircle: StaticTestCase = async (context) => {
     },
   });
 
+  const c3 = new Circle({
+    style: {
+      // key
+      cx: 100,
+      cy: 300,
+      fill: 'pink',
+      r: 40,
+      // icon
+      iconText: 'Y',
+      iconFontSize: 32,
+      iconFill: 'black',
+    },
+  });
+
   await canvas.init();
 
   canvas.appendChild(c1);
   canvas.appendChild(c2);
+  canvas.appendChild(c3);
 };

--- a/packages/g6/__tests__/demo/static/node-circle.ts
+++ b/packages/g6/__tests__/demo/static/node-circle.ts
@@ -5,11 +5,20 @@ export const nodeCircle: StaticTestCase = async (context) => {
   const { canvas } = context;
 
   const c1 = new Circle({
-    // @ts-ignore
     style: {
       // key
       cx: 100,
       cy: 100,
+      fill: 'green',
+      r: 40,
+    },
+  });
+
+  const c2 = new Circle({
+    style: {
+      // key
+      cx: 300,
+      cy: 300,
       fill: 'red',
       r: 40,
       // label
@@ -18,9 +27,18 @@ export const nodeCircle: StaticTestCase = async (context) => {
       labelFill: 'pink',
       labelPosition: 'bottom',
       // badge
-      badgeOptions: [],
+      badgeOptions: [
+        { text: 'A', position: 'right-top', backgroundFill: 'grey', fill: 'white', fontSize: 10, padding: [1, 4] },
+        { text: 'Important', position: 'right', backgroundFill: 'blue', fill: 'white', fontSize: 10 },
+        { text: 'Notice', position: 'left-bottom', backgroundFill: 'red', fill: 'white', fontSize: 10 },
+      ],
       // anchor
-      anchorOptions: [],
+      anchorOptions: [
+        { position: [0, 0.5], r: 2, stroke: 'black', lineWidth: 1, zIndex: 2 },
+        { position: [1, 0.5], r: 2, stroke: 'yellow', lineWidth: 2, zIndex: 2 },
+        { position: [0.5, 0], r: 2, stroke: 'green', lineWidth: 1, zIndex: 2 },
+        { position: [0.5, 1], r: 2, stroke: 'grey', lineWidth: 1, zIndex: 2 },
+      ],
       // icon
       iconSrc: 'https://gw.alipayobjects.com/zos/basement_prod/012bcf4f-423b-4922-8c24-32a89f8c41ce.svg',
       iconWidth: 32,
@@ -33,4 +51,5 @@ export const nodeCircle: StaticTestCase = async (context) => {
   await canvas.init();
 
   canvas.appendChild(c1);
+  canvas.appendChild(c2);
 };

--- a/packages/g6/__tests__/demo/static/node-circle.ts
+++ b/packages/g6/__tests__/demo/static/node-circle.ts
@@ -1,0 +1,36 @@
+import { Circle } from '../../../src/elements/nodes';
+import type { StaticTestCase } from '../types';
+
+export const nodeCircle: StaticTestCase = async (context) => {
+  const { canvas } = context;
+
+  const c1 = new Circle({
+    // @ts-ignore
+    style: {
+      // key
+      cx: 100,
+      cy: 100,
+      fill: 'red',
+      r: 40,
+      // label
+      labelText: 'circle node',
+      labelFontSize: 14,
+      labelFill: 'pink',
+      labelPosition: 'bottom',
+      // badge
+      badgeOptions: [],
+      // anchor
+      anchorOptions: [],
+      // icon
+      iconSrc: 'https://gw.alipayobjects.com/zos/basement_prod/012bcf4f-423b-4922-8c24-32a89f8c41ce.svg',
+      iconWidth: 32,
+      iconHeight: 32,
+      // halo
+      haloOpacity: 0.4,
+    },
+  });
+
+  await canvas.init();
+
+  canvas.appendChild(c1);
+};

--- a/packages/g6/__tests__/demo/static/shape-icon.ts
+++ b/packages/g6/__tests__/demo/static/shape-icon.ts
@@ -1,0 +1,33 @@
+import { Icon } from '../../../src/elements/shapes';
+import type { StaticTestCase } from '../types';
+
+export const shapeIcon: StaticTestCase = async (context) => {
+  const { canvas } = context;
+
+  const i1 = new Icon({
+    style: {
+      text: 'text icon',
+      fontSize: 24,
+      fontWeight: 400,
+      fill: 'black',
+      x: 50,
+      y: 50,
+    },
+  });
+
+  const i2 = new Icon({
+    style: {
+      src: 'https://gw.alipayobjects.com/mdn/rms_6ae20b/afts/img/A*N4ZMS7gHsUIAAAAAAAAAAABkARQnAQ',
+      width: 128,
+      height: 128,
+      x: 150,
+      y: 150,
+      stroke: 'pink',
+    },
+  });
+
+  await canvas.init();
+
+  canvas.appendChild(i1);
+  canvas.appendChild(i2);
+};

--- a/packages/g6/__tests__/integration/snapshots/static/node-circle.svg
+++ b/packages/g6/__tests__/integration/snapshots/static/node-circle.svg
@@ -1,0 +1,105 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="500"
+  height="500"
+  style="background: transparent; position: absolute; outline: none;"
+  color-interpolation-filters="sRGB"
+  tabindex="1"
+>
+  <defs />
+  <g id="g-svg-camera" transform="matrix(1,0,0,1,0,0)">
+    <g
+      id="g-root"
+      fill="none"
+      stroke="none"
+      visibility="visible"
+      font-size="16px"
+      font-family="sans-serif"
+      font-style="normal"
+      font-weight="normal"
+      font-variant="normal"
+      text-anchor="left"
+      stroke-dashoffset="0px"
+      transform="matrix(1,0,0,1,0,0)"
+    >
+      <g
+        id="g-svg-5"
+        fill="rgba(255,0,0,1)"
+        stroke="none"
+        r="40px"
+        transform="matrix(1,0,0,1,0,0)"
+      >
+        <g transform="matrix(1,0,0,1,100,100)">
+          <circle
+            id="node-circle-key"
+            fill="rgba(255,0,0,1)"
+            transform="translate(-40,-40)"
+            cx="40"
+            cy="40"
+            stroke="none"
+            r="40px"
+          />
+        </g>
+        <g
+          id="node-circle-label"
+          fill="rgba(255,192,203,1)"
+          stroke="none"
+          font-size="14px"
+          text-anchor="middle"
+          transform="matrix(1,0,0,1,100,140)"
+        >
+          <g transform="matrix(1,0,0,1,-42.310001,-5)">
+            <path
+              id="background"
+              fill="none"
+              d="M 0,0 l 85.62,0 l 0,37 l-85.62 0 z"
+              stroke="none"
+              width="85.62px"
+              height="37px"
+            />
+          </g>
+          <g
+            font-size="14px"
+            text-anchor="middle"
+            transform="matrix(1,0,0,1,0,0)"
+          >
+            <text
+              id="text"
+              fill="rgba(255,192,203,1)"
+              dominant-baseline="central"
+              paint-order="stroke"
+              dx="0.5"
+              dy="13.5px"
+              stroke="none"
+            >
+              circle node
+            </text>
+          </g>
+        </g>
+        <g opacity="0.4" transform="matrix(1,0,0,1,0,0)">
+          <circle
+            id="node-circle-halo"
+            fill="none"
+            cx="0"
+            cy="0"
+            stroke="none"
+          />
+        </g>
+        <g text-anchor="middle" transform="matrix(1,0,0,1,100,100)">
+          <image
+            id="node-circle-icon"
+            fill="none"
+            preserveAspectRatio="none"
+            x="0"
+            y="0"
+            href="https://gw.alipayobjects.com/zos/basement_prod/012bcf4f-423b-4922-8c24-32a89f8c41ce.svg"
+            transform="translate(-16,-16)"
+            stroke="none"
+            width="32px"
+            height="32px"
+          />
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/packages/g6/__tests__/integration/snapshots/static/node-circle.svg
+++ b/packages/g6/__tests__/integration/snapshots/static/node-circle.svg
@@ -31,7 +31,7 @@
       >
         <g transform="matrix(1,0,0,1,100,100)">
           <circle
-            id="node-circle-key"
+            id="key"
             fill="rgba(0,128,0,1)"
             transform="translate(-40,-40)"
             cx="40"
@@ -41,7 +41,7 @@
           />
         </g>
         <g
-          id="node-circle-label"
+          id="label"
           fill="none"
           stroke="none"
           text-anchor="middle"
@@ -68,34 +68,35 @@
           </g>
         </g>
         <g transform="matrix(1,0,0,1,0,0)">
-          <circle
-            id="node-circle-halo"
-            fill="none"
-            cx="0"
-            cy="0"
-            stroke="none"
-          />
+          <circle id="halo" fill="none" cx="0" cy="0" stroke="none" />
         </g>
-        <g text-anchor="middle" transform="matrix(1,0,0,1,100,100)">
-          <text
-            id="node-circle-icon"
-            fill="rgba(0,0,0,1)"
-            dominant-baseline="central"
-            paint-order="stroke"
-            stroke="none"
-          />
+        <g
+          id="icon"
+          fill="none"
+          stroke="none"
+          transform="matrix(1,0,0,1,100,100)"
+        >
+          <g text-anchor="middle" transform="matrix(1,0,0,1,0,0)">
+            <text
+              id="icon"
+              fill="none"
+              dominant-baseline="central"
+              paint-order="stroke"
+              stroke="none"
+            />
+          </g>
         </g>
       </g>
       <g
-        id="g-svg-12"
+        id="g-svg-13"
         fill="rgba(255,0,0,1)"
         stroke="none"
         r="40px"
         transform="matrix(1,0,0,1,0,0)"
       >
-        <g transform="matrix(1,0,0,1,300,300)">
+        <g transform="matrix(1,0,0,1,300,100)">
           <circle
-            id="node-circle-key"
+            id="key"
             fill="rgba(255,0,0,1)"
             transform="translate(-40,-40)"
             cx="40"
@@ -105,12 +106,12 @@
           />
         </g>
         <g
-          id="node-circle-label"
+          id="label"
           fill="rgba(255,192,203,1)"
           stroke="none"
           font-size="14px"
           text-anchor="middle"
-          transform="matrix(1,0,0,1,300,340)"
+          transform="matrix(1,0,0,1,300,140)"
         >
           <g transform="matrix(1,0,0,1,-42.310001,-5)">
             <path
@@ -141,34 +142,37 @@
           </g>
         </g>
         <g opacity="0.4" transform="matrix(1,0,0,1,0,0)">
-          <circle
-            id="node-circle-halo"
-            fill="none"
-            cx="0"
-            cy="0"
-            stroke="none"
-          />
+          <circle id="halo" fill="none" cx="0" cy="0" stroke="none" />
         </g>
-        <g text-anchor="middle" transform="matrix(1,0,0,1,300,300)">
-          <image
-            id="node-circle-icon"
-            fill="none"
-            preserveAspectRatio="none"
-            x="0"
-            y="0"
-            href="https://gw.alipayobjects.com/zos/basement_prod/012bcf4f-423b-4922-8c24-32a89f8c41ce.svg"
-            transform="translate(-16,-16)"
-            stroke="none"
-            width="32px"
-            height="32px"
-          />
+        <g
+          id="icon"
+          fill="none"
+          stroke="none"
+          width="32px"
+          height="32px"
+          transform="matrix(1,0,0,1,300,100)"
+        >
+          <g transform="matrix(1,0,0,1,0,0)">
+            <image
+              id="icon"
+              fill="none"
+              preserveAspectRatio="none"
+              x="0"
+              y="0"
+              href="https://gw.alipayobjects.com/zos/basement_prod/012bcf4f-423b-4922-8c24-32a89f8c41ce.svg"
+              transform="translate(-16,-16)"
+              stroke="none"
+              width="32px"
+              height="32px"
+            />
+          </g>
         </g>
         <g
           id="node-circle-badge-0"
           fill="rgba(255,255,255,1)"
           stroke="none"
           font-size="10px"
-          transform="matrix(1,0,0,1,340,260)"
+          transform="matrix(1,0,0,1,340,60)"
         >
           <g
             id="label"
@@ -206,7 +210,7 @@
           fill="rgba(255,255,255,1)"
           stroke="none"
           font-size="10px"
-          transform="matrix(1,0,0,1,340,300)"
+          transform="matrix(1,0,0,1,340,100)"
         >
           <g
             id="label"
@@ -244,7 +248,7 @@
           fill="rgba(255,255,255,1)"
           stroke="none"
           font-size="10px"
-          transform="matrix(1,0,0,1,260,340)"
+          transform="matrix(1,0,0,1,260,140)"
         >
           <g
             id="label"
@@ -277,7 +281,7 @@
             </g>
           </g>
         </g>
-        <g transform="matrix(1,0,0,1,260,300)">
+        <g transform="matrix(1,0,0,1,260,100)">
           <circle
             id="node-circle-anchor-0"
             fill="none"
@@ -288,7 +292,7 @@
             r="2px"
           />
         </g>
-        <g stroke-width="2px" transform="matrix(1,0,0,1,340,300)">
+        <g stroke-width="2px" transform="matrix(1,0,0,1,340,100)">
           <circle
             id="node-circle-anchor-1"
             fill="none"
@@ -299,7 +303,7 @@
             r="2px"
           />
         </g>
-        <g transform="matrix(1,0,0,1,300,260)">
+        <g transform="matrix(1,0,0,1,300,60)">
           <circle
             id="node-circle-anchor-2"
             fill="none"
@@ -310,7 +314,7 @@
             r="2px"
           />
         </g>
-        <g transform="matrix(1,0,0,1,300,340)">
+        <g transform="matrix(1,0,0,1,300,140)">
           <circle
             id="node-circle-anchor-3"
             fill="none"
@@ -320,6 +324,79 @@
             stroke="rgba(128,128,128,1)"
             r="2px"
           />
+        </g>
+      </g>
+      <g
+        id="g-svg-37"
+        fill="rgba(255,192,203,1)"
+        stroke="none"
+        r="40px"
+        transform="matrix(1,0,0,1,0,0)"
+      >
+        <g transform="matrix(1,0,0,1,100,300)">
+          <circle
+            id="key"
+            fill="rgba(255,192,203,1)"
+            transform="translate(-40,-40)"
+            cx="40"
+            cy="40"
+            stroke="none"
+            r="40px"
+          />
+        </g>
+        <g
+          id="label"
+          fill="none"
+          stroke="none"
+          text-anchor="middle"
+          transform="matrix(1,0,0,1,100,300)"
+        >
+          <g transform="matrix(1,0,0,1,-5,-5)">
+            <path
+              id="background"
+              fill="none"
+              d="M 0,0 l 10,0 l 0,10 l-10 0 z"
+              stroke="none"
+              width="10px"
+              height="10px"
+            />
+          </g>
+          <g text-anchor="middle" transform="matrix(1,0,0,1,0,0)">
+            <text
+              id="text"
+              fill="none"
+              dominant-baseline="central"
+              paint-order="stroke"
+              stroke="none"
+            />
+          </g>
+        </g>
+        <g transform="matrix(1,0,0,1,0,0)">
+          <circle id="halo" fill="none" cx="0" cy="0" stroke="none" />
+        </g>
+        <g
+          id="icon"
+          fill="rgba(0,0,0,1)"
+          stroke="none"
+          font-size="32px"
+          transform="matrix(1,0,0,1,100,300)"
+        >
+          <g
+            font-size="32px"
+            text-anchor="middle"
+            transform="matrix(1,0,0,1,0,0)"
+          >
+            <text
+              id="icon"
+              fill="rgba(0,0,0,1)"
+              dominant-baseline="central"
+              paint-order="stroke"
+              dx="0.5"
+              stroke="none"
+            >
+              Y
+            </text>
+          </g>
         </g>
       </g>
     </g>

--- a/packages/g6/__tests__/integration/snapshots/static/node-circle.svg
+++ b/packages/g6/__tests__/integration/snapshots/static/node-circle.svg
@@ -24,12 +24,76 @@
     >
       <g
         id="g-svg-5"
-        fill="rgba(255,0,0,1)"
+        fill="rgba(0,128,0,1)"
         stroke="none"
         r="40px"
         transform="matrix(1,0,0,1,0,0)"
       >
         <g transform="matrix(1,0,0,1,100,100)">
+          <circle
+            id="node-circle-key"
+            fill="rgba(0,128,0,1)"
+            transform="translate(-40,-40)"
+            cx="40"
+            cy="40"
+            stroke="none"
+            r="40px"
+          />
+        </g>
+        <g
+          id="node-circle-label"
+          fill="none"
+          stroke="none"
+          text-anchor="middle"
+          transform="matrix(1,0,0,1,100,100)"
+        >
+          <g transform="matrix(1,0,0,1,-5,-5)">
+            <path
+              id="background"
+              fill="none"
+              d="M 0,0 l 10,0 l 0,10 l-10 0 z"
+              stroke="none"
+              width="10px"
+              height="10px"
+            />
+          </g>
+          <g text-anchor="middle" transform="matrix(1,0,0,1,0,0)">
+            <text
+              id="text"
+              fill="none"
+              dominant-baseline="central"
+              paint-order="stroke"
+              stroke="none"
+            />
+          </g>
+        </g>
+        <g transform="matrix(1,0,0,1,0,0)">
+          <circle
+            id="node-circle-halo"
+            fill="none"
+            cx="0"
+            cy="0"
+            stroke="none"
+          />
+        </g>
+        <g text-anchor="middle" transform="matrix(1,0,0,1,100,100)">
+          <text
+            id="node-circle-icon"
+            fill="rgba(0,0,0,1)"
+            dominant-baseline="central"
+            paint-order="stroke"
+            stroke="none"
+          />
+        </g>
+      </g>
+      <g
+        id="g-svg-12"
+        fill="rgba(255,0,0,1)"
+        stroke="none"
+        r="40px"
+        transform="matrix(1,0,0,1,0,0)"
+      >
+        <g transform="matrix(1,0,0,1,300,300)">
           <circle
             id="node-circle-key"
             fill="rgba(255,0,0,1)"
@@ -46,7 +110,7 @@
           stroke="none"
           font-size="14px"
           text-anchor="middle"
-          transform="matrix(1,0,0,1,100,140)"
+          transform="matrix(1,0,0,1,300,340)"
         >
           <g transform="matrix(1,0,0,1,-42.310001,-5)">
             <path
@@ -85,7 +149,7 @@
             stroke="none"
           />
         </g>
-        <g text-anchor="middle" transform="matrix(1,0,0,1,100,100)">
+        <g text-anchor="middle" transform="matrix(1,0,0,1,300,300)">
           <image
             id="node-circle-icon"
             fill="none"
@@ -97,6 +161,164 @@
             stroke="none"
             width="32px"
             height="32px"
+          />
+        </g>
+        <g
+          id="node-circle-badge-0"
+          fill="rgba(255,255,255,1)"
+          stroke="none"
+          font-size="10px"
+          transform="matrix(1,0,0,1,340,260)"
+        >
+          <g
+            id="label"
+            fill="rgba(255,255,255,1)"
+            stroke="none"
+            font-size="10px"
+            transform="matrix(1,0,0,1,0,0)"
+          >
+            <g transform="matrix(1,0,0,1,-4,-13)">
+              <path
+                id="background"
+                fill="rgba(128,128,128,1)"
+                d="M 7.95,0 l 0,0 a 7.95,7.95,0,0,1,7.95,7.95 l 0,5.1 a 7.95,7.95,0,0,1,-7.95,7.95 l 0,0 a 7.95,7.95,0,0,1,-7.95,-7.95 l 0,-5.1 a 7.95,7.95,0,0,1,7.95,-7.95 z"
+                stroke="none"
+                width="15.9px"
+                height="21px"
+              />
+            </g>
+            <g font-size="10px" transform="matrix(1,0,0,1,0,0)">
+              <text
+                id="text"
+                fill="rgba(255,255,255,1)"
+                dominant-baseline="alphabetic"
+                paint-order="stroke"
+                dx="0.5"
+                stroke="none"
+              >
+                A
+              </text>
+            </g>
+          </g>
+        </g>
+        <g
+          id="node-circle-badge-1"
+          fill="rgba(255,255,255,1)"
+          stroke="none"
+          font-size="10px"
+          transform="matrix(1,0,0,1,340,300)"
+        >
+          <g
+            id="label"
+            fill="rgba(255,255,255,1)"
+            stroke="none"
+            font-size="10px"
+            transform="matrix(1,0,0,1,0,0)"
+          >
+            <g transform="matrix(1,0,0,1,-5,-17)">
+              <path
+                id="background"
+                fill="rgba(0,0,255,1)"
+                d="M 14.5,0 l 28.9,0 a 14.5,14.5,0,0,1,14.5,14.5 l 0,0 a 14.5,14.5,0,0,1,-14.5,14.5 l -28.9,0 a 14.5,14.5,0,0,1,-14.5,-14.5 l 0,0 a 14.5,14.5,0,0,1,14.5,-14.5 z"
+                stroke="none"
+                width="57.9px"
+                height="29px"
+              />
+            </g>
+            <g font-size="10px" transform="matrix(1,0,0,1,0,0)">
+              <text
+                id="text"
+                fill="rgba(255,255,255,1)"
+                dominant-baseline="alphabetic"
+                paint-order="stroke"
+                dx="0.5"
+                stroke="none"
+              >
+                Important
+              </text>
+            </g>
+          </g>
+        </g>
+        <g
+          id="node-circle-badge-2"
+          fill="rgba(255,255,255,1)"
+          stroke="none"
+          font-size="10px"
+          transform="matrix(1,0,0,1,260,340)"
+        >
+          <g
+            id="label"
+            fill="rgba(255,255,255,1)"
+            stroke="none"
+            font-size="10px"
+            transform="matrix(1,0,0,1,0,0)"
+          >
+            <g transform="matrix(1,0,0,1,-5,-17)">
+              <path
+                id="background"
+                fill="rgba(255,0,0,1)"
+                d="M 14.5,0 l 13.400000000000006,0 a 14.5,14.5,0,0,1,14.5,14.5 l 0,0 a 14.5,14.5,0,0,1,-14.5,14.5 l -13.400000000000006,0 a 14.5,14.5,0,0,1,-14.5,-14.5 l 0,0 a 14.5,14.5,0,0,1,14.5,-14.5 z"
+                stroke="none"
+                width="42.400000000000006px"
+                height="29px"
+              />
+            </g>
+            <g font-size="10px" transform="matrix(1,0,0,1,0,0)">
+              <text
+                id="text"
+                fill="rgba(255,255,255,1)"
+                dominant-baseline="alphabetic"
+                paint-order="stroke"
+                dx="0.5"
+                stroke="none"
+              >
+                Notice
+              </text>
+            </g>
+          </g>
+        </g>
+        <g transform="matrix(1,0,0,1,260,300)">
+          <circle
+            id="node-circle-anchor-0"
+            fill="none"
+            transform="translate(-2,-2)"
+            cx="2"
+            cy="2"
+            stroke="rgba(0,0,0,1)"
+            r="2px"
+          />
+        </g>
+        <g stroke-width="2px" transform="matrix(1,0,0,1,340,300)">
+          <circle
+            id="node-circle-anchor-1"
+            fill="none"
+            transform="translate(-2,-2)"
+            cx="2"
+            cy="2"
+            stroke="rgba(255,255,0,1)"
+            r="2px"
+          />
+        </g>
+        <g transform="matrix(1,0,0,1,300,260)">
+          <circle
+            id="node-circle-anchor-2"
+            fill="none"
+            transform="translate(-2,-2)"
+            cx="2"
+            cy="2"
+            stroke="rgba(0,128,0,1)"
+            r="2px"
+          />
+        </g>
+        <g transform="matrix(1,0,0,1,300,340)">
+          <circle
+            id="node-circle-anchor-3"
+            fill="none"
+            transform="translate(-2,-2)"
+            cx="2"
+            cy="2"
+            stroke="rgba(128,128,128,1)"
+            r="2px"
           />
         </g>
       </g>

--- a/packages/g6/__tests__/integration/snapshots/static/node-circle.svg
+++ b/packages/g6/__tests__/integration/snapshots/static/node-circle.svg
@@ -67,8 +67,16 @@
             />
           </g>
         </g>
-        <g transform="matrix(1,0,0,1,0,0)">
-          <circle id="halo" fill="none" cx="0" cy="0" stroke="none" />
+        <g transform="matrix(1,0,0,1,100,100)">
+          <circle
+            id="halo"
+            fill="rgba(0,128,0,1)"
+            transform="translate(-40,-40)"
+            cx="40"
+            cy="40"
+            stroke="none"
+            r="40px"
+          />
         </g>
         <g
           id="icon"
@@ -141,8 +149,21 @@
             </text>
           </g>
         </g>
-        <g opacity="0.4" transform="matrix(1,0,0,1,0,0)">
-          <circle id="halo" fill="none" cx="0" cy="0" stroke="none" />
+        <g
+          opacity="0.4"
+          pointer-events="none"
+          stroke-width="12px"
+          transform="matrix(1,0,0,1,300,100)"
+        >
+          <circle
+            id="halo"
+            fill="rgba(255,0,0,1)"
+            transform="translate(-40,-40)"
+            cx="40"
+            cy="40"
+            stroke="rgba(128,128,128,1)"
+            r="40px"
+          />
         </g>
         <g
           id="icon"
@@ -168,7 +189,7 @@
           </g>
         </g>
         <g
-          id="node-circle-badge-0"
+          id="badge-0"
           fill="rgba(255,255,255,1)"
           stroke="none"
           font-size="10px"
@@ -206,7 +227,7 @@
           </g>
         </g>
         <g
-          id="node-circle-badge-1"
+          id="badge-1"
           fill="rgba(255,255,255,1)"
           stroke="none"
           font-size="10px"
@@ -244,7 +265,7 @@
           </g>
         </g>
         <g
-          id="node-circle-badge-2"
+          id="badge-2"
           fill="rgba(255,255,255,1)"
           stroke="none"
           font-size="10px"
@@ -283,7 +304,7 @@
         </g>
         <g transform="matrix(1,0,0,1,260,100)">
           <circle
-            id="node-circle-anchor-0"
+            id="anchor-0"
             fill="none"
             transform="translate(-2,-2)"
             cx="2"
@@ -294,7 +315,7 @@
         </g>
         <g stroke-width="2px" transform="matrix(1,0,0,1,340,100)">
           <circle
-            id="node-circle-anchor-1"
+            id="anchor-1"
             fill="none"
             transform="translate(-2,-2)"
             cx="2"
@@ -305,7 +326,7 @@
         </g>
         <g transform="matrix(1,0,0,1,300,60)">
           <circle
-            id="node-circle-anchor-2"
+            id="anchor-2"
             fill="none"
             transform="translate(-2,-2)"
             cx="2"
@@ -316,7 +337,7 @@
         </g>
         <g transform="matrix(1,0,0,1,300,140)">
           <circle
-            id="node-circle-anchor-3"
+            id="anchor-3"
             fill="none"
             transform="translate(-2,-2)"
             cx="2"
@@ -371,8 +392,16 @@
             />
           </g>
         </g>
-        <g transform="matrix(1,0,0,1,0,0)">
-          <circle id="halo" fill="none" cx="0" cy="0" stroke="none" />
+        <g transform="matrix(1,0,0,1,100,300)">
+          <circle
+            id="halo"
+            fill="rgba(255,192,203,1)"
+            transform="translate(-40,-40)"
+            cx="40"
+            cy="40"
+            stroke="none"
+            r="40px"
+          />
         </g>
         <g
           id="icon"

--- a/packages/g6/__tests__/integration/snapshots/static/shape-icon.svg
+++ b/packages/g6/__tests__/integration/snapshots/static/shape-icon.svg
@@ -1,0 +1,76 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="500"
+  height="500"
+  style="background: transparent; position: absolute; outline: none;"
+  color-interpolation-filters="sRGB"
+  tabindex="1"
+>
+  <defs />
+  <g id="g-svg-camera" transform="matrix(1,0,0,1,0,0)">
+    <g
+      id="g-root"
+      fill="none"
+      stroke="none"
+      visibility="visible"
+      font-size="16px"
+      font-family="sans-serif"
+      font-style="normal"
+      font-weight="normal"
+      font-variant="normal"
+      text-anchor="left"
+      stroke-dashoffset="0px"
+      transform="matrix(1,0,0,1,0,0)"
+    >
+      <g
+        id="g-svg-5"
+        fill="rgba(0,0,0,1)"
+        stroke="none"
+        font-size="24px"
+        font-weight="400"
+        transform="matrix(1,0,0,1,50,50)"
+      >
+        <g
+          font-size="24px"
+          font-weight="400"
+          text-anchor="middle"
+          transform="matrix(1,0,0,1,0,0)"
+        >
+          <text
+            id="icon"
+            fill="rgba(0,0,0,1)"
+            dominant-baseline="central"
+            paint-order="stroke"
+            dx="0.5"
+            stroke="none"
+          >
+            text icon
+          </text>
+        </g>
+      </g>
+      <g
+        id="g-svg-7"
+        fill="none"
+        stroke="rgba(255,192,203,1)"
+        width="128px"
+        height="128px"
+        transform="matrix(1,0,0,1,150,150)"
+      >
+        <g transform="matrix(1,0,0,1,0,0)">
+          <image
+            id="icon"
+            fill="none"
+            preserveAspectRatio="none"
+            x="0"
+            y="0"
+            href="https://gw.alipayobjects.com/mdn/rms_6ae20b/afts/img/A*N4ZMS7gHsUIAAAAAAAAAAABkARQnAQ"
+            transform="translate(-64,-64)"
+            stroke="rgba(255,192,203,1)"
+            width="128px"
+            height="128px"
+          />
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/packages/g6/__tests__/unit/utils/element.spec.ts
+++ b/packages/g6/__tests__/unit/utils/element.spec.ts
@@ -15,6 +15,8 @@ describe('element', () => {
     expect(getXYByPosition(bbox, 'right-bottom')).toEqual([200, 200]);
 
     expect(getXYByPosition(bbox, 'center')).toEqual([150, 150]);
+
+    expect(getXYByPosition(bbox)).toEqual([150, 150]);
   });
 
   it('getAnchorPosition', () => {
@@ -69,6 +71,13 @@ describe('element', () => {
     });
 
     expect(getTextStyleByPosition(bbox, 'center')).toEqual({
+      x: 150,
+      y: 150,
+      textAlign: 'center',
+      textBaseline: 'middle',
+    });
+
+    expect(getTextStyleByPosition(bbox)).toEqual({
       x: 150,
       y: 150,
       textAlign: 'center',

--- a/packages/g6/__tests__/unit/utils/element.spec.ts
+++ b/packages/g6/__tests__/unit/utils/element.spec.ts
@@ -1,0 +1,78 @@
+import { AABB } from '@antv/g';
+import { getAnchorPosition, getTextStyleByPosition, getXYByPosition } from '../../../src/utils/element';
+
+describe('element', () => {
+  const bbox = new AABB();
+  bbox.setMinMax([100, 100, 0], [200, 200, 0]);
+
+  it('getXYByPosition', () => {
+    expect(getXYByPosition(bbox, 'left')).toEqual([100, 150]);
+    expect(getXYByPosition(bbox, 'right')).toEqual([200, 150]);
+    expect(getXYByPosition(bbox, 'top')).toEqual([150, 100]);
+    expect(getXYByPosition(bbox, 'bottom')).toEqual([150, 200]);
+
+    expect(getXYByPosition(bbox, 'left-top')).toEqual([100, 100]);
+    expect(getXYByPosition(bbox, 'right-bottom')).toEqual([200, 200]);
+
+    expect(getXYByPosition(bbox, 'center')).toEqual([150, 150]);
+  });
+
+  it('getAnchorPosition', () => {
+    expect(getAnchorPosition(bbox, 'left')).toEqual([100, 150]);
+    expect(getAnchorPosition(bbox, 'right')).toEqual([200, 150]);
+    expect(getAnchorPosition(bbox, 'top')).toEqual([150, 100]);
+    expect(getAnchorPosition(bbox, 'bottom')).toEqual([150, 200]);
+
+    expect(getAnchorPosition(bbox)).toEqual([150, 150]);
+
+    expect(getAnchorPosition(bbox, [0.5, 1])).toEqual([150, 200]);
+    expect(getAnchorPosition(bbox, [0, 0.5])).toEqual([100, 150]);
+  });
+
+  it('getTextStyleByPosition', () => {
+    expect(getTextStyleByPosition(bbox, 'left')).toEqual({
+      x: 100,
+      y: 150,
+      textAlign: 'right',
+      textBaseline: 'middle',
+    });
+    expect(getTextStyleByPosition(bbox, 'right')).toEqual({
+      x: 200,
+      y: 150,
+      textAlign: 'left',
+      textBaseline: 'middle',
+    });
+    expect(getTextStyleByPosition(bbox, 'top')).toEqual({
+      x: 150,
+      y: 100,
+      textAlign: 'center',
+      textBaseline: 'bottom',
+    });
+    expect(getTextStyleByPosition(bbox, 'bottom')).toEqual({
+      x: 150,
+      y: 200,
+      textAlign: 'center',
+      textBaseline: 'top',
+    });
+
+    expect(getTextStyleByPosition(bbox, 'left-top')).toEqual({
+      x: 100,
+      y: 100,
+      textAlign: 'right',
+      textBaseline: 'bottom',
+    });
+    expect(getTextStyleByPosition(bbox, 'right-bottom')).toEqual({
+      x: 200,
+      y: 200,
+      textAlign: 'left',
+      textBaseline: 'top',
+    });
+
+    expect(getTextStyleByPosition(bbox, 'center')).toEqual({
+      x: 150,
+      y: 150,
+      textAlign: 'center',
+      textBaseline: 'middle',
+    });
+  });
+});

--- a/packages/g6/__tests__/unit/utils/prefix.spec.ts
+++ b/packages/g6/__tests__/unit/utils/prefix.spec.ts
@@ -1,5 +1,6 @@
 import {
   addPrefix,
+  omitStyleProps,
   removePrefix,
   replacePrefix,
   startsWith,
@@ -33,9 +34,15 @@ describe('prefix', () => {
 
   it('subStyleProps', () => {
     expect(subStyleProps({ prefixAbc: 1, prefixDef: 2, Abc: 3 }, 'prefix')).toEqual({ abc: 1, def: 2 });
-    expect(subStyleProps({ prefixAbc: 1, prefixDef: 2, Abc: 3 }, 'prefix')).toEqual({ abc: 1, def: 2 });
     expect(subStyleProps({ Abc: 1, Def: 2 }, 'prefix')).toEqual({});
     expect(subStyleProps({}, 'prefix')).toEqual({});
+  });
+
+  it('omitStyleProps', () => {
+    expect(omitStyleProps({ prefixAbc: 1, prefixDef: 2, Abc: 3 }, 'prefix')).toEqual({ Abc: 3 });
+    expect(omitStyleProps({ Abc: 1, Def: 2 }, 'prefix')).toEqual({ Abc: 1, Def: 2 });
+    expect(omitStyleProps({}, 'prefix')).toEqual({});
+    expect(omitStyleProps({ prefixAbc: 1, prefixDef: 2, labelAbc: 3 }, ['prefix', 'label'])).toEqual({});
   });
 
   it('superStyleProps', () => {

--- a/packages/g6/src/elements/nodes/circle.ts
+++ b/packages/g6/src/elements/nodes/circle.ts
@@ -1,0 +1,36 @@
+import { DisplayObjectConfig, CircleStyleProps as GCircleStyleProps } from '@antv/g';
+import { deepMix } from '@antv/util';
+import { BadgeStyleProps } from 'elements/shapes/badge';
+import type { PrefixObject } from '../../types';
+import { BaseShape, BaseShapeStyleProps } from '../shapes';
+import { LabelStyleProps } from '../shapes/label';
+
+export type CircleStyleProps = BaseShapeStyleProps &
+  GCircleStyleProps &
+  PrefixObject<LabelStyleProps, 'label'> &
+  PrefixObject<GCircleStyleProps, 'halo'> &
+  PrefixObject<BadgeStyleProps, 'badge'> &
+  PrefixObject<GCircleStyleProps, 'anchor'>;
+
+type ParsedCircleStyleProps = Required<CircleStyleProps>;
+
+export type CircleOptions = DisplayObjectConfig<ParsedCircleStyleProps>;
+
+/**
+ * Design document: https://www.yuque.com/antv/g6/gl1iof1xpzg6ed98
+ * - key
+ * - label, background included
+ * - halo
+ * - icon
+ * - badges
+ * - anchors / ports
+ */
+export class Circle extends BaseShape<CircleStyleProps> {
+  static defaultStyleProps: Partial<CircleStyleProps> = {};
+
+  constructor(options) {
+    super(deepMix({}, { style: Circle.defaultStyleProps }, options));
+  }
+
+  render() {}
+}

--- a/packages/g6/src/elements/nodes/circle.ts
+++ b/packages/g6/src/elements/nodes/circle.ts
@@ -10,7 +10,7 @@ import { Badge, BaseShape, Icon, Label } from '../shapes';
 
 type NodeLabelStyleProps = LabelStyleProps & { position: LabelPosition };
 type NodeBadgeStyleProps = BadgeStyleProps & { position: BadgePosition };
-type NodeAnchorStyleProps = GCircleStyleProps & { position: AnchorPosition };
+type NodeAnchorStyleProps = GCircleStyleProps & { key?: string; position: AnchorPosition };
 type NodeIconStyleProps = IconStyleProps;
 
 export type CircleStyleProps = BaseShapeStyleProps &
@@ -141,7 +141,8 @@ export class Circle extends BaseShape<CircleStyleProps> {
     // 6. anchors
     const anchorStyle = this.getAnchorsStyle(attributes);
     anchorStyle.forEach((anchorStyle, i) => {
-      this.upsert(`anchor-${i}`, GCircle, anchorStyle, container);
+      const { key } = anchorStyle;
+      this.upsert(`anchor-${key ? key : i}`, GCircle, anchorStyle, container);
     });
   }
 

--- a/packages/g6/src/elements/nodes/circle.ts
+++ b/packages/g6/src/elements/nodes/circle.ts
@@ -1,16 +1,50 @@
-import { DisplayObjectConfig, CircleStyleProps as GCircleStyleProps } from '@antv/g';
+import {
+  DisplayObjectConfig,
+  Circle as GCircle,
+  CircleStyleProps as GCircleStyleProps,
+  Image as GImage,
+  Text as GText,
+  Group,
+  ImageStyleProps,
+  TextStyleProps,
+} from '@antv/g';
 import { deepMix } from '@antv/util';
-import { BadgeStyleProps } from 'elements/shapes/badge';
 import type { PrefixObject } from '../../types';
+import type { AnchorPosition, BadgePosition, LabelPosition } from '../../types/node';
+import { getAnchorPosition, getTextStyleByPosition, getXYByPosition } from '../../utils/element';
+import { omitStyleProps, subStyleProps } from '../../utils/prefix';
 import { BaseShape, BaseShapeStyleProps } from '../shapes';
-import { LabelStyleProps } from '../shapes/label';
+import { Badge, BadgeStyleProps } from '../shapes/badge';
+import { Label, LabelStyleProps } from '../shapes/label';
+
+type NodeLabelStyleProps = LabelStyleProps & { position: LabelPosition };
+type NodeBadgeStyleProps = BadgeStyleProps & { position: BadgePosition };
+type NodeAnchorStyleProps = GCircleStyleProps & { position: AnchorPosition };
+type NodeIconStyleProps = ImageStyleProps | TextStyleProps;
 
 export type CircleStyleProps = BaseShapeStyleProps &
+  // Key
   GCircleStyleProps &
-  PrefixObject<LabelStyleProps, 'label'> &
+  // Label
+  PrefixObject<NodeLabelStyleProps, 'label'> &
+  // Halo
   PrefixObject<GCircleStyleProps, 'halo'> &
-  PrefixObject<BadgeStyleProps, 'badge'> &
-  PrefixObject<GCircleStyleProps, 'anchor'>;
+  // Icon
+  PrefixObject<NodeIconStyleProps, 'icon'> &
+  // Badge
+  PrefixObject<
+    {
+      options: NodeBadgeStyleProps[];
+    },
+    'badge'
+  > &
+  // Anchor
+  PrefixObject<
+    {
+      options: NodeAnchorStyleProps[];
+    },
+    'anchor'
+  >;
 
 type ParsedCircleStyleProps = Required<CircleStyleProps>;
 
@@ -18,7 +52,7 @@ export type CircleOptions = DisplayObjectConfig<ParsedCircleStyleProps>;
 
 /**
  * Design document: https://www.yuque.com/antv/g6/gl1iof1xpzg6ed98
- * - key
+ * - key [default]
  * - label, background included
  * - halo
  * - icon
@@ -28,9 +62,91 @@ export type CircleOptions = DisplayObjectConfig<ParsedCircleStyleProps>;
 export class Circle extends BaseShape<CircleStyleProps> {
   static defaultStyleProps: Partial<CircleStyleProps> = {};
 
-  constructor(options) {
+  constructor(options: CircleOptions) {
     super(deepMix({}, { style: Circle.defaultStyleProps }, options));
   }
 
-  render() {}
+  protected getKeyStyle(attributes: CircleStyleProps) {
+    const style = this.getGraphicStyle(attributes);
+    return omitStyleProps<CircleStyleProps>(style, ['label', 'halo', 'icon', 'badge', 'anchor']);
+  }
+
+  protected getLabelStyle(attributes: CircleStyleProps) {
+    const style = this.getGraphicStyle(attributes);
+    return subStyleProps<CircleStyleProps>(style, 'label') as unknown as NodeLabelStyleProps;
+  }
+
+  protected getHaloStyle(attributes: CircleStyleProps) {
+    const style = this.getGraphicStyle(attributes);
+    return subStyleProps<CircleStyleProps>(style, 'halo');
+  }
+
+  protected getIconStyle(attributes: CircleStyleProps) {
+    const style = subStyleProps<CircleStyleProps>(this.getGraphicStyle(attributes), 'icon');
+    // If src exist, use G Image to draw.
+    // @ts-ignore
+    const defaultStyle = style.src ? { anchor: [0.5, 0.5] } : { textAlign: 'center', textBaseline: 'middle' };
+
+    return { ...defaultStyle, ...style } as NodeIconStyleProps;
+  }
+
+  protected getBadgesStyle(attributes: CircleStyleProps) {
+    return this.getGraphicStyle(attributes).badgeOptions as unknown as NodeBadgeStyleProps[];
+  }
+
+  protected getAnchorsStyle(attributes: CircleStyleProps) {
+    return this.getGraphicStyle(attributes).badgeOptions as unknown as NodeAnchorStyleProps[];
+  }
+
+  public render(attributes = this.attributes as ParsedCircleStyleProps, container: Group = this) {
+    // 1. key shape
+    const keyShape = this.upsert('node-circle-key', GCircle, this.getKeyStyle(attributes), container);
+    if (!keyShape) return;
+
+    // 2. label
+    const { position, ...labelStyle } = this.getLabelStyle(attributes);
+    this.upsert(
+      'node-circle-label',
+      Label,
+      {
+        ...getTextStyleByPosition(keyShape.getLocalBounds(), position),
+        ...labelStyle,
+      },
+      container,
+    );
+
+    // TODO: 3. halo
+    this.upsert('node-circle-halo', GCircle, this.getHaloStyle(attributes), container);
+
+    // 4. icon
+    const iconStyle = this.getIconStyle(attributes);
+    this.upsert(
+      'node-circle-icon',
+      // @ts-ignore
+      iconStyle.src ? GImage : GText,
+      {
+        ...getTextStyleByPosition(keyShape.getLocalBounds(), 'center'),
+        ...iconStyle,
+      },
+      container,
+    );
+
+    // 5. badges
+    const badgesStyle = this.getBadgesStyle(attributes);
+    badgesStyle.forEach((badgeStyle, i) => {
+      const { position, ...style } = badgeStyle;
+      const [x, y] = getXYByPosition(keyShape.getLocalBounds(), position);
+      this.upsert(`node-circle-badge-${i}`, Badge, { x, y, ...style }, container);
+    });
+
+    // 6. anchors
+    const anchorStyle = this.getAnchorsStyle(attributes);
+    anchorStyle.forEach((anchorStyle, i) => {
+      const { position, ...style } = anchorStyle;
+      const [cx, cy] = getAnchorPosition(keyShape.getLocalBounds(), position);
+      this.upsert(`node-circle-anchor-${i}`, GCircle, { cx, cy, ...style }, container);
+    });
+  }
+
+  connectedCallback() {}
 }

--- a/packages/g6/src/elements/nodes/circle.ts
+++ b/packages/g6/src/elements/nodes/circle.ts
@@ -1,13 +1,4 @@
-import {
-  DisplayObjectConfig,
-  Circle as GCircle,
-  CircleStyleProps as GCircleStyleProps,
-  Image as GImage,
-  Text as GText,
-  Group,
-  ImageStyleProps,
-  TextStyleProps,
-} from '@antv/g';
+import { DisplayObjectConfig, Circle as GCircle, CircleStyleProps as GCircleStyleProps, Group } from '@antv/g';
 import { deepMix } from '@antv/util';
 import type { PrefixObject } from '../../types';
 import type { AnchorPosition, BadgePosition, LabelPosition } from '../../types/node';
@@ -15,12 +6,13 @@ import { getAnchorPosition, getTextStyleByPosition, getXYByPosition } from '../.
 import { omitStyleProps, subStyleProps } from '../../utils/prefix';
 import { BaseShape, BaseShapeStyleProps } from '../shapes';
 import { Badge, BadgeStyleProps } from '../shapes/badge';
+import { Icon, IconStyleProps } from '../shapes/icon';
 import { Label, LabelStyleProps } from '../shapes/label';
 
 type NodeLabelStyleProps = LabelStyleProps & { position: LabelPosition };
 type NodeBadgeStyleProps = BadgeStyleProps & { position: BadgePosition };
 type NodeAnchorStyleProps = GCircleStyleProps & { position: AnchorPosition };
-type NodeIconStyleProps = ImageStyleProps | TextStyleProps;
+type NodeIconStyleProps = IconStyleProps;
 
 export type CircleStyleProps = BaseShapeStyleProps &
   // Key
@@ -82,12 +74,7 @@ export class Circle extends BaseShape<CircleStyleProps> {
   }
 
   protected getIconStyle(attributes: CircleStyleProps) {
-    const style = subStyleProps<CircleStyleProps>(this.getGraphicStyle(attributes), 'icon');
-    // If src exist, use G Image to draw.
-    // @ts-ignore
-    const defaultStyle = style.src ? { anchor: [0.5, 0.5] } : { textAlign: 'center', textBaseline: 'middle' };
-
-    return { ...defaultStyle, ...style } as NodeIconStyleProps;
+    return subStyleProps<CircleStyleProps>(this.getGraphicStyle(attributes), 'icon');
   }
 
   protected getBadgesStyle(attributes: CircleStyleProps) {
@@ -100,13 +87,13 @@ export class Circle extends BaseShape<CircleStyleProps> {
 
   public render(attributes = this.attributes as ParsedCircleStyleProps, container: Group = this) {
     // 1. key shape
-    const keyShape = this.upsert('node-circle-key', GCircle, this.getKeyStyle(attributes), container);
+    const keyShape = this.upsert('key', GCircle, this.getKeyStyle(attributes), container);
     if (!keyShape) return;
 
     // 2. label
     const { position, ...labelStyle } = this.getLabelStyle(attributes);
     this.upsert(
-      'node-circle-label',
+      'label',
       Label,
       {
         ...getTextStyleByPosition(keyShape.getLocalBounds(), position),
@@ -116,18 +103,20 @@ export class Circle extends BaseShape<CircleStyleProps> {
     );
 
     // TODO: 3. halo
-    this.upsert('node-circle-halo', GCircle, this.getHaloStyle(attributes), container);
+    this.upsert('halo', GCircle, this.getHaloStyle(attributes), container);
 
     // 4. icon
     const iconStyle = this.getIconStyle(attributes);
+    const [iconX, iconY] = getXYByPosition(keyShape.getLocalBounds(), 'center');
+
     this.upsert(
-      'node-circle-icon',
-      // @ts-ignore
-      iconStyle.src ? GImage : GText,
+      'icon',
+      Icon,
       {
-        ...getTextStyleByPosition(keyShape.getLocalBounds(), 'center'),
+        x: iconX,
+        y: iconY,
         ...iconStyle,
-      },
+      } as IconStyleProps,
       container,
     );
 

--- a/packages/g6/src/elements/nodes/circle.ts
+++ b/packages/g6/src/elements/nodes/circle.ts
@@ -1,13 +1,12 @@
-import { DisplayObjectConfig, Circle as GCircle, CircleStyleProps as GCircleStyleProps, Group } from '@antv/g';
+import type { DisplayObjectConfig, CircleStyleProps as GCircleStyleProps, Group } from '@antv/g';
+import { Circle as GCircle } from '@antv/g';
 import { deepMix } from '@antv/util';
 import type { PrefixObject } from '../../types';
 import type { AnchorPosition, BadgePosition, LabelPosition } from '../../types/node';
 import { getAnchorPosition, getTextStyleByPosition, getXYByPosition } from '../../utils/element';
 import { omitStyleProps, subStyleProps } from '../../utils/prefix';
-import { BaseShape, BaseShapeStyleProps } from '../shapes';
-import { Badge, BadgeStyleProps } from '../shapes/badge';
-import { Icon, IconStyleProps } from '../shapes/icon';
-import { Label, LabelStyleProps } from '../shapes/label';
+import type { BadgeStyleProps, BaseShapeStyleProps, IconStyleProps, LabelStyleProps } from '../shapes';
+import { Badge, BaseShape, Icon, Label } from '../shapes';
 
 type NodeLabelStyleProps = LabelStyleProps & { position: LabelPosition };
 type NodeBadgeStyleProps = BadgeStyleProps & { position: BadgePosition };
@@ -64,7 +63,7 @@ export class Circle extends BaseShape<CircleStyleProps> {
   }
 
   protected getLabelStyle(attributes: CircleStyleProps) {
-    const { position, ...labelStyle } = subStyleProps<CircleStyleProps>(
+    const { position, ...labelStyle } = subStyleProps<NodeLabelStyleProps>(
       this.getGraphicStyle(attributes),
       'label',
     ) as unknown as NodeLabelStyleProps;

--- a/packages/g6/src/elements/nodes/circle.ts
+++ b/packages/g6/src/elements/nodes/circle.ts
@@ -48,7 +48,7 @@ export type CircleStyleProps = BaseShapeStyleProps &
 
 type ParsedCircleStyleProps = Required<CircleStyleProps>;
 
-export type CircleOptions = DisplayObjectConfig<ParsedCircleStyleProps>;
+export type CircleOptions = DisplayObjectConfig<CircleStyleProps>;
 
 /**
  * Design document: https://www.yuque.com/antv/g6/gl1iof1xpzg6ed98
@@ -91,11 +91,11 @@ export class Circle extends BaseShape<CircleStyleProps> {
   }
 
   protected getBadgesStyle(attributes: CircleStyleProps) {
-    return this.getGraphicStyle(attributes).badgeOptions as unknown as NodeBadgeStyleProps[];
+    return this.getGraphicStyle(attributes).badgeOptions || ([] as unknown as NodeBadgeStyleProps[]);
   }
 
   protected getAnchorsStyle(attributes: CircleStyleProps) {
-    return this.getGraphicStyle(attributes).badgeOptions as unknown as NodeAnchorStyleProps[];
+    return this.getGraphicStyle(attributes).anchorOptions || ([] as unknown as NodeAnchorStyleProps[]);
   }
 
   public render(attributes = this.attributes as ParsedCircleStyleProps, container: Group = this) {

--- a/packages/g6/src/elements/nodes/index.ts
+++ b/packages/g6/src/elements/nodes/index.ts
@@ -1,0 +1,3 @@
+export { Circle } from './circle';
+
+export type { CircleOptions } from './circle';

--- a/packages/g6/src/elements/shapes/base-shape.ts
+++ b/packages/g6/src/elements/shapes/base-shape.ts
@@ -1,6 +1,6 @@
 import type { DisplayObject, DisplayObjectConfig, Group, GroupStyleProps, IAnimation } from '@antv/g';
 import { CustomElement } from '@antv/g';
-import { deepMix, isBoolean, isNil } from '@antv/util';
+import { deepMix, isNil } from '@antv/util';
 import { createAnimationsProxy } from '../../utils/animation';
 
 export interface BaseShapeStyleProps extends GroupStyleProps {}
@@ -46,7 +46,7 @@ export abstract class BaseShape<T extends BaseShapeStyleProps> extends CustomEle
     const target = this.shapeMap[key];
     // remove
     // 如果 style 为 false，则删除图形 / remove shape if style is false
-    if (target && isBoolean(style) && !style) {
+    if (target && style === false) {
       container.removeChild(target);
       delete this.shapeMap[key];
       return;

--- a/packages/g6/src/elements/shapes/icon.ts
+++ b/packages/g6/src/elements/shapes/icon.ts
@@ -1,0 +1,46 @@
+import { DisplayObjectConfig, Image as GImage, Text as GText, Group, ImageStyleProps, TextStyleProps } from '@antv/g';
+import { deepMix } from '@antv/util';
+import type { BaseShapeStyleProps } from './base-shape';
+import { BaseShape } from './base-shape';
+
+export type IconStyleProps = BaseShapeStyleProps & Partial<TextStyleProps> & Partial<ImageStyleProps>;
+
+export type IconOptions = DisplayObjectConfig<IconStyleProps>;
+
+export class Icon extends BaseShape<IconStyleProps> {
+  static defaultStyleProps: Partial<IconStyleProps> = {};
+
+  constructor(options: IconOptions) {
+    super(deepMix({}, { style: Icon.defaultStyleProps }, options));
+  }
+
+  private isGImage() {
+    return !!this.getAttribute('src');
+  }
+
+  protected getIconStyle(attributes: IconStyleProps = this.attributes): IconStyleProps {
+    const style = this.getGraphicStyle(attributes);
+
+    if (this.isGImage()) {
+      return {
+        ...style,
+        anchor: [0.5, 0.5],
+      };
+    }
+    return {
+      ...style,
+      textBaseline: 'middle',
+      textAlign: 'center',
+    };
+  }
+
+  public render(attributes = this.attributes, container: Group = this): void {
+    // @ts-ignore
+    this.upsert('icon', this.isGImage() ? GImage : GText, this.getIconStyle(attributes), container);
+  }
+
+  connectedCallback() {
+    // @ts-ignore
+    this.upsert('icon', this.isGImage() ? GImage : GText, this.getIconStyle(this.attributes), this);
+  }
+}

--- a/packages/g6/src/elements/shapes/index.ts
+++ b/packages/g6/src/elements/shapes/index.ts
@@ -9,7 +9,7 @@ export { BaseShape } from './base-shape';
 export { Icon } from './icon';
 export { Label } from './label';
 
-export type { BadgeOptions } from './badge';
+export type { BadgeStyleProps } from './badge';
 export type { BaseShapeStyleProps } from './base-shape';
-export type { IconOptions } from './icon';
-export type { LabelOptions } from './label';
+export type { IconStyleProps } from './icon';
+export type { LabelStyleProps } from './label';

--- a/packages/g6/src/elements/shapes/index.ts
+++ b/packages/g6/src/elements/shapes/index.ts
@@ -6,8 +6,10 @@
 
 export { Badge } from './badge';
 export { BaseShape } from './base-shape';
+export { Icon } from './icon';
 export { Label } from './label';
 
 export type { BadgeOptions } from './badge';
 export type { BaseShapeStyleProps } from './base-shape';
+export type { IconOptions } from './icon';
 export type { LabelOptions } from './label';

--- a/packages/g6/src/elements/shapes/index.ts
+++ b/packages/g6/src/elements/shapes/index.ts
@@ -5,7 +5,9 @@
  */
 
 export { Badge } from './badge';
+export { BaseShape } from './base-shape';
 export { Label } from './label';
 
 export type { BadgeOptions } from './badge';
+export type { BaseShapeStyleProps } from './base-shape';
 export type { LabelOptions } from './label';

--- a/packages/g6/src/types/node.ts
+++ b/packages/g6/src/types/node.ts
@@ -9,7 +9,7 @@ export type RelativePosition =
   | 'left-top'
   | 'left-bottom'
   | 'right'
-  | 'rigth-top'
+  | 'right-top'
   | 'right-bottom'
   | 'center';
 

--- a/packages/g6/src/types/node.ts
+++ b/packages/g6/src/types/node.ts
@@ -1,0 +1,19 @@
+export type RelativePosition =
+  | 'top'
+  | 'top-left'
+  | 'top-right'
+  | 'bottom'
+  | 'bottom-left'
+  | 'bottom-right'
+  | 'left'
+  | 'left-top'
+  | 'left-bottom'
+  | 'right'
+  | 'rigth-top'
+  | 'right-bottom'
+  | 'center';
+
+export type AnchorPosition = [number, number] | 'top' | 'left' | 'right' | 'bottom';
+
+export type BadgePosition = RelativePosition;
+export type LabelPosition = RelativePosition;

--- a/packages/g6/src/utils/element.ts
+++ b/packages/g6/src/utils/element.ts
@@ -9,7 +9,7 @@ import type { AnchorPosition, LabelPosition, RelativePosition } from '../types/n
  * @param position The postion relative with element.
  * @returns [x, y]
  */
-export function getXYByPosition(bbox: AABB, position: RelativePosition): Point {
+export function getXYByPosition(bbox: AABB, position: RelativePosition = 'center'): Point {
   const direction = position.split('-');
   const x = direction.includes('left') ? bbox.min[0] : direction.includes('right') ? bbox.max[0] : bbox.center[0];
   const y = direction.includes('top') ? bbox.min[1] : direction.includes('bottom') ? bbox.max[1] : bbox.center[1];
@@ -48,7 +48,7 @@ export function getAnchorPosition(bbox: AABB, position?: AnchorPosition): Point 
  * @param position The postion relative with element.
  * @returns Partial<TextStyleProps>
  */
-export function getTextStyleByPosition(bbox: AABB, position: LabelPosition): Partial<TextStyleProps> {
+export function getTextStyleByPosition(bbox: AABB, position: LabelPosition = 'center'): Partial<TextStyleProps> {
   const direction = position.split('-');
   const [x, y] = getXYByPosition(bbox, position);
 

--- a/packages/g6/src/utils/element.ts
+++ b/packages/g6/src/utils/element.ts
@@ -1,0 +1,64 @@
+import type { AABB, TextStyleProps } from '@antv/g';
+import { get, isString } from '@antv/util';
+import type { Point } from '../types';
+import type { AnchorPosition, LabelPosition, RelativePosition } from '../types/node';
+
+/**
+ * Get the Badge x, y by `position`.
+ * @param bbox BBox of element.
+ * @param position The postion relative with element.
+ * @returns [x, y]
+ */
+export function getXYByPosition(bbox: AABB, position: RelativePosition): Point {
+  const direction = position.split('-');
+  const x = direction.includes('left') ? bbox.min[0] : direction.includes('right') ? bbox.max[0] : bbox.center[0];
+  const y = direction.includes('top') ? bbox.min[1] : direction.includes('bottom') ? bbox.max[1] : bbox.center[1];
+  return [x, y];
+}
+
+/**
+ * Get the Anchor x, y by `position`.
+ * @param bbox BBox of element.
+ * @param position The postion relative with element.
+ * @returns [x, y]
+ */
+export function getAnchorPosition(bbox: AABB, position?: AnchorPosition): Point {
+  const MAP = {
+    top: [0.5, 0],
+    right: [1, 0.5],
+    bottom: [0.5, 1],
+    left: [0, 0.5],
+  };
+
+  const DEFAULT = [0.5, 0.5];
+
+  const p: [number, number] = isString(position) ? get(MAP, position.toLocaleLowerCase(), DEFAULT) : position;
+
+  const [x, y] = p || DEFAULT;
+
+  const w = bbox.max[0] - bbox.min[0];
+  const h = bbox.max[1] - bbox.min[1];
+
+  return [bbox.min[0] + w * x, bbox.min[1] + h * y];
+}
+
+/**
+ * Get the Text style by `position`.
+ * @param bbox BBox of element.
+ * @param position The postion relative with element.
+ * @returns Partial<TextStyleProps>
+ */
+export function getTextStyleByPosition(bbox: AABB, position: LabelPosition): Partial<TextStyleProps> {
+  const direction = position.split('-');
+  const [x, y] = getXYByPosition(bbox, position);
+
+  const textBaseline = direction.includes('top') ? 'bottom' : direction.includes('bottom') ? 'top' : 'middle';
+  const textAlign = direction.includes('left') ? 'right' : direction.includes('right') ? 'left' : 'center';
+
+  return {
+    x,
+    y,
+    textBaseline,
+    textAlign,
+  };
+}

--- a/packages/g6/src/utils/element.ts
+++ b/packages/g6/src/utils/element.ts
@@ -5,8 +5,8 @@ import type { AnchorPosition, LabelPosition, RelativePosition } from '../types/n
 
 /**
  * Get the Badge x, y by `position`.
- * @param bbox BBox of element.
- * @param position The postion relative with element.
+ * @param bbox - BBox of element.
+ * @param position - The postion relative with element.
  * @returns [x, y]
  */
 export function getXYByPosition(bbox: AABB, position: RelativePosition = 'center'): Point {
@@ -18,8 +18,8 @@ export function getXYByPosition(bbox: AABB, position: RelativePosition = 'center
 
 /**
  * Get the Anchor x, y by `position`.
- * @param bbox BBox of element.
- * @param position The postion relative with element.
+ * @param bbox - BBox of element.
+ * @param position - The postion relative with element.
  * @returns [x, y]
  */
 export function getAnchorPosition(bbox: AABB, position?: AnchorPosition): Point {
@@ -44,8 +44,8 @@ export function getAnchorPosition(bbox: AABB, position?: AnchorPosition): Point 
 
 /**
  * Get the Text style by `position`.
- * @param bbox BBox of element.
- * @param position The postion relative with element.
+ * @param bbox - BBox of element.
+ * @param position - The postion relative with element.
  * @returns Partial<TextStyleProps>
  */
 export function getTextStyleByPosition(bbox: AABB, position: LabelPosition = 'center'): Partial<TextStyleProps> {

--- a/packages/g6/src/utils/prefix.ts
+++ b/packages/g6/src/utils/prefix.ts
@@ -1,4 +1,4 @@
-import { lowerFirst, upperFirst } from '@antv/util';
+import { isString, lowerFirst, upperFirst } from '@antv/util';
 import type { PrefixObject, ReplacePrefix } from '../types';
 
 /**
@@ -69,9 +69,10 @@ export function subStyleProps<T extends object>(style: object, prefix: string) {
  * @param prefix - <zh/> 子样式前缀 | <en/> sub style prefix
  * @returns <zh/> 排除子样式后的样式 | <en/> style without sub style
  */
-export function omitStyleProps<T extends object>(style: object, prefix: string) {
+export function omitStyleProps<T extends object>(style: object, prefix: string | string[]) {
+  const prefixArray = isString(prefix) ? [prefix] : prefix;
   return Object.entries(style).reduce((acc, [key, value]) => {
-    if (!startsWith(key, prefix)) {
+    if (!prefixArray.find((p) => key.startsWith(p))) {
       acc[key as keyof T] = value;
     }
     return acc;


### PR DESCRIPTION
- [x] add node `circle`
  - [x] key
  - [x] label
  - [x] icon
  - [x] badge
  - [x] anchor
  - [x] halo
- [ ] theme
- [x] add test case for `circle`

![image](https://github.com/antvis/G6/assets/7856674/44a264ff-0db9-48d0-80f7-8548eac820ea)



```ts
const style = {
// key
  cx: 100,
  cy: 100,
  fill: 'red',
  r: 40,
  // label
  labelText: 'circle node',
  labelFontSize: 14,
  labelFill: 'pink',
  labelPosition: 'bottom',
  // badge
  badgeOptions: [],
  // anchor
  anchorOptions: [],
  // icon
  iconSrc: 'https://gw.alipayobjects.com/zos/basement_prod/012bcf4f-423b-4922-8c24-32a89f8c41ce.svg',
  iconWidth: 32,
  iconHeight: 32,
  // halo
  haloOpacity: 0.4,

}

const circle = new Circle({ style });
```
