### PR TITLE
chore: update tsconfig

### DIFF
--- a/packages/g6/tsconfig.json
+++ b/packages/g6/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "baseUrl": "src",
     "declaration": true,
     "experimentalDecorators": true,
     "lib": ["DOM", "ESNext"],


### PR DESCRIPTION
如图所示，指定 `baseUrl` 会导致 `vscode` 提示路径使用简写路径，移除后提示为正常相对路径

---

As shown in the figure, specifying `baseUrl` causes `vscode` to prompt the path to use the abbreviated path, which prompts the normal relative path when removed

移除前 / Before remove
<img width="491" alt="image" src="https://github.com/antvis/G6/assets/25787943/e40a706d-ee8d-44d3-ba20-7828e05c4156">

移除后 / After remove
<img width="487" alt="image" src="https://github.com/antvis/G6/assets/25787943/9dfbc702-0a1e-4a31-90c7-93bb738cf816">
