### PR TITLE
feat(edge): add cubic edge element and its vertical and. horizontal variants

### DIFF
--- a/packages/g6/__tests__/demo/animation/edge-cubic.ts
+++ b/packages/g6/__tests__/demo/animation/edge-cubic.ts
@@ -1,0 +1,34 @@
+import { Cubic } from '../../../src/elements/edges';
+import type { AnimationTestCase } from '../types';
+
+export const edgeCubic: AnimationTestCase = async (context) => {
+  const { canvas } = context;
+
+  const quadratic = new Cubic({
+    style: {
+      sourcePoint: [100, 50],
+      targetPoint: [300, 50],
+      lineWidth: 2,
+      stroke: '#1890FF',
+      labelText: 'cubic-edge',
+      labelFontSize: 12,
+      endArrow: true,
+    },
+  });
+
+  await canvas.init();
+
+  canvas.appendChild(quadratic);
+
+  const result = quadratic.animate(
+    [
+      { sourcePoint: [100, 150], targetPoint: [300, 200], lineWidth: 2, curveOffset: 30 },
+      { sourcePoint: [100, 150], targetPoint: [450, 350], lineWidth: 8, curveOffset: 60 },
+    ],
+    { duration: 1000, fill: 'both' },
+  );
+
+  return result;
+};
+
+edgeCubic.times = [0, 500, 1000];

