### PR TITLE
refactor: data controller support collect changes

### DIFF
--- a/packages/g6/__tests__/unit/utils/change.spec.ts
+++ b/packages/g6/__tests__/unit/utils/change.spec.ts
@@ -1,0 +1,35 @@
+import { reduceDataChanges } from '../../../src/utils/change';
+
+describe('change', () => {
+  it('reduceDataChanges', () => {
+    expect(
+      reduceDataChanges([
+        { type: 'NodeAdded', value: { id: 'node-0' } },
+        { type: 'NodeAdded', value: { id: 'node-1' } },
+        { type: 'NodeAdded', value: { id: 'node-2' } },
+        { type: 'EdgeAdded', value: { source: 'node-1', target: 'edge-2' } },
+        {
+          type: 'NodeUpdated',
+          value: { id: 'node-3', style: { fill: 'pink' } },
+          original: { id: 'node-3', style: { fill: 'red' } },
+        },
+        {
+          type: 'NodeUpdated',
+          value: { id: 'node-3', style: { fill: 'purple', lineWidth: 2 } },
+          original: { id: 'node-3', style: { fill: 'pink' } },
+        },
+        { type: 'NodeUpdated', value: { id: 'node-0', data: { value: 10 } }, original: { id: 'node-0' } },
+        { type: 'NodeRemoved', value: { id: 'node-0' } },
+      ]),
+    ).toEqual([
+      { type: 'NodeAdded', value: { id: 'node-1' } },
+      { type: 'NodeAdded', value: { id: 'node-2' } },
+      { type: 'EdgeAdded', value: { source: 'node-1', target: 'edge-2' } },
+      {
+        type: 'NodeUpdated',
+        value: { id: 'node-3', style: { fill: 'purple', lineWidth: 2 } },
+        original: { id: 'node-3', style: { fill: 'red' } },
+      },
+    ]);
+  });
+});

--- a/packages/g6/__tests__/unit/utils/data.spec.ts
+++ b/packages/g6/__tests__/unit/utils/data.spec.ts
@@ -1,5 +1,5 @@
 import type { EdgeData, NodeData } from '../../../src';
-import { mergeElementsData } from '../../../src/utils/data';
+import { cloneElementData, mergeElementsData } from '../../../src/utils/data';
 
 describe('data', () => {
   it('mergeElementsData', () => {
@@ -74,5 +74,19 @@ describe('data', () => {
         weight: 10,
       },
     });
+  });
+
+  it('cloneData', () => {
+    const data = { id: 'node-1', data: { value1: { a: 1 }, value2: 2 }, style: { fill: 'pink', startPoint: [0, 100] } };
+    const clonedData = cloneElementData(data);
+    expect(clonedData).toEqual(data);
+
+    data.data.value1.a = 2;
+    data.style.startPoint[0] = 100;
+    expect(clonedData).toEqual(data);
+
+    data.data.value2 = 3;
+    data.style.startPoint = [100, 100];
+    expect(clonedData).not.toEqual(data);
   });
 });

--- a/packages/g6/__tests__/unit/utils/data.spec.ts
+++ b/packages/g6/__tests__/unit/utils/data.spec.ts
@@ -76,7 +76,7 @@ describe('data', () => {
     });
   });
 
