### PR TITLE
fix(utils): fix issue that unexpected object attribute value animation

### DIFF
--- a/packages/g6/__tests__/integration/snapshots/animation/controller-element-200(2_3).svg
+++ b/packages/g6/__tests__/integration/snapshots/animation/controller-element-200(2_3).svg
@@ -22,7 +22,7 @@
             <path
               id="key"
               fill="none"
-              d="M 0,0 C 75 0,150 0,150 0"
+              d="M 0,0 L 150,0"
               stroke="rgba(139,155,175,1)"
               stroke-width="1"
               opacity="0.37293273049835485"
@@ -57,7 +57,7 @@
             <path
               id="key"
               fill="none"
-              d="M 75,100 C 37.5 50,0 0,0 0"
+              d="M 75,100 L 0,0"
               stroke="rgba(139,155,175,1)"
               stroke-width="1"
               opacity="0.37293273049835485"

--- a/packages/g6/__tests__/integration/snapshots/animation/controller-element-50(1_3).svg
+++ b/packages/g6/__tests__/integration/snapshots/animation/controller-element-50(1_3).svg
@@ -22,7 +22,7 @@
             <path
               id="key"
               fill="none"
-              d="M 0,0 C 75 0,150 0,150 0"
+              d="M 0,0 L 150,0"
               stroke="rgba(139,155,175,1)"
               stroke-width="1"
               opacity="0.8255817601983712"
@@ -57,7 +57,7 @@
             <path
               id="key"
               fill="none"
-              d="M 75,100 C 37.5 50,0 0,0 0"
+              d="M 75,100 L 0,0"
               stroke="rgba(139,155,175,1)"
               stroke-width="1"
               opacity="0.8255817601983712"

