### PR TITLE
feat: diamond node

### DIFF
--- a/packages/g6/__tests__/demo/static/index.ts
+++ b/packages/g6/__tests__/demo/static/index.ts
@@ -10,6 +10,7 @@ export * from './edge-polyline';
 export * from './edge-quadratic';
 export * from './layered-canvas';
 export * from './node-circle';
+export * from './node-diamond';
 export * from './node-ellipse';
 export * from './node-rect';
 export * from './node-star';

--- a/packages/g6/__tests__/demo/static/node-diamond.ts
+++ b/packages/g6/__tests__/demo/static/node-diamond.ts
@@ -1,0 +1,81 @@
+import { Diamond } from '../../../src/elements/nodes';
+import type { StaticTestCase } from '../types';
+
+export const nodeDiamond: StaticTestCase = async (context) => {
+  const { canvas } = context;
+
+  const diamond_1 = new Diamond({
+    style: {
+      // key
+      x: 100,
+      y: 100,
+      fill: 'green',
+      width: 40,
+      height: 40,
+      label: false,
+      labelText: 'not show',
+    },
+  });
+
+  const diamond_2 = new Diamond({
+    style: {
+      // key
+      x: 300,
+      y: 100,
+      fill: 'red',
+      width: 100,
+      height: 100,
+      lineWidth: 0,
+      stroke: 'blue',
+      // label
+      labelText: 'circle node',
+      labelFontSize: 14,
+      labelFill: 'pink',
+      labelPosition: 'bottom',
+      // badge
+      badgeOptions: [
+        { text: 'A', position: 'right-top', backgroundFill: 'grey', fill: 'white', fontSize: 10, padding: [1, 4] },
+        { text: 'Important', position: 'right', backgroundFill: 'blue', fill: 'white', fontSize: 10 },
+        { text: 'Notice', position: 'left-bottom', backgroundFill: 'red', fill: 'white', fontSize: 10 },
+      ],
+      // anchor
+      anchorOptions: [
+        { position: [0, 0.5], r: 2, stroke: 'black', lineWidth: 1, zIndex: 2 },
+        { position: [1, 0.5], r: 2, stroke: 'yellow', lineWidth: 2, zIndex: 2 },
+        { position: [0.5, 0], r: 2, stroke: 'green', lineWidth: 1, zIndex: 2 },
+        { position: [0.5, 1], r: 2, stroke: 'grey', lineWidth: 1, zIndex: 2 },
+      ],
+      // icon
+      iconSrc: 'https://gw.alipayobjects.com/zos/basement_prod/012bcf4f-423b-4922-8c24-32a89f8c41ce.svg',
+      iconWidth: 32,
+      iconHeight: 32,
+      // halo
+      halo: true,
+      haloOpacity: 0.4,
+      haloStroke: 'grey',
+      haloLineWidth: 10,
+      haloPointerEvents: 'none',
+    },
+  });
+
+  const diamond_3 = new Diamond({
+    style: {
+      // key
+      x: 100,
+      y: 300,
+      fill: 'pink',
+      width: 80,
+      height: 40,
+      // icon
+      iconText: 'Haha',
+      iconFontSize: 14,
+      iconFill: 'black',
+      // label
+      labelText: 'this is a looooog label',
+    },
+  });
+
+  canvas.appendChild(diamond_1);
+  canvas.appendChild(diamond_2);
+  canvas.appendChild(diamond_3);
+};