-  it('cloneData', () => {
+  it('cloneElementData', () => {
     const data = { id: 'node-1', data: { value1: { a: 1 }, value2: 2 }, style: { fill: 'pink', startPoint: [0, 100] } };
     const clonedData = cloneElementData(data);
     expect(clonedData).toEqual(data);

--- a/packages/g6/src/constants/change.ts
+++ b/packages/g6/src/constants/change.ts
@@ -1,0 +1,4 @@
+export const ChangeEvent = {
+  /** <zh/> 数据变更 | <en/> 数据变更 */
+  CHANGE: 'change',
+};

--- a/packages/g6/src/constants/change.ts
+++ b/packages/g6/src/constants/change.ts
@@ -2,3 +2,15 @@ export const ChangeEvent = {
   /** <zh/> 数据变更 | <en/> 数据变更 */
   CHANGE: 'change',
 };
+
+export const enum ChangeTypeEnum {
+  'NodeAdded' = 'NodeAdded',
+  'NodeUpdated' = 'NodeUpdated',
+  'NodeRemoved' = 'NodeRemoved',
+  'EdgeAdded' = 'EdgeAdded',
+  'EdgeUpdated' = 'EdgeUpdated',
+  'EdgeRemoved' = 'EdgeRemoved',
+  'ComboAdded' = 'ComboAdded',
+  'ComboUpdated' = 'ComboUpdated',
+  'ComboRemoved' = 'ComboRemoved',
+}

--- a/packages/g6/src/constants/index.ts
+++ b/packages/g6/src/constants/index.ts
@@ -1,0 +1,1 @@
+export * from './change';

--- a/packages/g6/src/runtime/data.ts
+++ b/packages/g6/src/runtime/data.ts
@@ -1,18 +1,24 @@
+import EventEmitter from '@antv/event-emitter';
 import { Graph as GraphLib, ID } from '@antv/graphlib';
 import { isEqual } from '@antv/util';
+import { ChangeEvent } from '../constants';
 import type { ComboData, DataOptions, EdgeData, NodeData } from '../spec';
 import type {
+  DataAdded,
+  DataChange,
   DataID,
+  DataRemoved,
+  DataUpdated,
   GraphlibData,
   NodeLikeData,
   PartialDataOptions,
   PartialEdgeData,
   PartialNodeLikeData,
-} from '../types/data';
+} from '../types';
 import type { EdgeDirection } from '../types/edge';
 import type { ElementType } from '../types/element';
 import type { Point } from '../types/point';
-import { mergeElementsData } from '../utils/data';
+import { cloneElementData, mergeElementsData } from '../utils/data';
 import { arrayDiff } from '../utils/diff';
 import { toG6Data, toGraphlibData } from '../utils/graphlib';
 import { idOf } from '../utils/id';
@@ -20,7 +26,7 @@ import { dfs } from '../utils/traverse';
 
 const COMBO_KEY = 'combo';
 
-export class DataController {
+export class DataController extends EventEmitter {
   public model: GraphlibData;
 
   /**
@@ -38,7 +44,37 @@ export class DataController {
   protected comboIds = new Set<ID>();
 
   constructor() {
+    super();
     this.model = new GraphLib();
+  }
+
+  /**
+   * <zh/> 获取详细数据变更
+   *
+   * <en/> Get detailed data changes
+   */
+  private changes: DataChange[] = [];
+
+  private pushChange(change: DataChange) {
+    const { type } = change;
+    if (type === 'NodeUpdated' || type === 'EdgeUpdated' || type === 'ComboUpdated') {
+      const { value, original } = change;
+      this.changes.push({ value: cloneElementData(value), original: cloneElementData(original), type } as DataUpdated);
+    } else {
+      this.changes.push({ value: cloneElementData(change.value), type } as DataAdded | DataRemoved);
+    }
+  }
+
+  private batchCount = 0;
+
+  public batch(callback: () => void) {
+    this.batchCount++;
+    this.model.batch(callback);
+    this.batchCount--;
+    if (this.batchCount === 0) {
+      this.emit(ChangeEvent.CHANGE, [...this.changes]);
+      this.changes = [];
+    }
   }
 
   public isCombo(id: ID) {
@@ -176,7 +212,7 @@ export class DataController {
     const edgeDiff = arrayDiff(originalEdges, modifiedEdges, (edge) => idOf(edge));
     const comboDiff = arrayDiff(originalCombos, modifiedCombos, (combo) => idOf(combo));
 
-    this.model.batch(() => {
+    this.batch(() => {
       this.addData({
         nodes: nodeDiff.enter,
         edges: edgeDiff.enter,
@@ -199,7 +235,7 @@ export class DataController {
 
   public addData(data: DataOptions) {
     const { nodes, edges, combos } = data;
-    this.model.batch(() => {
+    this.batch(() => {
       // add combo first
       this.addComboData(combos);
       this.addNodeData(nodes);
@@ -209,68 +245,69 @@ export class DataController {
 
   public addNodeData(nodes: NodeData[] = []) {
     if (!nodes.length) return;
-    this.model.addNodes(nodes.map(toGraphlibData));
-
+    this.model.addNodes(
+      nodes.map((node) => {
+        this.pushChange({ value: node, type: 'NodeAdded' });
+        return toGraphlibData(node);
+      }),
+    );
     this.updateNodeLikeHierarchy(nodes);
   }
 
   public addEdgeData(edges: EdgeData[] = []) {
     if (!edges.length) return;
-    this.model.addEdges(edges.map((edge) => toGraphlibData(edge)));
+    this.model.addEdges(
+      edges.map((edge) => {
+        this.pushChange({ value: edge, type: 'EdgeAdded' });
+        return toGraphlibData(edge);
+      }),
+    );
   }
 
   public addComboData(combos: ComboData[] = []) {
     if (!combos.length) return;
-    const { model: controller } = this;
+    const { model } = this;
 
-    if (!controller.hasTreeStructure(COMBO_KEY)) {
-      controller.attachTreeStructure(COMBO_KEY);
+    if (!model.hasTreeStructure(COMBO_KEY)) {
+      model.attachTreeStructure(COMBO_KEY);
     }
 
-    controller.addNodes(combos.map(toGraphlibData));
-
-    // record combo
-    combos.forEach((combo) => {
-      this.comboIds.add(idOf(combo));
-    });
+    model.addNodes(
+      combos.map((combo) => {
+        this.comboIds.add(idOf(combo));
+        this.pushChange({ value: combo, type: 'ComboAdded' });
+        return toGraphlibData(combo);
+      }),
+    );
 
     this.updateNodeLikeHierarchy(combos);
   }
 
-  protected updateNodeLikeHierarchy(data: NodeData[] | ComboData[]) {
-    const { model: controller } = this;
+  protected updateNodeLikeHierarchy(data: NodeLikeData[]) {
+    const { model } = this;
 
     let hasAttachTreeStructure = false;
 
     const attachTreeStructure = () => {
       if (hasAttachTreeStructure) return;
-      if (!controller.hasTreeStructure(COMBO_KEY)) {
-        controller.attachTreeStructure(COMBO_KEY);
+      if (!model.hasTreeStructure(COMBO_KEY)) {
+        model.attachTreeStructure(COMBO_KEY);
       }
       hasAttachTreeStructure = true;
     };
 
-    data.forEach((item) => {
-      const parentId = item?.style?.parentId;
+    data.forEach((datum) => {
+      const parentId = datum?.style?.parentId;
       if (parentId !== undefined) {
         attachTreeStructure();
-        controller.setParent(idOf(item), parentId, COMBO_KEY);
+        model.setParent(idOf(datum), parentId, COMBO_KEY);
       }
-
-      const children = (item?.style?.children as string[]) || [];
-      children.forEach((childId) => {
-        if (controller.hasNode(childId)) {
-          attachTreeStructure();
-          controller.setParent(childId, idOf(item), COMBO_KEY);
-          controller.mergeNodeData(childId, { style: { parentId: idOf(item) } });
-        }
-      });
     });
   }
 
   public updateData(data: PartialDataOptions) {
     const { nodes, edges, combos } = data;
-    this.model.batch(() => {
+    this.batch(() => {
       this.updateNodeData(nodes);
       this.updateComboData(combos);
       this.updateEdgeData(edges);
@@ -280,12 +317,14 @@ export class DataController {
   public updateNodeData(nodes: PartialNodeLikeData<NodeData>[] = []) {
     if (!nodes.length) return;
 
-    this.model.batch(() => {
+    this.batch(() => {
       nodes.forEach((modifiedNode) => {
-        const originalNode = this.model.getNode(idOf(modifiedNode));
+        const originalNode = this.model.getNode(idOf(modifiedNode)).data;
         if (isEqual(originalNode, modifiedNode)) return;
 
-        this.model.mergeNodeData(idOf(modifiedNode), mergeElementsData(originalNode.data, modifiedNode));
+        const value = mergeElementsData(originalNode, modifiedNode);
+        this.pushChange({ value, original: originalNode, type: 'NodeUpdated' });
+        this.model.mergeNodeData(idOf(modifiedNode), value);
       });
 
       this.updateNodeLikeHierarchy(nodes);
@@ -295,7 +334,7 @@ export class DataController {
   public updateEdgeData(edges: PartialEdgeData<EdgeData>[] = []) {
     if (!edges.length) return;
 
-    this.model.batch(() => {
+    this.batch(() => {
       edges.forEach((modifiedEdge) => {
         const originalEdge = this.model.getEdge(idOf(modifiedEdge)).data;
         if (isEqual(originalEdge, modifiedEdge)) return;
@@ -306,7 +345,9 @@ export class DataController {
         if (modifiedEdge.target && originalEdge.target !== modifiedEdge.target) {
           this.model.updateEdgeTarget(idOf(modifiedEdge), modifiedEdge.target);
         }
-        this.model.mergeEdgeData(idOf(modifiedEdge), mergeElementsData(originalEdge, modifiedEdge));
+        const updatedData = mergeElementsData(originalEdge, modifiedEdge);
+        this.model.mergeEdgeData(idOf(modifiedEdge), updatedData);
+        this.pushChange({ value: updatedData, original: originalEdge, type: 'EdgeUpdated' });
       });
     });
   }
@@ -327,7 +368,9 @@ export class DataController {
           this.translateComboTo([modifiedComboId], [x, y, z]);
         }
 
-        model.mergeNodeData(modifiedComboId, mergeElementsData(originalCombo, modifiedCombo));
+        const value = mergeElementsData(originalCombo, modifiedCombo);
+        this.pushChange({ value, original: originalCombo, type: 'ComboUpdated' });
+        model.mergeNodeData(modifiedComboId, value);
       });
 
       this.updateNodeLikeHierarchy(combos);
@@ -346,12 +389,15 @@ export class DataController {
           (succeed) => {
             const succeedID = idOf(succeed);
             const { x = 0, y = 0, z = 0 } = succeed.style || {};
-            model.mergeNodeData(
-              succeedID,
-              mergeElementsData(succeed, {
-                style: { x: x + dx, y: y + dy, z: z + dz },
-              }),
-            );
+            const value = mergeElementsData(succeed, {
+              style: { x: x + dx, y: y + dy, z: z + dz },
+            });
+            this.pushChange({
+              value,
+              original: succeed,
+              type: this.isCombo(succeedID) ? 'ComboUpdated' : 'NodeUpdated',
+            });
+            model.mergeNodeData(succeedID, value);
           },
           (node) => this.getComboChildrenData(idOf(node)),
           'BT',
@@ -377,12 +423,15 @@ export class DataController {
           (succeed) => {
             const succeedID = idOf(succeed);
             const { x = 0, y = 0, z = 0 } = succeed.style || {};
-            model.mergeNodeData(
-              succeedID,
-              mergeElementsData(succeed, {
-                style: { x: x + dx, y: y + dy, z: z + dz },
-              }),
-            );
+            const value = mergeElementsData(succeed, {
+              style: { x: x + dx, y: y + dy, z: z + dz },
+            });
+            this.pushChange({
+              value,
+              original: succeed,
+              type: this.isCombo(succeedID) ? 'ComboUpdated' : 'NodeUpdated',
+            });
+            model.mergeNodeData(succeedID, value);
           },
           (node) => this.getComboChildrenData(idOf(node)),
           'BT',
@@ -393,7 +442,7 @@ export class DataController {
 
   public removeData(data: DataID) {
     const { nodes, edges, combos } = data;
-    this.model.batch(() => {
+    this.batch(() => {
       // remove edges first
       this.removeEdgeData(edges);
       this.removeNodeData(nodes);
@@ -405,21 +454,28 @@ export class DataController {
 
   public removeNodeData(ids: ID[] = []) {
     if (!ids.length) return;
-    this.model.batch(() => {
-      ids.forEach((node) => this.removeNodeLikeHierarchy(node));
+    this.batch(() => {
+      ids.forEach((id) => {
+        this.pushChange({ value: this.getNodeData([id])[0], type: 'NodeRemoved' });
+        this.removeNodeLikeHierarchy(id);
+      });
       this.model.removeNodes(ids);
     });
   }
 
   public removeEdgeData(ids: ID[] = []) {
     if (!ids.length) return;
+    ids.forEach((id) => this.pushChange({ value: this.getEdgeData([id])[0], type: 'EdgeRemoved' }));
     this.model.removeEdges(ids);
   }
 
   public removeComboData(ids: ID[] = []) {
     if (!ids.length) return;
-    this.model.batch(() => {
-      ids.forEach((node) => this.removeNodeLikeHierarchy(node));
+    this.batch(() => {
+      ids.forEach((id) => {
+        this.pushChange({ value: this.getComboData([id])[0], type: 'ComboRemoved' });
+        this.removeNodeLikeHierarchy(id);
+      });
       this.model.removeNodes(ids);
     });
   }
@@ -440,11 +496,19 @@ export class DataController {
       const [data] = this.getNodeLikeData([id]);
 
       this.model.getChildren(id, COMBO_KEY).forEach((child) => {
-        this.model.setParent(idOf(child), data?.style?.parentId, COMBO_KEY);
-        this.model.mergeNodeData(
-          idOf(child),
-          mergeElementsData(child.data, { id: idOf(child), style: { parentId: data?.style?.parentId } }),
-        );
+        const childData = child.data;
+        const childId = idOf(childData);
+        this.model.setParent(idOf(childData), data?.style?.parentId, COMBO_KEY);
+        const value = mergeElementsData(childData, {
+          id: idOf(childData),
+          style: { parentId: data?.style?.parentId },
+        });
+        this.pushChange({
+          value,
+          original: childData,
+          type: this.isCombo(childId) ? 'ComboUpdated' : 'NodeUpdated',
+        });
+        this.model.mergeNodeData(idOf(childData), value);
       });
     }
   }

--- a/packages/g6/src/types/change.ts
+++ b/packages/g6/src/types/change.ts
@@ -1,3 +1,4 @@
+import { ChangeTypeEnum } from '../constants';
 import type { ComboData, EdgeData, NodeData } from '../spec/data';
 
 /**
@@ -14,49 +15,49 @@ export type DataUpdated = NodeUpdated | EdgeUpdated | ComboUpdated;
 export type DataRemoved = NodeRemoved | EdgeRemoved | ComboRemoved;
 
 export type NodeAdded = {
-  type: 'NodeAdded';
+  type: ChangeTypeEnum.NodeAdded;
   value: NodeData;
 };
 
 export type NodeUpdated = {
-  type: 'NodeUpdated';
+  type: ChangeTypeEnum.NodeUpdated;
   value: NodeData;
   original: NodeData;
 };
 
 export type NodeRemoved = {
-  type: 'NodeRemoved';
+  type: ChangeTypeEnum.NodeRemoved;
   value: NodeData;
 };
 
 export type EdgeAdded = {
-  type: 'EdgeAdded';
+  type: ChangeTypeEnum.EdgeAdded;
   value: EdgeData;
 };
 
 export type EdgeUpdated = {
-  type: 'EdgeUpdated';
+  type: ChangeTypeEnum.EdgeUpdated;
   value: EdgeData;
   original: EdgeData;
 };
 
 export type EdgeRemoved = {
-  type: 'EdgeRemoved';
+  type: ChangeTypeEnum.EdgeRemoved;
   value: EdgeData;
 };
 
 export type ComboAdded = {
-  type: 'ComboAdded';
+  type: ChangeTypeEnum.ComboAdded;
   value: ComboData;
 };
 
 export type ComboUpdated = {
-  type: 'ComboUpdated';
+  type: ChangeTypeEnum.ComboUpdated;
   value: ComboData;
   original: ComboData;
 };
 
 export type ComboRemoved = {
-  type: 'ComboRemoved';
+  type: ChangeTypeEnum.ComboRemoved;
   value: ComboData;
 };

--- a/packages/g6/src/types/change.ts
+++ b/packages/g6/src/types/change.ts
@@ -1,0 +1,62 @@
+import type { ComboData, EdgeData, NodeData } from '../spec/data';
+
+/**
+ * <zh/> 数据变更
+ *
+ * <en/> Data change
+ */
+export type DataChange = DataAdded | DataUpdated | DataRemoved;
+
+export type DataAdded = NodeAdded | EdgeAdded | ComboAdded;
+
+export type DataUpdated = NodeUpdated | EdgeUpdated | ComboUpdated;
+
+export type DataRemoved = NodeRemoved | EdgeRemoved | ComboRemoved;
+
+export type NodeAdded = {
+  type: 'NodeAdded';
+  value: NodeData;
+};
+
+export type NodeUpdated = {
+  type: 'NodeUpdated';
+  value: NodeData;
+  original: NodeData;
+};
+
+export type NodeRemoved = {
+  type: 'NodeRemoved';
+  value: NodeData;
+};
+
+export type EdgeAdded = {
+  type: 'EdgeAdded';
+  value: EdgeData;
+};
+
+export type EdgeUpdated = {
+  type: 'EdgeUpdated';
+  value: EdgeData;
+  original: EdgeData;
+};
+
+export type EdgeRemoved = {
+  type: 'EdgeRemoved';
+  value: EdgeData;
+};
+
+export type ComboAdded = {
+  type: 'ComboAdded';
+  value: ComboData;
+};
+
+export type ComboUpdated = {
+  type: 'ComboUpdated';
+  value: ComboData;
+  original: ComboData;
+};
+
+export type ComboRemoved = {
+  type: 'ComboRemoved';
+  value: ComboData;
+};

--- a/packages/g6/src/types/index.ts
+++ b/packages/g6/src/types/index.ts
@@ -1,5 +1,7 @@
 export type * from './callable';
 export type * from './canvas';
+export type * from './change';
+export type * from './data';
 export type * from './padding';
 export type * from './point';
 export type * from './prefix';

--- a/packages/g6/src/utils/change.ts
+++ b/packages/g6/src/utils/change.ts
@@ -1,0 +1,56 @@
+import type { ID } from '@antv/graphlib';
+import type { DataAdded, DataChange, DataRemoved, DataUpdated } from '../types';
+import { idOf } from './id';
+
+/**
+ * <zh/> 对数据操作进行约简
+ *
+ * <en/> Reduce data changes
+ * @param changes - <zh/> 数据操作 | <en/> data changes
+ * @returns <zh/> 约简后的数据操作 | <en/> reduced data changes
+ */
+export function reduceDataChanges(changes: DataChange[]): DataChange[] {
+  const results = {
+    Added: new Map<ID, DataAdded>(),
+    Updated: new Map<ID, DataUpdated>(),
+    Removed: new Map<ID, DataRemoved>(),
+  };
+
+  changes.forEach((change) => {
+    const { type, value } = change;
+    const id = idOf(value);
+
+    if (type === 'NodeAdded' || type === 'EdgeAdded' || type === 'ComboAdded') {
+      results.Added.set(id, change);
+    } else if (type === 'NodeUpdated' || type === 'EdgeUpdated' || type === 'ComboUpdated') {
+      // 如果存在 Added，将当前操作置为 Added 操作
+      // If there is an Added operation, set the current operation to Added
+      if (results.Added.has(id)) {
+        results.Added.set(id, { type: type.replace('Updated', 'Added'), value } as DataAdded);
+      }
+      // 如果存在 Updated，将当前操作置为 Updated 操作，但使用更早版本的 original
+      // If there is an Updated operation, set the current operation to Updated, but use an earlier version of original
+      else if (results.Updated.has(id)) {
+        const { original } = results.Updated.get(id)!;
+        results.Updated.set(id, { type, value, original } as DataUpdated);
+      } else results.Updated.set(id, change);
+    } else if (type === 'NodeRemoved' || type === 'EdgeRemoved' || type === 'ComboRemoved') {
+      // 如果存在 Added 或者 Updated 的操作，删除 Removed 操作
+      // If there is an Added or Updated operation, delete the Removed operation
+      if (results.Added.has(id) || results.Updated.has(id)) {
+        results.Added.delete(id);
+        results.Updated.delete(id);
+      } else {
+        results.Removed.set(id, change);
+      }
+    }
+  });
+
+  // 顺序并不重要
+  // The order is not important
+  return [
+    ...Array.from(results.Added.values()),
+    ...Array.from(results.Updated.values()),
+    ...Array.from(results.Removed.values()),
+  ];
+}

--- a/packages/g6/src/utils/data.ts
+++ b/packages/g6/src/utils/data.ts
@@ -45,7 +45,7 @@ export function mergeElementsData<T extends NodeData | EdgeData | ComboData>(ori
  */
 export function cloneElementData<T extends NodeData | EdgeData | ComboData>(data: T): T {
   const { data: customData, style, ...restAttrs } = data;
-  const clonedData = { ...restAttrs } as T;
+  const clonedData = restAttrs as T;
   if (customData) clonedData.data = { ...customData };
   if (style) clonedData.style = { ...style };
   return clonedData;

--- a/packages/g6/src/utils/data.ts
+++ b/packages/g6/src/utils/data.ts
@@ -31,3 +31,22 @@ export function mergeElementsData<T extends NodeData | EdgeData | ComboData>(ori
 
   return result as T;
 }
+
+/**
+ * <zh/> 克隆元素数据
+ *
+ * <en/> Clone clement data
+ * @param data - <zh/> 待克隆的数据 | <en/> data to be cloned
+ * @returns <zh/> 克隆后的数据 | <en/> cloned data
+ * @description
+ * <zh/> 只会克隆到第二层（data、style）
+ *
+ * <en/> Only clone to the second level (data, style)
+ */
+export function cloneElementData<T extends NodeData | EdgeData | ComboData>(data: T): T {
+  const { data: customData, style, ...restAttrs } = data;
+  const clonedData = { ...restAttrs } as T;
+  if (customData) clonedData.data = { ...customData };
+  if (style) clonedData.style = { ...style };
+  return clonedData;
+}


### PR DESCRIPTION
初版 G6 5.0 的更新机制是基于 graphlib `change` 事件驱动的，但与 G6 数据结构并非完全匹配，且需要依赖 Graph 进行事件监听和调度，提高了 Graph 的复杂度，其更新机制如下（以 `addData` 为例：）
1. addData 方法中添加一次性 graphlib `change` 事件监听
2. 触发 data controller `datachange` 事件，操作数据
3. 操作数据后触发 `change` 事件，回调中触发 `itemchange` 事件，更新元素

变更后，由 data controller 维护数据变更，更新机制如下（以 `setData` 为例）：
1. setData 中调用 data controller setData 方法
2. data controller 处理数据，并提交数据变更任务
3. element controller 接受数据变更任务
4. 绘制阶段：element controller 合并数据变更任务队列，更新元素

---

The update mechanism of the initial version G6 5.0 is driven by the graphlib change event, but it is not fully compatible with the G6 data structure. It requires reliance on the Graph for event monitoring and scheduling, increasing the complexity of the Graph. The update mechanism is as follows (using addData as an example):

1. Add a one-time graphlib change event listener in the addData method.
2. Trigger the data controller's datachange event, operate on the data.
3. After manipulating the data, trigger the change event, and in the callback, trigger the itemchange event to update the elements.

After the change, the data controller maintains data changes, and the update mechanism is as follows (using setData as an example):

1. In the setData method, call the data controller's setData method.
2. The data controller processes the data and submits the data change task.
3. The element controller accepts the data change task.
4. During the drawing phase, the element controller merges the data change task queue and updates the elements.