### PR TITLE
refactor: adjust render and draw async invoke

### DIFF
--- a/packages/g6/__tests__/demo/static/controller-layout-circular.ts
+++ b/packages/g6/__tests__/demo/static/controller-layout-circular.ts
@@ -1,10 +1,11 @@
 import type { G6Spec } from '../../../src';
+import { Graph } from '../../../src';
 import data from '../../dataset/soccer.json';
-import { createGraph } from '../../mock';
 import type { StaticTestCase } from '../types';
 
 export const controllerLayoutCircular: StaticTestCase = async ({ canvas, animation }) => {
   const options: G6Spec = {
+    container: canvas,
     animation,
     data,
     theme: 'light',
@@ -22,7 +23,7 @@ export const controllerLayoutCircular: StaticTestCase = async ({ canvas, animati
     },
   };
 
-  const graph = createGraph(options, canvas);
+  const graph = new Graph(options);
 
   await graph.render();
 };

--- a/packages/g6/__tests__/demo/static/controller-layout-circular.ts
+++ b/packages/g6/__tests__/demo/static/controller-layout-circular.ts
@@ -1,8 +1,6 @@
 import type { G6Spec } from '../../../src';
-import { DataController } from '../../../src/runtime/data';
-import { ElementController } from '../../../src/runtime/element';
-import { LayoutController } from '../../../src/runtime/layout';
 import data from '../../dataset/soccer.json';
+import { createGraph } from '../../mock';
 import type { StaticTestCase } from '../types';
 
 export const controllerLayoutCircular: StaticTestCase = async ({ canvas, animation }) => {
@@ -24,21 +22,7 @@ export const controllerLayoutCircular: StaticTestCase = async ({ canvas, animati
     },
   };
 
-  const graph = {
-    emit: () => {},
-  };
+  const graph = createGraph(options, canvas);
 
-  const model = new DataController();
-
-  model.addData(options?.data || {});
-
-  const context: any = { options, model, graph, canvas, viewport: { getCanvasSize: () => [500, 500] } };
-
-  const element = new ElementController(context);
-
-  await element.draw(context);
-
-  const layout = new LayoutController({ ...context, element });
-
-  await layout.layout();
+  await graph.render();
 };

--- a/packages/g6/__tests__/demo/static/controller-layout-compact-box.ts
+++ b/packages/g6/__tests__/demo/static/controller-layout-compact-box.ts
@@ -1,11 +1,11 @@
 import type { G6Spec } from '../../../src';
-import { treeToGraphData } from '../../../src';
+import { Graph, treeToGraphData } from '../../../src';
 import tree from '../../dataset/algorithm-category.json';
-import { createGraph } from '../../mock';
 import type { StaticTestCase } from '../types';
 
 export const controllerLayoutCompactBox: StaticTestCase = async ({ canvas, animation }) => {
   const options: G6Spec = {
+    container: canvas,
     animation,
     data: treeToGraphData(tree),
     theme: 'light',
@@ -47,7 +47,7 @@ export const controllerLayoutCompactBox: StaticTestCase = async ({ canvas, anima
     },
   };
 
-  const graph = createGraph(options, canvas);
+  const graph = new Graph(options);
 
   await graph.render();
 

--- a/packages/g6/__tests__/demo/static/controller-layout-compact-box.ts
+++ b/packages/g6/__tests__/demo/static/controller-layout-compact-box.ts
@@ -1,10 +1,7 @@
 import type { G6Spec } from '../../../src';
 import { treeToGraphData } from '../../../src';
-import { DataController } from '../../../src/runtime/data';
-import { ElementController } from '../../../src/runtime/element';
-import { LayoutController } from '../../../src/runtime/layout';
-import { ViewportController } from '../../../src/runtime/viewport';
 import tree from '../../dataset/algorithm-category.json';
+import { createGraph } from '../../mock';
 import type { StaticTestCase } from '../types';
 
 export const controllerLayoutCompactBox: StaticTestCase = async ({ canvas, animation }) => {
@@ -12,6 +9,7 @@ export const controllerLayoutCompactBox: StaticTestCase = async ({ canvas, anima
     animation,
     data: treeToGraphData(tree),
     theme: 'light',
+    zoom: 0.5,
     layout: {
       type: 'compact-box',
       animation,
@@ -49,25 +47,9 @@ export const controllerLayoutCompactBox: StaticTestCase = async ({ canvas, anima
     },
   };
 
-  const graph = {
-    emit: () => {},
-  };
+  const graph = createGraph(options, canvas);
 
-  const model = new DataController();
+  await graph.render();
 
-  model.addData(options?.data || {});
-
-  const viewport = new ViewportController({ canvas } as any);
-  viewport.zoom({ mode: 'absolute', value: 0.5 });
-  viewport.translate({ mode: 'absolute', value: [100, 300] });
-
-  const context: any = { options, model, graph, canvas, viewport };
-
-  const element = new ElementController(context);
-
-  await element.draw(context);
-
-  const layout = new LayoutController({ ...context, element });
-
-  await layout.layout();
+  await graph.translateTo([100, 300]);
 };

--- a/packages/g6/__tests__/demo/static/controller-layout-d3-force.ts
+++ b/packages/g6/__tests__/demo/static/controller-layout-d3-force.ts
@@ -1,8 +1,6 @@
 import type { G6Spec } from '../../../src';
-import { DataController } from '../../../src/runtime/data';
-import { ElementController } from '../../../src/runtime/element';
-import { LayoutController } from '../../../src/runtime/layout';
 import data from '../../dataset/soccer.json';
+import { createGraph } from '../../mock';
 import type { StaticTestCase } from '../types';
 
 export const controllerLayoutD3Force: StaticTestCase = async ({ canvas, animation }) => {
@@ -19,21 +17,7 @@ export const controllerLayoutD3Force: StaticTestCase = async ({ canvas, animatio
     node: { style: { width: 20, height: 20 } },
   };
 
-  const graph = {
-    emit: () => {},
-  };
+  const graph = createGraph(options, canvas);
 
-  const model = new DataController();
-
-  model.addData(options?.data || {});
-
-  const context: any = { options, model, graph, canvas, viewport: { getCanvasSize: () => [500, 500] } };
-
-  const element = new ElementController(context);
-
-  await element.draw(context);
-
-  const layout = new LayoutController({ ...context, element });
-
-  await layout.layout();
+  await graph.render();
 };

--- a/packages/g6/__tests__/demo/static/controller-layout-d3-force.ts
+++ b/packages/g6/__tests__/demo/static/controller-layout-d3-force.ts
@@ -1,10 +1,11 @@
 import type { G6Spec } from '../../../src';
+import { Graph } from '../../../src';
 import data from '../../dataset/soccer.json';
-import { createGraph } from '../../mock';
 import type { StaticTestCase } from '../types';
 
 export const controllerLayoutD3Force: StaticTestCase = async ({ canvas, animation }) => {
   const options: G6Spec = {
+    container: canvas,
     animation,
     data,
     theme: 'light',
@@ -17,7 +18,7 @@ export const controllerLayoutD3Force: StaticTestCase = async ({ canvas, animatio
     node: { style: { width: 20, height: 20 } },
   };
 
-  const graph = createGraph(options, canvas);
+  const graph = new Graph(options);
 
   await graph.render();
 };

--- a/packages/g6/__tests__/demo/static/controller-layout-dagre.ts
+++ b/packages/g6/__tests__/demo/static/controller-layout-dagre.ts
@@ -1,10 +1,11 @@
 import type { G6Spec } from '../../../src';
+import { Graph } from '../../../src';
 import data from '../../dataset/dagre.json';
-import { createGraph } from '../../mock';
 import type { StaticTestCase } from '../types';
 
 export const controllerLayoutDagre: StaticTestCase = async ({ canvas, animation }) => {
   const options: G6Spec = {
+    container: canvas,
     animation,
     data,
     theme: 'light',
@@ -25,7 +26,7 @@ export const controllerLayoutDagre: StaticTestCase = async ({ canvas, animation 
     },
   };
 
-  const graph = createGraph(options, canvas);
+  const graph = new Graph(options);
 
   await graph.render();
 };

--- a/packages/g6/__tests__/demo/static/controller-layout-dagre.ts
+++ b/packages/g6/__tests__/demo/static/controller-layout-dagre.ts
@@ -1,8 +1,6 @@
 import type { G6Spec } from '../../../src';
-import { DataController } from '../../../src/runtime/data';
-import { ElementController } from '../../../src/runtime/element';
-import { LayoutController } from '../../../src/runtime/layout';
 import data from '../../dataset/dagre.json';
+import { createGraph } from '../../mock';
 import type { StaticTestCase } from '../types';
 
 export const controllerLayoutDagre: StaticTestCase = async ({ canvas, animation }) => {
@@ -21,27 +19,13 @@ export const controllerLayoutDagre: StaticTestCase = async ({ canvas, animation 
     node: { style: { width: 20, height: 20 } },
     edge: {
       style: {
-        // type: 'polyline',
+        type: 'polyline',
         // TODO polyline
       },
     },
   };
 
-  const graph = {
-    emit: () => {},
-  };
+  const graph = createGraph(options, canvas);
 
-  const model = new DataController();
-
-  model.addData(options?.data || {});
-
-  const context: any = { options, model, graph, canvas, viewport: { getCanvasSize: () => [500, 500] } };
-
-  const element = new ElementController(context);
-
-  await element.draw(context);
-
-  const layout = new LayoutController({ ...context, element });
-
-  await layout.layout();
+  await graph.render();
 };

--- a/packages/g6/__tests__/demo/static/controller-layout-dendrogram.ts
+++ b/packages/g6/__tests__/demo/static/controller-layout-dendrogram.ts
@@ -1,10 +1,7 @@
 import type { G6Spec } from '../../../src';
 import { treeToGraphData } from '../../../src';
-import { DataController } from '../../../src/runtime/data';
-import { ElementController } from '../../../src/runtime/element';
-import { LayoutController } from '../../../src/runtime/layout';
-import { ViewportController } from '../../../src/runtime/viewport';
 import tree from '../../dataset/algorithm-category.json';
+import { createGraph } from '../../mock';
 import type { StaticTestCase } from '../types';
 
 export const controllerLayoutDendrogram: StaticTestCase = async ({ canvas, animation }) => {
@@ -27,27 +24,12 @@ export const controllerLayoutDendrogram: StaticTestCase = async ({ canvas, anima
         type: 'polyline',
       },
     },
+    zoom: 0.5,
   };
 
-  const graph = {
-    emit: () => {},
-  };
+  const graph = createGraph(options, canvas);
 
-  const model = new DataController();
+  await graph.render();
 
-  model.addData(options?.data || {});
-
-  const viewport = new ViewportController({ canvas } as any);
-  viewport.zoom({ mode: 'absolute', value: 0.5 });
-  viewport.translate({ mode: 'absolute', value: [-200, 350] });
-
-  const context: any = { options, model, graph, canvas, viewport };
-
-  const element = new ElementController(context);
-
-  await element.draw(context);
-
-  const layout = new LayoutController({ ...context, element });
-
-  await layout.layout();
+  await graph.translateTo([-200, 350]);
 };

--- a/packages/g6/__tests__/demo/static/controller-layout-dendrogram.ts
+++ b/packages/g6/__tests__/demo/static/controller-layout-dendrogram.ts
@@ -1,11 +1,11 @@
 import type { G6Spec } from '../../../src';
-import { treeToGraphData } from '../../../src';
+import { Graph, treeToGraphData } from '../../../src';
 import tree from '../../dataset/algorithm-category.json';
-import { createGraph } from '../../mock';
 import type { StaticTestCase } from '../types';
 
 export const controllerLayoutDendrogram: StaticTestCase = async ({ canvas, animation }) => {
   const options: G6Spec = {
+    container: canvas,
     animation,
     data: treeToGraphData(tree),
     theme: 'light',
@@ -27,7 +27,7 @@ export const controllerLayoutDendrogram: StaticTestCase = async ({ canvas, anima
     zoom: 0.5,
   };
 
-  const graph = createGraph(options, canvas);
+  const graph = new Graph(options);
 
   await graph.render();
 

--- a/packages/g6/__tests__/demo/static/controller-layout-force.ts
+++ b/packages/g6/__tests__/demo/static/controller-layout-force.ts
@@ -1,10 +1,11 @@
 import type { G6Spec } from '../../../src';
+import { Graph } from '../../../src';
 import data from '../../dataset/cluster.json';
-import { createGraph } from '../../mock';
 import type { StaticTestCase } from '../types';
 
 export const controllerLayoutForce: StaticTestCase = async ({ canvas, animation }) => {
   const options: G6Spec = {
+    container: canvas,
     animation,
     data,
     theme: 'light',
@@ -27,7 +28,7 @@ export const controllerLayoutForce: StaticTestCase = async ({ canvas, animation 
     },
   };
 
-  const graph = createGraph(options, canvas);
+  const graph = new Graph(options);
 
   await graph.render();
 };

--- a/packages/g6/__tests__/demo/static/controller-layout-force.ts
+++ b/packages/g6/__tests__/demo/static/controller-layout-force.ts
@@ -1,8 +1,6 @@
 import type { G6Spec } from '../../../src';
-import { DataController } from '../../../src/runtime/data';
-import { ElementController } from '../../../src/runtime/element';
-import { LayoutController } from '../../../src/runtime/layout';
 import data from '../../dataset/cluster.json';
+import { createGraph } from '../../mock';
 import type { StaticTestCase } from '../types';
 
 export const controllerLayoutForce: StaticTestCase = async ({ canvas, animation }) => {
@@ -29,23 +27,9 @@ export const controllerLayoutForce: StaticTestCase = async ({ canvas, animation 
     },
   };
 
-  const graph = {
-    emit: () => {},
-  };
+  const graph = createGraph(options, canvas);
 
-  const model = new DataController();
-
-  model.addData(options?.data || {});
-
-  const context: any = { options, model, graph, canvas, viewport: { getCanvasSize: () => [500, 500] } };
-
-  const element = new ElementController(context);
-
-  await element.draw(context);
-
-  const layout = new LayoutController({ ...context, element });
-
-  await layout.layout();
+  await graph.render();
 };
 
 controllerLayoutForce.skip = true;

--- a/packages/g6/__tests__/demo/static/controller-layout-forceatlas2-wasm.ts
+++ b/packages/g6/__tests__/demo/static/controller-layout-forceatlas2-wasm.ts
@@ -1,10 +1,8 @@
 import { ForceAtlas2Layout, initThreads, supportsThreads } from '@antv/layout-wasm';
 import type { G6Spec } from '../../../src';
 import { register } from '../../../src';
-import { DataController } from '../../../src/runtime/data';
-import { ElementController } from '../../../src/runtime/element';
-import { LayoutController } from '../../../src/runtime/layout';
 import data from '../../dataset/soccer.json';
+import { createGraph } from '../../mock';
 import type { StaticTestCase } from '../types';
 
 register('layout', 'forceatlas2-wasm', ForceAtlas2Layout);
@@ -32,21 +30,7 @@ export const controllerLayoutForceatlas2WASM: StaticTestCase = async ({ canvas, 
     node: { style: { width: 20, height: 20 } },
   };
 
-  const graph = {
-    emit: () => {},
-  };
+  const graph = createGraph(options, canvas);
 
-  const model = new DataController();
-
-  model.addData(options?.data || {});
-
-  const context: any = { options, model, graph, canvas, viewport: { getCanvasSize: () => [500, 500] } };
-
-  const element = new ElementController(context);
-
-  await element.draw(context);
-
-  const layout = new LayoutController({ ...context, element });
-
-  await layout.layout();
+  await graph.render();
 };

--- a/packages/g6/__tests__/demo/static/controller-layout-forceatlas2-wasm.ts
+++ b/packages/g6/__tests__/demo/static/controller-layout-forceatlas2-wasm.ts
@@ -1,8 +1,7 @@
 import { ForceAtlas2Layout, initThreads, supportsThreads } from '@antv/layout-wasm';
 import type { G6Spec } from '../../../src';
-import { register } from '../../../src';
+import { Graph, register } from '../../../src';
 import data from '../../dataset/soccer.json';
-import { createGraph } from '../../mock';
 import type { StaticTestCase } from '../types';
 
 register('layout', 'forceatlas2-wasm', ForceAtlas2Layout);
@@ -12,6 +11,7 @@ export const controllerLayoutForceatlas2WASM: StaticTestCase = async ({ canvas, 
   const threads = await initThreads(supported);
 
   const options: G6Spec = {
+    container: canvas,
     animation,
     data,
     theme: 'light',
@@ -30,7 +30,7 @@ export const controllerLayoutForceatlas2WASM: StaticTestCase = async ({ canvas, 
     node: { style: { width: 20, height: 20 } },
   };
 
-  const graph = createGraph(options, canvas);
+  const graph = new Graph(options);
 
   await graph.render();
 };

--- a/packages/g6/__tests__/demo/static/controller-layout-fruchterman-gpu.ts
+++ b/packages/g6/__tests__/demo/static/controller-layout-fruchterman-gpu.ts
@@ -1,14 +1,14 @@
 import { FruchtermanLayout } from '@antv/layout-gpu';
 import type { G6Spec } from '../../../src';
-import { register } from '../../../src';
+import { Graph, register } from '../../../src';
 import data from '../../dataset/soccer.json';
-import { createGraph } from '../../mock';
 import type { StaticTestCase } from '../types';
 
 register('layout', 'fruchterman-gpu', FruchtermanLayout);
 
 export const controllerLayoutFruchtermanGPU: StaticTestCase = async ({ canvas, animation }) => {
   const options: G6Spec = {
+    container: canvas,
     animation,
     data,
     theme: 'light',
@@ -24,7 +24,7 @@ export const controllerLayoutFruchtermanGPU: StaticTestCase = async ({ canvas, a
     node: { style: { width: 20, height: 20 } },
   };
 
-  const graph = createGraph(options, canvas);
+  const graph = new Graph(options);
 
   await graph.render();
 };

--- a/packages/g6/__tests__/demo/static/controller-layout-fruchterman-gpu.ts
+++ b/packages/g6/__tests__/demo/static/controller-layout-fruchterman-gpu.ts
@@ -1,10 +1,8 @@
 import { FruchtermanLayout } from '@antv/layout-gpu';
 import type { G6Spec } from '../../../src';
 import { register } from '../../../src';
-import { DataController } from '../../../src/runtime/data';
-import { ElementController } from '../../../src/runtime/element';
-import { LayoutController } from '../../../src/runtime/layout';
 import data from '../../dataset/soccer.json';
+import { createGraph } from '../../mock';
 import type { StaticTestCase } from '../types';
 
 register('layout', 'fruchterman-gpu', FruchtermanLayout);
@@ -26,21 +24,7 @@ export const controllerLayoutFruchtermanGPU: StaticTestCase = async ({ canvas, a
     node: { style: { width: 20, height: 20 } },
   };
 
-  const graph = {
-    emit: () => {},
-  };
+  const graph = createGraph(options, canvas);
 
-  const model = new DataController();
-
-  model.addData(options?.data || {});
-
-  const context: any = { options, model, graph, canvas, viewport: { getCanvasSize: () => [500, 500] } };
-
-  const element = new ElementController(context);
-
-  await element.draw(context);
-
-  const layout = new LayoutController({ ...context, element });
-
-  await layout.layout();
+  await graph.render();
 };

--- a/packages/g6/__tests__/demo/static/controller-layout-fruchterman-wasm.ts
+++ b/packages/g6/__tests__/demo/static/controller-layout-fruchterman-wasm.ts
@@ -1,8 +1,7 @@
 import { FruchtermanLayout, initThreads, supportsThreads } from '@antv/layout-wasm';
 import type { G6Spec } from '../../../src';
-import { register } from '../../../src';
+import { Graph, register } from '../../../src';
 import data from '../../dataset/soccer.json';
-import { createGraph } from '../../mock';
 import type { StaticTestCase } from '../types';
 
 register('layout', 'fruchterman-wasm', FruchtermanLayout);
@@ -12,6 +11,7 @@ export const controllerLayoutFruchtermanWASM: StaticTestCase = async ({ canvas, 
   const threads = await initThreads(supported);
 
   const options: G6Spec = {
+    container: canvas,
     animation,
     data,
     theme: 'light',
@@ -29,7 +29,7 @@ export const controllerLayoutFruchtermanWASM: StaticTestCase = async ({ canvas, 
     node: { style: { width: 20, height: 20 } },
   };
 
-  const graph = createGraph(options, canvas);
+  const graph = new Graph(options);
 
   await graph.render();
 };

--- a/packages/g6/__tests__/demo/static/controller-layout-fruchterman-wasm.ts
+++ b/packages/g6/__tests__/demo/static/controller-layout-fruchterman-wasm.ts
@@ -1,10 +1,8 @@
 import { FruchtermanLayout, initThreads, supportsThreads } from '@antv/layout-wasm';
 import type { G6Spec } from '../../../src';
 import { register } from '../../../src';
-import { DataController } from '../../../src/runtime/data';
-import { ElementController } from '../../../src/runtime/element';
-import { LayoutController } from '../../../src/runtime/layout';
 import data from '../../dataset/soccer.json';
+import { createGraph } from '../../mock';
 import type { StaticTestCase } from '../types';
 
 register('layout', 'fruchterman-wasm', FruchtermanLayout);
@@ -31,21 +29,7 @@ export const controllerLayoutFruchtermanWASM: StaticTestCase = async ({ canvas, 
     node: { style: { width: 20, height: 20 } },
   };
 
-  const graph = {
-    emit: () => {},
-  };
+  const graph = createGraph(options, canvas);
 
-  const model = new DataController();
-
-  model.addData(options?.data || {});
-
-  const context: any = { options, model, graph, canvas, viewport: { getCanvasSize: () => [500, 500] } };
-
-  const element = new ElementController(context);
-
-  await element.draw(context);
-
-  const layout = new LayoutController({ ...context, element });
-
-  await layout.layout();
+  await graph.render();
 };

--- a/packages/g6/__tests__/demo/static/controller-layout-grid.ts
+++ b/packages/g6/__tests__/demo/static/controller-layout-grid.ts
@@ -1,10 +1,11 @@
 import type { G6Spec } from '../../../src';
+import { Graph } from '../../../src';
 import data from '../../dataset/soccer.json';
-import { createGraph } from '../../mock';
 import type { StaticTestCase } from '../types';
 
 export const controllerLayoutGrid: StaticTestCase = async ({ canvas, animation }) => {
   const options: G6Spec = {
+    container: canvas,
     animation,
     padding: 0,
     data,
@@ -16,7 +17,7 @@ export const controllerLayoutGrid: StaticTestCase = async ({ canvas, animation }
     node: { style: { width: 20, height: 20 } },
   };
 
-  const graph = createGraph(options, canvas);
+  const graph = new Graph(options);
 
   await graph.render();
 };

--- a/packages/g6/__tests__/demo/static/controller-layout-grid.ts
+++ b/packages/g6/__tests__/demo/static/controller-layout-grid.ts
@@ -1,8 +1,6 @@
 import type { G6Spec } from '../../../src';
-import { DataController } from '../../../src/runtime/data';
-import { ElementController } from '../../../src/runtime/element';
-import { LayoutController } from '../../../src/runtime/layout';
 import data from '../../dataset/soccer.json';
+import { createGraph } from '../../mock';
 import type { StaticTestCase } from '../types';
 
 export const controllerLayoutGrid: StaticTestCase = async ({ canvas, animation }) => {
@@ -18,21 +16,7 @@ export const controllerLayoutGrid: StaticTestCase = async ({ canvas, animation }
     node: { style: { width: 20, height: 20 } },
   };
 
-  const graph = {
-    emit: () => {},
-  };
+  const graph = createGraph(options, canvas);
 
-  const model = new DataController();
-
-  model.addData(options?.data || {});
-
-  const context: any = { options, model, graph, canvas, viewport: { getCanvasSize: () => [500, 500] } };
-
-  const element = new ElementController(context);
-
-  await element.draw(context);
-
-  const layout = new LayoutController({ ...context, element });
-
-  await layout.layout();
+  await graph.render();
 };

--- a/packages/g6/__tests__/demo/static/controller-layout-indented.ts
+++ b/packages/g6/__tests__/demo/static/controller-layout-indented.ts
@@ -1,11 +1,11 @@
 import type { G6Spec } from '../../../src';
-import { treeToGraphData } from '../../../src';
+import { Graph, treeToGraphData } from '../../../src';
 import tree from '../../dataset/file-system.json';
-import { createGraph } from '../../mock';
 import type { StaticTestCase } from '../types';
 
 export const controllerLayoutIndented: StaticTestCase = async ({ canvas, animation }) => {
   const options: G6Spec = {
+    container: canvas,
     animation,
     data: treeToGraphData(tree),
     theme: 'light',
@@ -32,7 +32,7 @@ export const controllerLayoutIndented: StaticTestCase = async ({ canvas, animati
     zoom: 0.5,
   };
 
-  const graph = createGraph(options, canvas);
+  const graph = new Graph(options);
 
   await graph.render();
 

--- a/packages/g6/__tests__/demo/static/controller-layout-indented.ts
+++ b/packages/g6/__tests__/demo/static/controller-layout-indented.ts
@@ -1,10 +1,7 @@
 import type { G6Spec } from '../../../src';
 import { treeToGraphData } from '../../../src';
-import { DataController } from '../../../src/runtime/data';
-import { ElementController } from '../../../src/runtime/element';
-import { LayoutController } from '../../../src/runtime/layout';
-import { ViewportController } from '../../../src/runtime/viewport';
 import tree from '../../dataset/file-system.json';
+import { createGraph } from '../../mock';
 import type { StaticTestCase } from '../types';
 
 export const controllerLayoutIndented: StaticTestCase = async ({ canvas, animation }) => {
@@ -32,28 +29,12 @@ export const controllerLayoutIndented: StaticTestCase = async ({ canvas, animati
         // TODO polyline
       },
     },
+    zoom: 0.5,
   };
 
-  const graph = {
-    emit: () => {},
-  };
+  const graph = createGraph(options, canvas);
 
-  const model = new DataController();
+  await graph.render();
 
-  model.addData(options?.data || {});
-
-  const viewport = new ViewportController({ canvas } as any);
-
-  const context: any = { options, model, graph, canvas, viewport };
-
-  viewport.zoom({ mode: 'absolute', value: 0.5 });
-  viewport.translate({ mode: 'absolute', value: [0, -200] });
-
-  const element = new ElementController(context);
-
-  await element.draw(context);
-
-  const layout = new LayoutController({ ...context, element });
-
-  await layout.layout();
+  await graph.translateTo([0, -200]);
 };

--- a/packages/g6/__tests__/demo/static/controller-layout-mindmap.ts
+++ b/packages/g6/__tests__/demo/static/controller-layout-mindmap.ts
@@ -1,11 +1,11 @@
 import type { G6Spec } from '../../../src';
-import { treeToGraphData } from '../../../src';
+import { Graph, treeToGraphData } from '../../../src';
 import tree from '../../dataset/algorithm-category.json';
-import { createGraph } from '../../mock';
 import type { StaticTestCase } from '../types';
 
 export const controllerLayoutMindmap: StaticTestCase = async ({ canvas, animation }) => {
   const options: G6Spec = {
+    container: canvas,
     animation,
     data: treeToGraphData(tree),
     theme: 'light',
@@ -36,7 +36,7 @@ export const controllerLayoutMindmap: StaticTestCase = async ({ canvas, animatio
     zoom: 0.4,
   };
 
-  const graph = createGraph(options, canvas);
+  const graph = new Graph(options);
 
   await graph.render();
 

--- a/packages/g6/__tests__/demo/static/controller-layout-mindmap.ts
+++ b/packages/g6/__tests__/demo/static/controller-layout-mindmap.ts
@@ -1,10 +1,7 @@
 import type { G6Spec } from '../../../src';
 import { treeToGraphData } from '../../../src';
-import { DataController } from '../../../src/runtime/data';
-import { ElementController } from '../../../src/runtime/element';
-import { LayoutController } from '../../../src/runtime/layout';
-import { ViewportController } from '../../../src/runtime/viewport';
 import tree from '../../dataset/algorithm-category.json';
+import { createGraph } from '../../mock';
 import type { StaticTestCase } from '../types';
 
 export const controllerLayoutMindmap: StaticTestCase = async ({ canvas, animation }) => {
@@ -36,27 +33,12 @@ export const controllerLayoutMindmap: StaticTestCase = async ({ canvas, animatio
         type: 'polyline',
       },
     },
+    zoom: 0.4,
   };
 
-  const graph = {
-    emit: () => {},
-  };
+  const graph = createGraph(options, canvas);
 
-  const model = new DataController();
+  await graph.render();
 
-  model.addData(options?.data || {});
-
-  const viewport = new ViewportController({ canvas } as any);
-  viewport.zoom({ mode: 'absolute', value: 0.4 });
-  viewport.translate({ mode: 'absolute', value: [350, 0] });
-
-  const context: any = { options, model, graph, canvas, viewport };
-
-  const element = new ElementController(context);
-
-  await element.draw(context);
-
-  const layout = new LayoutController({ ...context, element });
-
-  await layout.layout();
+  await graph.translateTo([350, 0]);
 };

--- a/packages/g6/__tests__/demo/static/controller-layout-radial.ts
+++ b/packages/g6/__tests__/demo/static/controller-layout-radial.ts
@@ -1,10 +1,11 @@
 import type { G6Spec } from '../../../src';
+import { Graph } from '../../../src';
 import data from '../../dataset/radial.json';
-import { createGraph } from '../../mock';
 import type { StaticTestCase } from '../types';
 
 export const controllerLayoutRadial: StaticTestCase = async ({ canvas, animation }) => {
   const options: G6Spec = {
+    container: canvas,
     animation,
     padding: 0,
     data: data,
@@ -22,7 +23,7 @@ export const controllerLayoutRadial: StaticTestCase = async ({ canvas, animation
     },
   };
 
-  const graph = createGraph(options, canvas);
+  const graph = new Graph(options);
 
   await graph.render();
 };

--- a/packages/g6/__tests__/demo/static/controller-layout-radial.ts
+++ b/packages/g6/__tests__/demo/static/controller-layout-radial.ts
@@ -1,9 +1,6 @@
 import type { G6Spec } from '../../../src';
-import { DataController } from '../../../src/runtime/data';
-import { ElementController } from '../../../src/runtime/element';
-import { LayoutController } from '../../../src/runtime/layout';
-import { ViewportController } from '../../../src/runtime/viewport';
 import data from '../../dataset/radial.json';
+import { createGraph } from '../../mock';
 import type { StaticTestCase } from '../types';
 
 export const controllerLayoutRadial: StaticTestCase = async ({ canvas, animation }) => {
@@ -25,23 +22,7 @@ export const controllerLayoutRadial: StaticTestCase = async ({ canvas, animation
     },
   };
 
-  const graph = {
-    emit: () => {},
-  };
+  const graph = createGraph(options, canvas);
 
-  const model = new DataController();
-
-  model.addData(options?.data || {});
-
-  const viewport = new ViewportController({ canvas } as any);
-
-  const context: any = { options, model, graph, canvas, viewport };
-
-  const element = new ElementController(context);
-
-  await element.draw(context);
-
-  const layout = new LayoutController({ ...context, element });
-
-  await layout.layout();
+  await graph.render();
 };

--- a/packages/g6/src/runtime/element.ts
+++ b/packages/g6/src/runtime/element.ts
@@ -80,10 +80,9 @@ export class ElementController {
     this.initElementState(context.options.data || {});
   }
 
-  public async init() {
+  public init() {
     const { canvas } = this.context;
     if (!this.container) {
-      await canvas.init();
       this.container = {
         node: canvas.appendChild(new Group({ style: { zIndex: 2 } })),
         edge: canvas.appendChild(new Group({ style: { zIndex: 1 } })),
@@ -474,9 +473,9 @@ export class ElementController {
     const { model } = context;
 
     const tasks = reduceDataChanges(model.getChanges());
-    if (tasks.length === 0) return null;
+    if (tasks.length === 0) return;
 
-    await this.init();
+    this.init();
 
     const {
       NodeAdded = [],
@@ -555,7 +554,7 @@ export class ElementController {
       afterAnimate: (animation) =>
         this.emit(new AnimateEvent(GraphEvent.AFTER_ANIMATE, AnimationTypeEnum.DRAW, animation)),
       after: () => this.emit(new DrawEvent(GraphEvent.AFTER_DRAW)),
-    });
+    })?.finished.then(() => {});
   }
 
   private getShapeType(elementType: ElementType, renderData: Record<string, any>) {

--- a/packages/g6/src/runtime/element.ts
+++ b/packages/g6/src/runtime/element.ts
@@ -468,9 +468,8 @@ export class ElementController {
    *
    * <en/> start render process
    */
-  public async draw(context: RuntimeContext) {
-    this.context = context;
-    const { model } = context;
+  public async draw() {
+    const { model } = this.context;
 
     const tasks = reduceDataChanges(model.getChanges());
     if (tasks.length === 0) return;

--- a/packages/g6/src/runtime/graph.ts
+++ b/packages/g6/src/runtime/graph.ts
@@ -94,22 +94,7 @@ export class Graph extends EventEmitter {
    * <en/> To update devicePixelRatio and container properties, please destroy and recreate the instance
    */
   public setOptions(options: G6Spec): void {
-    const {
-      behaviors,
-      combo,
-      container,
-      data,
-      edge,
-      height,
-      layout,
-      node,
-      padding,
-      theme,
-      widgets,
-      width,
-      zoom,
-      zoomRange,
-    } = options;
+    const { behaviors, combo, container, data, edge, height, layout, node, padding, theme, widgets, width } = options;
 
     if (behaviors) this.setBehaviors(behaviors);
     if (combo) this.setCombo(combo);
@@ -120,9 +105,6 @@ export class Graph extends EventEmitter {
     if (theme) this.setTheme(theme);
     if (widgets) this.setWidgets(widgets);
     if (width || height) this.setSize(width || this.options.width || 0, height || this.options.height || 0);
-    // TODO 运行时配置
-    // if (zoom) this.zoomTo(zoom);
-    // if (zoomRange) this.setZoomRange(zoomRange);
   }
 
   public getSize(): [number, number] {
@@ -422,36 +404,24 @@ export class Graph extends EventEmitter {
     // TODO invoke getCenter
   }
 
-  public zoomBy(
-    ratio: number,
-    origin?: Point,
-    effectTiming?: ViewportAnimationEffectTiming,
-  ): Promise<void> | undefined {
-    return this.context.viewport!.zoom({ mode: 'relative', value: ratio, origin }, effectTiming);
+  public zoomBy(ratio: number, animation?: ViewportAnimationEffectTiming, origin?: Point): Promise<void> | undefined {
+    return this.context.viewport!.zoom({ mode: 'relative', value: ratio, origin }, animation);
   }
 
-  public zoomTo(zoom: number, origin?: Point, effectTiming?: ViewportAnimationEffectTiming): Promise<void> | undefined {
-    return this.context.viewport!.zoom({ mode: 'absolute', value: zoom, origin }, effectTiming);
+  public zoomTo(zoom: number, animation?: ViewportAnimationEffectTiming, origin?: Point): Promise<void> | undefined {
+    return this.context.viewport!.zoom({ mode: 'absolute', value: zoom, origin }, animation);
   }
 
   public getZoom(): number {
     return this.context.viewport!.getZoom();
   }
 
-  public rotateBy(
-    angle: number,
-    origin?: Point,
-    effectTiming?: ViewportAnimationEffectTiming,
-  ): Promise<void> | undefined {
-    return this.context.viewport!.rotate({ mode: 'relative', value: angle, origin }, effectTiming);
+  public rotateBy(angle: number, animation?: ViewportAnimationEffectTiming, origin?: Point): Promise<void> | undefined {
+    return this.context.viewport!.rotate({ mode: 'relative', value: angle, origin }, animation);
   }
 
-  public rotateTo(
-    angle: number,
-    origin?: Point,
-    effectTiming?: ViewportAnimationEffectTiming,
-  ): Promise<void> | undefined {
-    return this.context.viewport!.rotate({ mode: 'absolute', value: angle, origin }, effectTiming);
+  public rotateTo(angle: number, animation?: ViewportAnimationEffectTiming, origin?: Point): Promise<void> | undefined {
+    return this.context.viewport!.rotate({ mode: 'absolute', value: angle, origin }, animation);
   }
 
   public getRotation(): number {
@@ -460,18 +430,18 @@ export class Graph extends EventEmitter {
 
   public translateBy(
     offset: Point,
+    animation?: ViewportAnimationEffectTiming,
     origin?: Point,
-    effectTiming?: ViewportAnimationEffectTiming,
   ): Promise<void> | undefined {
-    return this.context.viewport!.translate({ mode: 'relative', value: offset, origin }, effectTiming);
+    return this.context.viewport!.translate({ mode: 'relative', value: offset, origin }, animation);
   }
 
   public translateTo(
     position: Point,
+    animation?: ViewportAnimationEffectTiming,
     origin?: Point,
-    effectTiming?: ViewportAnimationEffectTiming,
   ): Promise<void> | undefined {
-    return this.context.viewport!.translate({ mode: 'absolute', value: position, origin }, effectTiming);
+    return this.context.viewport!.translate({ mode: 'absolute', value: position, origin }, animation);
   }
 
   public getPosition(): Point {

--- a/packages/g6/src/runtime/graph.ts
+++ b/packages/g6/src/runtime/graph.ts
@@ -332,7 +332,7 @@ export class Graph extends EventEmitter {
     emit(this, new RenderEvent(GraphEvent.BEFORE_RENDER));
     await this.prepare();
 
-    await Promise.all([this.context.element?.draw(this.context), this.context.layout?.layout(this.context)]);
+    await Promise.all([this.context.element?.draw(), this.context.layout?.layout()]);
 
     emit(this, new RenderEvent(GraphEvent.AFTER_RENDER));
   }
@@ -345,11 +345,11 @@ export class Graph extends EventEmitter {
    */
   public async draw(): Promise<void> {
     await this.prepare();
-    return this.context.element!.draw(this.context);
+    return this.context.element!.draw();
   }
 
   public layout(): Promise<void> {
-    return this.context.layout!.layout(this.context);
+    return this.context.layout!.layout();
   }
 
   /**

--- a/packages/g6/src/runtime/graph.ts
+++ b/packages/g6/src/runtime/graph.ts
@@ -349,10 +349,9 @@ export class Graph extends EventEmitter {
   public async render(): Promise<void> {
     emit(this, new RenderEvent(GraphEvent.BEFORE_RENDER));
     await this.prepare();
-    await Promise.all([
-      (await this.context.element?.draw(this.context))?.finished,
-      await this.context.layout?.layout(),
-    ]);
+
+    await Promise.all([this.context.element?.draw(this.context), this.context.layout?.layout(this.context)]);
+
     emit(this, new RenderEvent(GraphEvent.AFTER_RENDER));
   }
 
@@ -362,15 +361,13 @@ export class Graph extends EventEmitter {
    * <en/> Draw elements
    * @returns <zh/> 渲染结果 | <en/> draw result
    */
-  public async draw() {
+  public async draw(): Promise<void> {
     await this.prepare();
-    await (
-      await this.context.element?.draw(this.context)
-    )?.finished;
+    return this.context.element!.draw(this.context);
   }
 
-  public async layout(): Promise<void> {
-    await this.context.layout?.layout();
+  public layout(): Promise<void> {
+    return this.context.layout!.layout(this.context);
   }
 
   /**

--- a/packages/g6/src/runtime/layout.ts
+++ b/packages/g6/src/runtime/layout.ts
@@ -82,7 +82,8 @@ export class LayoutController {
     this.updateElement({ nodes: positions, edges: [] }, false);
   }
 
-  public async layout() {
+  public async layout(context: RuntimeContext) {
+    this.context = context;
     if (!this.options) return;
     const pipeline = Array.isArray(this.options) ? this.options : [this.options];
 

--- a/packages/g6/src/runtime/layout.ts
+++ b/packages/g6/src/runtime/layout.ts
@@ -82,8 +82,7 @@ export class LayoutController {
     this.updateElement({ nodes: positions, edges: [] }, false);
   }
 
-  public async layout(context: RuntimeContext) {
-    this.context = context;
+  public async layout() {
     if (!this.options) return;
     const pipeline = Array.isArray(this.options) ? this.options : [this.options];
 

--- a/packages/g6/src/types/viewport.ts
+++ b/packages/g6/src/types/viewport.ts
@@ -1,9 +1,11 @@
 import type { Point } from './point';
 
-export type ViewportAnimationEffectTiming = {
-  easing?: string;
-  duration?: number;
-};
+export type ViewportAnimationEffectTiming =
+  | false
+  | {
+      easing?: string;
+      duration?: number;
+    };
 
 export type TranslateOptions = {
   /** <zh/> 平移模式 | <en/> translate mode */

--- a/packages/g6/src/utils/data.ts
+++ b/packages/g6/src/utils/data.ts
@@ -1,3 +1,4 @@
+import { get } from '@antv/util';
 import type { ComboData, EdgeData, GraphData, NodeData } from '../spec';
 
 /**
@@ -59,5 +60,5 @@ export function cloneElementData<T extends NodeData | EdgeData | ComboData>(data
  * @returns <zh/> 是否为空 | <en/> is empty
  */
 export function isEmptyData(data: GraphData) {
-  return !data.nodes?.length && !data.edges?.length && !data.combos?.length;
+  return !get(data, ['nodes', 'length']) && !get(data, ['edges', 'length']) && !get(data, ['combos', 'length']);
 }

--- a/packages/g6/src/utils/element.ts
+++ b/packages/g6/src/utils/element.ts
@@ -296,7 +296,7 @@ export function getRectPoints(width: number, height: number): Point[] {
  * @returns <zh/> 是否可见 | <en/> whether the element is visible
  */
 export function isVisible(element: DisplayObject) {
-  return element?.style?.visibility !== 'hidden';
+  return get(element, ['style', 'visibility']) !== 'hidden';
 }
 
 /**


### PR DESCRIPTION
* 调整 Graph API  render，draw 实现
* 移除 element controller 中 init 对于 canvas.init 的等待，因为已经在 Graph render、draw 等待完成
* 变更了平移、缩放 API 的参数顺序

---

* Adjust Graph API render to draw implementation 
* Remove init's wait for canvas.init in element controller, because Graph render and draw has been waited
* Changed the translate and zoom API parameter order 