--- a/packages/g6/__tests__/integration/snapshots/static/node-diamond.svg
+++ b/packages/g6/__tests__/integration/snapshots/static/node-diamond.svg
@@ -1,0 +1,296 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="500"
+  height="500"
+  style="background: transparent; position: absolute; outline: none;"
+  color-interpolation-filters="sRGB"
+  tabindex="1"
+>
+  <defs />
+  <g id="g-svg-camera" transform="matrix(1,0,0,1,0,0)">
+    <g id="g-root" fill="none" transform="matrix(1,0,0,1,0,0)">
+      <g
+        id="g-svg-5"
+        fill="none"
+        width="40"
+        height="40"
+        transform="matrix(1,0,0,1,100,100)"
+      >
+        <g transform="matrix(1,0,0,1,-20,-20)">
+          <polygon
+            id="key"
+            fill="rgba(0,128,0,1)"
+            points="20,0 40,20 20,40 0,20"
+          />
+        </g>
+      </g>
+      <g
+        id="g-svg-7"
+        fill="none"
+        width="100"
+        height="100"
+        transform="matrix(1,0,0,1,300,100)"
+      >
+        <g transform="matrix(1,0,0,1,-50,-50)">
+          <polygon
+            id="key"
+            fill="rgba(255,0,0,1)"
+            points="50,0 100,50 50,100 0,50"
+            stroke-width="1"
+            stroke="rgba(0,0,255,1)"
+          />
+        </g>
+        <g transform="matrix(1,0,0,1,-52.750000,-52.750000)">
+          <polygon
+            id="halo"
+            fill="rgba(0,0,0,0)"
+            points="52.75,0 105.5,52.75 52.75,105.5 0,52.75"
+            stroke-width="10"
+            stroke="rgba(128,128,128,1)"
+            pointer-events="none"
+            opacity="0.4"
+          />
+        </g>
+        <g
+          id="icon"
+          fill="none"
+          width="32"
+          height="32"
+          transform="matrix(1,0,0,1,0,0)"
+        >
+          <g transform="matrix(1,0,0,1,0,0)">
+            <image
+              id="icon"
+              fill="none"
+              preserveAspectRatio="none"
+              x="0"
+              y="0"
+              href="https://gw.alipayobjects.com/zos/basement_prod/012bcf4f-423b-4922-8c24-32a89f8c41ce.svg"
+              transform="translate(-16,-16)"
+              width="32"
+              height="32"
+            />
+          </g>
+        </g>
+        <g id="label" fill="none" transform="matrix(1,0,0,1,0,50)">
+          <g transform="matrix(1,0,0,1,-41.310001,-2)">
+            <path
+              id="background"
+              fill="none"
+              d="M 0,0 l 208,0 l 0,31 l-208 0 z"
+              opacity="0.75"
+              stroke-width="0"
+              width="208"
+              height="31"
+            />
+          </g>
+          <g transform="matrix(1,0,0,1,0,0)">
+            <text
+              id="text"
+              fill="rgba(255,192,203,1)"
+              dominant-baseline="central"
+              paint-order="stroke"
+              dx="0.5"
+              dy="13.5px"
+              font-size="14"
+              text-anchor="middle"
+            >
+              circle node
+            </text>
+          </g>
+        </g>
+        <g id="badge-0" fill="none" transform="matrix(1,0,0,1,50,-50)">
+          <g id="label" fill="none" transform="matrix(1,0,0,1,0,0)">
+            <g transform="matrix(1,0,0,1,-4,-20)">
+              <path
+                id="background"
+                fill="rgba(128,128,128,1)"
+                d="M 7.95,0 l 0,0 a 7.95,7.95,0,0,1,7.95,7.95 l 0,5.1 a 7.95,7.95,0,0,1,-7.95,7.95 l 0,0 a 7.95,7.95,0,0,1,-7.95,-7.95 l 0,-5.1 a 7.95,7.95,0,0,1,7.95,-7.95 z"
+                opacity="0.75"
+                stroke-width="0"
+                width="15.9"
+                height="21"
+              />
+            </g>
+            <g transform="matrix(1,0,0,1,0,0)">
+              <text
+                id="text"
+                fill="rgba(255,255,255,1)"
+                dominant-baseline="central"
+                paint-order="stroke"
+                dx="0.5"
+                dy="-9.5px"
+                font-size="10"
+                text-anchor="left"
+              >
+                A
+              </text>
+            </g>
+          </g>
+        </g>
+        <g id="badge-1" fill="none" transform="matrix(1,0,0,1,50,0)">
+          <g id="label" fill="none" transform="matrix(1,0,0,1,0,0)">
+            <g transform="matrix(1,0,0,1,-4,-11.500000)">
+              <path
+                id="background"
+                fill="rgba(0,0,255,1)"
+                d="M 11.5,0 l 32.9,0 a 11.5,11.5,0,0,1,11.5,11.5 l 0,0 a 11.5,11.5,0,0,1,-11.5,11.5 l -32.9,0 a 11.5,11.5,0,0,1,-11.5,-11.5 l 0,0 a 11.5,11.5,0,0,1,11.5,-11.5 z"
+                opacity="0.75"
+                stroke-width="0"
+                width="55.9"
+                height="23"
+              />
+            </g>
+            <g transform="matrix(1,0,0,1,0,0)">
+              <text
+                id="text"
+                fill="rgba(255,255,255,1)"
+                dominant-baseline="central"
+                paint-order="stroke"
+                dx="0.5"
+                font-size="10"
+                text-anchor="left"
+              >
+                Important
+              </text>
+            </g>
+          </g>
+        </g>
+        <g id="badge-2" fill="none" transform="matrix(1,0,0,1,-50,50)">
+          <g id="label" fill="none" transform="matrix(1,0,0,1,0,0)">
+            <g transform="matrix(1,0,0,1,-35.400002,-2)">
+              <path
+                id="background"
+                fill="rgba(255,0,0,1)"
+                d="M 11.5,0 l 17.400000000000006,0 a 11.5,11.5,0,0,1,11.5,11.5 l 0,0 a 11.5,11.5,0,0,1,-11.5,11.5 l -17.400000000000006,0 a 11.5,11.5,0,0,1,-11.5,-11.5 l 0,0 a 11.5,11.5,0,0,1,11.5,-11.5 z"
+                opacity="0.75"
+                stroke-width="0"
+                width="40.400000000000006"
+                height="23"
+              />
+            </g>
+            <g transform="matrix(1,0,0,1,0,0)">
+              <text
+                id="text"
+                fill="rgba(255,255,255,1)"
+                dominant-baseline="central"
+                paint-order="stroke"
+                dx="0.5"
+                dy="9.5px"
+                font-size="10"
+                text-anchor="end"
+              >
+                Notice
+              </text>
+            </g>
+          </g>
+        </g>
+        <g transform="matrix(1,0,0,1,-50,0)">
+          <circle
+            id="anchor-0"
+            fill="none"
+            transform="translate(-2,-2)"
+            cx="2"
+            cy="2"
+            r="2"
+            stroke="rgba(0,0,0,1)"
+            stroke-width="1"
+          />
+        </g>
+        <g transform="matrix(1,0,0,1,50,0)">
+          <circle
+            id="anchor-1"
+            fill="none"
+            transform="translate(-2,-2)"
+            cx="2"
+            cy="2"
+            r="2"
+            stroke="rgba(255,255,0,1)"
+            stroke-width="2"
+          />
+        </g>
+        <g transform="matrix(1,0,0,1,0,-50)">
+          <circle
+            id="anchor-2"
+            fill="none"
+            transform="translate(-2,-2)"
+            cx="2"
+            cy="2"
+            r="2"
+            stroke="rgba(0,128,0,1)"
+            stroke-width="1"
+          />
+        </g>
+        <g transform="matrix(1,0,0,1,0,50)">
+          <circle
+            id="anchor-3"
+            fill="none"
+            transform="translate(-2,-2)"
+            cx="2"
+            cy="2"
+            r="2"
+            stroke="rgba(128,128,128,1)"
+            stroke-width="1"
+          />
+        </g>
+      </g>
+      <g
+        id="g-svg-31"
+        fill="none"
+        width="80"
+        height="40"
+        transform="matrix(1,0,0,1,100,300)"
+      >
+        <g transform="matrix(1,0,0,1,-40,-20)">
+          <polygon
+            id="key"
+            fill="rgba(255,192,203,1)"
+            points="40,0 80,20 40,40 0,20"
+          />
+        </g>
+        <g id="icon" fill="none" transform="matrix(1,0,0,1,0,0)">
+          <g transform="matrix(1,0,0,1,0,0)">
+            <text
+              id="icon"
+              fill="rgba(0,0,0,1)"
+              dominant-baseline="central"
+              paint-order="stroke"
+              dx="0.5"
+              text-anchor="middle"
+              font-size="14"
+            >
+              Haha
+            </text>
+          </g>
+        </g>
+        <g id="label" fill="none" transform="matrix(1,0,0,1,0,20)">
+          <g transform="matrix(1,0,0,1,-66.820000,-2)">
+            <path
+              id="background"
+              fill="none"
+              d="M 0,0 l 168,0 l 0,27 l-168 0 z"
+              opacity="0.75"
+              stroke-width="0"
+              width="168"
+              height="27"
+            />
+          </g>
+          <g transform="matrix(1,0,0,1,0,0)">
+            <text
+              id="text"
+              fill="rgba(0,0,0,1)"
+              dominant-baseline="central"
+              paint-order="stroke"
+              dx="0.5"
+              dy="11.5px"
+              font-size="12"
+              text-anchor="middle"
+            >
+              this is a looooog label
+            </text>
+          </g>
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/packages/g6/src/elements/nodes/diamond.ts
+++ b/packages/g6/src/elements/nodes/diamond.ts
@@ -1,0 +1,65 @@
+import type { DisplayObjectConfig, Group, PolygonStyleProps } from '@antv/g';
+import { Polygon } from '@antv/g';
+import type { Point } from '../../types';
+import { getDiamondPoints } from '../../utils/element';
+import { getPolygonIntersectPoint } from '../../utils/point';
+import { subStyleProps } from '../../utils/prefix';
+import type { BaseNodeStyleProps } from './base-node';
+import { BaseNode } from './base-node';
+
+type KeyShapeStyleProps = Partial<PolygonStyleProps> & {
+  width?: number;
+  height?: number;
+};
+
+export type DiamondStyleProps = BaseNodeStyleProps<KeyShapeStyleProps>;
+
+type ParsedDiamondStyleProps = Required<DiamondStyleProps>;
+
+type DiamondOptions = DisplayObjectConfig<DiamondStyleProps>;
+
+/**
+ * Draw diamond based on BaseNode, override drawKeyShape.
+ */
+export class Diamond extends BaseNode<KeyShapeStyleProps, Polygon> {
+  constructor(options: DiamondOptions) {
+    super(options);
+  }
+
+  protected getKeyStyle(attributes: ParsedDiamondStyleProps): PolygonStyleProps {
+    const { width, height, ...keyStyle } = super.getKeyStyle(attributes) as Required<KeyShapeStyleProps>;
+    const points = getDiamondPoints(width, height) as [number, number][];
+    return { ...keyStyle, points };
+  }
+
+  protected getHaloStyle(attributes: ParsedDiamondStyleProps): PolygonStyleProps | false {
+    if (attributes.halo === false) return false;
+    const haloStyle = subStyleProps(this.getGraphicStyle(attributes), 'halo') as Partial<KeyShapeStyleProps>;
+    const keyStyle = this.getKeyStyle(attributes);
+    const lineWidth = Number(keyStyle.lineWidth || 0);
+    const haloLineWidth = Number(haloStyle.lineWidth || 0);
+    const { width = 0, height = 0 } = attributes;
+    const points = getDiamondPoints(
+      Number(width) + lineWidth + haloLineWidth + 4,
+      Number(height) + lineWidth + haloLineWidth + 4,
+    ) as [number, number][];
+
+    return {
+      ...keyStyle,
+      points,
+      ...haloStyle,
+    };
+  }
+
+  public getIntersectPoint(point: Point): Point {
+    const { points } = this.getKeyStyle(this.attributes as ParsedDiamondStyleProps);
+    const center = [this.attributes.x, this.attributes.y] as Point;
+    return getPolygonIntersectPoint(point, center, points);
+  }
+
+  protected drawKeyShape(attributes: ParsedDiamondStyleProps, container: Group): Polygon {
+    return this.upsert('key', Polygon, this.getKeyStyle(attributes), container) as Polygon;
+  }
+
+  connectedCallback() {}
+}

