### PR TITLE
refactor(elements): adjust element type definitions

### DIFF
--- a/packages/g6/src/elements/combos/base-combo.ts
+++ b/packages/g6/src/elements/combos/base-combo.ts
@@ -26,10 +26,7 @@ export type ParsedBaseComboStyleProps<KeyStyleProps extends BaseStyleProps> = Re
   BaseComboStyleProps<KeyStyleProps>
 >;
 
-export abstract class BaseCombo<
-  KeyShape extends DisplayObject,
-  KeyStyleProps extends BaseStyleProps = BaseStyleProps,
-> extends BaseNode<KeyShape, KeyStyleProps> {
+export abstract class BaseCombo<S extends BaseComboStyleProps = BaseComboStyleProps> extends BaseNode<S> {
   public type = 'combo';
 
   static defaultStyleProps: BaseComboStyleProps = {
@@ -45,19 +42,16 @@ export abstract class BaseCombo<
     collapsedMarkerTextBaseline: 'middle',
     collapsedMarkerTextAlign: 'center',
   };
-  constructor(options: DisplayObjectConfig<BaseComboStyleProps<KeyStyleProps>>) {
+  constructor(options: DisplayObjectConfig<BaseComboStyleProps>) {
     super(deepMix({}, { style: BaseCombo.defaultStyleProps }, options));
   }
 
   /**
    * Draw the key shape of combo
    */
-  protected abstract drawKeyShape(
-    attributes: ParsedBaseComboStyleProps<KeyStyleProps>,
-    container: Group,
-  ): KeyShape | undefined;
+  protected abstract drawKeyShape(attributes: Required<S>, container: Group): DisplayObject | undefined;
 
-  protected calculatePosition(attributes: ParsedBaseComboStyleProps<KeyStyleProps>): Position {
+  protected calculatePosition(attributes: Required<S>): Position {
     const { x: comboX, y: comboY, collapsed, collapsedOrigin } = attributes;
     if (!isEmpty(comboX) && !isEmpty(comboY)) return [comboX, comboY, 0] as Position;
 
@@ -78,7 +72,7 @@ export abstract class BaseCombo<
     return position;
   }
 
-  protected getKeySize(attributes: ParsedBaseComboStyleProps<KeyStyleProps>): STDSize {
+  protected getKeySize(attributes: Required<S>): STDSize {
     const { size, collapsed, collapsedSize } = attributes;
 
     if (collapsed && !isEmpty(collapsedSize)) return parseSize(collapsedSize);
@@ -88,11 +82,11 @@ export abstract class BaseCombo<
     return collapsed ? this.getCollapsedKeySize(attributes) : this.getExpandedKeySize(attributes);
   }
 
-  protected abstract getCollapsedKeySize(attributes: ParsedBaseComboStyleProps<KeyStyleProps>): STDSize;
+  protected abstract getCollapsedKeySize(attributes: Required<S>): STDSize;
 
-  protected abstract getExpandedKeySize(attributes: ParsedBaseComboStyleProps<KeyStyleProps>): STDSize;
+  protected abstract getExpandedKeySize(attributes: Required<S>): STDSize;
 
-  protected getContentBBox(attributes: ParsedBaseComboStyleProps<KeyStyleProps>): AABB {
+  protected getContentBBox(attributes: Required<S>): AABB {
     const { children = [], padding } = attributes;
     let childrenBBox = getCombinedBBox(children.map((child) => child.getBounds()));
     if (padding) {
@@ -101,11 +95,11 @@ export abstract class BaseCombo<
     return childrenBBox;
   }
 
-  protected drawCollapsedMarkerShape(attributes: ParsedBaseComboStyleProps<KeyStyleProps>, container: Group): void {
+  protected drawCollapsedMarkerShape(attributes: Required<S>, container: Group): void {
     this.upsert('collapsed-marker', Icon, this.getCollapsedMarkerStyle(attributes), container);
   }
 
-  protected getCollapsedMarkerStyle(attributes: ParsedBaseComboStyleProps<KeyStyleProps>): IconStyleProps | false {
+  protected getCollapsedMarkerStyle(attributes: Required<S>): IconStyleProps | false {
     if (!attributes.collapsed || !attributes.collapsedMarker) return false;
 
     const { type, ...collapsedMarkerStyle } = subStyleProps<CollapsedMarkerStyleProps>(
@@ -123,7 +117,7 @@ export abstract class BaseCombo<
     return { ...collapsedMarkerStyle, x, y };
   }
 
-  public render(attributes: ParsedBaseComboStyleProps<KeyStyleProps>, container: Group = this) {
+  public render(attributes: Required<S>, container: Group = this) {
     super.render(attributes, container);
 
     const [x, y] = this.calculatePosition(attributes);

--- a/packages/g6/src/elements/combos/circle.ts
+++ b/packages/g6/src/elements/combos/circle.ts
@@ -7,12 +7,12 @@ import { parseSize } from '../../utils/size';
 import type { BaseComboStyleProps, ParsedBaseComboStyleProps } from './base-combo';
 import { BaseCombo } from './base-combo';
 
-type KeyStyleProps = GCircleStyleProps;
 export type CircleComboStyleProps = BaseComboStyleProps<KeyStyleProps>;
 type ParsedCircleComboStyleProps = ParsedBaseComboStyleProps<KeyStyleProps>;
 type CircleComboOptions = DisplayObjectConfig<CircleComboStyleProps>;
+type KeyStyleProps = GCircleStyleProps;
 
-export class CircleCombo extends BaseCombo<GCircle, KeyStyleProps> {
+export class CircleCombo extends BaseCombo<CircleComboStyleProps> {
   constructor(options: CircleComboOptions) {
     super(options);
   }

--- a/packages/g6/src/elements/edges/index.ts
+++ b/packages/g6/src/elements/edges/index.ts
@@ -6,6 +6,7 @@ export { Line } from './line';
 export { Polyline } from './polyline';
 export { Quadratic } from './quadratic';
 
+export type { BaseEdgeStyleProps } from './base-edge';
 export type { CubicStyleProps } from './cubic';
 export type { CubicHorizontalStyleProps } from './cubic-horizontal';
 export type { CubicVerticalStyleProps } from './cubic-vertical';

--- a/packages/g6/src/elements/nodes/circle.ts
+++ b/packages/g6/src/elements/nodes/circle.ts
@@ -5,17 +5,17 @@ import { ICON_SIZE_RATIO } from '../../constants/element';
 import type { Point } from '../../types';
 import { getEllipseIntersectPoint } from '../../utils/point';
 import type { IconStyleProps } from '../shapes';
-import type { BaseNodeStyleProps, ParsedBaseNodeStyleProps } from './base-node';
+import type { BaseNodeStyleProps } from './base-node';
 import { BaseNode } from './base-node';
 
 export type CircleStyleProps = BaseNodeStyleProps<KeyStyleProps>;
-type ParsedCircleStyleProps = ParsedBaseNodeStyleProps<KeyStyleProps>;
+type ParsedCircleStyleProps = Required<CircleStyleProps>;
 type KeyStyleProps = GCircleStyleProps;
 
 /**
  * Draw circle based on BaseNode, override drawKeyShape.
  */
-export class Circle extends BaseNode<GCircle, KeyStyleProps> {
+export class Circle extends BaseNode<CircleStyleProps> {
   static defaultStyleProps: Partial<CircleStyleProps> = {
     size: 50,
   };

--- a/packages/g6/src/elements/nodes/ellipse.ts
+++ b/packages/g6/src/elements/nodes/ellipse.ts
@@ -5,14 +5,14 @@ import { ICON_SIZE_RATIO } from '../../constants/element';
 import type { Point } from '../../types';
 import { getEllipseIntersectPoint } from '../../utils/point';
 import type { IconStyleProps } from '../shapes';
-import type { BaseNodeStyleProps, ParsedBaseNodeStyleProps } from './base-node';
+import type { BaseNodeStyleProps } from './base-node';
 import { BaseNode } from './base-node';
 
 export type EllipseStyleProps = BaseNodeStyleProps<KeyStyleProps>;
-type ParsedEllipseStyleProps = ParsedBaseNodeStyleProps<KeyStyleProps>;
+type ParsedEllipseStyleProps = Required<EllipseStyleProps>;
 type KeyStyleProps = GEllipseStyleProps;
 
-export class Ellipse extends BaseNode<GEllipse, KeyStyleProps> {
+export class Ellipse extends BaseNode<EllipseStyleProps> {
   static defaultStyleProps: Partial<EllipseStyleProps> = {
     size: [80, 40],
   };

--- a/packages/g6/src/elements/nodes/image.ts
+++ b/packages/g6/src/elements/nodes/image.ts
@@ -6,15 +6,15 @@ import type { PrefixObject } from '../../types';
 import { subStyleProps } from '../../utils/prefix';
 import { add } from '../../utils/vector';
 import type { IconStyleProps } from '../shapes';
-import type { BaseNodeStyleProps, ParsedBaseNodeStyleProps } from './base-node';
+import type { BaseNodeStyleProps } from './base-node';
 import { BaseNode } from './base-node';
 
 export type ImageStyleProps = BaseNodeStyleProps<KeyStyleProps>;
-type ParsedImageStyleProps = ParsedBaseNodeStyleProps<KeyStyleProps>;
+type ParsedImageStyleProps = Required<ImageStyleProps>;
 type KeyStyleProps = GImageStyleProps & PrefixObject<HaloStyleProps, 'halo'>;
 type HaloStyleProps = GRectStyleProps;
 
-export class Image extends BaseNode<GImage, KeyStyleProps> {
+export class Image extends BaseNode<ImageStyleProps> {
   static defaultStyleProps: Partial<ImageStyleProps> = {
     size: 50,
   };

--- a/packages/g6/src/elements/nodes/polygon.ts
+++ b/packages/g6/src/elements/nodes/polygon.ts
@@ -2,17 +2,17 @@ import type { DisplayObjectConfig, PolygonStyleProps as GPolygonStyleProps, Grou
 import { Polygon as GPolygon } from '@antv/g';
 import type { Point } from '../../types';
 import { getPolygonIntersectPoint } from '../../utils/point';
-import type { BaseNodeStyleProps, ParsedBaseNodeStyleProps } from './base-node';
+import type { BaseNodeStyleProps } from './base-node';
 import { BaseNode } from './base-node';
 
 export type PolygonStyleProps = BaseNodeStyleProps<PolygonKeyStyleProps>;
-export type ParsedPolygonStyleProps = ParsedBaseNodeStyleProps<PolygonKeyStyleProps>;
+export type ParsedPolygonStyleProps = Required<PolygonStyleProps>;
 export type PolygonKeyStyleProps = GPolygonStyleProps;
 
 /**
  * Abstract class for polygon nodes,i.e triangle, diamond, hexagon, etc.
  */
-export abstract class Polygon extends BaseNode<GPolygon, PolygonKeyStyleProps> {
+export abstract class Polygon extends BaseNode<PolygonStyleProps> {
   constructor(options: DisplayObjectConfig<PolygonStyleProps>) {
     super(options);
   }

--- a/packages/g6/src/elements/nodes/rect.ts
+++ b/packages/g6/src/elements/nodes/rect.ts
@@ -3,17 +3,17 @@ import { Rect as GRect } from '@antv/g';
 import { deepMix } from '@antv/util';
 import { ICON_SIZE_RATIO } from '../../constants/element';
 import type { IconStyleProps } from '../shapes';
-import type { BaseNodeStyleProps, ParsedBaseNodeStyleProps } from './base-node';
+import type { BaseNodeStyleProps } from './base-node';
 import { BaseNode } from './base-node';
 
 export type RectStyleProps = BaseNodeStyleProps<KeyStyleProps>;
-type ParsedRectStyleProps = ParsedBaseNodeStyleProps<KeyStyleProps>;
+type ParsedRectStyleProps = Required<RectStyleProps>;
 type KeyStyleProps = GRectStyleProps;
 
 /**
  * Draw Rect based on BaseNode, override drawKeyShape.
  */
-export class Rect extends BaseNode<GRect, KeyStyleProps> {
+export class Rect extends BaseNode<RectStyleProps> {
   static defaultStyleProps: Partial<RectStyleProps> = {
     size: [100, 30],
     anchor: [0.5, 0.5],

--- a/packages/g6/src/elements/shapes/base-shape.ts
+++ b/packages/g6/src/elements/shapes/base-shape.ts
@@ -46,12 +46,12 @@ export abstract class BaseShape<StyleProps extends BaseShapeStyleProps> extends 
    * @param container - <zh> 容器 | <en> container
    * @returns <zh> 图形实例 | <en> shape instance
    */
-  protected upsert<P extends DisplayObject>(
+  protected upsert(
     key: string,
-    Ctor: { new (...args: any[]): P },
-    style: P['attributes'] | false,
+    Ctor: { new (...args: any[]): DisplayObject },
+    style: DisplayObject['attributes'] | false,
     container: DisplayObject,
-  ): P | undefined {
+  ): any | undefined {
     const target = this.shapeMap[key];
     // remove
     // 如果 style 为 false，则删除图形 / remove shape if style is false
@@ -75,7 +75,7 @@ export abstract class BaseShape<StyleProps extends BaseShapeStyleProps> extends 
     // update
     updateStyle(target, style);
 
-    return target as P;
+    return target;
   }
 
   /**

--- a/packages/g6/src/runtime/element.ts
+++ b/packages/g6/src/runtime/element.ts
@@ -7,7 +7,6 @@ import { groupBy, pick } from '@antv/util';
 import { executor as animationExecutor } from '../animations';
 import type { AnimationContext } from '../animations/types';
 import { AnimationType, ChangeTypeEnum, GraphEvent } from '../constants';
-import type { BaseEdge } from '../elements/edges/base-edge';
 import type { BaseNode } from '../elements/nodes';
 import type { BaseShape } from '../elements/shapes';
 import { getExtension } from '../registry';
@@ -17,11 +16,14 @@ import type { EdgeStyle } from '../spec/element/edge';
 import type { NodeLikeStyle } from '../spec/element/node';
 import type {
   AnimatableTask,
+  Combo,
   DataChange,
+  Edge,
   ElementData,
   ElementDatum,
   ElementType,
   LayoutResult,
+  Node,
   Positions,
   State,
   States,
@@ -313,15 +315,15 @@ export class ElementController {
   }
 
   public getNodes() {
-    return this.container.node.children as BaseNode<any, any>[];
+    return this.container.node.children as Node[];
   }
 
   public getEdges() {
-    return this.container.edge.children as BaseEdge[];
+    return this.container.edge.children as Edge[];
   }
 
   public getCombos() {
-    return this.container.combo.children as DisplayObject[];
+    return this.container.combo.children as Combo[];
   }
 
   private getAnimation(elementType: ElementType, stage: AnimationStage) {
@@ -404,8 +406,8 @@ export class ElementController {
     if (!data) return {};
 
     const { source, target } = data;
-    const sourceNode = this.getElement<BaseNode<any, any>>(source);
-    const targetNode = this.getElement<BaseNode<any, any>>(target);
+    const sourceNode = this.getElement<BaseNode>(source);
+    const targetNode = this.getElement<BaseNode>(target);
 
     return {
       sourceNode,

--- a/packages/g6/src/types/element.ts
+++ b/packages/g6/src/types/element.ts
@@ -1,4 +1,4 @@
-import type { BaseStyleProps, DisplayObject, PathStyleProps } from '@antv/g';
+import type { BaseStyleProps, PathStyleProps } from '@antv/g';
 import type { BaseCombo } from '../elements/combos';
 import type { BaseEdge } from '../elements/edges';
 import type { BaseNode } from '../elements/nodes';
@@ -10,11 +10,11 @@ export type ElementType = 'node' | 'edge' | 'combo';
 
 export type ElementOptions = NodeOptions | EdgeOptions | ComboOptions;
 
-export type Node = BaseNode<DisplayObject, BaseStyleProps>;
+export type Node = BaseNode;
 
 export type Edge = BaseEdge;
 
-export type Combo = BaseCombo<DisplayObject, BaseStyleProps>;
+export type Combo = BaseCombo;
 
 export type Element = Node | Edge | Combo;
 


### PR DESCRIPTION
* 调整元素类型定义
  * 放宽基类类型限制，放到子类中进行
  * BaseNode 不再需要范型 KeyShape 和 KeyShapeStyleProps, 现在传入节点 StyleProps 即可
  * BaseCombo 同 BaseNode

---

* Adjust element type definitions
  * Relax the base class type restrictions and move them to subclasses
  * BaseNode no longer requires generic KeyShape and KeyShapeStyleProps, now passing node StyleProps is sufficient
  * BaseCombo is the same as BaseNode