--- a/packages/g6/__tests__/demo/animation/edge-cubic.ts
+++ b/packages/g6/__tests__/demo/animation/edge-cubic.ts
@@ -4,7 +4,7 @@ import type { AnimationTestCase } from '../types';
 export const edgeCubic: AnimationTestCase = async (context) => {
   const { canvas } = context;
 
-  const quadratic = new Cubic({
+  const cubic = new Cubic({
     style: {
       sourcePoint: [100, 50],
       targetPoint: [300, 50],
@@ -18,9 +18,9 @@ export const edgeCubic: AnimationTestCase = async (context) => {
 
   await canvas.init();
 
-  canvas.appendChild(quadratic);
+  canvas.appendChild(cubic);
 
-  const result = quadratic.animate(
+  const result = cubic.animate(
     [
       { sourcePoint: [100, 150], targetPoint: [300, 200], lineWidth: 2, curveOffset: 30 },
       { sourcePoint: [100, 150], targetPoint: [450, 350], lineWidth: 8, curveOffset: 60 },

--- a/packages/g6/__tests__/demo/animation/index.ts
+++ b/packages/g6/__tests__/demo/animation/index.ts
@@ -5,6 +5,7 @@ export * from './animation-fade-in';
 export * from './animation-translate';
 export * from './animation-wave';
 export * from './animation-zoom-in';
+export * from './edge-cubic';
 export * from './edge-line';
 export * from './edge-quadratic';
 export * from './shape-label';

--- a/packages/g6/__tests__/demo/static/edge-cubic-horizontal.ts
+++ b/packages/g6/__tests__/demo/static/edge-cubic-horizontal.ts
@@ -1,0 +1,22 @@
+import { CubicHorizontal } from '../../../src/elements/edges';
+import type { StaticTestCase } from '../types';
+
+export const edgeCubicHorizontal: StaticTestCase = async (context) => {
+  const { canvas } = context;
+
+  await canvas.init();
+
+  [100, 150, 200, 250, 300].forEach((v) => {
+    canvas.appendChild(
+      new CubicHorizontal({
+        style: {
+          sourcePoint: [50, 200],
+          targetPoint: [250, v],
+          stroke: '#1890FF',
+          lineWidth: 2,
+          endArrow: true,
+        },
+      }),
+    );
+  });
+};

--- a/packages/g6/__tests__/demo/static/edge-cubic-vertical.ts
+++ b/packages/g6/__tests__/demo/static/edge-cubic-vertical.ts
@@ -1,0 +1,21 @@
+import { CubicVertical } from '../../../src/elements/edges';
+import type { StaticTestCase } from '../types';
+
+export const edgeCubicVertical: StaticTestCase = async (context) => {
+  const { canvas } = context;
+  await canvas.init();
+
+  [100, 150, 200, 250, 300].forEach((v) => {
+    canvas.appendChild(
+      new CubicVertical({
+        style: {
+          sourcePoint: [200, 100],
+          targetPoint: [v, 300],
+          stroke: '#1890FF',
+          lineWidth: 2,
+          endArrow: true,
+        },
+      }),
+    );
+  });
+};

--- a/packages/g6/__tests__/demo/static/edge-cubic.ts
+++ b/packages/g6/__tests__/demo/static/edge-cubic.ts
@@ -1,0 +1,89 @@
+import { Cubic } from '../../../src/elements/edges';
+import type { StaticTestCase } from '../types';
+
+export const edgeCubic: StaticTestCase = async (context) => {
+  const { canvas } = context;
+
+  const cubic1 = new Cubic({
+    style: {
+      // key shape
+      sourcePoint: [100, 50],
+      targetPoint: [300, 50],
+      stroke: '#1890FF',
+      lineWidth: 2,
+      // halo
+      halo: true,
+      haloOpacity: 0.25,
+      haloLineWidth: 12,
+      // label
+      labelText: 'default cubic',
+      labelFontSize: 12,
+      labelOffsetY: -15,
+      // end arrow
+      endArrow: true,
+    },
+  });
+
+  const cubic2 = new Cubic({
+    style: {
+      // key shape
+      sourcePoint: [100, 150],
+      targetPoint: [300, 150],
+      controlPoints: [
+        [200, 200],
+        [200, 100],
+      ],
+      stroke: '#1890FF',
+      lineWidth: 2,
+      // label
+      labelText: 'controlPoints=[[200, 200],[200,100]]',
+      labelFontSize: 12,
+      labelOffsetY: -15,
+      // end arrow
+      endArrow: true,
+    },
+  });
+
+  const cubic3 = new Cubic({
+    style: {
+      // key shape
+      sourcePoint: [100, 250],
+      targetPoint: [300, 250],
+      curveOffset: 50,
+      curvePosition: 0.5,
+      stroke: '#1890FF',
+      lineWidth: 2,
+      // label
+      labelText: 'curveOffset=50, curvePosition:0.5',
+      labelFontSize: 12,
+      labelOffsetY: -15,
+      // end arrow
+      endArrow: true,
+    },
+  });
+
+  const cubic4 = new Cubic({
+    style: {
+      // key shape
+      sourcePoint: [100, 350],
+      targetPoint: [300, 350],
+      curveOffset: 50,
+      curvePosition: 0.25,
+      stroke: '#1890FF',
+      lineWidth: 2,
+      // label
+      labelText: 'curveOffset=50, curvePosition:0.25',
+      labelFontSize: 12,
+      labelOffsetY: -15,
+      // end arrow
+      endArrow: true,
+    },
+  });
+
+  await canvas.init();
+
+  canvas.appendChild(cubic1);
+  canvas.appendChild(cubic2);
+  canvas.appendChild(cubic3);
+  canvas.appendChild(cubic4);
+};

--- a/packages/g6/__tests__/demo/static/index.ts
+++ b/packages/g6/__tests__/demo/static/index.ts
@@ -1,3 +1,4 @@
+export * from './edge-cubic';
 export * from './edge-line';
 export * from './edge-quadratic';
 export * from './layered-canvas';

--- a/packages/g6/__tests__/demo/static/index.ts
+++ b/packages/g6/__tests__/demo/static/index.ts
@@ -1,5 +1,6 @@
 export * from './edge-cubic';
 export * from './edge-cubic-horizontal';
+export * from './edge-cubic-vertical';
 export * from './edge-line';
 export * from './edge-quadratic';
 export * from './layered-canvas';

--- a/packages/g6/__tests__/demo/static/index.ts
+++ b/packages/g6/__tests__/demo/static/index.ts
@@ -1,4 +1,5 @@
 export * from './edge-cubic';
+export * from './edge-cubic-horizontal';
 export * from './edge-line';
 export * from './edge-quadratic';
 export * from './layered-canvas';

--- a/packages/g6/__tests__/integration/animation.spec.ts
+++ b/packages/g6/__tests__/integration/animation.spec.ts
@@ -1,3 +1,4 @@
+import '../../src/preset';
 import * as animationCases from '../demo/animation';
 import { createNodeGCanvas } from './utils/create-node-g-canvas';
 import { getCases } from './utils/get-cases';
@@ -23,7 +24,7 @@ describe('static', () => {
 
         for (const time of times) {
           animationResult.currentTime = time;
-          await sleep(20);
+          await sleep(32);
           await expect(canvas).toMatchSVGSnapshot(
             `${__dirname}/snapshots/animation`,
             // 命名示例：label-1000(1_3)

--- a/packages/g6/__tests__/integration/snapshots/animation/edge-cubic-0(1_3).svg
+++ b/packages/g6/__tests__/integration/snapshots/animation/edge-cubic-0(1_3).svg
@@ -1,0 +1,71 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="500"
+  height="500"
+  style="background: transparent; position: absolute; outline: none;"
+  color-interpolation-filters="sRGB"
+  tabindex="1"
+>
+  <defs />
+  <g id="g-svg-camera" transform="matrix(1,0,0,1,0,0)">
+    <g id="g-root" fill="none" transform="matrix(1,0,0,1,0,0)">
+      <g
+        id="g-svg-5"
+        fill="none"
+        marker-start="false"
+        marker-end="true"
+        transform="matrix(1,0,0,1,0,0)"
+      >
+        <g transform="matrix(1,0,0,1,100,149.792572)">
+          <path
+            id="key"
+            fill="none"
+            d="M 0,0.2074350425709781 C 92.72393124891002 -3.89683996178897,107.27606875108998 54.311710046930926,200 50.20743504257098"
+            stroke-width="2"
+            stroke="rgba(24,144,255,1)"
+          />
+          <g transform="matrix(-0.999022,0.044220,-0.044220,-0.999022,200,50.207436)">
+            <path
+              id="g-svg-8"
+              fill="rgba(24,144,255,1)"
+              d="M 0,5 L 10,0 L 10,10 Z"
+              transform="translate(-5,-5)"
+              stroke-width="2"
+              stroke="rgba(24,144,255,1)"
+              stroke-dasharray="0,0"
+            />
+          </g>
+        </g>
+        <g
+          id="label"
+          fill="none"
+          transform="matrix(0.982519,-0.186162,0.186162,0.982519,202.813110,43.360237)"
+        >
+          <g transform="matrix(1,0,0,1,-42.326870,-40.298687)">
+            <path
+              id="background"
+              fill="none"
+              d="M 0,0 l 85.6537385594458,0 l 0,57.5973797182875 l-85.6537385594458 0 z"
+              width="85.6537385594458"
+              height="57.5973797182875"
+            />
+          </g>
+          <g transform="matrix(1,0,0,1,0,0)">
+            <text
+              id="text"
+              fill="rgba(0,0,0,1)"
+              dominant-baseline="central"
+              paint-order="stroke"
+              dx="0.5"
+              dy="-11.5px"
+              text-anchor="middle"
+              font-size="12"
+            >
+              cubic-edge
+            </text>
+          </g>
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/packages/g6/__tests__/integration/snapshots/animation/edge-cubic-1000(3_3).svg
+++ b/packages/g6/__tests__/integration/snapshots/animation/edge-cubic-1000(3_3).svg
@@ -1,0 +1,71 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="500"
+  height="500"
+  style="background: transparent; position: absolute; outline: none;"
+  color-interpolation-filters="sRGB"
+  tabindex="1"
+>
+  <defs />
+  <g id="g-svg-camera" transform="matrix(1,0,0,1,0,0)">
+    <g id="g-root" fill="none" transform="matrix(1,0,0,1,0,0)">
+      <g
+        id="g-svg-5"
+        fill="none"
+        marker-start="false"
+        marker-end="true"
+        transform="matrix(1,0,0,1,0,0)"
+      >
+        <g transform="matrix(1,0,0,1,100,150)">
+          <path
+            id="key"
+            fill="none"
+            d="M 0,0 C 145.23166369858995 47.90541147253245,204.76833630141005 152.09458852746758,350 200"
+            stroke-width="8"
+            stroke="rgba(24,144,255,1)"
+          />
+          <g transform="matrix(-0.949670,-0.313253,0.313253,-0.949670,350,200)">
+            <path
+              id="g-svg-8"
+              fill="rgba(24,144,255,1)"
+              d="M 0,5 L 10,0 L 10,10 Z"
+              transform="translate(-5,-5)"
+              stroke-width="2"
+              stroke="rgba(24,144,255,1)"
+              stroke-dasharray="0,0"
+            />
+          </g>
+        </g>
+        <g
+          id="label"
+          fill="none"
+          transform="matrix(0.982519,-0.186162,0.186162,0.982519,202.813110,43.360237)"
+        >
+          <g transform="matrix(1,0,0,1,-42.326870,-40.298687)">
+            <path
+              id="background"
+              fill="none"
+              d="M 0,0 l 85.6537385594458,0 l 0,57.5973797182875 l-85.6537385594458 0 z"
+              width="85.6537385594458"
+              height="57.5973797182875"
+            />
+          </g>
+          <g transform="matrix(1,0,0,1,0,0)">
+            <text
+              id="text"
+              fill="rgba(0,0,0,1)"
+              dominant-baseline="central"
+              paint-order="stroke"
+              dx="0.5"
+              dy="-11.5px"
+              text-anchor="middle"
+              font-size="12"
+            >
+              cubic-edge
+            </text>
+          </g>
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/packages/g6/__tests__/integration/snapshots/animation/edge-cubic-500(2_3).svg
+++ b/packages/g6/__tests__/integration/snapshots/animation/edge-cubic-500(2_3).svg
@@ -1,0 +1,71 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="500"
+  height="500"
+  style="background: transparent; position: absolute; outline: none;"
+  color-interpolation-filters="sRGB"
+  tabindex="1"
+>
+  <defs />
+  <g id="g-svg-camera" transform="matrix(1,0,0,1,0,0)">
+    <g id="g-root" fill="none" transform="matrix(1,0,0,1,0,0)">
+      <g
+        id="g-svg-5"
+        fill="none"
+        marker-start="false"
+        marker-end="true"
+        transform="matrix(1,0,0,1,0,0)"
+      >
+        <g transform="matrix(1,0,0,1,100,150)">
+          <path
+            id="key"
+            fill="none"
+            d="M 0,0 C 118.97779747375 21.90056823408625,156.02220252625 103.09943176591378,275 125"
+            stroke-width="5"
+            stroke="rgba(24,144,255,1)"
+          />
+          <g transform="matrix(-0.983477,-0.181031,0.181031,-0.983477,275,125)">
+            <path
+              id="g-svg-8"
+              fill="rgba(24,144,255,1)"
+              d="M 0,5 L 10,0 L 10,10 Z"
+              transform="translate(-5,-5)"
+              stroke-width="2"
+              stroke="rgba(24,144,255,1)"
+              stroke-dasharray="0,0"
+            />
+          </g>
+        </g>
+        <g
+          id="label"
+          fill="none"
+          transform="matrix(0.982519,-0.186162,0.186162,0.982519,202.813110,43.360237)"
+        >
+          <g transform="matrix(1,0,0,1,-42.326870,-40.298687)">
+            <path
+              id="background"
+              fill="none"
+              d="M 0,0 l 85.6537385594458,0 l 0,57.5973797182875 l-85.6537385594458 0 z"
+              width="85.6537385594458"
+              height="57.5973797182875"
+            />
+          </g>
+          <g transform="matrix(1,0,0,1,0,0)">
+            <text
+              id="text"
+              fill="rgba(0,0,0,1)"
+              dominant-baseline="central"
+              paint-order="stroke"
+              dx="0.5"
+              dy="-11.5px"
+              text-anchor="middle"
+              font-size="12"
+            >
+              cubic-edge
+            </text>
+          </g>
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/packages/g6/__tests__/integration/snapshots/static/edge-cubic-horizontal.svg
+++ b/packages/g6/__tests__/integration/snapshots/static/edge-cubic-horizontal.svg
@@ -8,55 +8,37 @@
 >
   <defs />
   <g id="g-svg-camera" transform="matrix(1,0,0,1,0,0)">
-    <g
-      id="g-root"
-      fill="none"
-      stroke="none"
-      visibility="visible"
-      font-size="16px"
-      font-family="sans-serif"
-      font-style="normal"
-      font-weight="normal"
-      font-variant="normal"
-      text-anchor="left"
-      stroke-dashoffset="0px"
-      transform="matrix(1,0,0,1,0,0)"
-    >
+    <g id="g-root" fill="none" transform="matrix(1,0,0,1,0,0)">
       <g
         id="g-svg-5"
         fill="none"
-        stroke="rgba(24,144,255,1)"
-        stroke-width="2px"
         marker-start="false"
         marker-end="true"
         transform="matrix(1,0,0,1,0,0)"
       >
-        <g stroke-width="2px" transform="matrix(1,0,0,1,50,100)">
+        <g transform="matrix(1,0,0,1,50,100)">
           <path
             id="key"
             fill="none"
             d="M 0,100 C 100 100,100 0,200 0"
             stroke="rgba(24,144,255,1)"
+            stroke-width="2"
           />
-          <g
-            stroke-width="2px"
-            stroke-dasharray="0px,0px"
-            transform="matrix(-1,0,-0,-1,200,0)"
-          >
+          <g transform="matrix(-1,0,-0,-1,200,0)">
             <path
               id="g-svg-8"
               fill="rgba(24,144,255,1)"
               d="M 0,5 L 10,0 L 10,10 Z"
               transform="translate(-5,-5)"
               stroke="rgba(24,144,255,1)"
+              stroke-width="2"
+              stroke-dasharray="0,0"
             />
           </g>
         </g>
         <g
           id="label"
           fill="none"
-          stroke="none"
-          text-anchor="middle"
           transform="matrix(0.716471,-0.697616,0.697616,0.716471,148.680191,142.910706)"
         >
           <g transform="matrix(1,0,0,1,-5,-5)">
@@ -64,18 +46,17 @@
               id="background"
               fill="none"
               d="M 0,0 l 10,0 l 0,10 l-10 0 z"
-              stroke="none"
-              width="10px"
-              height="10px"
+              width="10"
+              height="10"
             />
           </g>
-          <g text-anchor="middle" transform="matrix(1,0,0,1,0,0)">
+          <g transform="matrix(1,0,0,1,0,0)">
             <text
               id="text"
-              fill="none"
-              dominant-baseline="alphabetic"
+              fill="rgba(0,0,0,1)"
+              dominant-baseline="text-after-edge"
               paint-order="stroke"
-              stroke="none"
+              text-anchor="middle"
             />
           </g>
         </g>
@@ -83,38 +64,33 @@
       <g
         id="g-svg-12"
         fill="none"
-        stroke="rgba(24,144,255,1)"
-        stroke-width="2px"
         marker-start="false"
         marker-end="true"
         transform="matrix(1,0,0,1,0,0)"
       >
-        <g stroke-width="2px" transform="matrix(1,0,0,1,50,150)">
+        <g transform="matrix(1,0,0,1,50,150)">
           <path
             id="key"
             fill="none"
             d="M 0,50 C 100 50,100 0,200 0"
             stroke="rgba(24,144,255,1)"
+            stroke-width="2"
           />
-          <g
-            stroke-width="2px"
-            stroke-dasharray="0px,0px"
-            transform="matrix(-1,0,-0,-1,200,0)"
-          >
+          <g transform="matrix(-1,0,-0,-1,200,0)">
             <path
               id="g-svg-15"
               fill="rgba(24,144,255,1)"
               d="M 0,5 L 10,0 L 10,10 Z"
               transform="translate(-5,-5)"
               stroke="rgba(24,144,255,1)"
+              stroke-width="2"
+              stroke-dasharray="0,0"
             />
           </g>
         </g>
         <g
           id="label"
           fill="none"
-          stroke="none"
-          text-anchor="middle"
           transform="matrix(0.899110,-0.437723,0.437723,0.899110,150.970108,167.854446)"
         >
           <g transform="matrix(1,0,0,1,-5,-5)">
@@ -122,18 +98,17 @@
               id="background"
               fill="none"
               d="M 0,0 l 10,0 l 0,10 l-10 0 z"
-              stroke="none"
-              width="10px"
-              height="10px"
+              width="10"
+              height="10"
             />
           </g>
-          <g text-anchor="middle" transform="matrix(1,0,0,1,0,0)">
+          <g transform="matrix(1,0,0,1,0,0)">
             <text
               id="text"
-              fill="none"
-              dominant-baseline="alphabetic"
+              fill="rgba(0,0,0,1)"
+              dominant-baseline="text-after-edge"
               paint-order="stroke"
-              stroke="none"
+              text-anchor="middle"
             />
           </g>
         </g>
@@ -141,57 +116,47 @@
       <g
         id="g-svg-19"
         fill="none"
-        stroke="rgba(24,144,255,1)"
-        stroke-width="2px"
         marker-start="false"
         marker-end="true"
         transform="matrix(1,0,0,1,0,0)"
       >
-        <g stroke-width="2px" transform="matrix(1,0,0,1,50,200)">
+        <g transform="matrix(1,0,0,1,50,200)">
           <path
             id="key"
             fill="none"
             d="M 0,0 C 100 0,100 0,200 0"
             stroke="rgba(24,144,255,1)"
+            stroke-width="2"
           />
-          <g
-            stroke-width="2px"
-            stroke-dasharray="0px,0px"
-            transform="matrix(-1,0,-0,-1,200,0)"
-          >
+          <g transform="matrix(-1,0,-0,-1,200,0)">
             <path
               id="g-svg-22"
               fill="rgba(24,144,255,1)"
               d="M 0,5 L 10,0 L 10,10 Z"
               transform="translate(-5,-5)"
               stroke="rgba(24,144,255,1)"
+              stroke-width="2"
+              stroke-dasharray="0,0"
             />
           </g>
         </g>
-        <g
-          id="label"
-          fill="none"
-          stroke="none"
-          text-anchor="middle"
-          transform="matrix(1,0,0,1,154,194)"
-        >
+        <g id="label" fill="none" transform="matrix(1,0,0,1,154,194)">
           <g transform="matrix(1,0,0,1,-5,-5)">
             <path
               id="background"
               fill="none"
               d="M 0,0 l 10,0 l 0,10 l-10 0 z"
-              stroke="none"
-              width="10px"
-              height="10px"
+              width="10"
+              height="10"
             />
           </g>
-          <g text-anchor="middle" transform="matrix(1,0,0,1,0,0)">
+          <g transform="matrix(1,0,0,1,0,0)">
             <text
               id="text"
-              fill="none"
-              dominant-baseline="alphabetic"
+              fill="rgba(0,0,0,1)"
+              dominant-baseline="text-after-edge"
               paint-order="stroke"
-              stroke="none"
+              text-anchor="middle"
             />
           </g>
         </g>
@@ -199,38 +164,33 @@
       <g
         id="g-svg-26"
         fill="none"
-        stroke="rgba(24,144,255,1)"
-        stroke-width="2px"
         marker-start="false"
         marker-end="true"
         transform="matrix(1,0,0,1,0,0)"
       >
-        <g stroke-width="2px" transform="matrix(1,0,0,1,50,200)">
+        <g transform="matrix(1,0,0,1,50,200)">
           <path
             id="key"
             fill="none"
             d="M 0,0 C 100 0,100 50,200 50"
             stroke="rgba(24,144,255,1)"
+            stroke-width="2"
           />
-          <g
-            stroke-width="2px"
-            stroke-dasharray="0px,0px"
-            transform="matrix(-1,0,-0,-1,200,50)"
-          >
+          <g transform="matrix(-1,0,-0,-1,200,50)">
             <path
               id="g-svg-29"
               fill="rgba(24,144,255,1)"
               d="M 0,5 L 10,0 L 10,10 Z"
               transform="translate(-5,-5)"
               stroke="rgba(24,144,255,1)"
+              stroke-width="2"
+              stroke-dasharray="0,0"
             />
           </g>
         </g>
         <g
           id="label"
           fill="none"
-          stroke="none"
-          text-anchor="middle"
           transform="matrix(0.899110,0.437723,-0.437723,0.899110,156.222778,221.356232)"
         >
           <g transform="matrix(1,0,0,1,-5,-5)">
@@ -238,18 +198,17 @@
               id="background"
               fill="none"
               d="M 0,0 l 10,0 l 0,10 l-10 0 z"
-              stroke="none"
-              width="10px"
-              height="10px"
+              width="10"
+              height="10"
             />
           </g>
-          <g text-anchor="middle" transform="matrix(1,0,0,1,0,0)">
+          <g transform="matrix(1,0,0,1,0,0)">
             <text
               id="text"
-              fill="none"
-              dominant-baseline="alphabetic"
+              fill="rgba(0,0,0,1)"
+              dominant-baseline="text-after-edge"
               paint-order="stroke"
-              stroke="none"
+              text-anchor="middle"
             />
           </g>
         </g>
@@ -257,38 +216,33 @@
       <g
         id="g-svg-33"
         fill="none"
-        stroke="rgba(24,144,255,1)"
-        stroke-width="2px"
         marker-start="false"
         marker-end="true"
         transform="matrix(1,0,0,1,0,0)"
       >
-        <g stroke-width="2px" transform="matrix(1,0,0,1,50,200)">
+        <g transform="matrix(1,0,0,1,50,200)">
           <path
             id="key"
             fill="none"
             d="M 0,0 C 100 0,100 100,200 100"
             stroke="rgba(24,144,255,1)"
+            stroke-width="2"
           />
-          <g
-            stroke-width="2px"
-            stroke-dasharray="0px,0px"
-            transform="matrix(-1,0,-0,-1,200,100)"
-          >
+          <g transform="matrix(-1,0,-0,-1,200,100)">
             <path
               id="g-svg-36"
               fill="rgba(24,144,255,1)"
               d="M 0,5 L 10,0 L 10,10 Z"
               transform="translate(-5,-5)"
               stroke="rgba(24,144,255,1)"
+              stroke-width="2"
+              stroke-dasharray="0,0"
             />
           </g>
         </g>
         <g
           id="label"
           fill="none"
-          stroke="none"
-          text-anchor="middle"
           transform="matrix(0.716471,0.697616,-0.697616,0.716471,157.051590,248.491638)"
         >
           <g transform="matrix(1,0,0,1,-5,-5)">
@@ -296,18 +250,17 @@
               id="background"
               fill="none"
               d="M 0,0 l 10,0 l 0,10 l-10 0 z"
-              stroke="none"
-              width="10px"
-              height="10px"
+              width="10"
+              height="10"
             />
           </g>
-          <g text-anchor="middle" transform="matrix(1,0,0,1,0,0)">
+          <g transform="matrix(1,0,0,1,0,0)">
             <text
               id="text"
-              fill="none"
-              dominant-baseline="alphabetic"
+              fill="rgba(0,0,0,1)"
+              dominant-baseline="text-after-edge"
               paint-order="stroke"
-              stroke="none"
+              text-anchor="middle"
             />
           </g>
         </g>

--- a/packages/g6/__tests__/integration/snapshots/static/edge-cubic-horizontal.svg
+++ b/packages/g6/__tests__/integration/snapshots/static/edge-cubic-horizontal.svg
@@ -1,0 +1,317 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="500"
+  height="500"
+  style="background: transparent; position: absolute; outline: none;"
+  color-interpolation-filters="sRGB"
+  tabindex="1"
+>
+  <defs />
+  <g id="g-svg-camera" transform="matrix(1,0,0,1,0,0)">
+    <g
+      id="g-root"
+      fill="none"
+      stroke="none"
+      visibility="visible"
+      font-size="16px"
+      font-family="sans-serif"
+      font-style="normal"
+      font-weight="normal"
+      font-variant="normal"
+      text-anchor="left"
+      stroke-dashoffset="0px"
+      transform="matrix(1,0,0,1,0,0)"
+    >
+      <g
+        id="g-svg-5"
+        fill="none"
+        stroke="rgba(24,144,255,1)"
+        stroke-width="2px"
+        marker-start="false"
+        marker-end="true"
+        transform="matrix(1,0,0,1,0,0)"
+      >
+        <g stroke-width="2px" transform="matrix(1,0,0,1,50,100)">
+          <path
+            id="key"
+            fill="none"
+            d="M 0,100 C 100 100,100 0,200 0"
+            stroke="rgba(24,144,255,1)"
+          />
+          <g
+            stroke-width="2px"
+            stroke-dasharray="0px,0px"
+            transform="matrix(-1,0,-0,-1,200,0)"
+          >
+            <path
+              id="g-svg-8"
+              fill="rgba(24,144,255,1)"
+              d="M 0,5 L 10,0 L 10,10 Z"
+              transform="translate(-5,-5)"
+              stroke="rgba(24,144,255,1)"
+            />
+          </g>
+        </g>
+        <g
+          id="label"
+          fill="none"
+          stroke="none"
+          text-anchor="middle"
+          transform="matrix(0.716471,-0.697616,0.697616,0.716471,148.680191,142.910706)"
+        >
+          <g transform="matrix(1,0,0,1,-5,-5)">
+            <path
+              id="background"
+              fill="none"
+              d="M 0,0 l 10,0 l 0,10 l-10 0 z"
+              stroke="none"
+              width="10px"
+              height="10px"
+            />
+          </g>
+          <g text-anchor="middle" transform="matrix(1,0,0,1,0,0)">
+            <text
+              id="text"
+              fill="none"
+              dominant-baseline="alphabetic"
+              paint-order="stroke"
+              stroke="none"
+            />
+          </g>
+        </g>
+      </g>
+      <g
+        id="g-svg-12"
+        fill="none"
+        stroke="rgba(24,144,255,1)"
+        stroke-width="2px"
+        marker-start="false"
+        marker-end="true"
+        transform="matrix(1,0,0,1,0,0)"
+      >
+        <g stroke-width="2px" transform="matrix(1,0,0,1,50,150)">
+          <path
+            id="key"
+            fill="none"
+            d="M 0,50 C 100 50,100 0,200 0"
+            stroke="rgba(24,144,255,1)"
+          />
+          <g
+            stroke-width="2px"
+            stroke-dasharray="0px,0px"
+            transform="matrix(-1,0,-0,-1,200,0)"
+          >
+            <path
+              id="g-svg-15"
+              fill="rgba(24,144,255,1)"
+              d="M 0,5 L 10,0 L 10,10 Z"
+              transform="translate(-5,-5)"
+              stroke="rgba(24,144,255,1)"
+            />
+          </g>
+        </g>
+        <g
+          id="label"
+          fill="none"
+          stroke="none"
+          text-anchor="middle"
+          transform="matrix(0.899110,-0.437723,0.437723,0.899110,150.970108,167.854446)"
+        >
+          <g transform="matrix(1,0,0,1,-5,-5)">
+            <path
+              id="background"
+              fill="none"
+              d="M 0,0 l 10,0 l 0,10 l-10 0 z"
+              stroke="none"
+              width="10px"
+              height="10px"
+            />
+          </g>
+          <g text-anchor="middle" transform="matrix(1,0,0,1,0,0)">
+            <text
+              id="text"
+              fill="none"
+              dominant-baseline="alphabetic"
+              paint-order="stroke"
+              stroke="none"
+            />
+          </g>
+        </g>
+      </g>
+      <g
+        id="g-svg-19"
+        fill="none"
+        stroke="rgba(24,144,255,1)"
+        stroke-width="2px"
+        marker-start="false"
+        marker-end="true"
+        transform="matrix(1,0,0,1,0,0)"
+      >
+        <g stroke-width="2px" transform="matrix(1,0,0,1,50,200)">
+          <path
+            id="key"
+            fill="none"
+            d="M 0,0 C 100 0,100 0,200 0"
+            stroke="rgba(24,144,255,1)"
+          />
+          <g
+            stroke-width="2px"
+            stroke-dasharray="0px,0px"
+            transform="matrix(-1,0,-0,-1,200,0)"
+          >
+            <path
+              id="g-svg-22"
+              fill="rgba(24,144,255,1)"
+              d="M 0,5 L 10,0 L 10,10 Z"
+              transform="translate(-5,-5)"
+              stroke="rgba(24,144,255,1)"
+            />
+          </g>
+        </g>
+        <g
+          id="label"
+          fill="none"
+          stroke="none"
+          text-anchor="middle"
+          transform="matrix(1,0,0,1,154,194)"
+        >
+          <g transform="matrix(1,0,0,1,-5,-5)">
+            <path
+              id="background"
+              fill="none"
+              d="M 0,0 l 10,0 l 0,10 l-10 0 z"
+              stroke="none"
+              width="10px"
+              height="10px"
+            />
+          </g>
+          <g text-anchor="middle" transform="matrix(1,0,0,1,0,0)">
+            <text
+              id="text"
+              fill="none"
+              dominant-baseline="alphabetic"
+              paint-order="stroke"
+              stroke="none"
+            />
+          </g>
+        </g>
+      </g>
+      <g
+        id="g-svg-26"
+        fill="none"
+        stroke="rgba(24,144,255,1)"
+        stroke-width="2px"
+        marker-start="false"
+        marker-end="true"
+        transform="matrix(1,0,0,1,0,0)"
+      >
+        <g stroke-width="2px" transform="matrix(1,0,0,1,50,200)">
+          <path
+            id="key"
+            fill="none"
+            d="M 0,0 C 100 0,100 50,200 50"
+            stroke="rgba(24,144,255,1)"
+          />
+          <g
+            stroke-width="2px"
+            stroke-dasharray="0px,0px"
+            transform="matrix(-1,0,-0,-1,200,50)"
+          >
+            <path
+              id="g-svg-29"
+              fill="rgba(24,144,255,1)"
+              d="M 0,5 L 10,0 L 10,10 Z"
+              transform="translate(-5,-5)"
+              stroke="rgba(24,144,255,1)"
+            />
+          </g>
+        </g>
+        <g
+          id="label"
+          fill="none"
+          stroke="none"
+          text-anchor="middle"
+          transform="matrix(0.899110,0.437723,-0.437723,0.899110,156.222778,221.356232)"
+        >
+          <g transform="matrix(1,0,0,1,-5,-5)">
+            <path
+              id="background"
+              fill="none"
+              d="M 0,0 l 10,0 l 0,10 l-10 0 z"
+              stroke="none"
+              width="10px"
+              height="10px"
+            />
+          </g>
+          <g text-anchor="middle" transform="matrix(1,0,0,1,0,0)">
+            <text
+              id="text"
+              fill="none"
+              dominant-baseline="alphabetic"
+              paint-order="stroke"
+              stroke="none"
+            />
+          </g>
+        </g>
+      </g>
+      <g
+        id="g-svg-33"
+        fill="none"
+        stroke="rgba(24,144,255,1)"
+        stroke-width="2px"
+        marker-start="false"
+        marker-end="true"
+        transform="matrix(1,0,0,1,0,0)"
+      >
+        <g stroke-width="2px" transform="matrix(1,0,0,1,50,200)">
+          <path
+            id="key"
+            fill="none"
+            d="M 0,0 C 100 0,100 100,200 100"
+            stroke="rgba(24,144,255,1)"
+          />
+          <g
+            stroke-width="2px"
+            stroke-dasharray="0px,0px"
+            transform="matrix(-1,0,-0,-1,200,100)"
+          >
+            <path
+              id="g-svg-36"
+              fill="rgba(24,144,255,1)"
+              d="M 0,5 L 10,0 L 10,10 Z"
+              transform="translate(-5,-5)"
+              stroke="rgba(24,144,255,1)"
+            />
+          </g>
+        </g>
+        <g
+          id="label"
+          fill="none"
+          stroke="none"
+          text-anchor="middle"
+          transform="matrix(0.716471,0.697616,-0.697616,0.716471,157.051590,248.491638)"
+        >
+          <g transform="matrix(1,0,0,1,-5,-5)">
+            <path
+              id="background"
+              fill="none"
+              d="M 0,0 l 10,0 l 0,10 l-10 0 z"
+              stroke="none"
+              width="10px"
+              height="10px"
+            />
+          </g>
+          <g text-anchor="middle" transform="matrix(1,0,0,1,0,0)">
+            <text
+              id="text"
+              fill="none"
+              dominant-baseline="alphabetic"
+              paint-order="stroke"
+              stroke="none"
+            />
+          </g>
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/packages/g6/__tests__/integration/snapshots/static/edge-cubic-vertical.svg
+++ b/packages/g6/__tests__/integration/snapshots/static/edge-cubic-vertical.svg
@@ -1,0 +1,317 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="500"
+  height="500"
+  style="background: transparent; position: absolute; outline: none;"
+  color-interpolation-filters="sRGB"
+  tabindex="1"
+>
+  <defs />
+  <g id="g-svg-camera" transform="matrix(1,0,0,1,0,0)">
+    <g
+      id="g-root"
+      fill="none"
+      stroke="none"
+      visibility="visible"
+      font-size="16px"
+      font-family="sans-serif"
+      font-style="normal"
+      font-weight="normal"
+      font-variant="normal"
+      text-anchor="left"
+      stroke-dashoffset="0px"
+      transform="matrix(1,0,0,1,0,0)"
+    >
+      <g
+        id="g-svg-5"
+        fill="none"
+        stroke="rgba(24,144,255,1)"
+        stroke-width="2px"
+        marker-start="false"
+        marker-end="true"
+        transform="matrix(1,0,0,1,0,0)"
+      >
+        <g stroke-width="2px" transform="matrix(1,0,0,1,100,100)">
+          <path
+            id="key"
+            fill="none"
+            d="M 100,0 C 100 100,0 100,0 200"
+            stroke="rgba(24,144,255,1)"
+          />
+          <g
+            stroke-width="2px"
+            stroke-dasharray="0px,0px"
+            transform="matrix(0,-1,1,0,0,200)"
+          >
+            <path
+              id="g-svg-8"
+              fill="rgba(24,144,255,1)"
+              d="M 0,5 L 10,0 L 10,10 Z"
+              transform="translate(-5,-5)"
+              stroke="rgba(24,144,255,1)"
+            />
+          </g>
+        </g>
+        <g
+          id="label"
+          fill="none"
+          stroke="none"
+          text-anchor="middle"
+          transform="matrix(0.697616,-0.716471,0.716471,0.697616,142.910706,198.680191)"
+        >
+          <g transform="matrix(1,0,0,1,-5,-5)">
+            <path
+              id="background"
+              fill="none"
+              d="M 0,0 l 10,0 l 0,10 l-10 0 z"
+              stroke="none"
+              width="10px"
+              height="10px"
+            />
+          </g>
+          <g text-anchor="middle" transform="matrix(1,0,0,1,0,0)">
+            <text
+              id="text"
+              fill="none"
+              dominant-baseline="alphabetic"
+              paint-order="stroke"
+              stroke="none"
+            />
+          </g>
+        </g>
+      </g>
+      <g
+        id="g-svg-12"
+        fill="none"
+        stroke="rgba(24,144,255,1)"
+        stroke-width="2px"
+        marker-start="false"
+        marker-end="true"
+        transform="matrix(1,0,0,1,0,0)"
+      >
+        <g stroke-width="2px" transform="matrix(1,0,0,1,150,100)">
+          <path
+            id="key"
+            fill="none"
+            d="M 50,0 C 50 100,0 100,0 200"
+            stroke="rgba(24,144,255,1)"
+          />
+          <g
+            stroke-width="2px"
+            stroke-dasharray="0px,0px"
+            transform="matrix(0,-1,1,0,0,200)"
+          >
+            <path
+              id="g-svg-15"
+              fill="rgba(24,144,255,1)"
+              d="M 0,5 L 10,0 L 10,10 Z"
+              transform="translate(-5,-5)"
+              stroke="rgba(24,144,255,1)"
+            />
+          </g>
+        </g>
+        <g
+          id="label"
+          fill="none"
+          stroke="none"
+          text-anchor="middle"
+          transform="matrix(0.437723,-0.899110,0.899110,0.437723,167.854446,200.970108)"
+        >
+          <g transform="matrix(1,0,0,1,-5,-5)">
+            <path
+              id="background"
+              fill="none"
+              d="M 0,0 l 10,0 l 0,10 l-10 0 z"
+              stroke="none"
+              width="10px"
+              height="10px"
+            />
+          </g>
+          <g text-anchor="middle" transform="matrix(1,0,0,1,0,0)">
+            <text
+              id="text"
+              fill="none"
+              dominant-baseline="alphabetic"
+              paint-order="stroke"
+              stroke="none"
+            />
+          </g>
+        </g>
+      </g>
+      <g
+        id="g-svg-19"
+        fill="none"
+        stroke="rgba(24,144,255,1)"
+        stroke-width="2px"
+        marker-start="false"
+        marker-end="true"
+        transform="matrix(1,0,0,1,0,0)"
+      >
+        <g stroke-width="2px" transform="matrix(1,0,0,1,200,100)">
+          <path
+            id="key"
+            fill="none"
+            d="M 0,0 C 0 100,0 100,0 200"
+            stroke="rgba(24,144,255,1)"
+          />
+          <g
+            stroke-width="2px"
+            stroke-dasharray="0px,0px"
+            transform="matrix(0,-1,1,0,0,200)"
+          >
+            <path
+              id="g-svg-22"
+              fill="rgba(24,144,255,1)"
+              d="M 0,5 L 10,0 L 10,10 Z"
+              transform="translate(-5,-5)"
+              stroke="rgba(24,144,255,1)"
+            />
+          </g>
+        </g>
+        <g
+          id="label"
+          fill="none"
+          stroke="none"
+          text-anchor="middle"
+          transform="matrix(0,1,-1,0,206,204)"
+        >
+          <g transform="matrix(1,0,0,1,-5,-5)">
+            <path
+              id="background"
+              fill="none"
+              d="M 0,0 l 10,0 l 0,10 l-10 0 z"
+              stroke="none"
+              width="10px"
+              height="10px"
+            />
+          </g>
+          <g text-anchor="middle" transform="matrix(1,0,0,1,0,0)">
+            <text
+              id="text"
+              fill="none"
+              dominant-baseline="alphabetic"
+              paint-order="stroke"
+              stroke="none"
+            />
+          </g>
+        </g>
+      </g>
+      <g
+        id="g-svg-26"
+        fill="none"
+        stroke="rgba(24,144,255,1)"
+        stroke-width="2px"
+        marker-start="false"
+        marker-end="true"
+        transform="matrix(1,0,0,1,0,0)"
+      >
+        <g stroke-width="2px" transform="matrix(1,0,0,1,200,100)">
+          <path
+            id="key"
+            fill="none"
+            d="M 0,0 C 0 100,50 100,50 200"
+            stroke="rgba(24,144,255,1)"
+          />
+          <g
+            stroke-width="2px"
+            stroke-dasharray="0px,0px"
+            transform="matrix(0,-1,1,0,50,200)"
+          >
+            <path
+              id="g-svg-29"
+              fill="rgba(24,144,255,1)"
+              d="M 0,5 L 10,0 L 10,10 Z"
+              transform="translate(-5,-5)"
+              stroke="rgba(24,144,255,1)"
+            />
+          </g>
+        </g>
+        <g
+          id="label"
+          fill="none"
+          stroke="none"
+          text-anchor="middle"
+          transform="matrix(0.437723,0.899110,-0.899110,0.437723,232.145554,200.970108)"
+        >
+          <g transform="matrix(1,0,0,1,-5,-5)">
+            <path
+              id="background"
+              fill="none"
+              d="M 0,0 l 10,0 l 0,10 l-10 0 z"
+              stroke="none"
+              width="10px"
+              height="10px"
+            />
+          </g>
+          <g text-anchor="middle" transform="matrix(1,0,0,1,0,0)">
+            <text
+              id="text"
+              fill="none"
+              dominant-baseline="alphabetic"
+              paint-order="stroke"
+              stroke="none"
+            />
+          </g>
+        </g>
+      </g>
+      <g
+        id="g-svg-33"
+        fill="none"
+        stroke="rgba(24,144,255,1)"
+        stroke-width="2px"
+        marker-start="false"
+        marker-end="true"
+        transform="matrix(1,0,0,1,0,0)"
+      >
+        <g stroke-width="2px" transform="matrix(1,0,0,1,200,100)">
+          <path
+            id="key"
+            fill="none"
+            d="M 0,0 C 0 100,100 100,100 200"
+            stroke="rgba(24,144,255,1)"
+          />
+          <g
+            stroke-width="2px"
+            stroke-dasharray="0px,0px"
+            transform="matrix(0,-1,1,0,100,200)"
+          >
+            <path
+              id="g-svg-36"
+              fill="rgba(24,144,255,1)"
+              d="M 0,5 L 10,0 L 10,10 Z"
+              transform="translate(-5,-5)"
+              stroke="rgba(24,144,255,1)"
+            />
+          </g>
+        </g>
+        <g
+          id="label"
+          fill="none"
+          stroke="none"
+          text-anchor="middle"
+          transform="matrix(0.697616,0.716471,-0.716471,0.697616,257.089294,198.680191)"
+        >
+          <g transform="matrix(1,0,0,1,-5,-5)">
+            <path
+              id="background"
+              fill="none"
+              d="M 0,0 l 10,0 l 0,10 l-10 0 z"
+              stroke="none"
+              width="10px"
+              height="10px"
+            />
+          </g>
+          <g text-anchor="middle" transform="matrix(1,0,0,1,0,0)">
+            <text
+              id="text"
+              fill="none"
+              dominant-baseline="alphabetic"
+              paint-order="stroke"
+              stroke="none"
+            />
+          </g>
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/packages/g6/__tests__/integration/snapshots/static/edge-cubic-vertical.svg
+++ b/packages/g6/__tests__/integration/snapshots/static/edge-cubic-vertical.svg
@@ -8,55 +8,37 @@
 >
   <defs />
   <g id="g-svg-camera" transform="matrix(1,0,0,1,0,0)">
-    <g
-      id="g-root"
-      fill="none"
-      stroke="none"
-      visibility="visible"
-      font-size="16px"
-      font-family="sans-serif"
-      font-style="normal"
-      font-weight="normal"
-      font-variant="normal"
-      text-anchor="left"
-      stroke-dashoffset="0px"
-      transform="matrix(1,0,0,1,0,0)"
-    >
+    <g id="g-root" fill="none" transform="matrix(1,0,0,1,0,0)">
       <g
         id="g-svg-5"
         fill="none"
-        stroke="rgba(24,144,255,1)"
-        stroke-width="2px"
         marker-start="false"
         marker-end="true"
         transform="matrix(1,0,0,1,0,0)"
       >
-        <g stroke-width="2px" transform="matrix(1,0,0,1,100,100)">
+        <g transform="matrix(1,0,0,1,100,100)">
           <path
             id="key"
             fill="none"
             d="M 100,0 C 100 100,0 100,0 200"
             stroke="rgba(24,144,255,1)"
+            stroke-width="2"
           />
-          <g
-            stroke-width="2px"
-            stroke-dasharray="0px,0px"
-            transform="matrix(0,-1,1,0,0,200)"
-          >
+          <g transform="matrix(0,-1,1,0,0,200)">
             <path
               id="g-svg-8"
               fill="rgba(24,144,255,1)"
               d="M 0,5 L 10,0 L 10,10 Z"
               transform="translate(-5,-5)"
               stroke="rgba(24,144,255,1)"
+              stroke-width="2"
+              stroke-dasharray="0,0"
             />
           </g>
         </g>
         <g
           id="label"
           fill="none"
-          stroke="none"
-          text-anchor="middle"
           transform="matrix(0.697616,-0.716471,0.716471,0.697616,142.910706,198.680191)"
         >
           <g transform="matrix(1,0,0,1,-5,-5)">
@@ -64,18 +46,17 @@
               id="background"
               fill="none"
               d="M 0,0 l 10,0 l 0,10 l-10 0 z"
-              stroke="none"
-              width="10px"
-              height="10px"
+              width="10"
+              height="10"
             />
           </g>
-          <g text-anchor="middle" transform="matrix(1,0,0,1,0,0)">
+          <g transform="matrix(1,0,0,1,0,0)">
             <text
               id="text"
-              fill="none"
-              dominant-baseline="alphabetic"
+              fill="rgba(0,0,0,1)"
+              dominant-baseline="text-after-edge"
               paint-order="stroke"
-              stroke="none"
+              text-anchor="middle"
             />
           </g>
         </g>
@@ -83,38 +64,33 @@
       <g
         id="g-svg-12"
         fill="none"
-        stroke="rgba(24,144,255,1)"
-        stroke-width="2px"
         marker-start="false"
         marker-end="true"
         transform="matrix(1,0,0,1,0,0)"
       >
-        <g stroke-width="2px" transform="matrix(1,0,0,1,150,100)">
+        <g transform="matrix(1,0,0,1,150,100)">
           <path
             id="key"
             fill="none"
             d="M 50,0 C 50 100,0 100,0 200"
             stroke="rgba(24,144,255,1)"
+            stroke-width="2"
           />
-          <g
-            stroke-width="2px"
-            stroke-dasharray="0px,0px"
-            transform="matrix(0,-1,1,0,0,200)"
-          >
+          <g transform="matrix(0,-1,1,0,0,200)">
             <path
               id="g-svg-15"
               fill="rgba(24,144,255,1)"
               d="M 0,5 L 10,0 L 10,10 Z"
               transform="translate(-5,-5)"
               stroke="rgba(24,144,255,1)"
+              stroke-width="2"
+              stroke-dasharray="0,0"
             />
           </g>
         </g>
         <g
           id="label"
           fill="none"
-          stroke="none"
-          text-anchor="middle"
           transform="matrix(0.437723,-0.899110,0.899110,0.437723,167.854446,200.970108)"
         >
           <g transform="matrix(1,0,0,1,-5,-5)">
@@ -122,18 +98,17 @@
               id="background"
               fill="none"
               d="M 0,0 l 10,0 l 0,10 l-10 0 z"
-              stroke="none"
-              width="10px"
-              height="10px"
+              width="10"
+              height="10"
             />
           </g>
-          <g text-anchor="middle" transform="matrix(1,0,0,1,0,0)">
+          <g transform="matrix(1,0,0,1,0,0)">
             <text
               id="text"
-              fill="none"
-              dominant-baseline="alphabetic"
+              fill="rgba(0,0,0,1)"
+              dominant-baseline="text-after-edge"
               paint-order="stroke"
-              stroke="none"
+              text-anchor="middle"
             />
           </g>
         </g>
@@ -141,57 +116,47 @@
       <g
         id="g-svg-19"
         fill="none"
-        stroke="rgba(24,144,255,1)"
-        stroke-width="2px"
         marker-start="false"
         marker-end="true"
         transform="matrix(1,0,0,1,0,0)"
       >
-        <g stroke-width="2px" transform="matrix(1,0,0,1,200,100)">
+        <g transform="matrix(1,0,0,1,200,100)">
           <path
             id="key"
             fill="none"
             d="M 0,0 C 0 100,0 100,0 200"
             stroke="rgba(24,144,255,1)"
+            stroke-width="2"
           />
-          <g
-            stroke-width="2px"
-            stroke-dasharray="0px,0px"
-            transform="matrix(0,-1,1,0,0,200)"
-          >
+          <g transform="matrix(0,-1,1,0,0,200)">
             <path
               id="g-svg-22"
               fill="rgba(24,144,255,1)"
               d="M 0,5 L 10,0 L 10,10 Z"
               transform="translate(-5,-5)"
               stroke="rgba(24,144,255,1)"
+              stroke-width="2"
+              stroke-dasharray="0,0"
             />
           </g>
         </g>
-        <g
-          id="label"
-          fill="none"
-          stroke="none"
-          text-anchor="middle"
-          transform="matrix(0,1,-1,0,206,204)"
-        >
+        <g id="label" fill="none" transform="matrix(0,1,-1,0,206,204)">
           <g transform="matrix(1,0,0,1,-5,-5)">
             <path
               id="background"
               fill="none"
               d="M 0,0 l 10,0 l 0,10 l-10 0 z"
-              stroke="none"
-              width="10px"
-              height="10px"
+              width="10"
+              height="10"
             />
           </g>
-          <g text-anchor="middle" transform="matrix(1,0,0,1,0,0)">
+          <g transform="matrix(1,0,0,1,0,0)">
             <text
               id="text"
-              fill="none"
-              dominant-baseline="alphabetic"
+              fill="rgba(0,0,0,1)"
+              dominant-baseline="text-after-edge"
               paint-order="stroke"
-              stroke="none"
+              text-anchor="middle"
             />
           </g>
         </g>
@@ -199,38 +164,33 @@
       <g
         id="g-svg-26"
         fill="none"
-        stroke="rgba(24,144,255,1)"
-        stroke-width="2px"
         marker-start="false"
         marker-end="true"
         transform="matrix(1,0,0,1,0,0)"
       >
-        <g stroke-width="2px" transform="matrix(1,0,0,1,200,100)">
+        <g transform="matrix(1,0,0,1,200,100)">
           <path
             id="key"
             fill="none"
             d="M 0,0 C 0 100,50 100,50 200"
             stroke="rgba(24,144,255,1)"
+            stroke-width="2"
           />
-          <g
-            stroke-width="2px"
-            stroke-dasharray="0px,0px"
-            transform="matrix(0,-1,1,0,50,200)"
-          >
+          <g transform="matrix(0,-1,1,0,50,200)">
             <path
               id="g-svg-29"
               fill="rgba(24,144,255,1)"
               d="M 0,5 L 10,0 L 10,10 Z"
               transform="translate(-5,-5)"
               stroke="rgba(24,144,255,1)"
+              stroke-width="2"
+              stroke-dasharray="0,0"
             />
           </g>
         </g>
         <g
           id="label"
           fill="none"
-          stroke="none"
-          text-anchor="middle"
           transform="matrix(0.437723,0.899110,-0.899110,0.437723,232.145554,200.970108)"
         >
           <g transform="matrix(1,0,0,1,-5,-5)">
@@ -238,18 +198,17 @@
               id="background"
               fill="none"
               d="M 0,0 l 10,0 l 0,10 l-10 0 z"
-              stroke="none"
-              width="10px"
-              height="10px"
+              width="10"
+              height="10"
             />
           </g>
-          <g text-anchor="middle" transform="matrix(1,0,0,1,0,0)">
+          <g transform="matrix(1,0,0,1,0,0)">
             <text
               id="text"
-              fill="none"
-              dominant-baseline="alphabetic"
+              fill="rgba(0,0,0,1)"
+              dominant-baseline="text-after-edge"
               paint-order="stroke"
-              stroke="none"
+              text-anchor="middle"
             />
           </g>
         </g>
@@ -257,38 +216,33 @@
       <g
         id="g-svg-33"
         fill="none"
-        stroke="rgba(24,144,255,1)"
-        stroke-width="2px"
         marker-start="false"
         marker-end="true"
         transform="matrix(1,0,0,1,0,0)"
       >
-        <g stroke-width="2px" transform="matrix(1,0,0,1,200,100)">
+        <g transform="matrix(1,0,0,1,200,100)">
           <path
             id="key"
             fill="none"
             d="M 0,0 C 0 100,100 100,100 200"
             stroke="rgba(24,144,255,1)"
+            stroke-width="2"
           />
-          <g
-            stroke-width="2px"
-            stroke-dasharray="0px,0px"
-            transform="matrix(0,-1,1,0,100,200)"
-          >
+          <g transform="matrix(0,-1,1,0,100,200)">
             <path
               id="g-svg-36"
               fill="rgba(24,144,255,1)"
               d="M 0,5 L 10,0 L 10,10 Z"
               transform="translate(-5,-5)"
               stroke="rgba(24,144,255,1)"
+              stroke-width="2"
+              stroke-dasharray="0,0"
             />
           </g>
         </g>
         <g
           id="label"
           fill="none"
-          stroke="none"
-          text-anchor="middle"
           transform="matrix(0.697616,0.716471,-0.716471,0.697616,257.089294,198.680191)"
         >
           <g transform="matrix(1,0,0,1,-5,-5)">
@@ -296,18 +250,17 @@
               id="background"
               fill="none"
               d="M 0,0 l 10,0 l 0,10 l-10 0 z"
-              stroke="none"
-              width="10px"
-              height="10px"
+              width="10"
+              height="10"
             />
           </g>
-          <g text-anchor="middle" transform="matrix(1,0,0,1,0,0)">
+          <g transform="matrix(1,0,0,1,0,0)">
             <text
               id="text"
-              fill="none"
-              dominant-baseline="alphabetic"
+              fill="rgba(0,0,0,1)"
+              dominant-baseline="text-after-edge"
               paint-order="stroke"
-              stroke="none"
+              text-anchor="middle"
             />
           </g>
         </g>

--- a/packages/g6/__tests__/integration/snapshots/static/edge-cubic.svg
+++ b/packages/g6/__tests__/integration/snapshots/static/edge-cubic.svg
@@ -8,94 +8,70 @@
 >
   <defs />
   <g id="g-svg-camera" transform="matrix(1,0,0,1,0,0)">
-    <g
-      id="g-root"
-      fill="none"
-      stroke="none"
-      visibility="visible"
-      font-size="16px"
-      font-family="sans-serif"
-      font-style="normal"
-      font-weight="normal"
-      font-variant="normal"
-      text-anchor="left"
-      stroke-dashoffset="0px"
-      transform="matrix(1,0,0,1,0,0)"
-    >
+    <g id="g-root" fill="none" transform="matrix(1,0,0,1,0,0)">
       <g
         id="g-svg-5"
         fill="none"
-        stroke="rgba(24,144,255,1)"
-        stroke-width="2px"
         marker-start="false"
         marker-end="true"
         transform="matrix(1,0,0,1,0,0)"
       >
-        <g
-          opacity="0.25"
-          pointer-events="none"
-          stroke-width="12px"
-          stroke-dasharray="0px,0px"
-          transform="matrix(1,0,0,1,100,44.226498)"
-        >
+        <g transform="matrix(1,0,0,1,100,44.226498)">
           <path
             id="halo"
             fill="none"
             d="M 0,5.773502691896255 C 100 25.773502691896255,100 -14.226497308103745,200 5.773502691896255"
             stroke="rgba(24,144,255,1)"
+            stroke-width="12"
+            stroke-dasharray="0,0"
+            pointer-events="none"
+            opacity="0.25"
           />
         </g>
-        <g stroke-width="2px" transform="matrix(1,0,0,1,100,44.226498)">
+        <g transform="matrix(1,0,0,1,100,44.226498)">
           <path
             id="key"
             fill="none"
             d="M 0,5.773502691896255 C 100 25.773502691896255,100 -14.226497308103745,200 5.773502691896255"
             stroke="rgba(24,144,255,1)"
+            stroke-width="2"
           />
-          <g
-            stroke-width="2px"
-            stroke-dasharray="0px,0px"
-            transform="matrix(-0.980581,-0.196116,0.196116,-0.980581,200,5.773503)"
-          >
+          <g transform="matrix(-0.980581,-0.196116,0.196116,-0.980581,200,5.773503)">
             <path
               id="g-svg-8"
               fill="rgba(24,144,255,1)"
               d="M 0,5 L 10,0 L 10,10 Z"
               transform="translate(-5,-5)"
               stroke="rgba(24,144,255,1)"
+              stroke-width="2"
+              stroke-dasharray="0,0"
             />
           </g>
         </g>
         <g
           id="label"
           fill="none"
-          stroke="none"
-          font-size="12px"
-          text-anchor="middle"
           transform="matrix(0.982519,-0.186162,0.186162,0.982519,201.137650,34.517567)"
         >
-          <g transform="matrix(1,0,0,1,-47.189770,-34.193607)">
+          <g transform="matrix(1,0,0,1,-47.006863,-42.010700)">
             <path
               id="background"
               fill="none"
-              d="M 0,0 l 96.37955336737453,0 l 0,62.387219870853585 l-96.37955336737453 0 z"
-              stroke="none"
-              width="96.37955336737453px"
-              height="62.387219870853585px"
+              d="M 0,0 l 95.01373867014786,0 l 0,61.02140517362693 l-95.01373867014786 0 z"
+              width="95.01373867014786"
+              height="61.02140517362693"
             />
           </g>
-          <g
-            font-size="12px"
-            text-anchor="middle"
-            transform="matrix(1,0,0,1,0,0)"
-          >
+          <g transform="matrix(1,0,0,1,0,0)">
             <text
               id="text"
-              fill="none"
-              dominant-baseline="alphabetic"
+              fill="rgba(0,0,0,1)"
+              dominant-baseline="central"
               paint-order="stroke"
-              dx="1"
-              stroke="none"
+              dx="0.5"
+              dy="-11.5px"
+              text-anchor="middle"
+              font-size="12"
             >
               default cubic
             </text>
@@ -105,63 +81,54 @@
       <g
         id="g-svg-13"
         fill="none"
-        stroke="rgba(24,144,255,1)"
-        stroke-width="2px"
         marker-start="false"
         marker-end="true"
         transform="matrix(1,0,0,1,0,0)"
       >
-        <g stroke-width="2px" transform="matrix(1,0,0,1,100,135.566238)">
+        <g transform="matrix(1,0,0,1,100,135.566238)">
           <path
             id="key"
             fill="none"
             d="M 0,14.43375672974065 C 100 64.43375672974065,100 -35.56624327025935,200 14.43375672974065"
             stroke="rgba(24,144,255,1)"
+            stroke-width="2"
           />
-          <g
-            stroke-width="2px"
-            stroke-dasharray="0px,0px"
-            transform="matrix(-0.894427,-0.447214,0.447214,-0.894427,200,14.433757)"
-          >
+          <g transform="matrix(-0.894427,-0.447214,0.447214,-0.894427,200,14.433757)">
             <path
               id="g-svg-16"
               fill="rgba(24,144,255,1)"
               d="M 0,5 L 10,0 L 10,10 Z"
               transform="translate(-5,-5)"
               stroke="rgba(24,144,255,1)"
+              stroke-width="2"
+              stroke-dasharray="0,0"
             />
           </g>
         </g>
         <g
           id="label"
           fill="none"
-          stroke="none"
-          font-size="12px"
-          text-anchor="middle"
           transform="matrix(0.903736,-0.428091,0.428091,0.903736,197.193588,134.731598)"
         >
-          <g transform="matrix(1,0,0,1,-146.945145,-123.421005)">
+          <g transform="matrix(1,0,0,1,-146.558258,-131.034119)">
             <path
               id="background"
               fill="none"
-              d="M 0,0 l 295.89027792815574,0 l 0,240.84199202534606 l-295.89027792815574 0 z"
-              stroke="none"
-              width="295.89027792815574px"
-              height="240.84199202534606px"
+              d="M 0,0 l 294.11651618864767,0 l 0,239.06823028583796 l-294.11651618864767 0 z"
+              width="294.11651618864767"
+              height="239.06823028583796"
             />
           </g>
-          <g
-            font-size="12px"
-            text-anchor="middle"
-            transform="matrix(1,0,0,1,0,0)"
-          >
+          <g transform="matrix(1,0,0,1,0,0)">
             <text
               id="text"
-              fill="none"
-              dominant-baseline="alphabetic"
+              fill="rgba(0,0,0,1)"
+              dominant-baseline="central"
               paint-order="stroke"
-              dx="1"
-              stroke="none"
+              dx="0.5"
+              dy="-11.5px"
+              text-anchor="middle"
+              font-size="12"
             >
               controlPoints=[[200, 200],[200,100]]
             </text>
@@ -171,63 +138,54 @@
       <g
         id="g-svg-20"
         fill="none"
-        stroke="rgba(24,144,255,1)"
-        stroke-width="2px"
         marker-start="false"
         marker-end="true"
         transform="matrix(1,0,0,1,0,0)"
       >
-        <g stroke-width="2px" transform="matrix(1,0,0,1,100,235.566238)">
+        <g transform="matrix(1,0,0,1,100,235.566238)">
           <path
             id="key"
             fill="none"
             d="M 0,14.43375672974065 C 100 -35.56624327025935,100 64.43375672974065,200 14.43375672974065"
             stroke="rgba(24,144,255,1)"
+            stroke-width="2"
           />
-          <g
-            stroke-width="2px"
-            stroke-dasharray="0px,0px"
-            transform="matrix(-0.894427,0.447214,-0.447214,-0.894427,200,14.433757)"
-          >
+          <g transform="matrix(-0.894427,0.447214,-0.447214,-0.894427,200,14.433757)">
             <path
               id="g-svg-23"
               fill="rgba(24,144,255,1)"
               d="M 0,5 L 10,0 L 10,10 Z"
               transform="translate(-5,-5)"
               stroke="rgba(24,144,255,1)"
+              stroke-width="2"
+              stroke-dasharray="0,0"
             />
           </g>
         </g>
         <g
           id="label"
           fill="none"
-          stroke="none"
-          font-size="12px"
-          text-anchor="middle"
           transform="matrix(0.903739,0.428085,-0.428085,0.903739,210.036224,238.156265)"
         >
-          <g transform="matrix(1,0,0,1,-116.585052,-99.928734)">
+          <g transform="matrix(1,0,0,1,-116.198174,-107.541862)">
             <path
               id="background"
               fill="none"
-              d="M 0,0 l 235.1700813725111,0 l 0,193.85746869310407 l-235.1700813725111 0 z"
-              stroke="none"
-              width="235.1700813725111px"
-              height="193.85746869310407px"
+              d="M 0,0 l 233.39632790301584,0 l 0,192.0837152236088 l-233.39632790301584 0 z"
+              width="233.39632790301584"
+              height="192.0837152236088"
             />
           </g>
-          <g
-            font-size="12px"
-            text-anchor="middle"
-            transform="matrix(1,0,0,1,0,0)"
-          >
+          <g transform="matrix(1,0,0,1,0,0)">
             <text
               id="text"
-              fill="none"
-              dominant-baseline="alphabetic"
+              fill="rgba(0,0,0,1)"
+              dominant-baseline="central"
               paint-order="stroke"
-              dx="1"
-              stroke="none"
+              dx="0.5"
+              dy="-11.5px"
+              text-anchor="middle"
+              font-size="12"
             >
               curveOffset=50, curvePosition:0.5
             </text>
@@ -237,63 +195,54 @@
       <g
         id="g-svg-27"
         fill="none"
-        stroke="rgba(24,144,255,1)"
-        stroke-width="2px"
         marker-start="false"
         marker-end="true"
         transform="matrix(1,0,0,1,0,0)"
       >
-        <g stroke-width="2px" transform="matrix(1,0,0,1,100,335.566254)">
+        <g transform="matrix(1,0,0,1,100,335.566254)">
           <path
             id="key"
             fill="none"
             d="M 0,14.43375672974065 C 50 -35.56624327025935,150 64.43375672974065,200 14.43375672974065"
             stroke="rgba(24,144,255,1)"
+            stroke-width="2"
           />
-          <g
-            stroke-width="2px"
-            stroke-dasharray="0px,0px"
-            transform="matrix(-0.707107,0.707107,-0.707107,-0.707107,200,14.433757)"
-          >
+          <g transform="matrix(-0.707107,0.707107,-0.707107,-0.707107,200,14.433757)">
             <path
               id="g-svg-30"
               fill="rgba(24,144,255,1)"
               d="M 0,5 L 10,0 L 10,10 Z"
               transform="translate(-5,-5)"
               stroke="rgba(24,144,255,1)"
+              stroke-width="2"
+              stroke-dasharray="0,0"
             />
           </g>
         </g>
         <g
           id="label"
           fill="none"
-          stroke="none"
-          font-size="12px"
-          text-anchor="middle"
           transform="matrix(0.952026,0.306016,-0.306016,0.952026,208.398346,336.943665)"
         >
-          <g transform="matrix(1,0,0,1,-118.012054,-82.357452)">
+          <g transform="matrix(1,0,0,1,-117.720718,-90.066116)">
             <path
               id="background"
               fill="none"
-              d="M 0,0 l 238.0241002602439,0 l 0,158.71488061727715 l-238.0241002602439 0 z"
-              stroke="none"
-              width="238.0241002602439px"
-              height="158.71488061727715px"
+              d="M 0,0 l 236.44142936090967,0 l 0,157.13220971794289 l-236.44142936090967 0 z"
+              width="236.44142936090967"
+              height="157.13220971794289"
             />
           </g>
-          <g
-            font-size="12px"
-            text-anchor="middle"
-            transform="matrix(1,0,0,1,0,0)"
-          >
+          <g transform="matrix(1,0,0,1,0,0)">
             <text
               id="text"
-              fill="none"
-              dominant-baseline="alphabetic"
+              fill="rgba(0,0,0,1)"
+              dominant-baseline="central"
               paint-order="stroke"
-              dx="1"
-              stroke="none"
+              dx="0.5"
+              dy="-11.5px"
+              text-anchor="middle"
+              font-size="12"
             >
               curveOffset=50, curvePosition:0.25
             </text>

--- a/packages/g6/__tests__/integration/snapshots/static/edge-cubic.svg
+++ b/packages/g6/__tests__/integration/snapshots/static/edge-cubic.svg
@@ -1,0 +1,305 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="500"
+  height="500"
+  style="background: transparent; position: absolute; outline: none;"
+  color-interpolation-filters="sRGB"
+  tabindex="1"
+>
+  <defs />
+  <g id="g-svg-camera" transform="matrix(1,0,0,1,0,0)">
+    <g
+      id="g-root"
+      fill="none"
+      stroke="none"
+      visibility="visible"
+      font-size="16px"
+      font-family="sans-serif"
+      font-style="normal"
+      font-weight="normal"
+      font-variant="normal"
+      text-anchor="left"
+      stroke-dashoffset="0px"
+      transform="matrix(1,0,0,1,0,0)"
+    >
+      <g
+        id="g-svg-5"
+        fill="none"
+        stroke="rgba(24,144,255,1)"
+        stroke-width="2px"
+        marker-start="false"
+        marker-end="true"
+        transform="matrix(1,0,0,1,0,0)"
+      >
+        <g
+          opacity="0.25"
+          pointer-events="none"
+          stroke-width="12px"
+          stroke-dasharray="0px,0px"
+          transform="matrix(1,0,0,1,100,44.226498)"
+        >
+          <path
+            id="halo"
+            fill="none"
+            d="M 0,5.773502691896255 C 100 25.773502691896255,100 -14.226497308103745,200 5.773502691896255"
+            stroke="rgba(24,144,255,1)"
+          />
+        </g>
+        <g stroke-width="2px" transform="matrix(1,0,0,1,100,44.226498)">
+          <path
+            id="key"
+            fill="none"
+            d="M 0,5.773502691896255 C 100 25.773502691896255,100 -14.226497308103745,200 5.773502691896255"
+            stroke="rgba(24,144,255,1)"
+          />
+          <g
+            stroke-width="2px"
+            stroke-dasharray="0px,0px"
+            transform="matrix(-0.980581,-0.196116,0.196116,-0.980581,200,5.773503)"
+          >
+            <path
+              id="g-svg-8"
+              fill="rgba(24,144,255,1)"
+              d="M 0,5 L 10,0 L 10,10 Z"
+              transform="translate(-5,-5)"
+              stroke="rgba(24,144,255,1)"
+            />
+          </g>
+        </g>
+        <g
+          id="label"
+          fill="none"
+          stroke="none"
+          font-size="12px"
+          text-anchor="middle"
+          transform="matrix(0.982519,-0.186162,0.186162,0.982519,201.137650,34.517567)"
+        >
+          <g transform="matrix(1,0,0,1,-47.189770,-34.193607)">
+            <path
+              id="background"
+              fill="none"
+              d="M 0,0 l 96.37955336737453,0 l 0,62.387219870853585 l-96.37955336737453 0 z"
+              stroke="none"
+              width="96.37955336737453px"
+              height="62.387219870853585px"
+            />
+          </g>
+          <g
+            font-size="12px"
+            text-anchor="middle"
+            transform="matrix(1,0,0,1,0,0)"
+          >
+            <text
+              id="text"
+              fill="none"
+              dominant-baseline="alphabetic"
+              paint-order="stroke"
+              dx="1"
+              stroke="none"
+            >
+              default cubic
+            </text>
+          </g>
+        </g>
+      </g>
+      <g
+        id="g-svg-13"
+        fill="none"
+        stroke="rgba(24,144,255,1)"
+        stroke-width="2px"
+        marker-start="false"
+        marker-end="true"
+        transform="matrix(1,0,0,1,0,0)"
+      >
+        <g stroke-width="2px" transform="matrix(1,0,0,1,100,135.566238)">
+          <path
+            id="key"
+            fill="none"
+            d="M 0,14.43375672974065 C 100 64.43375672974065,100 -35.56624327025935,200 14.43375672974065"
+            stroke="rgba(24,144,255,1)"
+          />
+          <g
+            stroke-width="2px"
+            stroke-dasharray="0px,0px"
+            transform="matrix(-0.894427,-0.447214,0.447214,-0.894427,200,14.433757)"
+          >
+            <path
+              id="g-svg-16"
+              fill="rgba(24,144,255,1)"
+              d="M 0,5 L 10,0 L 10,10 Z"
+              transform="translate(-5,-5)"
+              stroke="rgba(24,144,255,1)"
+            />
+          </g>
+        </g>
+        <g
+          id="label"
+          fill="none"
+          stroke="none"
+          font-size="12px"
+          text-anchor="middle"
+          transform="matrix(0.903736,-0.428091,0.428091,0.903736,197.193588,134.731598)"
+        >
+          <g transform="matrix(1,0,0,1,-146.945145,-123.421005)">
+            <path
+              id="background"
+              fill="none"
+              d="M 0,0 l 295.89027792815574,0 l 0,240.84199202534606 l-295.89027792815574 0 z"
+              stroke="none"
+              width="295.89027792815574px"
+              height="240.84199202534606px"
+            />
+          </g>
+          <g
+            font-size="12px"
+            text-anchor="middle"
+            transform="matrix(1,0,0,1,0,0)"
+          >
+            <text
+              id="text"
+              fill="none"
+              dominant-baseline="alphabetic"
+              paint-order="stroke"
+              dx="1"
+              stroke="none"
+            >
+              controlPoints=[[200, 200],[200,100]]
+            </text>
+          </g>
+        </g>
+      </g>
+      <g
+        id="g-svg-20"
+        fill="none"
+        stroke="rgba(24,144,255,1)"
+        stroke-width="2px"
+        marker-start="false"
+        marker-end="true"
+        transform="matrix(1,0,0,1,0,0)"
+      >
+        <g stroke-width="2px" transform="matrix(1,0,0,1,100,235.566238)">
+          <path
+            id="key"
+            fill="none"
+            d="M 0,14.43375672974065 C 100 -35.56624327025935,100 64.43375672974065,200 14.43375672974065"
+            stroke="rgba(24,144,255,1)"
+          />
+          <g
+            stroke-width="2px"
+            stroke-dasharray="0px,0px"
+            transform="matrix(-0.894427,0.447214,-0.447214,-0.894427,200,14.433757)"
+          >
+            <path
+              id="g-svg-23"
+              fill="rgba(24,144,255,1)"
+              d="M 0,5 L 10,0 L 10,10 Z"
+              transform="translate(-5,-5)"
+              stroke="rgba(24,144,255,1)"
+            />
+          </g>
+        </g>
+        <g
+          id="label"
+          fill="none"
+          stroke="none"
+          font-size="12px"
+          text-anchor="middle"
+          transform="matrix(0.903739,0.428085,-0.428085,0.903739,210.036224,238.156265)"
+        >
+          <g transform="matrix(1,0,0,1,-116.585052,-99.928734)">
+            <path
+              id="background"
+              fill="none"
+              d="M 0,0 l 235.1700813725111,0 l 0,193.85746869310407 l-235.1700813725111 0 z"
+              stroke="none"
+              width="235.1700813725111px"
+              height="193.85746869310407px"
+            />
+          </g>
+          <g
+            font-size="12px"
+            text-anchor="middle"
+            transform="matrix(1,0,0,1,0,0)"
+          >
+            <text
+              id="text"
+              fill="none"
+              dominant-baseline="alphabetic"
+              paint-order="stroke"
+              dx="1"
+              stroke="none"
+            >
+              curveOffset=50, curvePosition:0.5
+            </text>
+          </g>
+        </g>
+      </g>
+      <g
+        id="g-svg-27"
+        fill="none"
+        stroke="rgba(24,144,255,1)"
+        stroke-width="2px"
+        marker-start="false"
+        marker-end="true"
+        transform="matrix(1,0,0,1,0,0)"
+      >
+        <g stroke-width="2px" transform="matrix(1,0,0,1,100,335.566254)">
+          <path
+            id="key"
+            fill="none"
+            d="M 0,14.43375672974065 C 50 -35.56624327025935,150 64.43375672974065,200 14.43375672974065"
+            stroke="rgba(24,144,255,1)"
+          />
+          <g
+            stroke-width="2px"
+            stroke-dasharray="0px,0px"
+            transform="matrix(-0.707107,0.707107,-0.707107,-0.707107,200,14.433757)"
+          >
+            <path
+              id="g-svg-30"
+              fill="rgba(24,144,255,1)"
+              d="M 0,5 L 10,0 L 10,10 Z"
+              transform="translate(-5,-5)"
+              stroke="rgba(24,144,255,1)"
+            />
+          </g>
+        </g>
+        <g
+          id="label"
+          fill="none"
+          stroke="none"
+          font-size="12px"
+          text-anchor="middle"
+          transform="matrix(0.952026,0.306016,-0.306016,0.952026,208.398346,336.943665)"
+        >
+          <g transform="matrix(1,0,0,1,-118.012054,-82.357452)">
+            <path
+              id="background"
+              fill="none"
+              d="M 0,0 l 238.0241002602439,0 l 0,158.71488061727715 l-238.0241002602439 0 z"
+              stroke="none"
+              width="238.0241002602439px"
+              height="158.71488061727715px"
+            />
+          </g>
+          <g
+            font-size="12px"
+            text-anchor="middle"
+            transform="matrix(1,0,0,1,0,0)"
+          >
+            <text
+              id="text"
+              fill="none"
+              dominant-baseline="alphabetic"
+              paint-order="stroke"
+              dx="1"
+              stroke="none"
+            >
+              curveOffset=50, curvePosition:0.25
+            </text>
+          </g>
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/packages/g6/__tests__/integration/snapshots/static/edge-line.svg
+++ b/packages/g6/__tests__/integration/snapshots/static/edge-line.svg
@@ -8,30 +8,15 @@
 >
   <defs />
   <g id="g-svg-camera" transform="matrix(1,0,0,1,0,0)">
-    <g
-      id="g-root"
-      fill="none"
-      stroke="none"
-      visibility="visible"
-      font-size="16px"
-      font-family="sans-serif"
-      font-style="normal"
-      font-weight="normal"
-      font-variant="normal"
-      text-anchor="left"
-      stroke-dashoffset="0px"
-      transform="matrix(1,0,0,1,0,0)"
-    >
+    <g id="g-root" fill="none" transform="matrix(1,0,0,1,0,0)">
       <g
         id="g-svg-5"
         fill="none"
-        stroke="rgba(24,144,255,1)"
-        stroke-width="2px"
         marker-start="true"
         marker-end="false"
         transform="matrix(1,0,0,1,0,0)"
       >
-        <g stroke-width="2px" transform="matrix(1,0,0,1,100,50)">
+        <g transform="matrix(1,0,0,1,100,50)">
           <line
             id="key"
             fill="none"
@@ -40,51 +25,40 @@
             x2="200"
             y2="0"
             stroke="rgba(24,144,255,1)"
+            stroke-width="2"
           />
-          <g
-            stroke-width="2px"
-            stroke-dasharray="0px,0px"
-            transform="matrix(1,0,0,1,0,0)"
-          >
+          <g transform="matrix(1,0,0,1,0,0)">
             <path
               id="g-svg-8"
               fill="rgba(24,144,255,1)"
               d="M 0,5 L 5,0 L 10,5 L 5,10 Z"
               transform="translate(-5,-5)"
               stroke="rgba(24,144,255,1)"
+              stroke-width="2"
+              stroke-dasharray="0,0"
             />
           </g>
         </g>
-        <g
-          id="label"
-          fill="rgba(24,144,255,1)"
-          stroke="none"
-          font-size="12px"
-          text-anchor="middle"
-          transform="matrix(1,0,0,1,204,44)"
-        >
-          <g transform="matrix(1,0,0,1,-44.540001,-20)">
+        <g id="label" fill="none" transform="matrix(1,0,0,1,204,44)">
+          <g transform="matrix(1,0,0,1,-44.540001,-28)">
             <path
               id="background"
               fill="none"
-              d="M 0,0 l 91.08,0 l 0,34 l-91.08 0 z"
-              stroke="none"
-              width="91.08px"
-              height="34px"
+              d="M 0,0 l 90.08,0 l 0,33 l-90.08 0 z"
+              width="90.08"
+              height="33"
             />
           </g>
-          <g
-            font-size="12px"
-            text-anchor="middle"
-            transform="matrix(1,0,0,1,0,0)"
-          >
+          <g transform="matrix(1,0,0,1,0,0)">
             <text
               id="text"
               fill="rgba(24,144,255,1)"
-              dominant-baseline="alphabetic"
+              dominant-baseline="central"
               paint-order="stroke"
-              dx="1"
-              stroke="none"
+              dx="0.5"
+              dy="-11.5px"
+              text-anchor="middle"
+              font-size="12"
             >
               🌲line-edge
             </text>
@@ -94,20 +68,11 @@
       <g
         id="g-svg-12"
         fill="none"
-        stroke="rgba(24,144,255,1)"
-        stroke-width="2px"
         marker-start="true"
         marker-end="true"
-        stroke-dasharray="10px,10px"
         transform="matrix(1,0,0,1,0,0)"
       >
-        <g
-          opacity="0.25"
-          pointer-events="none"
-          stroke-width="12px"
-          stroke-dasharray="0px,0px"
-          transform="matrix(1,0,0,1,100,150)"
-        >
+        <g transform="matrix(1,0,0,1,100,150)">
           <line
             id="halo"
             fill="none"
@@ -115,14 +80,14 @@
             y1="0"
             x2="200"
             y2="50"
+            stroke-width="12"
+            stroke-dasharray="0,0"
             stroke="rgba(24,144,255,1)"
+            pointer-events="none"
+            opacity="0.25"
           />
         </g>
-        <g
-          stroke-width="2px"
-          stroke-dasharray="10px,10px"
-          transform="matrix(1,0,0,1,100,150)"
-        >
+        <g transform="matrix(1,0,0,1,100,150)">
           <line
             id="key"
             fill="none"
@@ -130,65 +95,57 @@
             y1="0"
             x2="200"
             y2="50"
+            stroke-width="2"
+            stroke-dasharray="10,10"
             stroke="rgba(24,144,255,1)"
           />
-          <g
-            stroke-width="2px"
-            stroke-dasharray="0px,0px"
-            transform="matrix(0.970143,0.242536,-0.242536,0.970143,0,0)"
-          >
+          <g transform="matrix(0.970143,0.242536,-0.242536,0.970143,0,0)">
             <path
               id="g-svg-15"
               fill="rgba(24,144,255,1)"
               d="M 0,5 A 5 5 0 1 0 10 5 A 5 5 0 1 0 0 5 Z"
               transform="translate(-5,-5)"
+              stroke-width="2"
+              stroke-dasharray="0,0"
               stroke="rgba(24,144,255,1)"
             />
           </g>
-          <g
-            stroke-width="2px"
-            stroke-dasharray="0px,0px"
-            transform="matrix(-0.970143,-0.242536,0.242536,-0.970143,200,50)"
-          >
+          <g transform="matrix(-0.970143,-0.242536,0.242536,-0.970143,200,50)">
             <path
               id="g-svg-17"
               fill="rgba(255,0,0,1)"
               d="M 0,5 L 10,0 L 10,10 Z"
               transform="translate(-5,-5)"
+              stroke-width="2"
+              stroke-dasharray="0,0"
               stroke="rgba(24,144,255,1)"
             />
           </g>
         </g>
         <g
           id="label"
-          fill="rgba(0,0,0,1)"
-          stroke="none"
-          font-size="12px"
-          text-anchor="middle"
+          fill="none"
           transform="matrix(0.970143,0.242536,-0.242536,0.970143,205.335785,170.149292)"
         >
-          <g transform="matrix(1,0,0,1,-33.187069,-28.430592)">
+          <g transform="matrix(1,0,0,1,-32.951775,-36.195297)">
             <path
               id="background"
               fill="none"
-              d="M 0,0 l 68.37411720861238,0 l 0,50.86117678317855 l-68.37411720861238 0 z"
-              stroke="none"
-              width="68.37411720861238px"
-              height="50.86117678317855px"
+              d="M 0,0 l 66.90352897487051,0 l 0,49.390588549436686 l-66.90352897487051 0 z"
+              width="66.90352897487051"
+              height="49.390588549436686"
             />
           </g>
-          <g
-            font-size="12px"
-            text-anchor="middle"
-            transform="matrix(1,0,0,1,0,0)"
-          >
+          <g transform="matrix(1,0,0,1,0,0)">
             <text
               id="text"
               fill="rgba(0,0,0,1)"
-              dominant-baseline="alphabetic"
+              dominant-baseline="central"
               paint-order="stroke"
-              dx="1"
-              stroke="none"
+              dx="0.5"
+              dy="-11.5px"
+              text-anchor="middle"
+              font-size="12"
             >
               line-edge
             </text>
@@ -198,20 +155,11 @@
       <g
         id="g-svg-22"
         fill="none"
-        stroke="rgba(24,144,255,1)"
-        stroke-width="2px"
         marker-start="true"
         marker-end="true"
-        stroke-dasharray="10px,10px"
         transform="matrix(1,0,0,1,0,0)"
       >
-        <g
-          opacity="0.25"
-          pointer-events="none"
-          stroke-width="2px"
-          stroke-dasharray="0px,0px"
-          transform="matrix(1,0,0,1,100,250)"
-        >
+        <g transform="matrix(1,0,0,1,100,250)">
           <line
             id="halo"
             fill="none"
@@ -219,14 +167,14 @@
             y1="50"
             x2="0"
             y2="0"
+            stroke-width="2"
+            stroke-dasharray="0,0"
             stroke="rgba(24,144,255,1)"
+            pointer-events="none"
+            opacity="0.25"
           />
         </g>
-        <g
-          stroke-width="2px"
-          stroke-dasharray="10px,10px"
-          transform="matrix(1,0,0,1,100,250)"
-        >
+        <g transform="matrix(1,0,0,1,100,250)">
           <line
             id="key"
             fill="none"
@@ -234,13 +182,11 @@
             y1="50"
             x2="0"
             y2="0"
+            stroke-width="2"
+            stroke-dasharray="10,10"
             stroke="rgba(24,144,255,1)"
           />
-          <g
-            stroke-width="2px"
-            stroke-dasharray="0px,0px"
-            transform="matrix(0.242536,-0.970143,0.970143,0.242536,200,50)"
-          >
+          <g transform="matrix(0.242536,-0.970143,0.970143,0.242536,200,50)">
             <image
               id="g-svg-25"
               fill="none"
@@ -248,51 +194,49 @@
               x="0"
               y="0"
               href="https://gw.alipayobjects.com/mdn/rms_6ae20b/afts/img/A*N4ZMS7gHsUIAAAAAAAAAAABkARQnAQ"
+              stroke-width="2"
+              stroke-dasharray="0,0"
               stroke="rgba(24,144,255,1)"
             />
           </g>
-          <g
-            stroke-width="2px"
-            stroke-dasharray="0px,0px"
-            transform="matrix(0.970143,0.242536,-0.242536,0.970143,0,0)"
-          >
+          <g transform="matrix(0.970143,0.242536,-0.242536,0.970143,0,0)">
             <circle
               id="g-svg-27"
               fill="none"
               transform="translate(-25,-25)"
               cx="25"
               cy="25"
+              stroke-width="2"
+              stroke-dasharray="0,0"
               stroke="rgba(24,144,255,1)"
-              r="25px"
+              r="25"
             />
           </g>
         </g>
         <g
           id="label"
-          fill="rgba(0,0,0,1)"
-          stroke="none"
-          font-size="12px"
-          text-anchor="end"
+          fill="none"
           transform="matrix(0.970143,0.242536,-0.242536,0.970143,277.201660,288.115753)"
         >
-          <g transform="matrix(1,0,0,1,-115.447052,-41.305889)">
+          <g transform="matrix(1,0,0,1,-115.211754,-49.070595)">
             <path
               id="background"
               fill="none"
-              d="M 0,0 l 123.09411654497103,0 l 0,76.6117655971751 l-123.09411654497103 0 z"
-              stroke="none"
-              width="123.09411654497103px"
-              height="76.6117655971751px"
+              d="M 0,0 l 121.62352831122915,0 l 0,75.14117736343321 l-121.62352831122915 0 z"
+              width="121.62352831122915"
+              height="75.14117736343321"
             />
           </g>
-          <g font-size="12px" text-anchor="end" transform="matrix(1,0,0,1,0,0)">
+          <g transform="matrix(1,0,0,1,0,0)">
             <text
               id="text"
               fill="rgba(0,0,0,1)"
-              dominant-baseline="alphabetic"
+              dominant-baseline="central"
               paint-order="stroke"
-              dx="1"
-              stroke="none"
+              dx="0.5"
+              dy="-11.5px"
+              text-anchor="end"
+              font-size="12"
             >
               reverted-line-edge
             </text>

--- a/packages/g6/__tests__/integration/snapshots/static/edge-quadratic.svg
+++ b/packages/g6/__tests__/integration/snapshots/static/edge-quadratic.svg
@@ -8,94 +8,70 @@
 >
   <defs />
   <g id="g-svg-camera" transform="matrix(1,0,0,1,0,0)">
-    <g
-      id="g-root"
-      fill="none"
-      stroke="none"
-      visibility="visible"
-      font-size="16px"
-      font-family="sans-serif"
-      font-style="normal"
-      font-weight="normal"
-      font-variant="normal"
-      text-anchor="left"
-      stroke-dashoffset="0px"
-      transform="matrix(1,0,0,1,0,0)"
-    >
+    <g id="g-root" fill="none" transform="matrix(1,0,0,1,0,0)">
       <g
         id="g-svg-5"
         fill="none"
-        stroke="rgba(24,144,255,1)"
-        stroke-width="2px"
         marker-start="false"
         marker-end="true"
         transform="matrix(1,0,0,1,0,0)"
       >
-        <g
-          opacity="0.25"
-          pointer-events="none"
-          stroke-width="12px"
-          stroke-dasharray="0px,0px"
-          transform="matrix(1,0,0,1,100,35)"
-        >
+        <g transform="matrix(1,0,0,1,100,35)">
           <path
             id="halo"
             fill="none"
             d="M 0,15 Q 100 -15,200 15"
             stroke="rgba(24,144,255,1)"
+            stroke-width="12"
+            stroke-dasharray="0,0"
+            pointer-events="none"
+            opacity="0.25"
           />
         </g>
-        <g stroke-width="2px" transform="matrix(1,0,0,1,100,35)">
+        <g transform="matrix(1,0,0,1,100,35)">
           <path
             id="key"
             fill="none"
             d="M 0,15 Q 100 -15,200 15"
             stroke="rgba(24,144,255,1)"
+            stroke-width="2"
           />
-          <g
-            stroke-width="2px"
-            stroke-dasharray="0px,0px"
-            transform="matrix(-0.957826,-0.287348,0.287348,-0.957826,200,15)"
-          >
+          <g transform="matrix(-0.957826,-0.287348,0.287348,-0.957826,200,15)">
             <path
               id="g-svg-8"
               fill="rgba(24,144,255,1)"
               d="M 0,5 L 10,0 L 10,10 Z"
               transform="translate(-5,-5)"
               stroke="rgba(24,144,255,1)"
+              stroke-width="2"
+              stroke-dasharray="0,0"
             />
           </g>
         </g>
         <g
           id="label"
           fill="none"
-          stroke="none"
-          font-size="12px"
-          text-anchor="middle"
           transform="matrix(0.999550,0.029986,-0.029986,0.999550,204.178116,29.122644)"
         >
-          <g transform="matrix(1,0,0,1,-55.159351,-23.023664)">
+          <g transform="matrix(1,0,0,1,-55.129379,-30.993690)">
             <path
               id="background"
               fill="none"
-              d="M 0,0 l 112.31869543715979,0 l 0,40.047326504443134 l-112.31869543715979 0 z"
-              stroke="none"
-              width="112.31869543715979px"
-              height="40.047326504443134px"
+              d="M 0,0 l 111.25874971373248,0 l 0,38.987380781015816 l-111.25874971373248 0 z"
+              width="111.25874971373248"
+              height="38.987380781015816"
             />
           </g>
-          <g
-            font-size="12px"
-            text-anchor="middle"
-            transform="matrix(1,0,0,1,0,0)"
-          >
+          <g transform="matrix(1,0,0,1,0,0)">
             <text
               id="text"
-              fill="none"
-              dominant-baseline="alphabetic"
+              fill="rgba(0,0,0,1)"
+              dominant-baseline="central"
               paint-order="stroke"
-              dx="1"
-              stroke="none"
+              dx="0.5"
+              dy="-11.5px"
+              text-anchor="middle"
+              font-size="12"
             >
               default quadratic
             </text>
@@ -105,63 +81,54 @@
       <g
         id="g-svg-13"
         fill="none"
-        stroke="rgba(24,144,255,1)"
-        stroke-width="2px"
         marker-start="false"
         marker-end="true"
         transform="matrix(1,0,0,1,0,0)"
       >
-        <g stroke-width="2px" transform="matrix(1,0,0,1,100,150)">
+        <g transform="matrix(1,0,0,1,100,150)">
           <path
             id="key"
             fill="none"
             d="M 0,0 Q 100 50,200 0"
             stroke="rgba(24,144,255,1)"
+            stroke-width="2"
           />
-          <g
-            stroke-width="2px"
-            stroke-dasharray="0px,0px"
-            transform="matrix(-0.894427,0.447214,-0.447214,-0.894427,200,0)"
-          >
+          <g transform="matrix(-0.894427,0.447214,-0.447214,-0.894427,200,0)">
             <path
               id="g-svg-16"
               fill="rgba(24,144,255,1)"
               d="M 0,5 L 10,0 L 10,10 Z"
               transform="translate(-5,-5)"
               stroke="rgba(24,144,255,1)"
+              stroke-width="2"
+              stroke-dasharray="0,0"
             />
           </g>
         </g>
         <g
           id="label"
           fill="none"
-          stroke="none"
-          font-size="12px"
-          text-anchor="middle"
           transform="matrix(0.998752,-0.049935,0.049935,0.998752,203.695404,168.807739)"
         >
-          <g transform="matrix(1,0,0,1,-85.936951,-28.053503)">
+          <g transform="matrix(1,0,0,1,-85.887077,-36.003628)">
             <path
               id="background"
               fill="none"
-              d="M 0,0 l 173.87391428120713,0 l 0,50.1070253812409 l-173.87391428120713 0 z"
-              stroke="none"
-              width="173.87391428120713px"
-              height="50.1070253812409px"
+              d="M 0,0 l 172.77416800310468,0 l 0,49.00727910313842 l-172.77416800310468 0 z"
+              width="172.77416800310468"
+              height="49.00727910313842"
             />
           </g>
-          <g
-            font-size="12px"
-            text-anchor="middle"
-            transform="matrix(1,0,0,1,0,0)"
-          >
+          <g transform="matrix(1,0,0,1,0,0)">
             <text
               id="text"
-              fill="none"
-              dominant-baseline="alphabetic"
+              fill="rgba(0,0,0,1)"
+              dominant-baseline="central"
               paint-order="stroke"
-              dx="1"
-              stroke="none"
+              dx="0.5"
+              dy="-11.5px"
+              text-anchor="middle"
+              font-size="12"
             >
               controlPoint=[200, 200]
             </text>
@@ -171,63 +138,54 @@
       <g
         id="g-svg-20"
         fill="none"
-        stroke="rgba(24,144,255,1)"
-        stroke-width="2px"
         marker-start="false"
         marker-end="true"
         transform="matrix(1,0,0,1,0,0)"
       >
-        <g stroke-width="2px" transform="matrix(1,0,0,1,100,225)">
+        <g transform="matrix(1,0,0,1,100,225)">
           <path
             id="key"
             fill="none"
             d="M 0,25 Q 100 -25,200 25"
             stroke="rgba(24,144,255,1)"
+            stroke-width="2"
           />
-          <g
-            stroke-width="2px"
-            stroke-dasharray="0px,0px"
-            transform="matrix(-0.894427,-0.447214,0.447214,-0.894427,200,25)"
-          >
+          <g transform="matrix(-0.894427,-0.447214,0.447214,-0.894427,200,25)">
             <path
               id="g-svg-23"
               fill="rgba(24,144,255,1)"
               d="M 0,5 L 10,0 L 10,10 Z"
               transform="translate(-5,-5)"
               stroke="rgba(24,144,255,1)"
+              stroke-width="2"
+              stroke-dasharray="0,0"
             />
           </g>
         </g>
         <g
           id="label"
           fill="none"
-          stroke="none"
-          font-size="12px"
-          text-anchor="middle"
           transform="matrix(0.998752,0.049935,-0.049935,0.998752,204.294617,219.207230)"
         >
-          <g transform="matrix(1,0,0,1,-108.496948,-30.303787)">
+          <g transform="matrix(1,0,0,1,-108.447075,-38.253914)">
             <path
               id="background"
               fill="none"
-              d="M 0,0 l 218.99391546491714,0 l 0,54.60757626551481 l-218.99391546491714 0 z"
-              stroke="none"
-              width="218.99391546491714px"
-              height="54.60757626551481px"
+              d="M 0,0 l 217.89416918681465,0 l 0,53.50782998741232 l-217.89416918681465 0 z"
+              width="217.89416918681465"
+              height="53.50782998741232"
             />
           </g>
-          <g
-            font-size="12px"
-            text-anchor="middle"
-            transform="matrix(1,0,0,1,0,0)"
-          >
+          <g transform="matrix(1,0,0,1,0,0)">
             <text
               id="text"
-              fill="none"
-              dominant-baseline="alphabetic"
+              fill="rgba(0,0,0,1)"
+              dominant-baseline="central"
               paint-order="stroke"
-              dx="1"
-              stroke="none"
+              dx="0.5"
+              dy="-11.5px"
+              text-anchor="middle"
+              font-size="12"
             >
               curveOffset=50, curvePosition:0.5
             </text>
@@ -237,63 +195,54 @@
       <g
         id="g-svg-27"
         fill="none"
-        stroke="rgba(24,144,255,1)"
-        stroke-width="2px"
         marker-start="false"
         marker-end="true"
         transform="matrix(1,0,0,1,0,0)"
       >
-        <g stroke-width="2px" transform="matrix(1,0,0,1,100,325)">
+        <g transform="matrix(1,0,0,1,100,325)">
           <path
             id="key"
             fill="none"
             d="M 0,25 Q 50 -25,200 25"
             stroke="rgba(24,144,255,1)"
+            stroke-width="2"
           />
-          <g
-            stroke-width="2px"
-            stroke-dasharray="0px,0px"
-            transform="matrix(-0.948683,-0.316228,0.316228,-0.948683,200,25)"
-          >
+          <g transform="matrix(-0.948683,-0.316228,0.316228,-0.948683,200,25)">
             <path
               id="g-svg-30"
               fill="rgba(24,144,255,1)"
               d="M 0,5 L 10,0 L 10,10 Z"
               transform="translate(-5,-5)"
               stroke="rgba(24,144,255,1)"
+              stroke-width="2"
+              stroke-dasharray="0,0"
             />
           </g>
         </g>
         <g
           id="label"
           fill="none"
-          stroke="none"
-          font-size="12px"
-          text-anchor="middle"
           transform="matrix(0.991600,0.129341,-0.129341,0.991600,203.144791,320.881134)"
         >
-          <g transform="matrix(1,0,0,1,-114.098114,-47.451683)">
+          <g transform="matrix(1,0,0,1,-113.969864,-55.323429)">
             <path
               id="background"
               fill="none"
-              d="M 0,0 l 230.1962301306265,0 l 0,88.90336656842001 l-230.1962301306265 0 z"
-              stroke="none"
-              width="230.1962301306265px"
-              height="88.90336656842001px"
+              d="M 0,0 l 228.93972031421305,0 l 0,87.6468567520066 l-228.93972031421305 0 z"
+              width="228.93972031421305"
+              height="87.6468567520066"
             />
           </g>
-          <g
-            font-size="12px"
-            text-anchor="middle"
-            transform="matrix(1,0,0,1,0,0)"
-          >
+          <g transform="matrix(1,0,0,1,0,0)">
             <text
               id="text"
-              fill="none"
-              dominant-baseline="alphabetic"
+              fill="rgba(0,0,0,1)"
+              dominant-baseline="central"
               paint-order="stroke"
-              dx="1"
-              stroke="none"
+              dx="0.5"
+              dy="-11.5px"
+              text-anchor="middle"
+              font-size="12"
             >
               curveOffset=50, curvePosition:0.25
             </text>

--- a/packages/g6/__tests__/integration/snapshots/static/layered-canvas.svg
+++ b/packages/g6/__tests__/integration/snapshots/static/layered-canvas.svg
@@ -8,20 +8,7 @@
 >
   <defs />
   <g id="g-svg-camera" transform="matrix(1,0,0,1,0,0)">
-    <g
-      id="g-root"
-      fill="none"
-      stroke="none"
-      visibility="visible"
-      font-size="16px"
-      font-family="sans-serif"
-      font-style="normal"
-      font-weight="normal"
-      font-variant="normal"
-      text-anchor="left"
-      stroke-dashoffset="0px"
-      transform="matrix(1,0,0,1,0,0)"
-    >
+    <g id="g-root" fill="none" transform="matrix(1,0,0,1,0,0)">
       <g transform="matrix(1,0,0,1,50,50)">
         <circle
           id="g-svg-5"
@@ -29,8 +16,7 @@
           transform="translate(-25,-25)"
           cx="25"
           cy="25"
-          stroke="none"
-          r="25px"
+          r="25"
         />
       </g>
       <g transform="matrix(1,0,0,1,100,100)">
@@ -38,9 +24,8 @@
           id="g-svg-6"
           fill="rgba(128,0,128,1)"
           d="M 0,0 l 50,0 l 0,50 l-50 0 z"
-          stroke="none"
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
         />
       </g>
     </g>

--- a/packages/g6/__tests__/integration/snapshots/static/node-circle.svg
+++ b/packages/g6/__tests__/integration/snapshots/static/node-circle.svg
@@ -8,27 +8,8 @@
 >
   <defs />
   <g id="g-svg-camera" transform="matrix(1,0,0,1,0,0)">
-    <g
-      id="g-root"
-      fill="none"
-      stroke="none"
-      visibility="visible"
-      font-size="16px"
-      font-family="sans-serif"
-      font-style="normal"
-      font-weight="normal"
-      font-variant="normal"
-      text-anchor="left"
-      stroke-dashoffset="0px"
-      transform="matrix(1,0,0,1,0,0)"
-    >
-      <g
-        id="g-svg-5"
-        fill="rgba(0,128,0,1)"
-        stroke="none"
-        r="40px"
-        transform="matrix(1,0,0,1,0,0)"
-      >
+    <g id="g-root" fill="none" transform="matrix(1,0,0,1,0,0)">
+      <g id="g-svg-5" fill="none" r="40" transform="matrix(1,0,0,1,0,0)">
         <g transform="matrix(1,0,0,1,100,100)">
           <circle
             id="key"
@@ -36,71 +17,45 @@
             transform="translate(-40,-40)"
             cx="40"
             cy="40"
-            stroke="none"
-            r="40px"
+            r="40"
           />
         </g>
-        <g
-          id="label"
-          fill="none"
-          stroke="none"
-          text-anchor="middle"
-          transform="matrix(1,0,0,1,100,100)"
-        >
+        <g id="label" fill="none" transform="matrix(1,0,0,1,100,100)">
           <g transform="matrix(1,0,0,1,-5,-5)">
             <path
               id="background"
               fill="none"
               d="M 0,0 l 10,0 l 0,10 l-10 0 z"
-              stroke="none"
-              width="10px"
-              height="10px"
+              width="10"
+              height="10"
             />
           </g>
-          <g text-anchor="middle" transform="matrix(1,0,0,1,0,0)">
+          <g transform="matrix(1,0,0,1,0,0)">
             <text
               id="text"
-              fill="none"
+              fill="rgba(0,0,0,1)"
               dominant-baseline="central"
               paint-order="stroke"
-              stroke="none"
+              text-anchor="middle"
             />
           </g>
         </g>
         <g transform="matrix(1,0,0,1,100,100)">
-          <circle
-            id="halo"
-            fill="rgba(0,128,0,1)"
-            cx="0"
-            cy="0"
-            stroke="none"
-            r="0px"
-          />
+          <circle id="halo" fill="rgba(0,128,0,1)" cx="0" cy="0" r="0" />
         </g>
-        <g
-          id="icon"
-          fill="none"
-          stroke="none"
-          transform="matrix(1,0,0,1,100,100)"
-        >
-          <g text-anchor="middle" transform="matrix(1,0,0,1,0,0)">
+        <g id="icon" fill="none" transform="matrix(1,0,0,1,100,100)">
+          <g transform="matrix(1,0,0,1,0,0)">
             <text
               id="icon"
-              fill="none"
+              fill="rgba(0,0,0,1)"
               dominant-baseline="central"
               paint-order="stroke"
-              stroke="none"
+              text-anchor="middle"
             />
           </g>
         </g>
       </g>
-      <g
-        id="g-svg-13"
-        fill="rgba(255,0,0,1)"
-        stroke="none"
-        r="40px"
-        transform="matrix(1,0,0,1,0,0)"
-      >
+      <g id="g-svg-13" fill="none" r="40" transform="matrix(1,0,0,1,0,0)">
         <g transform="matrix(1,0,0,1,300,100)">
           <circle
             id="key"
@@ -108,33 +63,20 @@
             transform="translate(-40,-40)"
             cx="40"
             cy="40"
-            stroke="none"
-            r="40px"
+            r="40"
           />
         </g>
-        <g
-          id="label"
-          fill="rgba(255,192,203,1)"
-          stroke="none"
-          font-size="14px"
-          text-anchor="middle"
-          transform="matrix(1,0,0,1,300,140)"
-        >
+        <g id="label" fill="none" transform="matrix(1,0,0,1,300,140)">
           <g transform="matrix(1,0,0,1,-42.310001,-5)">
             <path
               id="background"
               fill="none"
               d="M 0,0 l 85.62,0 l 0,37 l-85.62 0 z"
-              stroke="none"
-              width="85.62px"
-              height="37px"
+              width="85.62"
+              height="37"
             />
           </g>
-          <g
-            font-size="14px"
-            text-anchor="middle"
-            transform="matrix(1,0,0,1,0,0)"
-          >
+          <g transform="matrix(1,0,0,1,0,0)">
             <text
               id="text"
               fill="rgba(255,192,203,1)"
@@ -142,34 +84,32 @@
               paint-order="stroke"
               dx="0.5"
               dy="13.5px"
-              stroke="none"
+              text-anchor="middle"
+              font-size="14"
             >
               circle node
             </text>
           </g>
         </g>
-        <g
-          opacity="0.4"
-          pointer-events="none"
-          stroke-width="12px"
-          transform="matrix(1,0,0,1,300,100)"
-        >
+        <g transform="matrix(1,0,0,1,300,100)">
           <circle
             id="halo"
             fill="rgba(255,0,0,1)"
             transform="translate(-46,-46)"
             cx="46"
             cy="46"
+            r="46"
+            opacity="0.4"
             stroke="rgba(128,128,128,1)"
-            r="46px"
+            stroke-width="12"
+            pointer-events="none"
           />
         </g>
         <g
           id="icon"
           fill="none"
-          stroke="none"
-          width="32px"
-          height="32px"
+          width="32"
+          height="32"
           transform="matrix(1,0,0,1,300,100)"
         >
           <g transform="matrix(1,0,0,1,0,0)">
@@ -181,120 +121,83 @@
               y="0"
               href="https://gw.alipayobjects.com/zos/basement_prod/012bcf4f-423b-4922-8c24-32a89f8c41ce.svg"
               transform="translate(-16,-16)"
-              stroke="none"
-              width="32px"
-              height="32px"
+              width="32"
+              height="32"
             />
           </g>
         </g>
-        <g
-          id="badge-0"
-          fill="rgba(255,255,255,1)"
-          stroke="none"
-          font-size="10px"
-          transform="matrix(1,0,0,1,340,60)"
-        >
-          <g
-            id="label"
-            fill="rgba(255,255,255,1)"
-            stroke="none"
-            font-size="10px"
-            transform="matrix(1,0,0,1,0,0)"
-          >
-            <g transform="matrix(1,0,0,1,-4,-13)">
+        <g id="badge-0" fill="none" transform="matrix(1,0,0,1,340,60)">
+          <g id="label" fill="none" transform="matrix(1,0,0,1,0,0)">
+            <g transform="matrix(1,0,0,1,-4,-20)">
               <path
                 id="background"
                 fill="rgba(128,128,128,1)"
                 d="M 7.95,0 l 0,0 a 7.95,7.95,0,0,1,7.95,7.95 l 0,5.1 a 7.95,7.95,0,0,1,-7.95,7.95 l 0,0 a 7.95,7.95,0,0,1,-7.95,-7.95 l 0,-5.1 a 7.95,7.95,0,0,1,7.95,-7.95 z"
-                stroke="none"
-                width="15.9px"
-                height="21px"
+                width="15.9"
+                height="21"
               />
             </g>
-            <g font-size="10px" transform="matrix(1,0,0,1,0,0)">
+            <g transform="matrix(1,0,0,1,0,0)">
               <text
                 id="text"
                 fill="rgba(255,255,255,1)"
-                dominant-baseline="alphabetic"
+                dominant-baseline="central"
                 paint-order="stroke"
                 dx="0.5"
-                stroke="none"
+                dy="-9.5px"
+                font-size="10"
               >
                 A
               </text>
             </g>
           </g>
         </g>
-        <g
-          id="badge-1"
-          fill="rgba(255,255,255,1)"
-          stroke="none"
-          font-size="10px"
-          transform="matrix(1,0,0,1,340,100)"
-        >
-          <g
-            id="label"
-            fill="rgba(255,255,255,1)"
-            stroke="none"
-            font-size="10px"
-            transform="matrix(1,0,0,1,0,0)"
-          >
-            <g transform="matrix(1,0,0,1,-5,-17)">
+        <g id="badge-1" fill="none" transform="matrix(1,0,0,1,340,100)">
+          <g id="label" fill="none" transform="matrix(1,0,0,1,0,0)">
+            <g transform="matrix(1,0,0,1,-5,-24)">
               <path
                 id="background"
                 fill="rgba(0,0,255,1)"
                 d="M 14.5,0 l 28.9,0 a 14.5,14.5,0,0,1,14.5,14.5 l 0,0 a 14.5,14.5,0,0,1,-14.5,14.5 l -28.9,0 a 14.5,14.5,0,0,1,-14.5,-14.5 l 0,0 a 14.5,14.5,0,0,1,14.5,-14.5 z"
-                stroke="none"
-                width="57.9px"
-                height="29px"
+                width="57.9"
+                height="29"
               />
             </g>
-            <g font-size="10px" transform="matrix(1,0,0,1,0,0)">
+            <g transform="matrix(1,0,0,1,0,0)">
               <text
                 id="text"
                 fill="rgba(255,255,255,1)"
-                dominant-baseline="alphabetic"
+                dominant-baseline="central"
                 paint-order="stroke"
                 dx="0.5"
-                stroke="none"
+                dy="-9.5px"
+                font-size="10"
               >
                 Important
               </text>
             </g>
           </g>
         </g>
-        <g
-          id="badge-2"
-          fill="rgba(255,255,255,1)"
-          stroke="none"
-          font-size="10px"
-          transform="matrix(1,0,0,1,260,140)"
-        >
-          <g
-            id="label"
-            fill="rgba(255,255,255,1)"
-            stroke="none"
-            font-size="10px"
-            transform="matrix(1,0,0,1,0,0)"
-          >
-            <g transform="matrix(1,0,0,1,-5,-17)">
+        <g id="badge-2" fill="none" transform="matrix(1,0,0,1,260,140)">
+          <g id="label" fill="none" transform="matrix(1,0,0,1,0,0)">
+            <g transform="matrix(1,0,0,1,-5,-24)">
               <path
                 id="background"
                 fill="rgba(255,0,0,1)"
                 d="M 14.5,0 l 13.400000000000006,0 a 14.5,14.5,0,0,1,14.5,14.5 l 0,0 a 14.5,14.5,0,0,1,-14.5,14.5 l -13.400000000000006,0 a 14.5,14.5,0,0,1,-14.5,-14.5 l 0,0 a 14.5,14.5,0,0,1,14.5,-14.5 z"
-                stroke="none"
-                width="42.400000000000006px"
-                height="29px"
+                width="42.400000000000006"
+                height="29"
               />
             </g>
-            <g font-size="10px" transform="matrix(1,0,0,1,0,0)">
+            <g transform="matrix(1,0,0,1,0,0)">
               <text
                 id="text"
                 fill="rgba(255,255,255,1)"
-                dominant-baseline="alphabetic"
+                dominant-baseline="central"
                 paint-order="stroke"
                 dx="0.5"
-                stroke="none"
+                dy="-9.5px"
+                font-size="10"
               >
                 Notice
               </text>
@@ -308,19 +211,21 @@
             transform="translate(-2,-2)"
             cx="2"
             cy="2"
+            r="2"
             stroke="rgba(0,0,0,1)"
-            r="2px"
+            stroke-width="1"
           />
         </g>
-        <g stroke-width="2px" transform="matrix(1,0,0,1,340,100)">
+        <g transform="matrix(1,0,0,1,340,100)">
           <circle
             id="anchor-1"
             fill="none"
             transform="translate(-2,-2)"
             cx="2"
             cy="2"
+            r="2"
             stroke="rgba(255,255,0,1)"
-            r="2px"
+            stroke-width="2"
           />
         </g>
         <g transform="matrix(1,0,0,1,300,60)">
@@ -330,8 +235,9 @@
             transform="translate(-2,-2)"
             cx="2"
             cy="2"
+            r="2"
             stroke="rgba(0,128,0,1)"
-            r="2px"
+            stroke-width="1"
           />
         </g>
         <g transform="matrix(1,0,0,1,300,140)">
@@ -341,18 +247,13 @@
             transform="translate(-2,-2)"
             cx="2"
             cy="2"
+            r="2"
             stroke="rgba(128,128,128,1)"
-            r="2px"
+            stroke-width="1"
           />
         </g>
       </g>
-      <g
-        id="g-svg-37"
-        fill="rgba(255,192,203,1)"
-        stroke="none"
-        r="40px"
-        transform="matrix(1,0,0,1,0,0)"
-      >
+      <g id="g-svg-37" fill="none" r="40" transform="matrix(1,0,0,1,0,0)">
         <g transform="matrix(1,0,0,1,100,300)">
           <circle
             id="key"
@@ -360,66 +261,42 @@
             transform="translate(-40,-40)"
             cx="40"
             cy="40"
-            stroke="none"
-            r="40px"
+            r="40"
           />
         </g>
-        <g
-          id="label"
-          fill="none"
-          stroke="none"
-          text-anchor="middle"
-          transform="matrix(1,0,0,1,100,300)"
-        >
+        <g id="label" fill="none" transform="matrix(1,0,0,1,100,300)">
           <g transform="matrix(1,0,0,1,-5,-5)">
             <path
               id="background"
               fill="none"
               d="M 0,0 l 10,0 l 0,10 l-10 0 z"
-              stroke="none"
-              width="10px"
-              height="10px"
+              width="10"
+              height="10"
             />
           </g>
-          <g text-anchor="middle" transform="matrix(1,0,0,1,0,0)">
+          <g transform="matrix(1,0,0,1,0,0)">
             <text
               id="text"
-              fill="none"
+              fill="rgba(0,0,0,1)"
               dominant-baseline="central"
               paint-order="stroke"
-              stroke="none"
+              text-anchor="middle"
             />
           </g>
         </g>
         <g transform="matrix(1,0,0,1,100,300)">
-          <circle
-            id="halo"
-            fill="rgba(255,192,203,1)"
-            cx="0"
-            cy="0"
-            stroke="none"
-            r="0px"
-          />
+          <circle id="halo" fill="rgba(255,192,203,1)" cx="0" cy="0" r="0" />
         </g>
-        <g
-          id="icon"
-          fill="rgba(0,0,0,1)"
-          stroke="none"
-          font-size="32px"
-          transform="matrix(1,0,0,1,100,300)"
-        >
-          <g
-            font-size="32px"
-            text-anchor="middle"
-            transform="matrix(1,0,0,1,0,0)"
-          >
+        <g id="icon" fill="none" transform="matrix(1,0,0,1,100,300)">
+          <g transform="matrix(1,0,0,1,0,0)">
             <text
               id="icon"
               fill="rgba(0,0,0,1)"
               dominant-baseline="central"
               paint-order="stroke"
               dx="0.5"
-              stroke="none"
+              font-size="32"
+              text-anchor="middle"
             >
               Y
             </text>

--- a/packages/g6/__tests__/integration/snapshots/static/shape-badge.svg
+++ b/packages/g6/__tests__/integration/snapshots/static/shape-badge.svg
@@ -8,40 +8,16 @@
 >
   <defs />
   <g id="g-svg-camera" transform="matrix(1,0,0,1,0,0)">
-    <g
-      id="g-root"
-      fill="none"
-      stroke="none"
-      visibility="visible"
-      font-size="16px"
-      font-family="sans-serif"
-      font-style="normal"
-      font-weight="normal"
-      font-variant="normal"
-      text-anchor="left"
-      stroke-dashoffset="0px"
-      transform="matrix(1,0,0,1,0,0)"
-    >
-      <g
-        id="g-svg-5"
-        fill="rgba(255,255,255,1)"
-        stroke="none"
-        transform="matrix(1,0,0,1,100,50)"
-      >
-        <g
-          id="label"
-          fill="rgba(255,255,255,1)"
-          stroke="none"
-          transform="matrix(1,0,0,1,0,0)"
-        >
+    <g id="g-root" fill="none" transform="matrix(1,0,0,1,0,0)">
+      <g id="g-svg-5" fill="none" transform="matrix(1,0,0,1,100,50)">
+        <g id="label" fill="none" transform="matrix(1,0,0,1,0,0)">
           <g transform="matrix(1,0,0,1,-10,-5)">
             <path
               id="background"
               fill="rgba(230,108,91,1)"
               d="M 20.5,0 l 55.040000000000006,0 a 20.5,20.5,0,0,1,20.5,20.5 l 0,0 a 20.5,20.5,0,0,1,-20.5,20.5 l -55.040000000000006,0 a 20.5,20.5,0,0,1,-20.5,-20.5 l 0,0 a 20.5,20.5,0,0,1,20.5,-20.5 z"
-              stroke="none"
-              width="96.04px"
-              height="41px"
+              width="96.04"
+              height="41"
             />
           </g>
           <g transform="matrix(1,0,0,1,0,0)">
@@ -52,33 +28,21 @@
               paint-order="stroke"
               dx="0.5"
               dy="15.5px"
-              stroke="none"
             >
               Important
             </text>
           </g>
         </g>
       </g>
-      <g
-        id="g-svg-9"
-        fill="rgba(255,255,255,1)"
-        stroke="none"
-        transform="matrix(1,0,0,1,100,100)"
-      >
-        <g
-          id="label"
-          fill="rgba(255,255,255,1)"
-          stroke="none"
-          transform="matrix(1,0,0,1,0,0)"
-        >
+      <g id="g-svg-9" fill="none" transform="matrix(1,0,0,1,100,100)">
+        <g id="label" fill="none" transform="matrix(1,0,0,1,0,0)">
           <g transform="matrix(1,0,0,1,-10,-5)">
             <path
               id="background"
               fill="rgba(130,145,178,1)"
               d="M 16.02,0 l 0,0 a 16.02,16.02,0,0,1,16.02,16.02 l 0,8.96 a 16.02,16.02,0,0,1,-16.02,16.02 l 0,0 a 16.02,16.02,0,0,1,-16.02,-16.02 l 0,-8.96 a 16.02,16.02,0,0,1,16.02,-16.02 z"
-              stroke="none"
-              width="32.04px"
-              height="41px"
+              width="32.04"
+              height="41"
             />
           </g>
           <g transform="matrix(1,0,0,1,0,0)">
@@ -89,38 +53,24 @@
               paint-order="stroke"
               dx="0.5"
               dy="15.5px"
-              stroke="none"
             >
               A
             </text>
           </g>
         </g>
       </g>
-      <g
-        id="g-svg-13"
-        fill="rgba(255,255,255,1)"
-        stroke="none"
-        font-size="10px"
-        transform="matrix(1,0,0,1,100,150)"
-      >
-        <g
-          id="label"
-          fill="rgba(255,255,255,1)"
-          stroke="none"
-          font-size="10px"
-          transform="matrix(1,0,0,1,0,0)"
-        >
+      <g id="g-svg-13" fill="none" transform="matrix(1,0,0,1,100,150)">
+        <g id="label" fill="none" transform="matrix(1,0,0,1,0,0)">
           <g transform="matrix(1,0,0,1,-8,-3)">
             <path
               id="background"
               fill="rgba(255,140,0,1)"
               d="M 12.5,0 l 23.400000000000006,0 a 12.5,12.5,0,0,1,12.5,12.5 l 0,0 a 12.5,12.5,0,0,1,-12.5,12.5 l -23.400000000000006,0 a 12.5,12.5,0,0,1,-12.5,-12.5 l 0,0 a 12.5,12.5,0,0,1,12.5,-12.5 z"
-              stroke="none"
-              width="48.400000000000006px"
-              height="25px"
+              width="48.400000000000006"
+              height="25"
             />
           </g>
-          <g font-size="10px" transform="matrix(1,0,0,1,0,0)">
+          <g transform="matrix(1,0,0,1,0,0)">
             <text
               id="text"
               fill="rgba(255,255,255,1)"
@@ -128,38 +78,25 @@
               paint-order="stroke"
               dx="0.5"
               dy="9.5px"
-              stroke="none"
+              font-size="10"
             >
               Notice
             </text>
           </g>
         </g>
       </g>
-      <g
-        id="g-svg-17"
-        fill="rgba(255,255,255,1)"
-        stroke="rgba(0,0,0,1)"
-        transform="matrix(1,0,0,1,100,200)"
-        opacity="0.4"
-      >
-        <g
-          id="label"
-          fill="rgba(255,255,255,1)"
-          stroke="rgba(0,0,0,1)"
-          transform="matrix(1,0,0,1,0,0)"
-          opacity="0.4"
-        >
+      <g id="g-svg-17" fill="none" transform="matrix(1,0,0,1,100,200)">
+        <g id="label" fill="none" transform="matrix(1,0,0,1,0,0)">
           <g transform="matrix(1,0,0,1,-10,-5)">
             <path
               id="background"
               fill="rgba(255,192,203,1)"
               d="M 20.5,0 l 128.96,0 a 20.5,20.5,0,0,1,20.5,20.5 l 0,0 a 20.5,20.5,0,0,1,-20.5,20.5 l -128.96,0 a 20.5,20.5,0,0,1,-20.5,-20.5 l 0,0 a 20.5,20.5,0,0,1,20.5,-20.5 z"
-              stroke="none"
-              width="169.96px"
-              height="41px"
+              width="169.96"
+              height="41"
             />
           </g>
-          <g transform="matrix(1,0,0,1,0,0)" opacity="0.4">
+          <g transform="matrix(1,0,0,1,0,0)">
             <text
               id="text"
               fill="rgba(255,255,255,1)"
@@ -167,6 +104,7 @@
               paint-order="stroke"
               dx="0.5"
               dy="15.5px"
+              opacity="0.4"
               stroke="rgba(0,0,0,1)"
             >
               Update Badge Text

--- a/packages/g6/__tests__/integration/snapshots/static/shape-icon.svg
+++ b/packages/g6/__tests__/integration/snapshots/static/shape-icon.svg
@@ -8,41 +8,18 @@
 >
   <defs />
   <g id="g-svg-camera" transform="matrix(1,0,0,1,0,0)">
-    <g
-      id="g-root"
-      fill="none"
-      stroke="none"
-      visibility="visible"
-      font-size="16px"
-      font-family="sans-serif"
-      font-style="normal"
-      font-weight="normal"
-      font-variant="normal"
-      text-anchor="left"
-      stroke-dashoffset="0px"
-      transform="matrix(1,0,0,1,0,0)"
-    >
-      <g
-        id="g-svg-5"
-        fill="rgba(0,0,0,1)"
-        stroke="none"
-        font-size="24px"
-        font-weight="400"
-        transform="matrix(1,0,0,1,50,50)"
-      >
-        <g
-          font-size="24px"
-          font-weight="400"
-          text-anchor="middle"
-          transform="matrix(1,0,0,1,0,0)"
-        >
+    <g id="g-root" fill="none" transform="matrix(1,0,0,1,0,0)">
+      <g id="g-svg-5" fill="none" transform="matrix(1,0,0,1,50,50)">
+        <g transform="matrix(1,0,0,1,0,0)">
           <text
             id="icon"
             fill="rgba(0,0,0,1)"
             dominant-baseline="central"
             paint-order="stroke"
             dx="0.5"
-            stroke="none"
+            font-size="24"
+            font-weight="400"
+            text-anchor="middle"
           >
             text icon
           </text>
@@ -51,9 +28,8 @@
       <g
         id="g-svg-7"
         fill="none"
-        stroke="rgba(255,192,203,1)"
-        width="128px"
-        height="128px"
+        width="128"
+        height="128"
         transform="matrix(1,0,0,1,150,150)"
       >
         <g transform="matrix(1,0,0,1,0,0)">
@@ -65,9 +41,9 @@
             y="0"
             href="https://gw.alipayobjects.com/mdn/rms_6ae20b/afts/img/A*N4ZMS7gHsUIAAAAAAAAAAABkARQnAQ"
             transform="translate(-64,-64)"
+            width="128"
+            height="128"
             stroke="rgba(255,192,203,1)"
-            width="128px"
-            height="128px"
           />
         </g>
       </g>

--- a/packages/g6/__tests__/integration/snapshots/static/shape-label.svg
+++ b/packages/g6/__tests__/integration/snapshots/static/shape-label.svg
@@ -8,124 +8,96 @@
 >
   <defs />
   <g id="g-svg-camera" transform="matrix(1,0,0,1,0,0)">
-    <g
-      id="g-root"
-      fill="none"
-      stroke="none"
-      visibility="visible"
-      font-size="16px"
-      font-family="sans-serif"
-      font-style="normal"
-      font-weight="normal"
-      font-variant="normal"
-      text-anchor="left"
-      stroke-dashoffset="0px"
-      transform="matrix(1,0,0,1,0,0)"
-    >
-      <g
-        id="g-svg-5"
-        fill="rgba(0,0,0,1)"
-        stroke="none"
-        font-size="14px"
-        transform="matrix(1,0,0,1,50,50)"
-      >
-        <g transform="matrix(1,0,0,1,-5,-23)">
+    <g id="g-root" fill="none" transform="matrix(1,0,0,1,0,0)">
+      <g id="g-svg-5" fill="none" transform="matrix(1,0,0,1,50,50)">
+        <g transform="matrix(1,0,0,1,-5,-32)">
           <path
             id="background"
             fill="none"
             d="M 0,0 l 80.16,0 l 0,37 l-80.16 0 z"
-            stroke="none"
-            width="80.16px"
-            height="37px"
+            width="80.16"
+            height="37"
           />
         </g>
-        <g font-size="14px" transform="matrix(1,0,0,1,0,0)">
+        <g transform="matrix(1,0,0,1,0,0)">
           <text
             id="text"
             fill="rgba(0,0,0,1)"
-            dominant-baseline="alphabetic"
+            dominant-baseline="central"
             paint-order="stroke"
             dx="0.5"
-            stroke="none"
+            dy="-13.5px"
+            font-size="14"
           >
             label1 text
           </text>
         </g>
       </g>
-      <g
-        id="g-svg-8"
-        fill="none"
-        stroke="rgba(255,192,203,1)"
-        font-size="20px"
-        transform="matrix(1,0,0,1,50,150)"
-      >
-        <g stroke-width="2px" transform="matrix(1,0,0,1,-5,-30)">
+      <g id="g-svg-8" fill="none" transform="matrix(1,0,0,1,50,150)">
+        <g transform="matrix(1,0,0,1,-5,-42)">
           <path
             id="background"
             fill="none"
             d="M 0,0 l 112.59999999999998,0 l 0,47 l-112.59999999999998 0 z"
+            stroke-width="2"
             stroke="rgba(255,192,203,1)"
-            width="112.59999999999998px"
-            height="47px"
+            width="112.59999999999998"
+            height="47"
           />
         </g>
-        <g font-size="20px" transform="matrix(1,0,0,1,0,0)">
+        <g transform="matrix(1,0,0,1,0,0)">
           <text
             id="text"
-            fill="none"
-            dominant-baseline="alphabetic"
+            fill="rgba(0,0,0,1)"
+            dominant-baseline="central"
             paint-order="stroke"
             dx="0.5"
+            dy="-18.5px"
+            font-size="20"
             stroke="rgba(255,192,203,1)"
           >
             label2 text
           </text>
         </g>
       </g>
-      <g
-        id="g-svg-11"
-        fill="rgba(255,0,0,1)"
-        stroke="rgba(255,192,203,1)"
-        font-size="32px"
-        transform="matrix(1,0,0,1,50,250)"
-      >
-        <g opacity="0.5" stroke-width="2px" transform="matrix(1,0,0,1,-5,-45)">
+      <g id="g-svg-11" fill="none" transform="matrix(1,0,0,1,50,250)">
+        <g transform="matrix(1,0,0,1,-5,-64)">
           <path
             id="background"
             fill="none"
             d="M 0,0 l 174.2,0 l 0,69 l-174.2 0 z"
+            stroke-width="2"
+            opacity="0.5"
             stroke="rgba(255,215,0,1)"
-            width="174.2px"
-            height="69px"
+            width="174.2"
+            height="69"
           />
         </g>
-        <g font-size="32px" transform="matrix(1,0,0,1,0,0)">
+        <g transform="matrix(1,0,0,1,0,0)">
           <text
             id="text"
             fill="rgba(255,0,0,1)"
-            dominant-baseline="alphabetic"
+            dominant-baseline="central"
             paint-order="stroke"
             dx="0.5"
+            dy="-29.5px"
+            font-size="32"
             stroke="rgba(255,192,203,1)"
           >
             label3 text
           </text>
         </g>
       </g>
-      <g
-        id="g-svg-14"
-        fill="rgba(228,84,84,1)"
-        stroke="none"
-        transform="matrix(1,0,0,1,50,350)"
-      >
-        <g stroke-dasharray="5px,5px" transform="matrix(1,0,0,1,-5,-36)">
+      <g id="g-svg-14" fill="none" transform="matrix(1,0,0,1,50,350)">
+        <g transform="matrix(1,0,0,1,-5,-36)">
           <path
             id="background"
             fill="rgba(252,233,233,1)"
             d="M 0,0 l 260,0 l 0,72 l-260 0 z"
+            stroke-dasharray="5,5"
             stroke="rgba(228,84,84,1)"
-            width="260px"
-            height="72px"
+            width="260"
+            height="72"
           />
         </g>
         <g transform="matrix(1,0,0,1,0,0)">
@@ -134,7 +106,6 @@
             fill="rgba(228,84,84,1)"
             dominant-baseline="central"
             paint-order="stroke"
-            stroke="none"
           >
             <tspan x="0" dx="0.5" dy="-15.5">
               Long Text Long Text Long Text

--- a/packages/g6/__tests__/integration/static.spec.ts
+++ b/packages/g6/__tests__/integration/static.spec.ts
@@ -1,3 +1,4 @@
+import '../../src/preset';
 import * as staticCases from '../demo/static';
 import { createNodeGCanvas } from './utils/create-node-g-canvas';
 import { getCases } from './utils/get-cases';

--- a/packages/g6/__tests__/main.ts
+++ b/packages/g6/__tests__/main.ts
@@ -1,6 +1,7 @@
 import { Renderer as CanvasRenderer } from '@antv/g-canvas';
 import { Renderer as SVGRenderer } from '@antv/g-svg';
 import { Renderer as WebGLRenderer } from '@antv/g-webgl';
+import '../src/preset';
 import { Canvas } from '../src/runtime/canvas';
 import * as animations from './demo/animation';
 import * as statics from './demo/static';

--- a/packages/g6/src/elements/edges/cubic-horizontal.ts
+++ b/packages/g6/src/elements/edges/cubic-horizontal.ts
@@ -1,7 +1,7 @@
 import type { DisplayObjectConfig, PathStyleProps } from '@antv/g';
 import { deepMix } from '@antv/util';
 import type { Point } from '../../types';
-import { type BaseEdgeStyleProps } from './base-edge';
+import type { BaseEdgeStyleProps } from './base-edge';
 import { Cubic } from './cubic';
 
 type CubicHorizontalKeyStyleProps = PathStyleProps & {

--- a/packages/g6/src/elements/edges/cubic-horizontal.ts
+++ b/packages/g6/src/elements/edges/cubic-horizontal.ts
@@ -1,0 +1,57 @@
+import type { DisplayObjectConfig, PathStyleProps } from '@antv/g';
+import { deepMix } from '@antv/util';
+import type { Point } from '../../types';
+import { type BaseEdgeStyleProps } from './base-edge';
+import { Cubic } from './cubic';
+
+type CubicHorizontalKeyStyleProps = PathStyleProps & {
+  /**
+   * <zh/> 边的起点
+   * <en/> The source point. Represents the start of the edge
+   */
+  sourcePoint: Point;
+  /**
+   * <zh/> 边的终点
+   * <en/> The target point. Represents the end of the edge
+   */
+  targetPoint: Point;
+  /**
+   * <zh/> 控制点在两端点连线上的相对位置，范围为`0-1`
+   * <en/> The relative position of the control point on the line, ranging from `0-1`
+   */
+  curvePosition?: number | [number, number];
+  /**
+   * <zh/> 控制点距离两端点连线的距离，可理解为控制边的弯曲程度
+   * <en/> The distance of the control point from the line
+   */
+  curveOffset?: number | [number, number];
+};
+
+export type CubicHorizontalStyleProps = BaseEdgeStyleProps<CubicHorizontalKeyStyleProps>;
+
+type CubicHorizontalOptions = DisplayObjectConfig<CubicHorizontalStyleProps>;
+
+export class CubicHorizontal extends Cubic {
+  static defaultStyleProps: Partial<CubicHorizontalStyleProps> = {
+    curvePosition: [0.5, 0.5],
+    curveOffset: [0, 0],
+    isBillboard: true,
+  };
+
+  constructor(options: CubicHorizontalOptions) {
+    super(deepMix({}, { style: CubicHorizontal.defaultStyleProps }, options));
+  }
+
+  protected getControlPoints(
+    sourcePoint: Point,
+    targetPoint: Point,
+    curvePosition: [number, number],
+    curveOffset: [number, number],
+  ): [Point, Point] {
+    const xDist = targetPoint[0] - sourcePoint[0];
+    return [
+      [sourcePoint[0] + xDist * curvePosition[0] + curveOffset[0], sourcePoint[1]],
+      [targetPoint[0] - xDist * curvePosition[1] + curveOffset[1], targetPoint[1]],
+    ];
+  }
+}

--- a/packages/g6/src/elements/edges/cubic-vertical.ts
+++ b/packages/g6/src/elements/edges/cubic-vertical.ts
@@ -1,7 +1,7 @@
 import type { DisplayObjectConfig, PathStyleProps } from '@antv/g';
 import { deepMix } from '@antv/util';
 import type { Point } from '../../types';
-import { type BaseEdgeStyleProps } from './base-edge';
+import type { BaseEdgeStyleProps } from './base-edge';
 import { Cubic } from './cubic';
 
 type CubicVerticalKeyStyleProps = PathStyleProps & {

--- a/packages/g6/src/elements/edges/cubic-vertical.ts
+++ b/packages/g6/src/elements/edges/cubic-vertical.ts
@@ -1,0 +1,57 @@
+import type { DisplayObjectConfig, PathStyleProps } from '@antv/g';
+import { deepMix } from '@antv/util';
+import type { Point } from '../../types';
+import { type BaseEdgeStyleProps } from './base-edge';
+import { Cubic } from './cubic';
+
+type CubicVerticalKeyStyleProps = PathStyleProps & {
+  /**
+   * <zh/> 边的起点
+   * <en/> The source point. Represents the start of the edge
+   */
+  sourcePoint: Point;
+  /**
+   * <zh/> 边的终点
+   * <en/> The target point. Represents the end of the edge
+   */
+  targetPoint: Point;
+  /**
+   * <zh/> 控制点在两端点连线上的相对位置，范围为`0-1`
+   * <en/> The relative position of the control point on the line, ranging from `0-1`
+   */
+  curvePosition?: number | [number, number];
+  /**
+   * <zh/> 控制点距离两端点连线的距离，可理解为控制边的弯曲程度
+   * <en/> The distance of the control point from the line
+   */
+  curveOffset?: number | [number, number];
+};
+
+export type CubicVerticalStyleProps = BaseEdgeStyleProps<CubicVerticalKeyStyleProps>;
+
+type CubicVerticalOptions = DisplayObjectConfig<CubicVerticalStyleProps>;
+
+export class CubicVertical extends Cubic {
+  static defaultStyleProps: Partial<CubicVerticalStyleProps> = {
+    curvePosition: [0.5, 0.5],
+    curveOffset: [0, 0],
+    isBillboard: true,
+  };
+
+  constructor(options: CubicVerticalOptions) {
+    super(deepMix({}, { style: CubicVertical.defaultStyleProps }, options));
+  }
+
+  protected getControlPoints(
+    sourcePoint: Point,
+    targetPoint: Point,
+    curvePosition: [number, number],
+    curveOffset: [number, number],
+  ): [Point, Point] {
+    const yDist = targetPoint[1] - sourcePoint[1];
+    return [
+      [sourcePoint[0], sourcePoint[1] + yDist * curvePosition[0] + curveOffset[0]],
+      [targetPoint[0], targetPoint[1] - yDist * curvePosition[1] + curveOffset[1]],
+    ];
+  }
+}

--- a/packages/g6/src/elements/edges/cubic.ts
+++ b/packages/g6/src/elements/edges/cubic.ts
@@ -3,7 +3,8 @@ import { Path } from '@antv/g';
 import { deepMix } from '@antv/util';
 import type { Point } from '../../types';
 import { calculateControlPoint, getCubicPath, parseCurveOffset, parseCurvePosition } from '../../utils/edge';
-import { BaseEdge, type BaseEdgeStyleProps } from './base-edge';
+import type { BaseEdgeStyleProps } from './base-edge';
+import { BaseEdge } from './base-edge';
 
 type CubicKeyStyleProps = PathStyleProps & {
   /**

--- a/packages/g6/src/elements/edges/cubic.ts
+++ b/packages/g6/src/elements/edges/cubic.ts
@@ -1,0 +1,90 @@
+import type { DisplayObjectConfig, Group, PathStyleProps } from '@antv/g';
+import { Path } from '@antv/g';
+import { deepMix } from '@antv/util';
+import type { Point } from '../../types';
+import { calculateControlPoint, getCubicPath, parseCurveOffset, parseCurvePosition } from '../../utils/edge';
+import { BaseEdge, type BaseEdgeStyleProps } from './base-edge';
+
+type CubicKeyStyleProps = PathStyleProps & {
+  /**
+   * <zh/> 边的起点
+   * <en/> The source point. Represents the start of the edge
+   */
+  sourcePoint: Point;
+  /**
+   * <zh/> 边的终点
+   * <en/> The target point. Represents the end of the edge
+   */
+  targetPoint: Point;
+  /**
+   * <zh/> 控制点数组，用于定义曲线的形状。如果不指定，将会通过`curveOffset`和`curvePosition`来计算控制点
+   * <en/> Control points. Used to define the shape of the curve. If not specified, it will be calculated using `curveOffset` and `curvePosition`.
+   */
+  controlPoints?: [Point, Point];
+  /**
+   * <zh/> 控制点在两端点连线上的相对位置，范围为`0-1`
+   * <en/> The relative position of the control point on the line, ranging from `0-1`
+   */
+  curvePosition?: number | [number, number];
+  /**
+   * <zh/> 控制点距离两端点连线的距离，可理解为控制边的弯曲程度
+   * <en/> The distance of the control point from the line
+   */
+  curveOffset?: number | [number, number];
+};
+
+export type CubicStyleProps = BaseEdgeStyleProps<CubicKeyStyleProps>;
+
+type ParsedCubicStyleProps = Required<CubicStyleProps>;
+
+type CubicOptions = DisplayObjectConfig<CubicStyleProps>;
+
+export class Cubic extends BaseEdge<PathStyleProps, Path> {
+  static defaultStyleProps: Partial<CubicStyleProps> = {
+    curvePosition: [0.5, 0.5],
+    curveOffset: [-20, 20],
+    isBillboard: true,
+  };
+
+  constructor(options: CubicOptions) {
+    super(deepMix({}, { style: Cubic.defaultStyleProps }, options));
+  }
+
+  protected drawKeyShape(attributes: ParsedCubicStyleProps, container: Group): Path | undefined {
+    return this.upsert('key', Path, this.getKeyStyle(attributes), container);
+  }
+
+  protected getKeyStyle(attributes: ParsedCubicStyleProps): PathStyleProps {
+    const { sourcePoint, targetPoint, controlPoints, curvePosition, curveOffset, ...keyStyle } = super.getKeyStyle(
+      attributes,
+    ) as Required<CubicKeyStyleProps>;
+
+    const actualControlPoints = this.getControlPoints(
+      sourcePoint,
+      targetPoint,
+      parseCurvePosition(curvePosition),
+      parseCurveOffset(curveOffset),
+      controlPoints,
+    );
+
+    return {
+      ...keyStyle,
+      path: getCubicPath(sourcePoint, targetPoint, actualControlPoints),
+    };
+  }
+
+  protected getControlPoints(
+    sourcePoint: Point,
+    targetPoint: Point,
+    curvePosition: [number, number],
+    curveOffset: [number, number],
+    controlPoints?: [Point, Point],
+  ): [Point, Point] {
+    return controlPoints?.length === 2
+      ? controlPoints
+      : [
+          calculateControlPoint(sourcePoint, targetPoint, curvePosition[0], curveOffset[0]),
+          calculateControlPoint(sourcePoint, targetPoint, curvePosition[1], curveOffset[1]),
+        ];
+  }
+}

--- a/packages/g6/src/elements/edges/index.ts
+++ b/packages/g6/src/elements/edges/index.ts
@@ -1,9 +1,11 @@
 export { Cubic } from './cubic';
 export { CubicHorizontal } from './cubic-horizontal';
+export { CubicVertical } from './cubic-vertical';
 export { Line } from './line';
 export { Quadratic } from './quadratic';
 
 export type { CubicStyleProps } from './cubic';
 export type { CubicHorizontalStyleProps } from './cubic-horizontal';
+export type { CubicVerticalStyleProps } from './cubic-vertical';
 export type { LineStyleProps } from './line';
 export type { QuadraticStyleProps } from './quadratic';

--- a/packages/g6/src/elements/edges/index.ts
+++ b/packages/g6/src/elements/edges/index.ts
@@ -1,7 +1,9 @@
 export { Cubic } from './cubic';
+export { CubicHorizontal } from './cubic-horizontal';
 export { Line } from './line';
 export { Quadratic } from './quadratic';
 
 export type { CubicStyleProps } from './cubic';
+export type { CubicHorizontalStyleProps } from './cubic-horizontal';
 export type { LineStyleProps } from './line';
 export type { QuadraticStyleProps } from './quadratic';

--- a/packages/g6/src/elements/edges/index.ts
+++ b/packages/g6/src/elements/edges/index.ts
@@ -1,5 +1,7 @@
+export { Cubic } from './cubic';
 export { Line } from './line';
 export { Quadratic } from './quadratic';
 
+export type { CubicStyleProps } from './cubic';
 export type { LineStyleProps } from './line';
 export type { QuadraticStyleProps } from './quadratic';

--- a/packages/g6/src/utils/edge.ts
+++ b/packages/g6/src/utils/edge.ts
@@ -1,5 +1,5 @@
 import type { PathArray } from '@antv/util';
-import { pick } from '@antv/util';
+import { isNumber, pick } from '@antv/util';
 import type { Point, Vector2 } from '../types';
 import type { EdgeKey, EdgeLabelPosition, EdgeLabelStyleProps } from '../types/edge';
 import { isHorizontal } from './point';
@@ -135,7 +135,7 @@ export function getQuadraticPath(
  * @param curveOffset - <zh/> 控制点距离两端点连线的距离 | <en/> The distance between the control point and the line
  * @returns <zh/> 控制点 | <en/> Control points
  */
-function calculateControlPoint(
+export function calculateControlPoint(
   sourcePoint: Point,
   targetPoint: Point,
   curvePosition: number,
@@ -150,4 +150,54 @@ function calculateControlPoint(
   controlPoint[0] += curveOffset * perpVector[0];
   controlPoint[1] += curveOffset * perpVector[1];
   return controlPoint;
+}
+
+/** ==================== Cubic Edge =========================== */
+
+/**
+ * <zh/> 解析控制点距离两端点连线的距离 `curveOffset`
+ *
+ * <en/> parse the distance of the control point from the line `curveOffset`
+ * @param curveOffset - <zh/> curveOffset | <en/> curveOffset
+ * @returns <zh/> 标准 curveOffset | <en/> standard curveOffset
+ */
+export function parseCurveOffset(curveOffset: number | [number, number]): [number, number] {
+  if (isNumber(curveOffset)) return [curveOffset, -curveOffset];
+  return curveOffset;
+}
+
+/**
+ * <zh/> 解析控制点在两端点连线上的相对位置 `curvePosition`，范围为`0-1`
+ *
+ * <en/> parse the relative position of the control point on the line `curvePosition`
+ * @param curvePosition - <zh/> curvePosition | <en/> curvePosition
+ * @returns <zh/> 标准 curvePosition | <en/> standard curvePosition
+ */
+export function parseCurvePosition(curvePosition: number | [number, number]): [number, number] {
+  if (isNumber(curvePosition)) return [curvePosition, 1 - curvePosition];
+  return curvePosition;
+}
+
+/**
+ * <zh/> 获取三次贝塞尔曲线绘制路径
+ *
+ * <en/> Calculate the path for drawing a cubic Bessel curve
+ * @param sourcePoint - <zh/> 边的起点 | <en/> Source point
+ * @param targetPoint - <zh/> 边的终点 | <en/> Target point
+ * @param controlPoints - <zh/> 控制点 | <en/> Control point
+ * @returns <zh/> 返回绘制曲线的路径 | <en/> Returns curve path
+ */
+export function getCubicPath(sourcePoint: Point, targetPoint: Point, controlPoints: [Point, Point]): PathArray {
+  return [
+    ['M', sourcePoint[0], sourcePoint[1]],
+    [
+      'C',
+      controlPoints[0][0],
+      controlPoints[0][1],
+      controlPoints[1][0],
+      controlPoints[1][1],
+      targetPoint[0],
+      targetPoint[1],
+    ],
+  ];
 }


### PR DESCRIPTION
- [x] Add cubic edge element
- [x] Add vertical cubic edge element
- [x] Add horizontal cubic edge element
- [x] test cubic edge animation

`cubic`

 <img src="https://github.com/antvis/G6/assets/55794321/0ac1a868-54e1-4a8e-97d1-776a9bad7662" width = "300" alt="cubic"/>

 <img src="https://github.com/antvis/G6/assets/55794321/4e857131-7790-439d-922e-b628c8e535b6" width = "300" alt="cubic"/>

`cubic-horizontal`

 <img src="https://github.com/antvis/G6/assets/55794321/e785c8b3-e2a7-4eb6-a380-a131f8c981d7" width = "300" alt="cubic"/>

`cubic-vertical`

 <img src="https://github.com/antvis/G6/assets/55794321/ed6a3ccb-edc9-4c6c-ae09-d97a7e41b77a" width = "300" alt="cubic"/>

```ts
type CubicKeyStyleProps = PathStyleProps & {
  /**
   * <zh/> 边的起点
   * <en/> The source point. Represents the start of the edge
   */
  sourcePoint: Point;
  /**
   * <zh/> 边的终点
   * <en/> The target point. Represents the end of the edge
   */
  targetPoint: Point;
  /**
   * <zh/> 控制点数组，用于定义曲线的形状。如果不指定，将会通过`curveOffset`和`curvePosition`来计算控制点
   * <en/> Control points. Used to define the shape of the curve. If not specified, it will be calculated using `curveOffset` and `curvePosition`.
   */
  controlPoints?: [Point, Point];
  /**
   * <zh/> 控制点在两端点连线上的相对位置，范围为`0-1`
   * <en/> The relative position of the control point on the line, ranging from `0-1`
   */
  curvePosition?: number | [number, number];
  /**
   * <zh/> 控制点距离两端点连线的距离，可理解为控制边的弯曲程度
   * <en/> The distance of the control point from the line
   */
  curveOffset?: number | [number, number];
};
```

> The `controlPoints` attribute is **cubic-specific**, and for **cubic-vertical** and **cubic-horizontal** don't take into account control points passed in from outside the user.