--- a/packages/g6/__tests__/unit/utils/animation.spec.ts
+++ b/packages/g6/__tests__/unit/utils/animation.spec.ts
@@ -37,8 +37,8 @@ describe('animation', () => {
   it('preprocessKeyframes', () => {
     expect(
       preprocessKeyframes([
-        { fill: 'red', opacity: 0, stroke: 1, lineWidth: 0, lineDash: undefined },
-        { fill: 'blue', opacity: 1, lineWidth: 0, lineDash: undefined },
+        { fill: 'red', opacity: 0, stroke: 1, lineWidth: 0, lineDash: undefined, startPoint: [0, 0, 0] },
+        { fill: 'blue', opacity: 1, lineWidth: 0, lineDash: undefined, startPoint: [0, 0, 0] },
       ]),
     ).toEqual([
       { fill: 'red', opacity: 0 },

--- a/packages/g6/src/elements/edges/base-edge.ts
+++ b/packages/g6/src/elements/edges/base-edge.ts
@@ -9,7 +9,15 @@ import type {
 import { Path } from '@antv/g';
 import type { PathArray } from '@antv/util';
 import { deepMix, isEmpty, isEqual, isFunction } from '@antv/util';
-import type { BaseEdgeProps, EdgeKey, EdgeLabelStyleProps, LoopEdgePosition, Point, PrefixObject } from '../../types';
+import type {
+  BaseEdgeProps,
+  EdgeKey,
+  EdgeLabelStyleProps,
+  Keyframe,
+  LoopEdgePosition,
+  Point,
+  PrefixObject,
+} from '../../types';
 import { getCubicPath, getLabelPositionStyle, getLoopPoints } from '../../utils/edge';
 import { findPort, isSameNode } from '../../utils/element';
 import { getEllipseIntersectPoint } from '../../utils/point';
@@ -275,7 +283,7 @@ export abstract class BaseEdge<KT extends BaseEdgeProps<object>> extends BaseSha
     this.drawHaloShape(attributes, container);
   }
 
-  animate(keyframes: Keyframe[] | PropertyIndexedKeyframes, options?: number | KeyframeAnimationOptions) {
+  animate(keyframes: Keyframe[], options?: number | KeyframeAnimationOptions) {
     const result = super.animate(keyframes, options);
 
     result.onframe = () => {

--- a/packages/g6/src/elements/shapes/base-shape.ts
+++ b/packages/g6/src/elements/shapes/base-shape.ts
@@ -1,6 +1,7 @@
 import type { DisplayObject, DisplayObjectConfig, Group, GroupStyleProps, IAnimation } from '@antv/g';
 import { CustomElement } from '@antv/g';
 import { deepMix } from '@antv/util';
+import type { Keyframe } from '../../types';
 import { createAnimationsProxy, preprocessKeyframes } from '../../utils/animation';
 
 export interface BaseShapeStyleProps extends GroupStyleProps {}
@@ -123,10 +124,7 @@ export abstract class BaseShape<T extends BaseShapeStyleProps> extends CustomEle
     return style;
   }
 
-  public animate(
-    keyframes: PropertyIndexedKeyframes | Keyframe[],
-    options?: number | KeyframeAnimationOptions,
-  ): IAnimation {
+  public animate(keyframes: Keyframe[], options?: number | KeyframeAnimationOptions): IAnimation {
     this.animateMap = {};
 
     const result = super.animate(keyframes, options)!;

--- a/packages/g6/src/types/animation.ts
+++ b/packages/g6/src/types/animation.ts
@@ -1,0 +1,3 @@
+export type Keyframe = {
+  [key: string]: any;
+};

--- a/packages/g6/src/types/index.ts
+++ b/packages/g6/src/types/index.ts
@@ -1,3 +1,4 @@
+export type * from './animation';
 export type * from './callable';
 export type * from './canvas';
 export type * from './change';

--- a/packages/g6/src/utils/animation.ts
+++ b/packages/g6/src/utils/animation.ts
@@ -1,5 +1,6 @@
 import type { DisplayObject, IAnimation } from '@antv/g';
 import { isEqual, isNil } from '@antv/util';
+import type { Keyframe } from '../types';
 import { getDescendantShapes } from './shape';
 
 /**
@@ -44,16 +45,13 @@ export function createAnimationsProxy(sourceAnimation: IAnimation, targetAnimati
 export function preprocessKeyframes(keyframes: Keyframe[]): Keyframe[] {
   // 转化为 PropertyIndexedKeyframes 格式方便后续处理
   // convert to PropertyIndexedKeyframes format for subsequent processing
-  const propertyIndexedKeyframes = keyframes.reduce(
-    (acc, kf) => {
-      Object.entries(kf).forEach(([key, value]) => {
-        if (acc[key] === undefined) acc[key] = [value];
-        else acc[key].push(value);
-      });
-      return acc;
-    },
-    {} as Record<string, any[]>,
-  );
+  const propertyIndexedKeyframes: Record<string, any[]> = keyframes.reduce((acc, kf) => {
+    Object.entries(kf).forEach(([key, value]) => {
+      if (acc[key] === undefined) acc[key] = [value];
+      else acc[key].push(value);
+    });
+    return acc;
+  }, {});
 
   // 过滤掉无用动画的属性（属性值为 undefined、或者值完全一致）
   // filter out useless animation properties (property value is undefined, or value is exactly the same)

--- a/packages/g6/src/utils/animation.ts
+++ b/packages/g6/src/utils/animation.ts
@@ -1,5 +1,5 @@
 import type { DisplayObject, IAnimation } from '@antv/g';
-import { isNil } from '@antv/util';
+import { isEqual, isNil } from '@antv/util';
 import { getDescendantShapes } from './shape';
 
 /**
@@ -64,7 +64,7 @@ export function preprocessKeyframes(keyframes: Keyframe[]): Keyframe[] {
       // 属性值不能为空 / property value cannot be empty
       values.some((value) => isNil(value)) ||
       // 属性值必须不完全一致 / property value must not be exactly the same
-      values.every((value) => value === values[0])
+      values.every((value) => isEqual(value, values[0]))
     ) {
       delete propertyIndexedKeyframes[key];
     }


### PR DESCRIPTION
之前 `preprocessKeyframes` 方法通过 `===` 来比较属性值是否相等，导致一些对象属性出现不必要的动画更新。

例如边的起点属性 `startPoint`，前后都为 `[0, 0]` 时，不应该进行执行动画。

---

Previously, the `preprocessKeyframes` method used `===` to compare the values of the attributes, causing some object attributes to be unnecessarily animated. For example, when the starting attribute of the edge `startPoint` is `[0, 0]` before and after, animation should not be performed.