--- a/packages/g6/src/elements/nodes/index.ts
+++ b/packages/g6/src/elements/nodes/index.ts
@@ -2,6 +2,8 @@ export { BaseNode } from './base-node';
 export type { BaseNodeStyleProps } from './base-node';
 export { Circle } from './circle';
 export type { CircleStyleProps } from './circle';
+export { Diamond } from './diamond';
+export type { DiamondStyleProps } from './diamond';
 export { Ellipse } from './ellipse';
 export type { EllipseNodeStyleProps } from './ellipse';
 export { Rect } from './rect';

--- a/packages/g6/src/utils/element.ts
+++ b/packages/g6/src/utils/element.ts
@@ -257,3 +257,18 @@ export function getRectPoints(width: number, height: number): Point[] {
     [-width / 2, -height / 2],
   ];
 }
+
+/**
+ * Get Diamond PathArray.
+ * @param width - diamond width
+ * @param height - diamond height
+ * @returns The PathArray for G
+ */
+export function getDiamondPoints(width: number, height: number): Point[] {
+  return [
+    [0, -height / 2],
+    [width / 2, 0],
+    [0, height / 2],
+    [-width / 2, 0],
+  ];
+}


### PR DESCRIPTION
## keyShape configuration
- width: The width of diamond
- height: The height of diamond

## Description
Explain why haloStyle's lineWidth has an offset of 4

- without offset：
<img width="821" alt="image" src="https://github.com/antvis/G6/assets/55946653/5d050726-476c-4bff-a353-afc8261e8c55">

- with offset :
<img width="761" alt="image" src="https://github.com/antvis/G6/assets/55946653/163b0475-7134-4b21-8e33-504b4265a76c">

因为halo的zIndex在key之后，如果不加上offset，当halo的透明度小于1时，在图形边缘会形成一行描边。
是否考虑将halo的绘制顺序放在key之前? @hustcc @Aarebecca 
