### PR TITLE
fix: dev scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,8 @@
   "private": true,
   "repository": "https://github.com/antvis/G6.git",
   "scripts": {
+    "site": "pnpm -r --stream --filter=./packages/site run dev",
+    "watch": "pnpm -r --stream --filter=!./site run start",
     "postinstall": "husky install",
     "prepare": "husky install",
     "build": "run-s build:*",

--- a/packages/g6/vite.config.js
+++ b/packages/g6/vite.config.js
@@ -11,7 +11,7 @@ export default defineConfig({
     // @see https://github.com/vitejs/vite/issues/10839#issuecomment-1345193175
     // @see https://vitejs.dev/guide/dep-pre-bundling.html#customizing-the-behavior
     // @see https://vitejs.dev/config/dep-optimization-options.html#optimizedeps-exclude
-    exclude: ['@antv/layout-wasm'],
+    exclude: [],
   },
   plugins: [
     {


### PR DESCRIPTION
1. 新增 `dev`、`watch` scripts 用于简化启动流程
2. 修复 dev 启动 `gl-matrix` 错误