### PR TITLE
WIP feat: add 3d sphere node type

### DIFF
--- a/packages/g6/__tests__/demo/static/common.ts
+++ b/packages/g6/__tests__/demo/static/common.ts
@@ -33,6 +33,7 @@ export * from './node-circle';
 export * from './node-ellipse';
 export * from './node-image';
 export * from './node-rect';
+export * from './node-sphere';
 export * from './node-star';
 export * from './node-triangle';
 export * from './shape-badge';

--- a/packages/g6/__tests__/demo/static/node-sphere.ts
+++ b/packages/g6/__tests__/demo/static/node-sphere.ts
@@ -1,7 +1,50 @@
-import { Graph } from '../../../src';
+import { Canvas } from '@antv/g';
+import { CubeGeometry, Mesh, MeshBasicMaterial, Plugin as Plugin3D } from '@antv/g-plugin-3d';
+import { Plugin as PluginControl } from '@antv/g-plugin-control';
+import { Renderer } from '@antv/g-webgl';
 import type { StaticTestCase } from '../types';
 
-export const nodeSphere: StaticTestCase = async ({ canvas, animation }) => {
+export const nodeSphere: StaticTestCase = async () => {
+  const renderer = new Renderer();
+  renderer.registerPlugin(new Plugin3D());
+  renderer.registerPlugin(new PluginControl());
+
+  // create a canvas
+  const canvas = new Canvas({
+    container: 'test-root',
+    width: 600,
+    height: 500,
+    renderer,
+  });
+
+  await canvas.ready;
+
+  // use GPU device
+  const plugin = renderer.getPlugin('device-renderer');
+  const device = plugin.getDevice();
+
+  const cubeGeometry = new CubeGeometry(device, {
+    width: 200,
+    height: 200,
+    depth: 200,
+  });
+  const basicMaterial = new MeshBasicMaterial(device, {});
+
+  const cube = new Mesh({
+    style: {
+      x: 100,
+      y: 100,
+      z: 0,
+      fill: '#1890FF',
+      opacity: 1,
+      geometry: cubeGeometry,
+      material: basicMaterial,
+    },
+  });
+  // cube.setPosition(300, 250, 0);
+  canvas.appendChild(cube);
+
+  /**
   const data = {
     nodes: [
       { id: 'sphere' },
@@ -14,7 +57,7 @@ export const nodeSphere: StaticTestCase = async ({ canvas, animation }) => {
       { id: 'sphere-inactive' },
     ],
   };
-
+   
   const graph = new Graph({
     container: canvas,
     data,
@@ -26,6 +69,7 @@ export const nodeSphere: StaticTestCase = async ({ canvas, animation }) => {
         y: 100,
         z: 100,
         fill: '#1783FF',
+        texture: 'https://gw.alipayobjects.com/mdn/rms_6ae20b/afts/img/A*npAsSLPX4A4AAAAAAAAAAAAAARQnAQ',
         labelText: (d) => d.id,
       },
       state: {
@@ -52,11 +96,12 @@ export const nodeSphere: StaticTestCase = async ({ canvas, animation }) => {
     },
     animation,
   });
-
+   
   await graph.render();
-
+   
   graph.setElementState('sphere-active', 'active');
   graph.setElementState('sphere-selected', 'selected');
   graph.setElementState('sphere-highlight', 'highlight');
   graph.setElementState('sphere-inactive', 'inactive');
+   */
 };

--- a/packages/g6/__tests__/demo/static/node-sphere.ts
+++ b/packages/g6/__tests__/demo/static/node-sphere.ts
@@ -1,0 +1,62 @@
+import { Graph } from '../../../src';
+import type { StaticTestCase } from '../types';
+
+export const nodeSphere: StaticTestCase = async ({ canvas, animation }) => {
+  const data = {
+    nodes: [
+      { id: 'sphere' },
+      { id: 'sphere-halo' },
+      { id: 'sphere-badges' },
+      { id: 'sphere-ports' },
+      { id: 'sphere-active' },
+      { id: 'sphere-selected' },
+      { id: 'sphere-highlight' },
+      { id: 'sphere-inactive' },
+    ],
+  };
+
+  const graph = new Graph({
+    container: canvas,
+    data,
+    node: {
+      style: {
+        type: 'sphere', // 👈🏻 Node shape type.
+        size: 100,
+        x: 100,
+        y: 100,
+        z: 100,
+        fill: '#1783FF',
+        labelText: (d) => d.id,
+      },
+      state: {
+        active: {
+          halo: true,
+        },
+        selected: {
+          halo: true,
+          lineWidth: 2,
+          stroke: '#000',
+        },
+        highlight: {
+          halo: false,
+          lineWidth: 2,
+          stroke: '#000',
+        },
+        inactive: {
+          opacity: 0.2,
+        },
+      },
+    },
+    layout: {
+      type: 'grid',
+    },
+    animation,
+  });
+
+  await graph.render();
+
+  graph.setElementState('sphere-active', 'active');
+  graph.setElementState('sphere-selected', 'selected');
+  graph.setElementState('sphere-highlight', 'highlight');
+  graph.setElementState('sphere-inactive', 'inactive');
+};

--- a/packages/g6/__tests__/index.html
+++ b/packages/g6/__tests__/index.html
@@ -68,6 +68,7 @@
   </head>
 
   <body style="font-family: Arial, Helvetica, sans-serif">
+    <div id="test-root"></div>
     <div id="app">
       <div id="panel">
         <div id="timer">

--- a/packages/g6/__tests__/mock/create.ts
+++ b/packages/g6/__tests__/mock/create.ts
@@ -1,6 +1,8 @@
 import type { IRenderer } from '@antv/g';
 import { resetEntityCounter } from '@antv/g';
 import { Renderer as CanvasRenderer } from '@antv/g-canvas';
+import { Plugin as Plugin3D } from '@antv/g-plugin-3d';
+import { Plugin as PluginControl } from '@antv/g-plugin-control';
 import { Plugin as DragAndDropPlugin } from '@antv/g-plugin-dragndrop';
 import { Renderer as SVGRenderer } from '@antv/g-svg';
 import { Renderer as WebGLRenderer } from '@antv/g-webgl';
@@ -27,8 +29,12 @@ export function createGraph(options: G6Spec, graphCanvas?: Canvas) {
 
 function getRenderer(renderer: string) {
   switch (renderer) {
-    case 'webgl':
-      return new WebGLRenderer();
+    case 'webgl': {
+      const instance = new WebGLRenderer();
+      instance.registerPlugin(new Plugin3D());
+      instance.registerPlugin(new PluginControl());
+      return instance;
+    }
     case 'svg':
       return new SVGRenderer();
     case 'canvas':

--- a/packages/g6/__tests__/mock/create.ts
+++ b/packages/g6/__tests__/mock/create.ts
@@ -3,7 +3,6 @@ import { resetEntityCounter } from '@antv/g';
 import { Renderer as CanvasRenderer } from '@antv/g-canvas';
 import { Plugin as Plugin3D } from '@antv/g-plugin-3d';
 import { Plugin as PluginControl } from '@antv/g-plugin-control';
-import { Plugin as DragAndDropPlugin } from '@antv/g-plugin-dragndrop';
 import { Renderer as SVGRenderer } from '@antv/g-svg';
 import { Renderer as WebGLRenderer } from '@antv/g-webgl';
 import type { G6Spec } from '../../src';
@@ -68,13 +67,11 @@ export function createGraphCanvas(
   } as unknown as HTMLCanvasElement;
   const context = new OffscreenCanvasContext(offscreenNodeCanvas);
 
-  const instance = getRenderer(renderer) as any as IRenderer;
-  instance.registerPlugin(new DragAndDropPlugin({ dragstartDistanceThreshold: 10 }));
   return new Canvas({
     container,
     width,
     height,
-    renderer: () => instance,
+    renderer: () => getRenderer(renderer) as any as IRenderer,
     // @ts-expect-error document offscreenCanvas is not in the type definition
     document: container.ownerDocument,
     offscreenCanvas: offscreenNodeCanvas,

--- a/packages/g6/__tests__/mock/index.ts
+++ b/packages/g6/__tests__/mock/index.ts
@@ -1,2 +1,3 @@
 export { createGraph, createGraphCanvas } from './create';
 export { Graph } from './graph';
+export { createDeterministicRandom } from './random';

--- a/packages/g6/__tests__/mock/random.ts
+++ b/packages/g6/__tests__/mock/random.ts
@@ -1,0 +1,11 @@
+/**
+ * Get random number(0 - 1) generator, with deterministic random number.
+ * @returns Random number
+ */
+export function createDeterministicRandom() {
+  let i = 0;
+  return () => {
+    i++;
+    return (Math.PI * i) % 1;
+  };
+}

--- a/packages/g6/__tests__/mock/random.ts
+++ b/packages/g6/__tests__/mock/random.ts
@@ -6,6 +6,6 @@ export function createDeterministicRandom() {
   let i = 0;
   return () => {
     i++;
-    return (Math.PI * i) % 1;
+    return (Math.E * i) % 1;
   };
 }

--- a/packages/g6/__tests__/unit/utils/random.spec.ts
+++ b/packages/g6/__tests__/unit/utils/random.spec.ts
@@ -1,0 +1,12 @@
+import { createDeterministicRandom } from '../../mock/random';
+
+describe('createDeterministicRandom', () => {
+  it('should generate a random number between 0 and 1', () => {
+    const r1 = createDeterministicRandom();
+    const r2 = createDeterministicRandom();
+
+    expect(new Array(100).fill(0).map(r1)).toEqual(new Array(100).fill(0).map(r2));
+    expect(r1()).toBeGreaterThanOrEqual(0);
+    expect(r1()).toBeLessThan(1);
+  });
+});

--- a/packages/g6/src/elements/edges/base-edge.ts
+++ b/packages/g6/src/elements/edges/base-edge.ts
@@ -76,7 +76,7 @@ export type ParsedBaseEdgeStyleProps<KT> = Required<BaseEdgeStyleProps<KT>>;
 
 export type BaseEdgeOptions<KT> = DisplayObjectConfig<BaseEdgeStyleProps<KT>>;
 
-export abstract class BaseEdge<KT extends BaseEdgeProps<object>> extends BaseShape<BaseEdgeStyleProps<KT>> {
+export abstract class BaseEdge<KT extends BaseEdgeProps> extends BaseShape<BaseEdgeStyleProps<KT>> {
   static defaultStyleProps: Partial<BaseEdgeStyleProps<any>> = {
     isBillboard: true,
     label: true,

--- a/packages/g6/src/elements/edges/cubic-horizontal.ts
+++ b/packages/g6/src/elements/edges/cubic-horizontal.ts
@@ -4,7 +4,7 @@ import type { BaseEdgeProps, Point } from '../../types';
 import type { BaseEdgeStyleProps } from './base-edge';
 import { Cubic } from './cubic';
 
-type CubicHorizontalKeyStyleProps = BaseEdgeProps<{
+type CubicHorizontalKeyStyleProps = BaseEdgeProps & {
   /**
    * <zh/> 控制点在两端点连线上的相对位置，范围为`0-1`
    * <en/> The relative position of the control point on the line, ranging from `0-1`
@@ -15,7 +15,7 @@ type CubicHorizontalKeyStyleProps = BaseEdgeProps<{
    * <en/> The distance of the control point from the line
    */
   curveOffset?: number | [number, number];
-}>;
+};
 export type CubicHorizontalStyleProps = BaseEdgeStyleProps<CubicHorizontalKeyStyleProps>;
 type CubicHorizontalOptions = DisplayObjectConfig<CubicHorizontalStyleProps>;
 

--- a/packages/g6/src/elements/edges/cubic-vertical.ts
+++ b/packages/g6/src/elements/edges/cubic-vertical.ts
@@ -4,7 +4,7 @@ import type { BaseEdgeProps, Point } from '../../types';
 import type { BaseEdgeStyleProps } from './base-edge';
 import { Cubic } from './cubic';
 
-type CubicVerticalKeyStyleProps = BaseEdgeProps<{
+type CubicVerticalKeyStyleProps = BaseEdgeProps & {
   /**
    * <zh/> 控制点在两端点连线上的相对位置，范围为`0-1`
    * <en/> The relative position of the control point on the line, ranging from `0-1`
@@ -15,7 +15,7 @@ type CubicVerticalKeyStyleProps = BaseEdgeProps<{
    * <en/> The distance of the control point from the line
    */
   curveOffset?: number | [number, number];
-}>;
+};
 export type CubicVerticalStyleProps = BaseEdgeStyleProps<CubicVerticalKeyStyleProps>;
 type CubicVerticalOptions = DisplayObjectConfig<CubicVerticalStyleProps>;
 

--- a/packages/g6/src/elements/edges/cubic.ts
+++ b/packages/g6/src/elements/edges/cubic.ts
@@ -6,7 +6,7 @@ import { getCubicPath, getCurveControlPoint, parseCurveOffset, parseCurvePositio
 import type { BaseEdgeStyleProps } from './base-edge';
 import { BaseEdge } from './base-edge';
 
-type CubicKeyStyleProps = BaseEdgeProps<{
+type CubicKeyStyleProps = BaseEdgeProps & {
   /**
    * <zh/> 控制点数组，用于定义曲线的形状。如果不指定，将会通过`curveOffset`和`curvePosition`来计算控制点
    * <en/> Control points. Used to define the shape of the curve. If not specified, it will be calculated using `curveOffset` and `curvePosition`.
@@ -22,7 +22,7 @@ type CubicKeyStyleProps = BaseEdgeProps<{
    * <en/> The distance of the control point from the line
    */
   curveOffset?: number | [number, number];
-}>;
+};
 export type CubicStyleProps = BaseEdgeStyleProps<CubicKeyStyleProps>;
 type CubicOptions = DisplayObjectConfig<CubicStyleProps>;
 

--- a/packages/g6/src/elements/edges/polyline.ts
+++ b/packages/g6/src/elements/edges/polyline.ts
@@ -10,7 +10,7 @@ import { orth } from '../../utils/router/orth';
 import type { BaseEdgeStyleProps, LoopStyleProps, ParsedBaseEdgeStyleProps } from './base-edge';
 import { BaseEdge } from './base-edge';
 
-type PolylineKeyStyleProps = BaseEdgeProps<{
+type PolylineKeyStyleProps = BaseEdgeProps & {
   /**
    * <zh/> 圆角半径
    * <en/> The radius of the rounded corner
@@ -36,7 +36,7 @@ type PolylineKeyStyleProps = BaseEdgeProps<{
    * <en/> Padding for routing calculation
    */
   routerPadding?: Padding;
-}>;
+};
 export type PolylineStyleProps = BaseEdgeStyleProps<PolylineKeyStyleProps>;
 type ParsedPolylineStyleProps = ParsedBaseEdgeStyleProps<PolylineKeyStyleProps>;
 type PolylineOptions = DisplayObjectConfig<PolylineStyleProps>;

--- a/packages/g6/src/elements/edges/quadratic.ts
+++ b/packages/g6/src/elements/edges/quadratic.ts
@@ -6,7 +6,7 @@ import { getCurveControlPoint, getQuadraticPath } from '../../utils/edge';
 import type { BaseEdgeStyleProps, ParsedBaseEdgeStyleProps } from './base-edge';
 import { BaseEdge } from './base-edge';
 
-type QuadraticKeyStyleProps = BaseEdgeProps<{
+type QuadraticKeyStyleProps = BaseEdgeProps & {
   /**
    * <zh/> 控制点，用于定义曲线的形状。如果不指定，将会通过`curveOffset`和`curvePosition`来计算控制点
    * <en/> Control point. Used to define the shape of the curve. If not specified, it will be calculated using `curveOffset` and `curvePosition`.
@@ -22,7 +22,7 @@ type QuadraticKeyStyleProps = BaseEdgeProps<{
    * <en/> The distance of the control point from the line
    */
   curveOffset?: number;
-}>;
+};
 export type QuadraticStyleProps = BaseEdgeStyleProps<QuadraticKeyStyleProps>;
 type QuadraticOptions = DisplayObjectConfig<QuadraticStyleProps>;
 

--- a/packages/g6/src/elements/index.ts
+++ b/packages/g6/src/elements/index.ts
@@ -1,2 +1,2 @@
 export { Cubic, CubicHorizontal, CubicVertical, Line, Polyline, Quadratic } from './edges';
-export { Circle, Ellipse, Image, Rect, Star, Triangle } from './nodes';
+export { Circle, Ellipse, Image, Rect, Sphere, Star, Triangle } from './nodes';

--- a/packages/g6/src/elements/nodes/circle.ts
+++ b/packages/g6/src/elements/nodes/circle.ts
@@ -8,14 +8,15 @@ import type { IconStyleProps } from '../shapes';
 import type { BaseNodeStyleProps } from './base-node';
 import { BaseNode } from './base-node';
 
-export type CircleStyleProps = BaseNodeStyleProps<BaseNodeProps>;
+type CircleKeyStyleProps = BaseNodeProps & GCircleStyleProps;
+export type CircleStyleProps = BaseNodeStyleProps<CircleKeyStyleProps>;
 type ParsedCircleStyleProps = Required<CircleStyleProps>;
 type CircleOptions = DisplayObjectConfig<CircleStyleProps>;
 
 /**
  * Draw circle based on BaseNode, override drawKeyShape.
  */
-export class Circle extends BaseNode<BaseNodeProps, GCircle> {
+export class Circle extends BaseNode<CircleKeyStyleProps, GCircle> {
   static defaultStyleProps: Partial<CircleStyleProps> = {
     width: 50,
     height: 50,
@@ -29,14 +30,14 @@ export class Circle extends BaseNode<BaseNodeProps, GCircle> {
     return this.upsert('key', GCircle, this.getKeyStyle(attributes), container);
   }
 
-  protected getKeyStyle(attributes: ParsedCircleStyleProps): GCircleStyleProps {
-    const { x, y, z, width, height, ...keyStyle } = super.getKeyStyle(attributes) as unknown as ParsedCircleStyleProps;
+  protected getKeyStyle(attributes: ParsedCircleStyleProps): CircleKeyStyleProps {
+    const { x, y, z, width, height, ...keyStyle } = super.getKeyStyle(attributes);
     return {
       ...keyStyle,
       cx: x,
       cy: y,
       cz: z,
-      r: Math.min(width, height) / 2,
+      r: Math.min(width as number, height as number) / 2,
     };
   }
 

--- a/packages/g6/src/elements/nodes/ellipse.ts
+++ b/packages/g6/src/elements/nodes/ellipse.ts
@@ -8,11 +8,12 @@ import type { IconStyleProps } from '../shapes';
 import type { BaseNodeStyleProps } from './base-node';
 import { BaseNode } from './base-node';
 
-export type EllipseStyleProps = BaseNodeStyleProps<BaseNodeProps>;
+type EllipseKeyStyleProps = BaseNodeProps & GEllipseStyleProps;
+export type EllipseStyleProps = BaseNodeStyleProps<EllipseKeyStyleProps>;
 type ParsedEllipseStyleProps = Required<EllipseStyleProps>;
 type EllipseOptions = DisplayObjectConfig<EllipseStyleProps>;
 
-export class Ellipse extends BaseNode<BaseNodeProps, GEllipse> {
+export class Ellipse extends BaseNode<EllipseKeyStyleProps, GEllipse> {
   static defaultStyleProps: Partial<EllipseStyleProps> = {
     width: 80,
     height: 40,
@@ -27,14 +28,14 @@ export class Ellipse extends BaseNode<BaseNodeProps, GEllipse> {
   }
 
   protected getKeyStyle(attributes: ParsedEllipseStyleProps): GEllipseStyleProps {
-    const { x, y, z, width, height, ...keyStyle } = super.getKeyStyle(attributes) as unknown as ParsedEllipseStyleProps;
+    const { x, y, z, width, height, ...keyStyle } = super.getKeyStyle(attributes);
     return {
       ...keyStyle,
       cx: x,
       cy: y,
       cz: z,
-      rx: width / 2,
-      ry: height / 2,
+      rx: (width as number) / 2,
+      ry: (height as number) / 2,
     };
   }
 

--- a/packages/g6/src/elements/nodes/image.ts
+++ b/packages/g6/src/elements/nodes/image.ts
@@ -1,19 +1,20 @@
-import type { DisplayObjectConfig, Group } from '@antv/g';
+import type { DisplayObjectConfig, RectStyleProps as GRectStyleProps, Group } from '@antv/g';
 import { Image as GImage, ImageStyleProps as GImageStyleProps, Rect as GRect } from '@antv/g';
 import { deepMix } from '@antv/util';
 import { ICON_SIZE_RATIO } from '../../constants/element';
-import type { BaseNodeProps } from '../../types';
+import type { BaseNodeProps, PrefixObject } from '../../types';
 import { subStyleProps } from '../../utils/prefix';
 import type { IconStyleProps } from '../shapes';
 import type { BaseNodeStyleProps } from './base-node';
 import { BaseNode } from './base-node';
-import { PolygonKeyStyleProps, PolygonStyleProps } from './polygon';
 
-type ImageKeyStyleProps = BaseNodeProps<BaseNodeProps & GImageStyleProps>;
-export type ImageStyleProps = BaseNodeStyleProps<ImageKeyStyleProps>;
+type ImageKeyStyleProps = BaseNodeProps & GImageStyleProps;
+type HaloStyleProps = GRectStyleProps;
+export type ImageStyleProps = BaseNodeStyleProps<ImageKeyStyleProps> &
+  // Halo
+  PrefixObject<HaloStyleProps, 'halo'>;
 type ParsedImageStyleProps = Required<ImageStyleProps>;
 type ImageOptions = DisplayObjectConfig<ImageStyleProps>;
-type HaloStyleProps = Required<PolygonStyleProps<PolygonKeyStyleProps>>;
 
 export class Image extends BaseNode<ImageKeyStyleProps, GImage> {
   static defaultStyleProps: Partial<ImageStyleProps> = {
@@ -25,7 +26,7 @@ export class Image extends BaseNode<ImageKeyStyleProps, GImage> {
     super(deepMix({}, { style: Image.defaultStyleProps }, options));
   }
 
-  protected getKeyStyle(attributes: ParsedImageStyleProps): GImageStyleProps {
+  protected getKeyStyle(attributes: ParsedImageStyleProps): ImageKeyStyleProps {
     const keyStyle = super.getKeyStyle(attributes) as unknown as ParsedImageStyleProps;
     return {
       ...keyStyle,
@@ -33,6 +34,7 @@ export class Image extends BaseNode<ImageKeyStyleProps, GImage> {
     };
   }
 
+  // @ts-expect-error The return type of this method is not compatible with the return type of its overridden method.
   protected getHaloStyle(attributes: ParsedImageStyleProps): false | HaloStyleProps {
     if (attributes.halo === false) return false;
 
@@ -43,7 +45,7 @@ export class Image extends BaseNode<ImageKeyStyleProps, GImage> {
     const height = Number(attributes.height) + haloLineWidth;
     const fill = 'transparent';
 
-    return { ...keyStyle, ...haloStyle, width, height, fill } as HaloStyleProps;
+    return { ...keyStyle, ...haloStyle, width, height, fill } as unknown as HaloStyleProps;
   }
 
   protected getIconStyle(attributes: ParsedImageStyleProps): false | IconStyleProps {

--- a/packages/g6/src/elements/nodes/index.ts
+++ b/packages/g6/src/elements/nodes/index.ts
@@ -3,6 +3,7 @@ export { Circle } from './circle';
 export { Ellipse } from './ellipse';
 export { Image } from './image';
 export { Rect } from './rect';
+export { Sphere } from './sphere';
 export { Star } from './star';
 export { Triangle } from './triangle';
 
@@ -11,5 +12,6 @@ export type { CircleStyleProps } from './circle';
 export type { EllipseStyleProps } from './ellipse';
 export type { ImageStyleProps } from './image';
 export type { RectStyleProps } from './rect';
+export type { SphereStyleProps } from './sphere';
 export type { StarStyleProps } from './star';
 export type { TriangleStyleProps } from './triangle';

--- a/packages/g6/src/elements/nodes/polygon.ts
+++ b/packages/g6/src/elements/nodes/polygon.ts
@@ -5,32 +5,32 @@ import { getPolygonIntersectPoint } from '../../utils/point';
 import type { BaseNodeStyleProps } from './base-node';
 import { BaseNode } from './base-node';
 
-export type PolygonKeyStyleProps<R = object> = BaseNodeProps<BaseNodeProps & R>;
-export type PolygonStyleProps<P extends object> = BaseNodeStyleProps<P>;
-type ParsedPolygonStyleProps<P extends object> = Required<PolygonStyleProps<P>>;
-type PolygonOptions<P extends object> = DisplayObjectConfig<PolygonStyleProps<P>>;
+type PolygonKeyStyleProps = BaseNodeProps & GPolygonStyleProps;
+export type PolygonStyleProps<P extends PolygonKeyStyleProps> = BaseNodeStyleProps<P>;
+type ParsedPolygonStyleProps<P extends PolygonKeyStyleProps> = Required<PolygonStyleProps<P>>;
+type PolygonOptions<P extends PolygonKeyStyleProps> = DisplayObjectConfig<PolygonStyleProps<P>>;
 
 /**
  * Abstract class for polygon nodes,i.e triangle, diamond, hexagon, etc.
  */
-export abstract class Polygon<P extends object> extends BaseNode<P, GPolygon> {
+export abstract class Polygon<P extends PolygonKeyStyleProps> extends BaseNode<P, GPolygon> {
   constructor(options: PolygonOptions<P>) {
     super(options);
   }
 
   protected drawKeyShape(attributes: ParsedPolygonStyleProps<P>, container: Group): GPolygon | undefined {
-    return this.upsert('key', GPolygon, this.getKeyStyle(attributes) as GPolygonStyleProps, container);
+    return this.upsert('key', GPolygon, this.getKeyStyle(attributes), container);
   }
 
-  protected getKeyStyle(attributes: ParsedPolygonStyleProps<P>): GPolygonStyleProps {
-    const { width, height, ...keyStyle } = super.getKeyStyle(attributes) as unknown as ParsedPolygonStyleProps<P>;
-    return { ...keyStyle, points: this.getPoints(attributes) as [number, number][] };
+  protected getKeyStyle(attributes: ParsedPolygonStyleProps<P>): P {
+    const { width, height, ...keyStyle } = super.getKeyStyle(attributes);
+    return { ...keyStyle, points: this.getPoints(attributes) as [number, number][] } as P;
   }
 
   protected abstract getPoints(attributes: ParsedPolygonStyleProps<P>): Point[];
 
   public getIntersectPoint(point: Point): Point {
-    const { points } = this.getKeyStyle(this.attributes as ParsedPolygonStyleProps<P>);
+    const { points } = this.getKeyStyle(this.attributes as any);
     const center = [this.attributes.x, this.attributes.y] as Point;
     return getPolygonIntersectPoint(point, center, points!);
   }

--- a/packages/g6/src/elements/nodes/rect.ts
+++ b/packages/g6/src/elements/nodes/rect.ts
@@ -7,14 +7,15 @@ import type { IconStyleProps } from '../shapes';
 import type { BaseNodeStyleProps } from './base-node';
 import { BaseNode } from './base-node';
 
-export type RectStyleProps = BaseNodeStyleProps<BaseNodeProps>;
+type RectKeyStyleProps = BaseNodeProps & GRectStyleProps;
+export type RectStyleProps = BaseNodeStyleProps<RectKeyStyleProps>;
 type ParsedRectStyleProps = Required<RectStyleProps>;
 type RectOptions = DisplayObjectConfig<RectStyleProps>;
 
 /**
  * Draw Rect based on BaseNode, override drawKeyShape.
  */
-export class Rect extends BaseNode<BaseNodeProps, GRect> {
+export class Rect extends BaseNode<RectKeyStyleProps, GRect> {
   static defaultStyleProps: Partial<RectStyleProps> = {
     width: 100,
     height: 30,
@@ -24,9 +25,9 @@ export class Rect extends BaseNode<BaseNodeProps, GRect> {
     super(deepMix({}, { style: Rect.defaultStyleProps }, options));
   }
 
-  protected getKeyStyle(attributes: ParsedRectStyleProps): GRectStyleProps {
+  protected getKeyStyle(attributes: ParsedRectStyleProps): RectKeyStyleProps {
     return {
-      ...(super.getKeyStyle(attributes) as GRectStyleProps),
+      ...(super.getKeyStyle(attributes) as RectKeyStyleProps),
       anchor: [0.5, 0.5], // !!! It cannot be set to default values because G.CustomElement cannot handle it properly.
     };
   }

--- a/packages/g6/src/elements/nodes/sphere.ts
+++ b/packages/g6/src/elements/nodes/sphere.ts
@@ -1,0 +1,25 @@
+import type { DisplayObjectConfig, Group } from '@antv/g';
+import type { BaseNodeProps } from '../../types';
+import type { BaseNodeStyleProps } from './base-node';
+import { BaseNode } from './base-node';
+
+export type SphereStyleProps = BaseNodeStyleProps<BaseNodeProps>;
+type ParsedSphereStyleProps = Required<SphereStyleProps>;
+type SphereOptions = DisplayObjectConfig<SphereStyleProps>;
+
+/**
+ * Draw Sphere with g-webgl. Sphere can only be used in g-webgl renderer. See https://g.antv.antgroup.com/api/3d/geometry.
+ *
+ * Sphere should be in a extra package, such as @antv/g6-extendsions.
+ */
+export class Sphere extends BaseNode<BaseNodeProps, any> {
+  static defaultStyleProps: Partial<SphereStyleProps> = {};
+
+  constructor(options: SphereOptions) {
+    super(options);
+  }
+
+  protected drawKeyShape(attributes: ParsedSphereStyleProps, container: Group) {
+    throw new Error('Method not implemented.');
+  }
+}

--- a/packages/g6/src/elements/nodes/sphere.ts
+++ b/packages/g6/src/elements/nodes/sphere.ts
@@ -1,18 +1,68 @@
 import type { DisplayObjectConfig, Group } from '@antv/g';
+import type { IMeshBasicMaterial, SphereGeometryProps } from '@antv/g-plugin-3d';
+import { Mesh as GMesh } from '@antv/g-plugin-3d';
 import type { BaseNodeProps } from '../../types';
 import type { BaseNodeStyleProps } from './base-node';
 import { BaseNode } from './base-node';
 
-export type SphereStyleProps = BaseNodeStyleProps<BaseNodeProps>;
+type SphereKeyStyleProps = BaseNodeProps &
+  SphereGeometryProps &
+  IMeshBasicMaterial & {
+    /**
+     * The texture of the sphere. Will load by plugin.
+     *
+     * ```ts
+     * const map = plugin.loadTexture(
+     *  'https://gw.alipayobjects.com/mdn/rms_6ae20b/afts/img/A*_aqoS73Se3sAAAAAAAAAAAAAARQnAQ',
+     * );
+     * ```
+     */
+    texture?: string;
+  };
+export type SphereStyleProps = BaseNodeStyleProps<SphereKeyStyleProps>;
 type ParsedSphereStyleProps = Required<SphereStyleProps>;
 type SphereOptions = DisplayObjectConfig<SphereStyleProps>;
+
+/**
+  const plugin = renderer.getPlugin('device-renderer');
+  const device = plugin.getDevice();
+ 
+  // 1. load texture with URL
+  const map = plugin.loadTexture(
+    'https://gw.alipayobjects.com/mdn/rms_6ae20b/afts/img/A*_aqoS73Se3sAAAAAAAAAAAAAARQnAQ',
+  );
+ 
+  const geometry = new SphereGeometry(device, {
+    width: 200,
+    height: 200,
+    depth: 200,
+  });
+  const material = new MeshBasicMaterial(device, {
+    map,
+  });
+ 
+  const cube = new Mesh({
+    style: {
+      fill: '#1890FF',
+      opacity: 1,
+      geometry: cubeGeometry,
+      material: basicMaterial,
+    },
+  });
+ 
+  cube.setPosition(300, 250, 0);
+ 
+  canvas.appendChild(cube);
+ 
+ */
 
 /**
  * Draw Sphere with g-webgl. Sphere can only be used in g-webgl renderer. See https://g.antv.antgroup.com/api/3d/geometry.
  *
  * Sphere should be in a extra package, such as @antv/g6-extendsions.
  */
-export class Sphere extends BaseNode<BaseNodeProps, any> {
+// @ts-expect-error The return type of this method is not compatible with the return type of its overridden method.
+export class Sphere extends BaseNode<BaseNodeProps, GMesh> {
   static defaultStyleProps: Partial<SphereStyleProps> = {};
 
   constructor(options: SphereOptions) {
@@ -20,6 +70,6 @@ export class Sphere extends BaseNode<BaseNodeProps, any> {
   }
 
   protected drawKeyShape(attributes: ParsedSphereStyleProps, container: Group) {
-    throw new Error('Method not implemented.');
+    return undefined;
   }
 }

--- a/packages/g6/src/elements/nodes/sphere.ts
+++ b/packages/g6/src/elements/nodes/sphere.ts
@@ -1,75 +1,115 @@
 import type { DisplayObjectConfig, Group } from '@antv/g';
 import type { IMeshBasicMaterial, SphereGeometryProps } from '@antv/g-plugin-3d';
-import { Mesh as GMesh } from '@antv/g-plugin-3d';
+import { Mesh as GMesh, MeshBasicMaterial, SphereGeometry } from '@antv/g-plugin-3d';
+import { Renderer as GWebGLRenderer } from '@antv/g-webgl';
+import { RuntimeContext } from '../../runtime/types';
 import type { BaseNodeProps } from '../../types';
+import { omitStyleProps } from '../../utils/prefix';
 import type { BaseNodeStyleProps } from './base-node';
 import { BaseNode } from './base-node';
 
-type SphereKeyStyleProps = BaseNodeProps &
-  SphereGeometryProps &
-  IMeshBasicMaterial & {
-    /**
-     * The texture of the sphere. Will load by plugin.
-     *
-     * ```ts
-     * const map = plugin.loadTexture(
-     *  'https://gw.alipayobjects.com/mdn/rms_6ae20b/afts/img/A*_aqoS73Se3sAAAAAAAAAAAAAARQnAQ',
-     * );
-     * ```
-     */
-    texture?: string;
-  };
-export type SphereStyleProps = BaseNodeStyleProps<SphereKeyStyleProps>;
+const GEOMETRY_SIZE = 10;
+
+type SphereKeyStyleProps = BaseNodeProps & {
+  /**
+   * geometry options of the sphere.
+   */
+  geometry: SphereGeometryProps;
+  /**
+   * meterial options of the sphere.
+   */
+  material: IMeshBasicMaterial;
+  /**
+   * The texture of the sphere. Will load by plugin.
+   *
+   * ```ts
+   * const map = plugin.loadTexture(
+   *  'https://gw.alipayobjects.com/mdn/rms_6ae20b/afts/img/A*_aqoS73Se3sAAAAAAAAAAAAAARQnAQ',
+   * );
+   * ```
+   */
+  texture?: string;
+};
+export type SphereStyleProps = BaseNodeStyleProps<SphereKeyStyleProps> & {
+  // Pass the renderer to the Sphere from runtime.
+  context: RuntimeContext;
+};
 type ParsedSphereStyleProps = Required<SphereStyleProps>;
 type SphereOptions = DisplayObjectConfig<SphereStyleProps>;
-
-/**
-  const plugin = renderer.getPlugin('device-renderer');
-  const device = plugin.getDevice();
- 
-  // 1. load texture with URL
-  const map = plugin.loadTexture(
-    'https://gw.alipayobjects.com/mdn/rms_6ae20b/afts/img/A*_aqoS73Se3sAAAAAAAAAAAAAARQnAQ',
-  );
- 
-  const geometry = new SphereGeometry(device, {
-    width: 200,
-    height: 200,
-    depth: 200,
-  });
-  const material = new MeshBasicMaterial(device, {
-    map,
-  });
- 
-  const cube = new Mesh({
-    style: {
-      fill: '#1890FF',
-      opacity: 1,
-      geometry: cubeGeometry,
-      material: basicMaterial,
-    },
-  });
- 
-  cube.setPosition(300, 250, 0);
- 
-  canvas.appendChild(cube);
- 
- */
 
 /**
  * Draw Sphere with g-webgl. Sphere can only be used in g-webgl renderer. See https://g.antv.antgroup.com/api/3d/geometry.
  *
  * Sphere should be in a extra package, such as @antv/g6-extendsions.
  */
-// @ts-expect-error The return type of this method is not compatible with the return type of its overridden method.
-export class Sphere extends BaseNode<BaseNodeProps, GMesh> {
+export class Sphere extends BaseNode<BaseNodeProps, any> {
   static defaultStyleProps: Partial<SphereStyleProps> = {};
+
+  /**
+   * Cache the geometry.
+   */
+  private static geometry: SphereGeometry;
+  /**
+   * Cache the material.
+   */
+  private static material: MeshBasicMaterial<any>;
 
   constructor(options: SphereOptions) {
     super(options);
   }
 
+  protected getKeyStyle(attributes: ParsedSphereStyleProps): SphereKeyStyleProps {
+    const { geometry, material, texture, color, ...style } = omitStyleProps(attributes, [
+      'label',
+      'halo',
+      'icon',
+      'badge',
+      'port',
+    ]) as SphereKeyStyleProps;
+
+    // Get renderer, plugin and device from context.
+    const { canvas } = attributes.context;
+    const renderer = canvas.renderers.main;
+    if (!(renderer instanceof GWebGLRenderer)) throw new Error('Sphere can only be used in g-webgl renderer.');
+    // @ts-expect-error ignore
+    const plugin = renderer.getPlugin('device-renderer');
+    const device = plugin.getDevice();
+    const map = texture ? plugin.loadTexture(texture) : undefined;
+
+    if (!Sphere.geometry) {
+      Sphere.geometry = new SphereGeometry(device, {
+        ...geometry,
+        radius: 200,
+        latitudeBands: 32,
+        longitudeBands: 32,
+      });
+    }
+
+    if (!Sphere.material) {
+      Sphere.material = new MeshBasicMaterial(device, {
+        map,
+        ...material,
+      });
+    }
+
+    return {
+      fill: color,
+      ...style,
+      geometry: Sphere.geometry,
+      material: Sphere.material,
+      texture,
+    };
+  }
+
   protected drawKeyShape(attributes: ParsedSphereStyleProps, container: Group) {
-    return undefined;
+    const style = this.getKeyStyle(attributes);
+    // @ts-expect-error ignore
+    const shape = this.upsert('key', GMesh, this.getKeyStyle(attributes), container) as any;
+    if (shape) {
+      shape.setOrigin(0, 0, 0);
+      const scaling = Number(style.size) / GEOMETRY_SIZE;
+      shape.scale(scaling);
+    }
+    return shape;
   }
 }

--- a/packages/g6/src/elements/nodes/star.ts
+++ b/packages/g6/src/elements/nodes/star.ts
@@ -1,19 +1,22 @@
 import type { DisplayObjectConfig } from '@antv/g';
+import { PolygonStyleProps as GPolygonStyleProps } from '@antv/g';
 import { ICON_SIZE_RATIO } from '../../constants/element';
-import type { Point, StarPortPosition } from '../../types';
+import type { BaseNodeProps, Point, StarPortPosition } from '../../types';
 import { getPortPosition, getStarPoints, getStarPorts } from '../../utils/element';
 import type { IconStyleProps } from '../shapes';
 import { NodePortStyleProps } from './base-node';
-import type { PolygonKeyStyleProps, PolygonStyleProps } from './polygon';
+import type { PolygonStyleProps } from './polygon';
 import { Polygon } from './polygon';
 
-type StarKeyStyleProps = PolygonKeyStyleProps<{
-  /**
-   * <zh/> 内半径
-   * <en/> Inner radius
-   */
-  innerR?: number;
-}>;
+type StarKeyStyleProps = BaseNodeProps &
+  GPolygonStyleProps & {
+    /**
+     * <zh/> 内半径
+     * <en/> Inner radius
+     */
+    innerR?: number;
+  };
+
 export type StarStyleProps = PolygonStyleProps<StarKeyStyleProps>;
 type ParsedStarStyleProps = Required<StarStyleProps>;
 type StarOptions = DisplayObjectConfig<StarStyleProps>;

--- a/packages/g6/src/elements/nodes/triangle.ts
+++ b/packages/g6/src/elements/nodes/triangle.ts
@@ -1,29 +1,30 @@
 import type { DisplayObjectConfig } from '@antv/g';
+import { PolygonStyleProps as GPolygonStyleProps } from '@antv/g';
 import { deepMix, isEmpty } from '@antv/util';
 import { ICON_SIZE_RATIO } from '../../constants/element';
-import type { Point, TrianglePortPosition } from '../../types';
+import type { BaseNodeProps, Point, TrianglePortPosition } from '../../types';
 import { getIncircleRadius, getTriangleCenter } from '../../utils/bbox';
 import { getPortPosition, getTrianglePoints, getTrianglePorts } from '../../utils/element';
 import { subStyleProps } from '../../utils/prefix';
 import { IconStyleProps } from '../shapes';
 import type { BaseNodeStyleProps, NodePortStyleProps } from './base-node';
-import type { PolygonKeyStyleProps } from './polygon';
 import { Polygon } from './polygon';
 
 export type TriangleDirection = 'up' | 'left' | 'right' | 'down';
-type TriangleKeyShapeStyleProps = PolygonKeyStyleProps<{
-  /**
-   * <zh/> 三角形的方向
-   * <en/> The direction of the triangle
-   */
-  direction?: TriangleDirection;
-}>;
-export type TriangleStyleProps = BaseNodeStyleProps<TriangleKeyShapeStyleProps>;
+type TriangleKeyStyleProps = BaseNodeProps &
+  GPolygonStyleProps & {
+    /**
+     * <zh/> 三角形的方向
+     * <en/> The direction of the triangle
+     */
+    direction?: TriangleDirection;
+  };
+export type TriangleStyleProps = BaseNodeStyleProps<TriangleKeyStyleProps>;
 type ParsedTriangleStyleProps = Required<TriangleStyleProps>;
 type TriangleOptions = DisplayObjectConfig<TriangleStyleProps>;
 
-export class Triangle extends Polygon<TriangleKeyShapeStyleProps> {
-  static defaultStyleProps: Partial<TriangleKeyShapeStyleProps> = {
+export class Triangle extends Polygon<TriangleKeyStyleProps> {
+  static defaultStyleProps: Partial<TriangleKeyStyleProps> = {
     width: 40,
     height: 40,
     direction: 'up',

--- a/packages/g6/src/registry/build-in.ts
+++ b/packages/g6/src/registry/build-in.ts
@@ -10,6 +10,7 @@ import {
   Polyline,
   Quadratic,
   Rect,
+  Sphere,
   Star,
   Triangle,
 } from '../elements';
@@ -78,6 +79,7 @@ export const BUILT_IN_PLUGINS = {
     rect: Rect,
     star: Star,
     triangle: Triangle,
+    sphere: Sphere,
   },
   palette: {
     spectral,

--- a/packages/g6/src/runtime/canvas.ts
+++ b/packages/g6/src/runtime/canvas.ts
@@ -57,17 +57,15 @@ export class Canvas {
         (acc, name) => {
           const renderer = isFunction(getRenderer) ? getRenderer?.(name) : new CanvasRenderer();
 
-          renderer.registerPlugin(
-            new DragNDropPlugin({
-              isDocumentDraggable: true,
-              isDocumentDroppable: true,
-              dragstartDistanceThreshold: 10,
-              dragstartTimeThreshold: 100,
-            }),
-          );
-
-          if (name !== 'main') {
-            renderer.unregisterPlugin(renderer.getPlugin('dom-interaction'));
+          if (name === 'main') {
+            renderer.registerPlugin(
+              new DragNDropPlugin({
+                isDocumentDraggable: true,
+                isDocumentDroppable: true,
+                dragstartDistanceThreshold: 10,
+                dragstartTimeThreshold: 100,
+              }),
+            );
           }
 
           const canvas = new GCanvas({

--- a/packages/g6/src/types/element.ts
+++ b/packages/g6/src/types/element.ts
@@ -26,6 +26,11 @@ export type BaseNodeProps = {
    */
   z?: number;
   /**
+   * <zh/> 节点大小，快捷设置节点宽高
+   * <en/> The size of node, which is a shortcut to set the width and height of node
+   */
+  size?: number;
+  /**
    * <zh/> 节点宽度
    * <en/> The width of node
    */

--- a/packages/g6/src/types/element.ts
+++ b/packages/g6/src/types/element.ts
@@ -7,19 +7,9 @@ export type ElementType = 'node' | 'edge' | 'combo';
 
 export type ElementOptions = NodeOptions | EdgeOptions | ComboOptions;
 
-export type Node = BaseNode<BaseNodeProps<any>, DisplayObject>;
+export type Node = BaseNode<BaseNodeProps, DisplayObject>;
 
-export type ExtractGShapeStyleProps<T> = T extends DisplayObject<infer S, any> ? S : never;
-
-export type BaseElementProps = {
-  /**
-   * <zh/> 主色
-   * <en/> Subject color
-   */
-  color?: string;
-};
-
-export type BaseNodeProps<ShapeProps = object> = BaseElementProps & {
+export type BaseNodeProps = {
   /**
    * <zh/> x 坐标
    * <en/> The x-coordinate of node
@@ -50,10 +40,19 @@ export type BaseNodeProps<ShapeProps = object> = BaseElementProps & {
    * <en/> The depth of node
    */
   depth?: number;
-} & BaseStyleProps &
-  ShapeProps;
+  /**
+   * <zh/> 主色
+   * <en/> Subject color
+   */
+  color?: string;
+} & BaseStyleProps;
 
-export type BaseEdgeProps<ShapeProps = object> = BaseElementProps & {
+export type BaseEdgeProps = {
+  /**
+   * <zh/> 主色
+   * <en/> Subject color
+   */
+  color?: string;
   /**
    * <zh/> 边的起点 shape
    * <en/> The source shape. Represents the start of the edge
@@ -84,5 +83,4 @@ export type BaseEdgeProps<ShapeProps = object> = BaseElementProps & {
    * <en/> The target point. Represents the end of the edge
    */
   targetPoint?: Point;
-} & PathStyleProps &
-  ShapeProps;
+} & PathStyleProps;


### PR DESCRIPTION
- [ ] sphere node
- [ ] test case
- [ ] demo

3D 插件会大幅度增加包大小，所以建议是放到一个扩展包，类似于 `@antv/g6-extendsions`。


```ts
import { Graph, register } from '@antv/g6'; 
import { Sphere, type SphereStyle Props } from '@antv/g6-extensions';

register('node', 'sphere', Sphere);


const graph = new Graph({
  node: {
    style: {
      type: 'sphere'
    }
  }
});
```