### PR TITLE
feat(behaviors): add drag node behavior

### DIFF
--- a/packages/g6/__tests__/demo/case/behavior-drag-node.ts
+++ b/packages/g6/__tests__/demo/case/behavior-drag-node.ts
@@ -23,7 +23,7 @@ export const behaviorDragNode: STDTestCase = async (context) => {
     edge: {
       style: { endArrow: true },
     },
-    behaviors: [{ type: 'drag-node', shadow: false, hideEdges: 'both' }],
+    behaviors: [{ type: 'drag-node' }],
   });
 
   await graph.render();
@@ -39,7 +39,7 @@ export const behaviorDragNode: STDTestCase = async (context) => {
     };
     return [
       panel.add(config, 'enable').onChange(handleChange),
-      panel.add(config, 'hideEdges').onChange(handleChange),
+      panel.add(config, 'hideEdges', ['none', 'in', 'out', 'both']).onChange(handleChange),
       panel.add(config, 'shadow').onChange(handleChange),
     ];
   };

--- a/packages/g6/__tests__/demo/case/behavior-drag-node.ts
+++ b/packages/g6/__tests__/demo/case/behavior-drag-node.ts
@@ -1,0 +1,48 @@
+import { Graph } from '@/src';
+import type { STDTestCase } from '../types';
+
+export const behaviorDragNode: STDTestCase = async (context) => {
+  const graph = new Graph({
+    ...context,
+    data: {
+      nodes: [
+        { id: 'node-1', style: { x: 100, y: 100 } },
+        { id: 'node-2', style: { x: 200, y: 100, parentId: 'combo-1' } },
+        { id: 'node-3', style: { x: 100, y: 200 } },
+        { id: 'node-4', style: { x: 200, y: 200, parentId: 'combo-1' } },
+      ],
+      edges: [
+        { source: 'node-1', target: 'node-2' },
+        { source: 'node-2', target: 'node-4' },
+        { source: 'node-1', target: 'node-3' },
+        { source: 'node-3', target: 'node-4' },
+      ],
+      combos: [{ id: 'combo-1' }],
+    },
+    node: { style: { size: 20 } },
+    edge: {
+      style: { endArrow: true },
+    },
+    behaviors: [{ type: 'drag-node', shadow: false, hideEdges: 'both' }],
+  });
+
+  await graph.render();
+
+  behaviorDragNode.form = (panel) => {
+    const config = {
+      enable: true,
+      hideEdges: 'none',
+      shadow: false,
+    };
+    const handleChange = () => {
+      graph.setBehaviors([{ type: 'drag-node', ...config }]);
+    };
+    return [
+      panel.add(config, 'enable').onChange(handleChange),
+      panel.add(config, 'hideEdges').onChange(handleChange),
+      panel.add(config, 'shadow').onChange(handleChange),
+    ];
+  };
+
+  return graph;
+};

--- a/packages/g6/__tests__/demo/case/index.ts
+++ b/packages/g6/__tests__/demo/case/index.ts
@@ -1,4 +1,5 @@
 export * from './behavior-drag-canvas';
+export * from './behavior-drag-node';
 export * from './behavior-zoom-canvas';
 export * from './combo';
 export * from './common-graph';

--- a/packages/g6/__tests__/demo/static/controller-layout-compact-box.ts
+++ b/packages/g6/__tests__/demo/static/controller-layout-compact-box.ts
@@ -1,5 +1,5 @@
 import type { G6Spec } from '@/src';
-import { Graph, treeToGraphData } from '@/src';
+import { Graph, Utils } from '@/src';
 import tree from '@@/dataset/algorithm-category.json';
 import type { STDTestCase } from '../types';
 
@@ -9,7 +9,7 @@ export const controllerLayoutCompactBox: STDTestCase = async (context) => {
     x: 50,
     y: 300,
     zoom: 0.5,
-    data: treeToGraphData(tree),
+    data: Utils.treeToGraphData(tree),
     theme: 'light',
     layout: {
       type: 'compact-box',

--- a/packages/g6/__tests__/demo/static/controller-layout-dendrogram.ts
+++ b/packages/g6/__tests__/demo/static/controller-layout-dendrogram.ts
@@ -1,5 +1,5 @@
 import type { G6Spec } from '@/src';
-import { Graph, treeToGraphData } from '@/src';
+import { Graph, Utils } from '@/src';
 import tree from '@@/dataset/algorithm-category.json';
 import type { STDTestCase } from '../types';
 
@@ -9,7 +9,7 @@ export const controllerLayoutDendrogram: STDTestCase = async (context) => {
     x: -200,
     y: 350,
     zoom: 0.5,
-    data: treeToGraphData(tree),
+    data: Utils.treeToGraphData(tree),
     theme: 'light',
     layout: {
       type: 'dendrogram',

--- a/packages/g6/__tests__/demo/static/controller-layout-indented.ts
+++ b/packages/g6/__tests__/demo/static/controller-layout-indented.ts
@@ -1,5 +1,5 @@
 import type { G6Spec } from '@/src';
-import { Graph, treeToGraphData } from '@/src';
+import { Graph, Utils } from '@/src';
 import tree from '@@/dataset/file-system.json';
 import type { STDTestCase } from '../types';
 
@@ -8,7 +8,7 @@ export const controllerLayoutIndented: STDTestCase = async (context) => {
     ...context,
     y: -200,
     zoom: 0.5,
-    data: treeToGraphData(tree),
+    data: Utils.treeToGraphData(tree),
     theme: 'light',
     layout: {
       type: 'indented',

--- a/packages/g6/__tests__/demo/static/controller-layout-mindmap.ts
+++ b/packages/g6/__tests__/demo/static/controller-layout-mindmap.ts
@@ -1,5 +1,5 @@
 import type { G6Spec } from '@/src';
-import { Graph, treeToGraphData } from '@/src';
+import { Graph, Utils } from '@/src';
 import tree from '@@/dataset/algorithm-category.json';
 import type { STDTestCase } from '../types';
 
@@ -9,7 +9,7 @@ export const controllerLayoutMindmap: STDTestCase = async (context) => {
     x: 350,
     y: 100,
     zoom: 0.4,
-    data: treeToGraphData(tree),
+    data: Utils.treeToGraphData(tree),
     theme: 'light',
     layout: {
       type: 'mindmap',

--- a/packages/g6/__tests__/integration/snapshots/static/edge-arrow.svg
+++ b/packages/g6/__tests__/integration/snapshots/static/edge-arrow.svg
@@ -43,7 +43,7 @@
             />
             <g transform="matrix(-1,-0,0,-1,212,0)">
               <path
-                id="g-svg-97"
+                id="g-svg-43"
                 fill="rgba(153,173,209,1)"
                 d="M 0,5 L 10,0 L 10,10 Z"
                 transform="translate(-5,-5)"
@@ -54,7 +54,7 @@
                 stroke-dasharray="0,0"
               />
               <path
-                id="g-svg-97"
+                id="g-svg-43"
                 fill="transparent"
                 d="M 0,5 L 10,0 L 10,10 Z"
                 transform="translate(-5,-5)"
@@ -125,7 +125,7 @@
             />
             <g transform="matrix(-1,0,-0,-1,212,0)">
               <path
-                id="g-svg-99"
+                id="g-svg-50"
                 fill="rgba(153,173,209,1)"
                 d="M 0,5 L 10,0 L 10,10 Z"
                 transform="translate(-5,-5)"
@@ -136,7 +136,7 @@
                 stroke-dasharray="0,0"
               />
               <path
-                id="g-svg-99"
+                id="g-svg-50"
                 fill="transparent"
                 d="M 0,5 L 10,0 L 10,10 Z"
                 transform="translate(-5,-5)"
@@ -207,7 +207,7 @@
             />
             <g transform="matrix(-1,0,-0,-1,212,0)">
               <path
-                id="g-svg-101"
+                id="g-svg-57"
                 fill="none"
                 d="M 10,0 L 0,5 L 10,10"
                 transform="translate(-5,-5)"
@@ -218,7 +218,7 @@
                 stroke-dasharray="0,0"
               />
               <path
-                id="g-svg-101"
+                id="g-svg-57"
                 fill="none"
                 d="M 10,0 L 0,5 L 10,10"
                 transform="translate(-5,-5)"
@@ -289,7 +289,7 @@
             />
             <g transform="matrix(-1,0,-0,-1,212,0)">
               <path
-                id="g-svg-103"
+                id="g-svg-64"
                 fill="rgba(153,173,209,1)"
                 d="M 0,5 L 10,0 L 6.666666666666667,5 L 10,10 Z"
                 transform="translate(-5,-5)"
@@ -300,7 +300,7 @@
                 stroke-dasharray="0,0"
               />
               <path
-                id="g-svg-103"
+                id="g-svg-64"
                 fill="transparent"
                 d="M 0,5 L 10,0 L 6.666666666666667,5 L 10,10 Z"
                 transform="translate(-5,-5)"
@@ -371,7 +371,7 @@
             />
             <g transform="matrix(-1,0,-0,-1,212,0)">
               <path
-                id="g-svg-105"
+                id="g-svg-71"
                 fill="rgba(153,173,209,1)"
                 d="M 0,5 A 5 5 0 1 0 10 5 A 5 5 0 1 0 0 5 Z"
                 transform="translate(-5,-5)"
@@ -382,7 +382,7 @@
                 stroke-dasharray="0,0"
               />
               <path
-                id="g-svg-105"
+                id="g-svg-71"
                 fill="transparent"
                 d="M 0,5 A 5 5 0 1 0 10 5 A 5 5 0 1 0 0 5 Z"
                 transform="translate(-5,-5)"
@@ -453,7 +453,7 @@
             />
             <g transform="matrix(-1,0,-0,-1,212,0)">
               <path
-                id="g-svg-107"
+                id="g-svg-78"
                 fill="rgba(153,173,209,1)"
                 d="M 0,0 L 10,0 L 10,10 L 0,10 Z"
                 transform="translate(-5,-5)"
@@ -464,7 +464,7 @@
                 stroke-dasharray="0,0"
               />
               <path
-                id="g-svg-107"
+                id="g-svg-78"
                 fill="transparent"
                 d="M 0,0 L 10,0 L 10,10 L 0,10 Z"
                 transform="translate(-5,-5)"
@@ -535,7 +535,7 @@
             />
             <g transform="matrix(-1,0,-0,-1,212,0)">
               <path
-                id="g-svg-109"
+                id="g-svg-85"
                 fill="rgba(153,173,209,1)"
                 d="M 0,5 L 5,0 L 10,5 L 5,10 Z"
                 transform="translate(-5,-5)"
@@ -546,7 +546,7 @@
                 stroke-dasharray="0,0"
               />
               <path
-                id="g-svg-109"
+                id="g-svg-85"
                 fill="transparent"
                 d="M 0,5 L 5,0 L 10,5 L 5,10 Z"
                 transform="translate(-5,-5)"
@@ -617,7 +617,7 @@
             />
             <g transform="matrix(-1,0,-0,-1,212,0)">
               <path
-                id="g-svg-111"
+                id="g-svg-92"
                 fill="rgba(153,173,209,1)"
                 d="M 0,5 L 5,0 L 5,10 Z M 8.571428571428571,0 L 10,0 L 10,10 L 8.571428571428571,10 Z"
                 transform="translate(-5,-5)"
@@ -628,7 +628,7 @@
                 stroke-dasharray="0,0"
               />
               <path
-                id="g-svg-111"
+                id="g-svg-92"
                 fill="transparent"
                 d="M 0,5 L 5,0 L 5,10 Z M 8.571428571428571,0 L 10,0 L 10,10 L 8.571428571428571,10 Z"
                 transform="translate(-5,-5)"

--- a/packages/g6/__tests__/integration/snapshots/static/edge-custom-arrow.svg
+++ b/packages/g6/__tests__/integration/snapshots/static/edge-custom-arrow.svg
@@ -43,7 +43,7 @@
             />
             <g transform="matrix(-1,0,-0,-1,204,0)">
               <path
-                id="g-svg-42"
+                id="g-svg-23"
                 fill="rgba(246,189,22,1)"
                 d="M 0,14 L 10,18 L 14,28 L 18,18 L 28,14 L 18,10 L 14,0 L 10,10 Z"
                 transform="translate(-14,-14)"
@@ -54,7 +54,7 @@
                 stroke-dasharray="0,0"
               />
               <path
-                id="g-svg-42"
+                id="g-svg-23"
                 fill="transparent"
                 d="M 0,14 L 10,18 L 14,28 L 18,18 L 28,14 L 18,10 L 14,0 L 10,10 Z"
                 transform="translate(-14,-14)"
@@ -125,7 +125,7 @@
             />
             <g transform="matrix(-1,0,-0,-1,208,0)">
               <path
-                id="g-svg-44"
+                id="g-svg-30"
                 fill="rgba(246,189,22,1)"
                 d="M 0,5 L 0,15 L 12,20 L 12,0 Z"
                 transform="translate(-6,-10)"
@@ -136,7 +136,7 @@
                 stroke-dasharray="0,0"
               />
               <path
-                id="g-svg-44"
+                id="g-svg-30"
                 fill="transparent"
                 d="M 0,5 L 0,15 L 12,20 L 12,0 Z"
                 transform="translate(-6,-10)"
@@ -207,7 +207,7 @@
             />
             <g transform="matrix(-0,-1,1,-0,203,0)">
               <image
-                id="g-svg-46"
+                id="g-svg-37"
                 fill="rgba(246,189,22,1)"
                 preserveAspectRatio="none"
                 x="0"
@@ -221,7 +221,7 @@
                 stroke-dasharray="0,0"
               />
               <image
-                id="g-svg-46"
+                id="g-svg-37"
                 fill="transparent"
                 preserveAspectRatio="none"
                 x="0"

--- a/packages/g6/__tests__/integration/snapshots/static/edge-line.svg
+++ b/packages/g6/__tests__/integration/snapshots/static/edge-line.svg
@@ -43,7 +43,7 @@
             />
             <g transform="matrix(0.233081,-0.972457,0.972457,0.233081,1.398486,176.987228)">
               <path
-                id="g-svg-65"
+                id="g-svg-25"
                 fill="rgba(153,173,209,1)"
                 d="M 0,5 L 10,0 L 10,10 Z"
                 transform="translate(-5,-5)"
@@ -54,7 +54,7 @@
                 stroke-dasharray="0,0"
               />
               <path
-                id="g-svg-65"
+                id="g-svg-25"
                 fill="transparent"
                 d="M 0,5 L 10,0 L 10,10 Z"
                 transform="translate(-5,-5)"
@@ -151,7 +151,7 @@
             />
             <g transform="matrix(0.958718,-0.284358,0.284358,0.958718,5.752308,51.753220)">
               <path
-                id="g-svg-77"
+                id="g-svg-32"
                 fill="rgba(153,173,209,1)"
                 d="M 0,5 L 10,0 L 10,10 Z"
                 transform="translate(-5,-5)"
@@ -162,7 +162,7 @@
                 stroke-dasharray="0,0"
               />
               <path
-                id="g-svg-77"
+                id="g-svg-32"
                 fill="transparent"
                 d="M 0,5 L 10,0 L 10,10 Z"
                 transform="translate(-5,-5)"
@@ -259,7 +259,7 @@
             />
             <g transform="matrix(-0.233140,0.972443,-0.972443,-0.233140,42.431557,5.834659)">
               <path
-                id="g-svg-80"
+                id="g-svg-39"
                 fill="rgba(153,173,209,1)"
                 d="M 0,5 L 10,0 L 10,10 Z"
                 transform="translate(-5,-5)"
@@ -270,7 +270,7 @@
                 stroke-dasharray="0,0"
               />
               <path
-                id="g-svg-80"
+                id="g-svg-39"
                 fill="transparent"
                 d="M 0,5 L 10,0 L 10,10 Z"
                 transform="translate(-5,-5)"
@@ -346,7 +346,7 @@
             />
             <g transform="matrix(0.725589,0.688128,-0.688128,0.725589,4.353534,4.128770)">
               <path
-                id="g-svg-83"
+                id="g-svg-46"
                 fill="rgba(153,173,209,1)"
                 d="M 0,5 L 10,0 L 10,10 Z"
                 transform="translate(-5,-5)"
@@ -357,7 +357,7 @@
                 stroke-dasharray="0,0"
               />
               <path
-                id="g-svg-83"
+                id="g-svg-46"
                 fill="transparent"
                 d="M 0,5 L 10,0 L 10,10 Z"
                 transform="translate(-5,-5)"
@@ -433,18 +433,18 @@
             />
             <g transform="matrix(-0.725633,-0.688082,0.688082,-0.725633,132.065247,125.230858)">
               <path
-                id="g-svg-85"
-                fill="rgba(210,218,233,1)"
+                id="g-svg-53"
+                fill="rgba(153,173,209,1)"
                 d="M 0,5 L 10,0 L 10,10 Z"
                 transform="translate(-5,-5)"
                 stroke-width="1"
-                stroke="rgba(210,218,233,1)"
+                stroke="rgba(153,173,209,1)"
                 width="10"
                 height="10"
                 stroke-dasharray="0,0"
               />
               <path
-                id="g-svg-85"
+                id="g-svg-53"
                 fill="transparent"
                 d="M 0,5 L 10,0 L 10,10 Z"
                 transform="translate(-5,-5)"
@@ -519,18 +519,18 @@
             />
             <g transform="matrix(-0.958717,0.284361,-0.284361,-0.958717,174.486526,1.706166)">
               <path
-                id="g-svg-87"
-                fill="rgba(217,217,217,1)"
+                id="g-svg-60"
+                fill="rgba(153,173,209,1)"
                 d="M 0,5 L 10,0 L 10,10 Z"
                 transform="translate(-5,-5)"
                 stroke-width="1"
-                stroke="rgba(217,217,217,1)"
+                stroke="rgba(153,173,209,1)"
                 width="10"
                 height="10"
                 stroke-dasharray="0,0"
               />
               <path
-                id="g-svg-87"
+                id="g-svg-60"
                 fill="transparent"
                 d="M 0,5 L 10,0 L 10,10 Z"
                 transform="translate(-5,-5)"

--- a/packages/g6/__tests__/snapshots/behaviors/behavior-drag-node/behavior-drag-node.svg
+++ b/packages/g6/__tests__/snapshots/behaviors/behavior-drag-node/behavior-drag-node.svg
@@ -1,0 +1,315 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="500"
+  height="500"
+  style="background: transparent; position: absolute; outline: none;"
+  color-interpolation-filters="sRGB"
+  tabindex="1"
+>
+  <defs />
+  <g id="g-svg-camera" transform="matrix(1,0,0,1,0,0)">
+    <g id="g-root" fill="none" transform="matrix(1,0,0,1,0,0)">
+      <g id="g-svg-7" fill="none" transform="matrix(1,0,0,1,0,0)">
+        <g id="combo-1" fill="none" transform="matrix(1,0,0,1,200,150)">
+          <g transform="matrix(1,0,0,1,0,0)">
+            <circle
+              id="key"
+              fill="rgba(253,253,253,1)"
+              transform="translate(-72.80109889280519,-72.80109889280519)"
+              cx="72.80109889280519"
+              cy="72.80109889280519"
+              stroke-dasharray="0,0"
+              stroke-width="1"
+              stroke="rgba(153,173,209,1)"
+              r="72.80109889280519"
+            />
+          </g>
+        </g>
+      </g>
+      <g id="g-svg-6" fill="none" transform="matrix(1,0,0,1,0,0)">
+        <g
+          id="node-1-node-2"
+          fill="none"
+          marker-start="false"
+          marker-end="true"
+          transform="matrix(1,0,0,1,0,0)"
+        >
+          <g
+            id="node-1-node-2"
+            fill="none"
+            marker-start="false"
+            marker-end="true"
+            stroke="transparent"
+            stroke-width="3"
+          />
+          <g transform="matrix(1,0,0,1,110,100)">
+            <path
+              id="key"
+              fill="none"
+              d="M 0,0 L 74,7.347880794884119e-16"
+              stroke-width="1"
+              stroke="rgba(153,173,209,1)"
+            />
+            <path
+              id="key"
+              fill="none"
+              d="M 0,0 L 74,7.347880794884119e-16"
+              stroke-width="3"
+              stroke="transparent"
+            />
+            <g transform="matrix(-1,0,-0,-1,74,0)">
+              <path
+                id="g-svg-19"
+                fill="rgba(153,173,209,1)"
+                d="M 0,5 L 10,0 L 10,10 Z"
+                transform="translate(-5,-5)"
+                stroke-width="1"
+                stroke="rgba(153,173,209,1)"
+                width="10"
+                height="10"
+                stroke-dasharray="0,0"
+              />
+              <path
+                id="g-svg-19"
+                fill="transparent"
+                d="M 0,5 L 10,0 L 10,10 Z"
+                transform="translate(-5,-5)"
+                stroke-width="3"
+                stroke="transparent"
+                width="10"
+                height="10"
+                stroke-dasharray="0,0"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          id="node-2-node-4"
+          fill="none"
+          marker-start="false"
+          marker-end="true"
+          transform="matrix(1,0,0,1,0,0)"
+        >
+          <g
+            id="node-2-node-4"
+            fill="none"
+            marker-start="false"
+            marker-end="true"
+            stroke="transparent"
+            stroke-width="3"
+          />
+          <g transform="matrix(1,0,0,1,200,110)">
+            <path
+              id="key"
+              fill="none"
+              d="M 0,0 L 3.6739403974420594e-16,74"
+              stroke-width="1"
+              stroke="rgba(153,173,209,1)"
+            />
+            <path
+              id="key"
+              fill="none"
+              d="M 0,0 L 3.6739403974420594e-16,74"
+              stroke-width="3"
+              stroke="transparent"
+            />
+            <g transform="matrix(0,-1,1,0,0,74)">
+              <path
+                id="g-svg-23"
+                fill="rgba(153,173,209,1)"
+                d="M 0,5 L 10,0 L 10,10 Z"
+                transform="translate(-5,-5)"
+                stroke-width="1"
+                stroke="rgba(153,173,209,1)"
+                width="10"
+                height="10"
+                stroke-dasharray="0,0"
+              />
+              <path
+                id="g-svg-23"
+                fill="transparent"
+                d="M 0,5 L 10,0 L 10,10 Z"
+                transform="translate(-5,-5)"
+                stroke-width="3"
+                stroke="transparent"
+                width="10"
+                height="10"
+                stroke-dasharray="0,0"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          id="node-1-node-3"
+          fill="none"
+          marker-start="false"
+          marker-end="true"
+          transform="matrix(1,0,0,1,0,0)"
+        >
+          <g
+            id="node-1-node-3"
+            fill="none"
+            marker-start="false"
+            marker-end="true"
+            stroke="transparent"
+            stroke-width="3"
+          />
+          <g transform="matrix(1,0,0,1,100,110)">
+            <path
+              id="key"
+              fill="none"
+              d="M 0,0 L 3.6739403974420594e-16,74"
+              stroke-width="1"
+              stroke="rgba(153,173,209,1)"
+            />
+            <path
+              id="key"
+              fill="none"
+              d="M 0,0 L 3.6739403974420594e-16,74"
+              stroke-width="3"
+              stroke="transparent"
+            />
+            <g transform="matrix(0,-1,1,0,0,74)">
+              <path
+                id="g-svg-27"
+                fill="rgba(153,173,209,1)"
+                d="M 0,5 L 10,0 L 10,10 Z"
+                transform="translate(-5,-5)"
+                stroke-width="1"
+                stroke="rgba(153,173,209,1)"
+                width="10"
+                height="10"
+                stroke-dasharray="0,0"
+              />
+              <path
+                id="g-svg-27"
+                fill="transparent"
+                d="M 0,5 L 10,0 L 10,10 Z"
+                transform="translate(-5,-5)"
+                stroke-width="3"
+                stroke="transparent"
+                width="10"
+                height="10"
+                stroke-dasharray="0,0"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          id="node-3-node-4"
+          fill="none"
+          marker-start="false"
+          marker-end="true"
+          transform="matrix(1,0,0,1,0,0)"
+        >
+          <g
+            id="node-3-node-4"
+            fill="none"
+            marker-start="false"
+            marker-end="true"
+            stroke="transparent"
+            stroke-width="3"
+          />
+          <g transform="matrix(1,0,0,1,110,200)">
+            <path
+              id="key"
+              fill="none"
+              d="M 0,0 L 74,7.347880794884119e-16"
+              stroke-width="1"
+              stroke="rgba(153,173,209,1)"
+            />
+            <path
+              id="key"
+              fill="none"
+              d="M 0,0 L 74,7.347880794884119e-16"
+              stroke-width="3"
+              stroke="transparent"
+            />
+            <g transform="matrix(-1,0,-0,-1,74,0)">
+              <path
+                id="g-svg-31"
+                fill="rgba(153,173,209,1)"
+                d="M 0,5 L 10,0 L 10,10 Z"
+                transform="translate(-5,-5)"
+                stroke-width="1"
+                stroke="rgba(153,173,209,1)"
+                width="10"
+                height="10"
+                stroke-dasharray="0,0"
+              />
+              <path
+                id="g-svg-31"
+                fill="transparent"
+                d="M 0,5 L 10,0 L 10,10 Z"
+                transform="translate(-5,-5)"
+                stroke-width="3"
+                stroke="transparent"
+                width="10"
+                height="10"
+                stroke-dasharray="0,0"
+              />
+            </g>
+          </g>
+        </g>
+      </g>
+      <g id="g-svg-5" fill="none" transform="matrix(1,0,0,1,0,0)">
+        <g id="node-1" fill="none" transform="matrix(1,0,0,1,100,100)">
+          <g transform="matrix(1,0,0,1,0,0)">
+            <circle
+              id="key"
+              fill="rgba(34,126,255,1)"
+              transform="translate(-10,-10)"
+              cx="10"
+              cy="10"
+              stroke-width="0"
+              stroke="rgba(0,0,0,1)"
+              r="10"
+            />
+          </g>
+        </g>
+        <g id="node-2" fill="none" transform="matrix(1,0,0,1,200,100)">
+          <g transform="matrix(1,0,0,1,0,0)">
+            <circle
+              id="key"
+              fill="rgba(34,126,255,1)"
+              transform="translate(-10,-10)"
+              cx="10"
+              cy="10"
+              stroke-width="0"
+              stroke="rgba(0,0,0,1)"
+              r="10"
+            />
+          </g>
+        </g>
+        <g id="node-3" fill="none" transform="matrix(1,0,0,1,100,200)">
+          <g transform="matrix(1,0,0,1,0,0)">
+            <circle
+              id="key"
+              fill="rgba(34,126,255,1)"
+              transform="translate(-10,-10)"
+              cx="10"
+              cy="10"
+              stroke-width="0"
+              stroke="rgba(0,0,0,1)"
+              r="10"
+            />
+          </g>
+        </g>
+        <g id="node-4" fill="none" transform="matrix(1,0,0,1,200,200)">
+          <g transform="matrix(1,0,0,1,0,0)">
+            <circle
+              id="key"
+              fill="rgba(34,126,255,1)"
+              transform="translate(-10,-10)"
+              cx="10"
+              cy="10"
+              stroke-width="0"
+              stroke="rgba(0,0,0,1)"
+              r="10"
+            />
+          </g>
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/packages/g6/__tests__/snapshots/behaviors/behavior-drag-node/behavior-drag-node__after-drag.svg
+++ b/packages/g6/__tests__/snapshots/behaviors/behavior-drag-node/behavior-drag-node__after-drag.svg
@@ -1,0 +1,323 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="500"
+  height="500"
+  style="background: transparent; position: absolute; outline: none;"
+  color-interpolation-filters="sRGB"
+  tabindex="1"
+>
+  <defs />
+  <g id="g-svg-camera" transform="matrix(1,0,0,1,0,0)">
+    <g id="g-root" fill="none" transform="matrix(1,0,0,1,0,0)">
+      <g id="g-svg-7" fill="none" transform="matrix(1,0,0,1,0,0)">
+        <g id="combo-1" fill="none" transform="matrix(1,0,0,1,200,150)">
+          <g transform="matrix(1,0,0,1,0,0)">
+            <circle
+              id="key"
+              fill="rgba(253,253,253,1)"
+              transform="translate(-72.80109889280519,-72.80109889280519)"
+              cx="72.80109889280519"
+              cy="72.80109889280519"
+              stroke-dasharray="0,0"
+              stroke-width="1"
+              stroke="rgba(153,173,209,1)"
+              r="72.80109889280519"
+            />
+          </g>
+        </g>
+      </g>
+      <g id="g-svg-6" fill="none" transform="matrix(1,0,0,1,0,0)">
+        <g
+          id="node-1-node-2"
+          fill="none"
+          marker-start="false"
+          marker-end="true"
+          transform="matrix(1,0,0,1,0,0)"
+        >
+          <g
+            id="node-1-node-2"
+            fill="none"
+            marker-start="false"
+            marker-end="true"
+            stroke="transparent"
+            stroke-width="3"
+          />
+          <g transform="matrix(1,0,0,1,110,100)">
+            <path
+              id="key"
+              fill="none"
+              d="M 0,0 L 74,7.347880794884119e-16"
+              stroke-width="1"
+              stroke="rgba(153,173,209,1)"
+            />
+            <path
+              id="key"
+              fill="none"
+              d="M 0,0 L 74,7.347880794884119e-16"
+              stroke-width="3"
+              stroke="transparent"
+            />
+            <g transform="matrix(-1,0,-0,-1,74,0)">
+              <path
+                id="g-svg-19"
+                fill="rgba(153,173,209,1)"
+                d="M 0,5 L 10,0 L 10,10 Z"
+                transform="translate(-5,-5)"
+                stroke-width="1"
+                stroke="rgba(153,173,209,1)"
+                width="10"
+                height="10"
+                stroke-dasharray="0,0"
+              />
+              <path
+                id="g-svg-19"
+                fill="transparent"
+                d="M 0,5 L 10,0 L 10,10 Z"
+                transform="translate(-5,-5)"
+                stroke-width="3"
+                stroke="transparent"
+                width="10"
+                height="10"
+                stroke-dasharray="0,0"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          id="node-2-node-4"
+          fill="none"
+          marker-start="false"
+          marker-end="true"
+          transform="matrix(1,0,0,1,0,0)"
+        >
+          <g
+            id="node-2-node-4"
+            fill="none"
+            marker-start="false"
+            marker-end="true"
+            stroke="transparent"
+            stroke-width="3"
+          />
+          <g transform="matrix(1,0,0,1,201.643997,109.863937)">
+            <path
+              id="key"
+              fill="none"
+              d="M 0,0 L 15.725626330060688,94.35375798036425"
+              stroke-width="1"
+              stroke="rgba(153,173,209,1)"
+              visibility="visible"
+            />
+            <path
+              id="key"
+              fill="none"
+              d="M 0,0 L 3.6739403974420594e-16,74"
+              stroke-width="3"
+              stroke="transparent"
+              visibility="visible"
+            />
+            <g transform="matrix(-0.164399,-0.986394,0.986394,-0.164399,15.725626,94.353760)">
+              <path
+                id="g-svg-23"
+                fill="rgba(153,173,209,1)"
+                d="M 0,5 L 10,0 L 10,10 Z"
+                transform="translate(-5,-5)"
+                stroke-width="1"
+                stroke="rgba(153,173,209,1)"
+                width="10"
+                height="10"
+                stroke-dasharray="0,0"
+                visibility="visible"
+              />
+              <path
+                id="g-svg-23"
+                fill="transparent"
+                d="M 0,5 L 10,0 L 10,10 Z"
+                transform="translate(-5,-5)"
+                stroke-width="3"
+                stroke="transparent"
+                width="10"
+                height="10"
+                stroke-dasharray="0,0"
+                visibility="visible"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          id="node-1-node-3"
+          fill="none"
+          marker-start="false"
+          marker-end="true"
+          transform="matrix(1,0,0,1,0,0)"
+        >
+          <g
+            id="node-1-node-3"
+            fill="none"
+            marker-start="false"
+            marker-end="true"
+            stroke="transparent"
+            stroke-width="3"
+          />
+          <g transform="matrix(1,0,0,1,100,110)">
+            <path
+              id="key"
+              fill="none"
+              d="M 0,0 L 3.6739403974420594e-16,74"
+              stroke-width="1"
+              stroke="rgba(153,173,209,1)"
+            />
+            <path
+              id="key"
+              fill="none"
+              d="M 0,0 L 3.6739403974420594e-16,74"
+              stroke-width="3"
+              stroke="transparent"
+            />
+            <g transform="matrix(0,-1,1,0,0,74)">
+              <path
+                id="g-svg-27"
+                fill="rgba(153,173,209,1)"
+                d="M 0,5 L 10,0 L 10,10 Z"
+                transform="translate(-5,-5)"
+                stroke-width="1"
+                stroke="rgba(153,173,209,1)"
+                width="10"
+                height="10"
+                stroke-dasharray="0,0"
+              />
+              <path
+                id="g-svg-27"
+                fill="transparent"
+                d="M 0,5 L 10,0 L 10,10 Z"
+                transform="translate(-5,-5)"
+                stroke-width="3"
+                stroke="transparent"
+                width="10"
+                height="10"
+                stroke-dasharray="0,0"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          id="node-3-node-4"
+          fill="none"
+          marker-start="false"
+          marker-end="true"
+          transform="matrix(1,0,0,1,0,0)"
+        >
+          <g
+            id="node-3-node-4"
+            fill="none"
+            marker-start="false"
+            marker-end="true"
+            stroke="transparent"
+            stroke-width="3"
+          />
+          <g transform="matrix(1,0,0,1,109.863937,201.643997)">
+            <path
+              id="key"
+              fill="none"
+              d="M 0,0 L 94.35375798036425,15.725626330060688"
+              stroke-width="1"
+              stroke="rgba(153,173,209,1)"
+              visibility="visible"
+            />
+            <path
+              id="key"
+              fill="none"
+              d="M 0,0 L 74,7.347880794884119e-16"
+              stroke-width="3"
+              stroke="transparent"
+              visibility="visible"
+            />
+            <g transform="matrix(-0.986394,-0.164399,0.164399,-0.986394,94.353760,15.725626)">
+              <path
+                id="g-svg-31"
+                fill="rgba(153,173,209,1)"
+                d="M 0,5 L 10,0 L 10,10 Z"
+                transform="translate(-5,-5)"
+                stroke-width="1"
+                stroke="rgba(153,173,209,1)"
+                width="10"
+                height="10"
+                stroke-dasharray="0,0"
+                visibility="visible"
+              />
+              <path
+                id="g-svg-31"
+                fill="transparent"
+                d="M 0,5 L 10,0 L 10,10 Z"
+                transform="translate(-5,-5)"
+                stroke-width="3"
+                stroke="transparent"
+                width="10"
+                height="10"
+                stroke-dasharray="0,0"
+                visibility="visible"
+              />
+            </g>
+          </g>
+        </g>
+      </g>
+      <g id="g-svg-5" fill="none" transform="matrix(1,0,0,1,0,0)">
+        <g id="node-1" fill="none" transform="matrix(1,0,0,1,100,100)">
+          <g transform="matrix(1,0,0,1,0,0)">
+            <circle
+              id="key"
+              fill="rgba(34,126,255,1)"
+              transform="translate(-10,-10)"
+              cx="10"
+              cy="10"
+              stroke-width="0"
+              stroke="rgba(0,0,0,1)"
+              r="10"
+            />
+          </g>
+        </g>
+        <g id="node-2" fill="none" transform="matrix(1,0,0,1,200,100)">
+          <g transform="matrix(1,0,0,1,0,0)">
+            <circle
+              id="key"
+              fill="rgba(34,126,255,1)"
+              transform="translate(-10,-10)"
+              cx="10"
+              cy="10"
+              stroke-width="0"
+              stroke="rgba(0,0,0,1)"
+              r="10"
+            />
+          </g>
+        </g>
+        <g id="node-3" fill="none" transform="matrix(1,0,0,1,100,200)">
+          <g transform="matrix(1,0,0,1,0,0)">
+            <circle
+              id="key"
+              fill="rgba(34,126,255,1)"
+              transform="translate(-10,-10)"
+              cx="10"
+              cy="10"
+              stroke-width="0"
+              stroke="rgba(0,0,0,1)"
+              r="10"
+            />
+          </g>
+        </g>
+        <g id="node-4" fill="none" transform="matrix(1,0,0,1,220,220)">
+          <g transform="matrix(1,0,0,1,0,0)">
+            <circle
+              id="key"
+              fill="rgba(34,126,255,1)"
+              transform="translate(-10,-10)"
+              cx="10"
+              cy="10"
+              stroke-width="0"
+              stroke="rgba(0,0,0,1)"
+              r="10"
+            />
+          </g>
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/packages/g6/__tests__/snapshots/behaviors/behavior-drag-node/behavior-drag-node__after-drag.svg
+++ b/packages/g6/__tests__/snapshots/behaviors/behavior-drag-node/behavior-drag-node__after-drag.svg
@@ -105,7 +105,6 @@
               d="M 0,0 L 15.725626330060688,94.35375798036425"
               stroke-width="1"
               stroke="rgba(153,173,209,1)"
-              visibility="visible"
             />
             <path
               id="key"
@@ -113,7 +112,6 @@
               d="M 0,0 L 3.6739403974420594e-16,74"
               stroke-width="3"
               stroke="transparent"
-              visibility="visible"
             />
             <g transform="matrix(-0.164399,-0.986394,0.986394,-0.164399,15.725626,94.353760)">
               <path
@@ -126,7 +124,6 @@
                 width="10"
                 height="10"
                 stroke-dasharray="0,0"
-                visibility="visible"
               />
               <path
                 id="g-svg-23"
@@ -138,7 +135,6 @@
                 width="10"
                 height="10"
                 stroke-dasharray="0,0"
-                visibility="visible"
               />
             </g>
           </g>
@@ -221,7 +217,6 @@
               d="M 0,0 L 94.35375798036425,15.725626330060688"
               stroke-width="1"
               stroke="rgba(153,173,209,1)"
-              visibility="visible"
             />
             <path
               id="key"
@@ -229,7 +224,6 @@
               d="M 0,0 L 74,7.347880794884119e-16"
               stroke-width="3"
               stroke="transparent"
-              visibility="visible"
             />
             <g transform="matrix(-0.986394,-0.164399,0.164399,-0.986394,94.353760,15.725626)">
               <path
@@ -242,7 +236,6 @@
                 width="10"
                 height="10"
                 stroke-dasharray="0,0"
-                visibility="visible"
               />
               <path
                 id="g-svg-31"
@@ -254,7 +247,6 @@
                 width="10"
                 height="10"
                 stroke-dasharray="0,0"
-                visibility="visible"
               />
             </g>
           </g>

--- a/packages/g6/__tests__/snapshots/behaviors/behavior-drag-node/behavior-drag-node__hideEdges-both.svg
+++ b/packages/g6/__tests__/snapshots/behaviors/behavior-drag-node/behavior-drag-node__hideEdges-both.svg
@@ -1,0 +1,323 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="500"
+  height="500"
+  style="background: transparent; position: absolute; outline: none;"
+  color-interpolation-filters="sRGB"
+  tabindex="1"
+>
+  <defs />
+  <g id="g-svg-camera" transform="matrix(1,0,0,1,0,0)">
+    <g id="g-root" fill="none" transform="matrix(1,0,0,1,0,0)">
+      <g id="g-svg-7" fill="none" transform="matrix(1,0,0,1,0,0)">
+        <g id="combo-1" fill="none" transform="matrix(1,0,0,1,200,150)">
+          <g transform="matrix(1,0,0,1,0,0)">
+            <circle
+              id="key"
+              fill="rgba(253,253,253,1)"
+              transform="translate(-72.80109889280519,-72.80109889280519)"
+              cx="72.80109889280519"
+              cy="72.80109889280519"
+              stroke-dasharray="0,0"
+              stroke-width="1"
+              stroke="rgba(153,173,209,1)"
+              r="72.80109889280519"
+            />
+          </g>
+        </g>
+      </g>
+      <g id="g-svg-6" fill="none" transform="matrix(1,0,0,1,0,0)">
+        <g
+          id="node-1-node-2"
+          fill="none"
+          marker-start="false"
+          marker-end="true"
+          transform="matrix(1,0,0,1,0,0)"
+        >
+          <g
+            id="node-1-node-2"
+            fill="none"
+            marker-start="false"
+            marker-end="true"
+            stroke="transparent"
+            stroke-width="3"
+          />
+          <g transform="matrix(1,0,0,1,110,100)">
+            <path
+              id="key"
+              fill="none"
+              d="M 0,0 L 74,7.347880794884119e-16"
+              stroke-width="1"
+              stroke="rgba(153,173,209,1)"
+            />
+            <path
+              id="key"
+              fill="none"
+              d="M 0,0 L 74,7.347880794884119e-16"
+              stroke-width="3"
+              stroke="transparent"
+            />
+            <g transform="matrix(-1,0,-0,-1,74,0)">
+              <path
+                id="g-svg-19"
+                fill="rgba(153,173,209,1)"
+                d="M 0,5 L 10,0 L 10,10 Z"
+                transform="translate(-5,-5)"
+                stroke-width="1"
+                stroke="rgba(153,173,209,1)"
+                width="10"
+                height="10"
+                stroke-dasharray="0,0"
+              />
+              <path
+                id="g-svg-19"
+                fill="transparent"
+                d="M 0,5 L 10,0 L 10,10 Z"
+                transform="translate(-5,-5)"
+                stroke-width="3"
+                stroke="transparent"
+                width="10"
+                height="10"
+                stroke-dasharray="0,0"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          id="node-2-node-4"
+          fill="none"
+          marker-start="false"
+          marker-end="true"
+          transform="matrix(1,0,0,1,0,0)"
+        >
+          <g
+            id="node-2-node-4"
+            fill="none"
+            marker-start="false"
+            marker-end="true"
+            stroke="transparent"
+            stroke-width="3"
+          />
+          <g transform="matrix(1,0,0,1,202.747208,109.615242)">
+            <path
+              id="key"
+              fill="none"
+              d="M 0,0 L 32.857250674668144,115.00037736133861"
+              stroke-width="1"
+              stroke="rgba(153,173,209,1)"
+              visibility="hidden"
+            />
+            <path
+              id="key"
+              fill="none"
+              d="M 0,0 L 3.6739403974420594e-16,74"
+              stroke-width="3"
+              stroke="transparent"
+              visibility="hidden"
+            />
+            <g transform="matrix(-0.274721,-0.961524,0.961524,-0.274721,32.857250,115.000374)">
+              <path
+                id="g-svg-23"
+                fill="rgba(153,173,209,1)"
+                d="M 0,5 L 10,0 L 10,10 Z"
+                transform="translate(-5,-5)"
+                stroke-width="1"
+                stroke="rgba(153,173,209,1)"
+                width="10"
+                height="10"
+                stroke-dasharray="0,0"
+                visibility="hidden"
+              />
+              <path
+                id="g-svg-23"
+                fill="transparent"
+                d="M 0,5 L 10,0 L 10,10 Z"
+                transform="translate(-5,-5)"
+                stroke-width="3"
+                stroke="transparent"
+                width="10"
+                height="10"
+                stroke-dasharray="0,0"
+                visibility="hidden"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          id="node-1-node-3"
+          fill="none"
+          marker-start="false"
+          marker-end="true"
+          transform="matrix(1,0,0,1,0,0)"
+        >
+          <g
+            id="node-1-node-3"
+            fill="none"
+            marker-start="false"
+            marker-end="true"
+            stroke="transparent"
+            stroke-width="3"
+          />
+          <g transform="matrix(1,0,0,1,100,110)">
+            <path
+              id="key"
+              fill="none"
+              d="M 0,0 L 3.6739403974420594e-16,74"
+              stroke-width="1"
+              stroke="rgba(153,173,209,1)"
+            />
+            <path
+              id="key"
+              fill="none"
+              d="M 0,0 L 3.6739403974420594e-16,74"
+              stroke-width="3"
+              stroke="transparent"
+            />
+            <g transform="matrix(0,-1,1,0,0,74)">
+              <path
+                id="g-svg-27"
+                fill="rgba(153,173,209,1)"
+                d="M 0,5 L 10,0 L 10,10 Z"
+                transform="translate(-5,-5)"
+                stroke-width="1"
+                stroke="rgba(153,173,209,1)"
+                width="10"
+                height="10"
+                stroke-dasharray="0,0"
+              />
+              <path
+                id="g-svg-27"
+                fill="transparent"
+                d="M 0,5 L 10,0 L 10,10 Z"
+                transform="translate(-5,-5)"
+                stroke-width="3"
+                stroke="transparent"
+                width="10"
+                height="10"
+                stroke-dasharray="0,0"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          id="node-3-node-4"
+          fill="none"
+          marker-start="false"
+          marker-end="true"
+          transform="matrix(1,0,0,1,0,0)"
+        >
+          <g
+            id="node-3-node-4"
+            fill="none"
+            marker-start="false"
+            marker-end="true"
+            stroke="transparent"
+            stroke-width="3"
+          />
+          <g transform="matrix(1,0,0,1,109.615242,202.747208)">
+            <path
+              id="key"
+              fill="none"
+              d="M 0,0 L 115.00037736133861,32.857250674668144"
+              stroke-width="1"
+              stroke="rgba(153,173,209,1)"
+              visibility="hidden"
+            />
+            <path
+              id="key"
+              fill="none"
+              d="M 0,0 L 74,7.347880794884119e-16"
+              stroke-width="3"
+              stroke="transparent"
+              visibility="hidden"
+            />
+            <g transform="matrix(-0.961524,-0.274721,0.274721,-0.961524,115.000374,32.857250)">
+              <path
+                id="g-svg-31"
+                fill="rgba(153,173,209,1)"
+                d="M 0,5 L 10,0 L 10,10 Z"
+                transform="translate(-5,-5)"
+                stroke-width="1"
+                stroke="rgba(153,173,209,1)"
+                width="10"
+                height="10"
+                stroke-dasharray="0,0"
+                visibility="hidden"
+              />
+              <path
+                id="g-svg-31"
+                fill="transparent"
+                d="M 0,5 L 10,0 L 10,10 Z"
+                transform="translate(-5,-5)"
+                stroke-width="3"
+                stroke="transparent"
+                width="10"
+                height="10"
+                stroke-dasharray="0,0"
+                visibility="hidden"
+              />
+            </g>
+          </g>
+        </g>
+      </g>
+      <g id="g-svg-5" fill="none" transform="matrix(1,0,0,1,0,0)">
+        <g id="node-1" fill="none" transform="matrix(1,0,0,1,100,100)">
+          <g transform="matrix(1,0,0,1,0,0)">
+            <circle
+              id="key"
+              fill="rgba(34,126,255,1)"
+              transform="translate(-10,-10)"
+              cx="10"
+              cy="10"
+              stroke-width="0"
+              stroke="rgba(0,0,0,1)"
+              r="10"
+            />
+          </g>
+        </g>
+        <g id="node-2" fill="none" transform="matrix(1,0,0,1,200,100)">
+          <g transform="matrix(1,0,0,1,0,0)">
+            <circle
+              id="key"
+              fill="rgba(34,126,255,1)"
+              transform="translate(-10,-10)"
+              cx="10"
+              cy="10"
+              stroke-width="0"
+              stroke="rgba(0,0,0,1)"
+              r="10"
+            />
+          </g>
+        </g>
+        <g id="node-3" fill="none" transform="matrix(1,0,0,1,100,200)">
+          <g transform="matrix(1,0,0,1,0,0)">
+            <circle
+              id="key"
+              fill="rgba(34,126,255,1)"
+              transform="translate(-10,-10)"
+              cx="10"
+              cy="10"
+              stroke-width="0"
+              stroke="rgba(0,0,0,1)"
+              r="10"
+            />
+          </g>
+        </g>
+        <g id="node-4" fill="none" transform="matrix(1,0,0,1,240,240)">
+          <g transform="matrix(1,0,0,1,0,0)">
+            <circle
+              id="key"
+              fill="rgba(34,126,255,1)"
+              transform="translate(-10,-10)"
+              cx="10"
+              cy="10"
+              stroke-width="0"
+              stroke="rgba(0,0,0,1)"
+              r="10"
+            />
+          </g>
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/packages/g6/__tests__/snapshots/behaviors/behavior-drag-node/behavior-drag-node__hideEdges-in.svg
+++ b/packages/g6/__tests__/snapshots/behaviors/behavior-drag-node/behavior-drag-node__hideEdges-in.svg
@@ -1,0 +1,327 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="500"
+  height="500"
+  style="background: transparent; position: absolute; outline: none;"
+  color-interpolation-filters="sRGB"
+  tabindex="1"
+>
+  <defs />
+  <g id="g-svg-camera" transform="matrix(1,0,0,1,0,0)">
+    <g id="g-root" fill="none" transform="matrix(1,0,0,1,0,0)">
+      <g id="g-svg-7" fill="none" transform="matrix(1,0,0,1,0,0)">
+        <g id="combo-1" fill="none" transform="matrix(1,0,0,1,200,150)">
+          <g transform="matrix(1,0,0,1,0,0)">
+            <circle
+              id="key"
+              fill="rgba(253,253,253,1)"
+              transform="translate(-72.80109889280519,-72.80109889280519)"
+              cx="72.80109889280519"
+              cy="72.80109889280519"
+              stroke-dasharray="0,0"
+              stroke-width="1"
+              stroke="rgba(153,173,209,1)"
+              r="72.80109889280519"
+            />
+          </g>
+        </g>
+      </g>
+      <g id="g-svg-6" fill="none" transform="matrix(1,0,0,1,0,0)">
+        <g
+          id="node-1-node-2"
+          fill="none"
+          marker-start="false"
+          marker-end="true"
+          transform="matrix(1,0,0,1,0,0)"
+        >
+          <g
+            id="node-1-node-2"
+            fill="none"
+            marker-start="false"
+            marker-end="true"
+            stroke="transparent"
+            stroke-width="3"
+          />
+          <g transform="matrix(1,0,0,1,110,100)">
+            <path
+              id="key"
+              fill="none"
+              d="M 0,0 L 74,7.347880794884119e-16"
+              stroke-width="1"
+              stroke="rgba(153,173,209,1)"
+            />
+            <path
+              id="key"
+              fill="none"
+              d="M 0,0 L 74,7.347880794884119e-16"
+              stroke-width="3"
+              stroke="transparent"
+            />
+            <g transform="matrix(-1,0,-0,-1,74,0)">
+              <path
+                id="g-svg-19"
+                fill="rgba(153,173,209,1)"
+                d="M 0,5 L 10,0 L 10,10 Z"
+                transform="translate(-5,-5)"
+                stroke-width="1"
+                stroke="rgba(153,173,209,1)"
+                width="10"
+                height="10"
+                stroke-dasharray="0,0"
+              />
+              <path
+                id="g-svg-19"
+                fill="transparent"
+                d="M 0,5 L 10,0 L 10,10 Z"
+                transform="translate(-5,-5)"
+                stroke-width="3"
+                stroke="transparent"
+                width="10"
+                height="10"
+                stroke-dasharray="0,0"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          id="node-2-node-4"
+          fill="none"
+          marker-start="false"
+          marker-end="true"
+          transform="matrix(1,0,0,1,0,0)"
+        >
+          <g
+            id="node-2-node-4"
+            fill="none"
+            marker-start="false"
+            marker-end="true"
+            stroke="transparent"
+            stroke-width="3"
+          />
+          <g transform="matrix(1,0,0,1,202.747208,109.615242)">
+            <path
+              id="key"
+              fill="none"
+              d="M 0,0 L 32.857250674668144,115.00037736133861"
+              stroke-width="1"
+              stroke="rgba(153,173,209,1)"
+              visibility="visible"
+            />
+            <path
+              id="key"
+              fill="none"
+              d="M 0,0 L 3.6739403974420594e-16,74"
+              stroke-width="3"
+              stroke="transparent"
+              visibility="visible"
+            />
+            <g transform="matrix(-0.274721,-0.961524,0.961524,-0.274721,32.857250,115.000374)">
+              <path
+                id="g-svg-23"
+                fill="rgba(153,173,209,1)"
+                d="M 0,5 L 10,0 L 10,10 Z"
+                transform="translate(-5,-5)"
+                stroke-width="1"
+                stroke="rgba(153,173,209,1)"
+                width="10"
+                height="10"
+                stroke-dasharray="0,0"
+                visibility="visible"
+              />
+              <path
+                id="g-svg-23"
+                fill="transparent"
+                d="M 0,5 L 10,0 L 10,10 Z"
+                transform="translate(-5,-5)"
+                stroke-width="3"
+                stroke="transparent"
+                width="10"
+                height="10"
+                stroke-dasharray="0,0"
+                visibility="visible"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          id="node-1-node-3"
+          fill="none"
+          marker-start="false"
+          marker-end="true"
+          transform="matrix(1,0,0,1,0,0)"
+        >
+          <g
+            id="node-1-node-3"
+            fill="none"
+            marker-start="false"
+            marker-end="true"
+            stroke="transparent"
+            stroke-width="3"
+          />
+          <g transform="matrix(1,0,0,1,100,110)">
+            <path
+              id="key"
+              fill="none"
+              d="M 0,0 L 3.6739403974420594e-16,94"
+              stroke-width="1"
+              stroke="rgba(153,173,209,1)"
+              visibility="hidden"
+            />
+            <path
+              id="key"
+              fill="none"
+              d="M 0,0 L 3.6739403974420594e-16,74"
+              stroke-width="3"
+              stroke="transparent"
+              visibility="hidden"
+            />
+            <g transform="matrix(0,-1,1,0,0,94)">
+              <path
+                id="g-svg-27"
+                fill="rgba(153,173,209,1)"
+                d="M 0,5 L 10,0 L 10,10 Z"
+                transform="translate(-5,-5)"
+                stroke-width="1"
+                stroke="rgba(153,173,209,1)"
+                width="10"
+                height="10"
+                stroke-dasharray="0,0"
+                visibility="hidden"
+              />
+              <path
+                id="g-svg-27"
+                fill="transparent"
+                d="M 0,5 L 10,0 L 10,10 Z"
+                transform="translate(-5,-5)"
+                stroke-width="3"
+                stroke="transparent"
+                width="10"
+                height="10"
+                stroke-dasharray="0,0"
+                visibility="hidden"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          id="node-3-node-4"
+          fill="none"
+          marker-start="false"
+          marker-end="true"
+          transform="matrix(1,0,0,1,0,0)"
+        >
+          <g
+            id="node-3-node-4"
+            fill="none"
+            marker-start="false"
+            marker-end="true"
+            stroke="transparent"
+            stroke-width="3"
+          />
+          <g transform="matrix(1,0,0,1,109.899498,221.414215)">
+            <path
+              id="key"
+              fill="none"
+              d="M 0,0 L 114.26131316480968,16.32304473782993"
+              stroke-width="1"
+              stroke="rgba(153,173,209,1)"
+              visibility="visible"
+            />
+            <path
+              id="key"
+              fill="none"
+              d="M 0,0 L 74,7.347880794884119e-16"
+              stroke-width="3"
+              stroke="transparent"
+              visibility="visible"
+            />
+            <g transform="matrix(-0.989950,-0.141421,0.141421,-0.989950,114.261314,16.323044)">
+              <path
+                id="g-svg-31"
+                fill="rgba(153,173,209,1)"
+                d="M 0,5 L 10,0 L 10,10 Z"
+                transform="translate(-5,-5)"
+                stroke-width="1"
+                stroke="rgba(153,173,209,1)"
+                width="10"
+                height="10"
+                stroke-dasharray="0,0"
+                visibility="visible"
+              />
+              <path
+                id="g-svg-31"
+                fill="transparent"
+                d="M 0,5 L 10,0 L 10,10 Z"
+                transform="translate(-5,-5)"
+                stroke-width="3"
+                stroke="transparent"
+                width="10"
+                height="10"
+                stroke-dasharray="0,0"
+                visibility="visible"
+              />
+            </g>
+          </g>
+        </g>
+      </g>
+      <g id="g-svg-5" fill="none" transform="matrix(1,0,0,1,0,0)">
+        <g id="node-1" fill="none" transform="matrix(1,0,0,1,100,100)">
+          <g transform="matrix(1,0,0,1,0,0)">
+            <circle
+              id="key"
+              fill="rgba(34,126,255,1)"
+              transform="translate(-10,-10)"
+              cx="10"
+              cy="10"
+              stroke-width="0"
+              stroke="rgba(0,0,0,1)"
+              r="10"
+            />
+          </g>
+        </g>
+        <g id="node-2" fill="none" transform="matrix(1,0,0,1,200,100)">
+          <g transform="matrix(1,0,0,1,0,0)">
+            <circle
+              id="key"
+              fill="rgba(34,126,255,1)"
+              transform="translate(-10,-10)"
+              cx="10"
+              cy="10"
+              stroke-width="0"
+              stroke="rgba(0,0,0,1)"
+              r="10"
+            />
+          </g>
+        </g>
+        <g id="node-3" fill="none" transform="matrix(1,0,0,1,100,220)">
+          <g transform="matrix(1,0,0,1,0,0)">
+            <circle
+              id="key"
+              fill="rgba(34,126,255,1)"
+              transform="translate(-10,-10)"
+              cx="10"
+              cy="10"
+              stroke-width="0"
+              stroke="rgba(0,0,0,1)"
+              r="10"
+            />
+          </g>
+        </g>
+        <g id="node-4" fill="none" transform="matrix(1,0,0,1,240,240)">
+          <g transform="matrix(1,0,0,1,0,0)">
+            <circle
+              id="key"
+              fill="rgba(34,126,255,1)"
+              transform="translate(-10,-10)"
+              cx="10"
+              cy="10"
+              stroke-width="0"
+              stroke="rgba(0,0,0,1)"
+              r="10"
+            />
+          </g>
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/packages/g6/__tests__/snapshots/behaviors/behavior-drag-node/behavior-drag-node__hideEdges-out.svg
+++ b/packages/g6/__tests__/snapshots/behaviors/behavior-drag-node/behavior-drag-node__hideEdges-out.svg
@@ -1,0 +1,327 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="500"
+  height="500"
+  style="background: transparent; position: absolute; outline: none;"
+  color-interpolation-filters="sRGB"
+  tabindex="1"
+>
+  <defs />
+  <g id="g-svg-camera" transform="matrix(1,0,0,1,0,0)">
+    <g id="g-root" fill="none" transform="matrix(1,0,0,1,0,0)">
+      <g id="g-svg-7" fill="none" transform="matrix(1,0,0,1,0,0)">
+        <g id="combo-1" fill="none" transform="matrix(1,0,0,1,200,150)">
+          <g transform="matrix(1,0,0,1,0,0)">
+            <circle
+              id="key"
+              fill="rgba(253,253,253,1)"
+              transform="translate(-72.80109889280519,-72.80109889280519)"
+              cx="72.80109889280519"
+              cy="72.80109889280519"
+              stroke-dasharray="0,0"
+              stroke-width="1"
+              stroke="rgba(153,173,209,1)"
+              r="72.80109889280519"
+            />
+          </g>
+        </g>
+      </g>
+      <g id="g-svg-6" fill="none" transform="matrix(1,0,0,1,0,0)">
+        <g
+          id="node-1-node-2"
+          fill="none"
+          marker-start="false"
+          marker-end="true"
+          transform="matrix(1,0,0,1,0,0)"
+        >
+          <g
+            id="node-1-node-2"
+            fill="none"
+            marker-start="false"
+            marker-end="true"
+            stroke="transparent"
+            stroke-width="3"
+          />
+          <g transform="matrix(1,0,0,1,110,100)">
+            <path
+              id="key"
+              fill="none"
+              d="M 0,0 L 74,7.347880794884119e-16"
+              stroke-width="1"
+              stroke="rgba(153,173,209,1)"
+            />
+            <path
+              id="key"
+              fill="none"
+              d="M 0,0 L 74,7.347880794884119e-16"
+              stroke-width="3"
+              stroke="transparent"
+            />
+            <g transform="matrix(-1,0,-0,-1,74,0)">
+              <path
+                id="g-svg-19"
+                fill="rgba(153,173,209,1)"
+                d="M 0,5 L 10,0 L 10,10 Z"
+                transform="translate(-5,-5)"
+                stroke-width="1"
+                stroke="rgba(153,173,209,1)"
+                width="10"
+                height="10"
+                stroke-dasharray="0,0"
+              />
+              <path
+                id="g-svg-19"
+                fill="transparent"
+                d="M 0,5 L 10,0 L 10,10 Z"
+                transform="translate(-5,-5)"
+                stroke-width="3"
+                stroke="transparent"
+                width="10"
+                height="10"
+                stroke-dasharray="0,0"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          id="node-2-node-4"
+          fill="none"
+          marker-start="false"
+          marker-end="true"
+          transform="matrix(1,0,0,1,0,0)"
+        >
+          <g
+            id="node-2-node-4"
+            fill="none"
+            marker-start="false"
+            marker-end="true"
+            stroke="transparent"
+            stroke-width="3"
+          />
+          <g transform="matrix(1,0,0,1,202.747208,109.615242)">
+            <path
+              id="key"
+              fill="none"
+              d="M 0,0 L 32.857250674668144,115.00037736133861"
+              stroke-width="1"
+              stroke="rgba(153,173,209,1)"
+              visibility="visible"
+            />
+            <path
+              id="key"
+              fill="none"
+              d="M 0,0 L 3.6739403974420594e-16,74"
+              stroke-width="3"
+              stroke="transparent"
+              visibility="visible"
+            />
+            <g transform="matrix(-0.274721,-0.961524,0.961524,-0.274721,32.857250,115.000374)">
+              <path
+                id="g-svg-23"
+                fill="rgba(153,173,209,1)"
+                d="M 0,5 L 10,0 L 10,10 Z"
+                transform="translate(-5,-5)"
+                stroke-width="1"
+                stroke="rgba(153,173,209,1)"
+                width="10"
+                height="10"
+                stroke-dasharray="0,0"
+                visibility="visible"
+              />
+              <path
+                id="g-svg-23"
+                fill="transparent"
+                d="M 0,5 L 10,0 L 10,10 Z"
+                transform="translate(-5,-5)"
+                stroke-width="3"
+                stroke="transparent"
+                width="10"
+                height="10"
+                stroke-dasharray="0,0"
+                visibility="visible"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          id="node-1-node-3"
+          fill="none"
+          marker-start="false"
+          marker-end="true"
+          transform="matrix(1,0,0,1,0,0)"
+        >
+          <g
+            id="node-1-node-3"
+            fill="none"
+            marker-start="false"
+            marker-end="true"
+            stroke="transparent"
+            stroke-width="3"
+          />
+          <g transform="matrix(1,0,0,1,100,110)">
+            <path
+              id="key"
+              fill="none"
+              d="M 0,0 L 3.6739403974420594e-16,114"
+              stroke-width="1"
+              stroke="rgba(153,173,209,1)"
+              visibility="visible"
+            />
+            <path
+              id="key"
+              fill="none"
+              d="M 0,0 L 3.6739403974420594e-16,74"
+              stroke-width="3"
+              stroke="transparent"
+              visibility="visible"
+            />
+            <g transform="matrix(0,-1,1,0,0,114)">
+              <path
+                id="g-svg-27"
+                fill="rgba(153,173,209,1)"
+                d="M 0,5 L 10,0 L 10,10 Z"
+                transform="translate(-5,-5)"
+                stroke-width="1"
+                stroke="rgba(153,173,209,1)"
+                width="10"
+                height="10"
+                stroke-dasharray="0,0"
+                visibility="visible"
+              />
+              <path
+                id="g-svg-27"
+                fill="transparent"
+                d="M 0,5 L 10,0 L 10,10 Z"
+                transform="translate(-5,-5)"
+                stroke-width="3"
+                stroke="transparent"
+                width="10"
+                height="10"
+                stroke-dasharray="0,0"
+                visibility="visible"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          id="node-3-node-4"
+          fill="none"
+          marker-start="false"
+          marker-end="true"
+          transform="matrix(1,0,0,1,0,0)"
+        >
+          <g
+            id="node-3-node-4"
+            fill="none"
+            marker-start="false"
+            marker-end="true"
+            stroke="transparent"
+            stroke-width="3"
+          />
+          <g transform="matrix(1,0,0,1,110,240)">
+            <path
+              id="key"
+              fill="none"
+              d="M 0,0 L 114,7.347880794884119e-16"
+              stroke-width="1"
+              stroke="rgba(153,173,209,1)"
+              visibility="hidden"
+            />
+            <path
+              id="key"
+              fill="none"
+              d="M 0,0 L 74,7.347880794884119e-16"
+              stroke-width="3"
+              stroke="transparent"
+              visibility="hidden"
+            />
+            <g transform="matrix(-1,0,-0,-1,114,0)">
+              <path
+                id="g-svg-31"
+                fill="rgba(153,173,209,1)"
+                d="M 0,5 L 10,0 L 10,10 Z"
+                transform="translate(-5,-5)"
+                stroke-width="1"
+                stroke="rgba(153,173,209,1)"
+                width="10"
+                height="10"
+                stroke-dasharray="0,0"
+                visibility="hidden"
+              />
+              <path
+                id="g-svg-31"
+                fill="transparent"
+                d="M 0,5 L 10,0 L 10,10 Z"
+                transform="translate(-5,-5)"
+                stroke-width="3"
+                stroke="transparent"
+                width="10"
+                height="10"
+                stroke-dasharray="0,0"
+                visibility="hidden"
+              />
+            </g>
+          </g>
+        </g>
+      </g>
+      <g id="g-svg-5" fill="none" transform="matrix(1,0,0,1,0,0)">
+        <g id="node-1" fill="none" transform="matrix(1,0,0,1,100,100)">
+          <g transform="matrix(1,0,0,1,0,0)">
+            <circle
+              id="key"
+              fill="rgba(34,126,255,1)"
+              transform="translate(-10,-10)"
+              cx="10"
+              cy="10"
+              stroke-width="0"
+              stroke="rgba(0,0,0,1)"
+              r="10"
+            />
+          </g>
+        </g>
+        <g id="node-2" fill="none" transform="matrix(1,0,0,1,200,100)">
+          <g transform="matrix(1,0,0,1,0,0)">
+            <circle
+              id="key"
+              fill="rgba(34,126,255,1)"
+              transform="translate(-10,-10)"
+              cx="10"
+              cy="10"
+              stroke-width="0"
+              stroke="rgba(0,0,0,1)"
+              r="10"
+            />
+          </g>
+        </g>
+        <g id="node-3" fill="none" transform="matrix(1,0,0,1,100,240)">
+          <g transform="matrix(1,0,0,1,0,0)">
+            <circle
+              id="key"
+              fill="rgba(34,126,255,1)"
+              transform="translate(-10,-10)"
+              cx="10"
+              cy="10"
+              stroke-width="0"
+              stroke="rgba(0,0,0,1)"
+              r="10"
+            />
+          </g>
+        </g>
+        <g id="node-4" fill="none" transform="matrix(1,0,0,1,240,240)">
+          <g transform="matrix(1,0,0,1,0,0)">
+            <circle
+              id="key"
+              fill="rgba(34,126,255,1)"
+              transform="translate(-10,-10)"
+              cx="10"
+              cy="10"
+              stroke-width="0"
+              stroke="rgba(0,0,0,1)"
+              r="10"
+            />
+          </g>
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/packages/g6/__tests__/snapshots/behaviors/behavior-drag-node/behavior-drag-node__shadow-after-drag.svg
+++ b/packages/g6/__tests__/snapshots/behaviors/behavior-drag-node/behavior-drag-node__shadow-after-drag.svg
@@ -1,0 +1,341 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="500"
+  height="500"
+  style="background: transparent; position: absolute; outline: none;"
+  color-interpolation-filters="sRGB"
+  tabindex="1"
+>
+  <defs />
+  <g id="g-svg-camera" transform="matrix(1,0,0,1,0,0)">
+    <g id="g-root" fill="none" transform="matrix(1,0,0,1,0,0)">
+      <g id="g-svg-7" fill="none" transform="matrix(1,0,0,1,0,0)">
+        <g id="combo-1" fill="none" transform="matrix(1,0,0,1,200,150)">
+          <g transform="matrix(1,0,0,1,0,0)">
+            <circle
+              id="key"
+              fill="rgba(253,253,253,1)"
+              transform="translate(-72.80109889280519,-72.80109889280519)"
+              cx="72.80109889280519"
+              cy="72.80109889280519"
+              stroke-dasharray="0,0"
+              stroke-width="1"
+              stroke="rgba(153,173,209,1)"
+              r="72.80109889280519"
+            />
+          </g>
+        </g>
+      </g>
+      <g id="g-svg-6" fill="none" transform="matrix(1,0,0,1,0,0)">
+        <g
+          id="node-1-node-2"
+          fill="none"
+          marker-start="false"
+          marker-end="true"
+          transform="matrix(1,0,0,1,0,0)"
+        >
+          <g
+            id="node-1-node-2"
+            fill="none"
+            marker-start="false"
+            marker-end="true"
+            stroke="transparent"
+            stroke-width="3"
+          />
+          <g transform="matrix(1,0,0,1,110,100)">
+            <path
+              id="key"
+              fill="none"
+              d="M 0,0 L 74,7.347880794884119e-16"
+              stroke-width="1"
+              stroke="rgba(153,173,209,1)"
+            />
+            <path
+              id="key"
+              fill="none"
+              d="M 0,0 L 74,7.347880794884119e-16"
+              stroke-width="3"
+              stroke="transparent"
+            />
+            <g transform="matrix(-1,0,-0,-1,74,0)">
+              <path
+                id="g-svg-19"
+                fill="rgba(153,173,209,1)"
+                d="M 0,5 L 10,0 L 10,10 Z"
+                transform="translate(-5,-5)"
+                stroke-width="1"
+                stroke="rgba(153,173,209,1)"
+                width="10"
+                height="10"
+                stroke-dasharray="0,0"
+              />
+              <path
+                id="g-svg-19"
+                fill="transparent"
+                d="M 0,5 L 10,0 L 10,10 Z"
+                transform="translate(-5,-5)"
+                stroke-width="3"
+                stroke="transparent"
+                width="10"
+                height="10"
+                stroke-dasharray="0,0"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          id="node-2-node-4"
+          fill="none"
+          marker-start="false"
+          marker-end="true"
+          transform="matrix(1,0,0,1,0,0)"
+        >
+          <g
+            id="node-2-node-4"
+            fill="none"
+            marker-start="false"
+            marker-end="true"
+            stroke="transparent"
+            stroke-width="3"
+          />
+          <g transform="matrix(1,0,0,1,203.511230,109.363289)">
+            <path
+              id="key"
+              fill="none"
+              d="M 0,0 L 50.87079051870184,135.65544138320485"
+              stroke-width="1"
+              stroke="rgba(153,173,209,1)"
+              visibility="visible"
+            />
+            <path
+              id="key"
+              fill="none"
+              d="M 0,0 L 3.6739403974420594e-16,74"
+              stroke-width="3"
+              stroke="transparent"
+              visibility="visible"
+            />
+            <g transform="matrix(-0.351123,-0.936329,0.936329,-0.351123,50.870792,135.655441)">
+              <path
+                id="g-svg-23"
+                fill="rgba(153,173,209,1)"
+                d="M 0,5 L 10,0 L 10,10 Z"
+                transform="translate(-5,-5)"
+                stroke-width="1"
+                stroke="rgba(153,173,209,1)"
+                width="10"
+                height="10"
+                stroke-dasharray="0,0"
+                visibility="visible"
+              />
+              <path
+                id="g-svg-23"
+                fill="transparent"
+                d="M 0,5 L 10,0 L 10,10 Z"
+                transform="translate(-5,-5)"
+                stroke-width="3"
+                stroke="transparent"
+                width="10"
+                height="10"
+                stroke-dasharray="0,0"
+                visibility="visible"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          id="node-1-node-3"
+          fill="none"
+          marker-start="false"
+          marker-end="true"
+          transform="matrix(1,0,0,1,0,0)"
+        >
+          <g
+            id="node-1-node-3"
+            fill="none"
+            marker-start="false"
+            marker-end="true"
+            stroke="transparent"
+            stroke-width="3"
+          />
+          <g transform="matrix(1,0,0,1,100,110)">
+            <path
+              id="key"
+              fill="none"
+              d="M 0,0 L 3.6739403974420594e-16,114"
+              stroke-width="1"
+              stroke="rgba(153,173,209,1)"
+              visibility="visible"
+            />
+            <path
+              id="key"
+              fill="none"
+              d="M 0,0 L 3.6739403974420594e-16,74"
+              stroke-width="3"
+              stroke="transparent"
+              visibility="visible"
+            />
+            <g transform="matrix(0,-1,1,0,0,114)">
+              <path
+                id="g-svg-27"
+                fill="rgba(153,173,209,1)"
+                d="M 0,5 L 10,0 L 10,10 Z"
+                transform="translate(-5,-5)"
+                stroke-width="1"
+                stroke="rgba(153,173,209,1)"
+                width="10"
+                height="10"
+                stroke-dasharray="0,0"
+                visibility="visible"
+              />
+              <path
+                id="g-svg-27"
+                fill="transparent"
+                d="M 0,5 L 10,0 L 10,10 Z"
+                transform="translate(-5,-5)"
+                stroke-width="3"
+                stroke="transparent"
+                width="10"
+                height="10"
+                stroke-dasharray="0,0"
+                visibility="visible"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          id="node-3-node-4"
+          fill="none"
+          marker-start="false"
+          marker-end="true"
+          transform="matrix(1,0,0,1,0,0)"
+        >
+          <g
+            id="node-3-node-4"
+            fill="none"
+            marker-start="false"
+            marker-end="true"
+            stroke="transparent"
+            stroke-width="3"
+          />
+          <g transform="matrix(1,0,0,1,109.922775,241.240341)">
+            <path
+              id="key"
+              fill="none"
+              d="M 0,0 L 134.20077520544467,16.775096900680598"
+              stroke-width="1"
+              stroke="rgba(153,173,209,1)"
+              visibility="visible"
+            />
+            <path
+              id="key"
+              fill="none"
+              d="M 0,0 L 74,7.347880794884119e-16"
+              stroke-width="3"
+              stroke="transparent"
+              visibility="visible"
+            />
+            <g transform="matrix(-0.992278,-0.124035,0.124035,-0.992278,134.200775,16.775097)">
+              <path
+                id="g-svg-31"
+                fill="rgba(153,173,209,1)"
+                d="M 0,5 L 10,0 L 10,10 Z"
+                transform="translate(-5,-5)"
+                stroke-width="1"
+                stroke="rgba(153,173,209,1)"
+                width="10"
+                height="10"
+                stroke-dasharray="0,0"
+                visibility="visible"
+              />
+              <path
+                id="g-svg-31"
+                fill="transparent"
+                d="M 0,5 L 10,0 L 10,10 Z"
+                transform="translate(-5,-5)"
+                stroke-width="3"
+                stroke="transparent"
+                width="10"
+                height="10"
+                stroke-dasharray="0,0"
+                visibility="visible"
+              />
+            </g>
+          </g>
+        </g>
+      </g>
+      <g id="g-svg-5" fill="none" transform="matrix(1,0,0,1,0,0)">
+        <g id="node-1" fill="none" transform="matrix(1,0,0,1,100,100)">
+          <g transform="matrix(1,0,0,1,0,0)">
+            <circle
+              id="key"
+              fill="rgba(34,126,255,1)"
+              transform="translate(-10,-10)"
+              cx="10"
+              cy="10"
+              stroke-width="0"
+              stroke="rgba(0,0,0,1)"
+              r="10"
+            />
+          </g>
+        </g>
+        <g id="node-2" fill="none" transform="matrix(1,0,0,1,200,100)">
+          <g transform="matrix(1,0,0,1,0,0)">
+            <circle
+              id="key"
+              fill="rgba(34,126,255,1)"
+              transform="translate(-10,-10)"
+              cx="10"
+              cy="10"
+              stroke-width="0"
+              stroke="rgba(0,0,0,1)"
+              r="10"
+            />
+          </g>
+        </g>
+        <g id="node-3" fill="none" transform="matrix(1,0,0,1,100,240)">
+          <g transform="matrix(1,0,0,1,0,0)">
+            <circle
+              id="key"
+              fill="rgba(34,126,255,1)"
+              transform="translate(-10,-10)"
+              cx="10"
+              cy="10"
+              stroke-width="0"
+              stroke="rgba(0,0,0,1)"
+              r="10"
+            />
+          </g>
+        </g>
+        <g id="node-4" fill="none" transform="matrix(1,0,0,1,260,260)">
+          <g transform="matrix(1,0,0,1,0,0)">
+            <circle
+              id="key"
+              fill="rgba(34,126,255,1)"
+              transform="translate(-10,-10)"
+              cx="10"
+              cy="10"
+              stroke-width="0"
+              stroke="rgba(0,0,0,1)"
+              r="10"
+            />
+          </g>
+        </g>
+      </g>
+      <g transform="matrix(1,0,0,1,250,250)">
+        <path
+          id="g-svg-34"
+          fill="rgba(243,249,255,1)"
+          d="M 0,0 l 20,0 l 0,20 l-20 0 z"
+          fill-opacity="0.5"
+          stroke="rgba(255,0,0,1)"
+          stroke-dasharray="5,5"
+          width="20"
+          height="20"
+          pointer-events="none"
+          visibility="hidden"
+        />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/packages/g6/__tests__/snapshots/behaviors/behavior-drag-node/behavior-drag-node__shadow.svg
+++ b/packages/g6/__tests__/snapshots/behaviors/behavior-drag-node/behavior-drag-node__shadow.svg
@@ -1,0 +1,340 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="500"
+  height="500"
+  style="background: transparent; position: absolute; outline: none;"
+  color-interpolation-filters="sRGB"
+  tabindex="1"
+>
+  <defs />
+  <g id="g-svg-camera" transform="matrix(1,0,0,1,0,0)">
+    <g id="g-root" fill="none" transform="matrix(1,0,0,1,0,0)">
+      <g id="g-svg-7" fill="none" transform="matrix(1,0,0,1,0,0)">
+        <g id="combo-1" fill="none" transform="matrix(1,0,0,1,200,150)">
+          <g transform="matrix(1,0,0,1,0,0)">
+            <circle
+              id="key"
+              fill="rgba(253,253,253,1)"
+              transform="translate(-72.80109889280519,-72.80109889280519)"
+              cx="72.80109889280519"
+              cy="72.80109889280519"
+              stroke-dasharray="0,0"
+              stroke-width="1"
+              stroke="rgba(153,173,209,1)"
+              r="72.80109889280519"
+            />
+          </g>
+        </g>
+      </g>
+      <g id="g-svg-6" fill="none" transform="matrix(1,0,0,1,0,0)">
+        <g
+          id="node-1-node-2"
+          fill="none"
+          marker-start="false"
+          marker-end="true"
+          transform="matrix(1,0,0,1,0,0)"
+        >
+          <g
+            id="node-1-node-2"
+            fill="none"
+            marker-start="false"
+            marker-end="true"
+            stroke="transparent"
+            stroke-width="3"
+          />
+          <g transform="matrix(1,0,0,1,110,100)">
+            <path
+              id="key"
+              fill="none"
+              d="M 0,0 L 74,7.347880794884119e-16"
+              stroke-width="1"
+              stroke="rgba(153,173,209,1)"
+            />
+            <path
+              id="key"
+              fill="none"
+              d="M 0,0 L 74,7.347880794884119e-16"
+              stroke-width="3"
+              stroke="transparent"
+            />
+            <g transform="matrix(-1,0,-0,-1,74,0)">
+              <path
+                id="g-svg-19"
+                fill="rgba(153,173,209,1)"
+                d="M 0,5 L 10,0 L 10,10 Z"
+                transform="translate(-5,-5)"
+                stroke-width="1"
+                stroke="rgba(153,173,209,1)"
+                width="10"
+                height="10"
+                stroke-dasharray="0,0"
+              />
+              <path
+                id="g-svg-19"
+                fill="transparent"
+                d="M 0,5 L 10,0 L 10,10 Z"
+                transform="translate(-5,-5)"
+                stroke-width="3"
+                stroke="transparent"
+                width="10"
+                height="10"
+                stroke-dasharray="0,0"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          id="node-2-node-4"
+          fill="none"
+          marker-start="false"
+          marker-end="true"
+          transform="matrix(1,0,0,1,0,0)"
+        >
+          <g
+            id="node-2-node-4"
+            fill="none"
+            marker-start="false"
+            marker-end="true"
+            stroke="transparent"
+            stroke-width="3"
+          />
+          <g transform="matrix(1,0,0,1,202.747208,109.615242)">
+            <path
+              id="key"
+              fill="none"
+              d="M 0,0 L 32.857250674668144,115.00037736133861"
+              stroke-width="1"
+              stroke="rgba(153,173,209,1)"
+              visibility="visible"
+            />
+            <path
+              id="key"
+              fill="none"
+              d="M 0,0 L 3.6739403974420594e-16,74"
+              stroke-width="3"
+              stroke="transparent"
+              visibility="visible"
+            />
+            <g transform="matrix(-0.274721,-0.961524,0.961524,-0.274721,32.857250,115.000374)">
+              <path
+                id="g-svg-23"
+                fill="rgba(153,173,209,1)"
+                d="M 0,5 L 10,0 L 10,10 Z"
+                transform="translate(-5,-5)"
+                stroke-width="1"
+                stroke="rgba(153,173,209,1)"
+                width="10"
+                height="10"
+                stroke-dasharray="0,0"
+                visibility="visible"
+              />
+              <path
+                id="g-svg-23"
+                fill="transparent"
+                d="M 0,5 L 10,0 L 10,10 Z"
+                transform="translate(-5,-5)"
+                stroke-width="3"
+                stroke="transparent"
+                width="10"
+                height="10"
+                stroke-dasharray="0,0"
+                visibility="visible"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          id="node-1-node-3"
+          fill="none"
+          marker-start="false"
+          marker-end="true"
+          transform="matrix(1,0,0,1,0,0)"
+        >
+          <g
+            id="node-1-node-3"
+            fill="none"
+            marker-start="false"
+            marker-end="true"
+            stroke="transparent"
+            stroke-width="3"
+          />
+          <g transform="matrix(1,0,0,1,100,110)">
+            <path
+              id="key"
+              fill="none"
+              d="M 0,0 L 3.6739403974420594e-16,114"
+              stroke-width="1"
+              stroke="rgba(153,173,209,1)"
+              visibility="visible"
+            />
+            <path
+              id="key"
+              fill="none"
+              d="M 0,0 L 3.6739403974420594e-16,74"
+              stroke-width="3"
+              stroke="transparent"
+              visibility="visible"
+            />
+            <g transform="matrix(0,-1,1,0,0,114)">
+              <path
+                id="g-svg-27"
+                fill="rgba(153,173,209,1)"
+                d="M 0,5 L 10,0 L 10,10 Z"
+                transform="translate(-5,-5)"
+                stroke-width="1"
+                stroke="rgba(153,173,209,1)"
+                width="10"
+                height="10"
+                stroke-dasharray="0,0"
+                visibility="visible"
+              />
+              <path
+                id="g-svg-27"
+                fill="transparent"
+                d="M 0,5 L 10,0 L 10,10 Z"
+                transform="translate(-5,-5)"
+                stroke-width="3"
+                stroke="transparent"
+                width="10"
+                height="10"
+                stroke-dasharray="0,0"
+                visibility="visible"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          id="node-3-node-4"
+          fill="none"
+          marker-start="false"
+          marker-end="true"
+          transform="matrix(1,0,0,1,0,0)"
+        >
+          <g
+            id="node-3-node-4"
+            fill="none"
+            marker-start="false"
+            marker-end="true"
+            stroke="transparent"
+            stroke-width="3"
+          />
+          <g transform="matrix(1,0,0,1,110,240)">
+            <path
+              id="key"
+              fill="none"
+              d="M 0,0 L 114,7.347880794884119e-16"
+              stroke-width="1"
+              stroke="rgba(153,173,209,1)"
+              visibility="visible"
+            />
+            <path
+              id="key"
+              fill="none"
+              d="M 0,0 L 74,7.347880794884119e-16"
+              stroke-width="3"
+              stroke="transparent"
+              visibility="visible"
+            />
+            <g transform="matrix(-1,0,-0,-1,114,0)">
+              <path
+                id="g-svg-31"
+                fill="rgba(153,173,209,1)"
+                d="M 0,5 L 10,0 L 10,10 Z"
+                transform="translate(-5,-5)"
+                stroke-width="1"
+                stroke="rgba(153,173,209,1)"
+                width="10"
+                height="10"
+                stroke-dasharray="0,0"
+                visibility="visible"
+              />
+              <path
+                id="g-svg-31"
+                fill="transparent"
+                d="M 0,5 L 10,0 L 10,10 Z"
+                transform="translate(-5,-5)"
+                stroke-width="3"
+                stroke="transparent"
+                width="10"
+                height="10"
+                stroke-dasharray="0,0"
+                visibility="visible"
+              />
+            </g>
+          </g>
+        </g>
+      </g>
+      <g id="g-svg-5" fill="none" transform="matrix(1,0,0,1,0,0)">
+        <g id="node-1" fill="none" transform="matrix(1,0,0,1,100,100)">
+          <g transform="matrix(1,0,0,1,0,0)">
+            <circle
+              id="key"
+              fill="rgba(34,126,255,1)"
+              transform="translate(-10,-10)"
+              cx="10"
+              cy="10"
+              stroke-width="0"
+              stroke="rgba(0,0,0,1)"
+              r="10"
+            />
+          </g>
+        </g>
+        <g id="node-2" fill="none" transform="matrix(1,0,0,1,200,100)">
+          <g transform="matrix(1,0,0,1,0,0)">
+            <circle
+              id="key"
+              fill="rgba(34,126,255,1)"
+              transform="translate(-10,-10)"
+              cx="10"
+              cy="10"
+              stroke-width="0"
+              stroke="rgba(0,0,0,1)"
+              r="10"
+            />
+          </g>
+        </g>
+        <g id="node-3" fill="none" transform="matrix(1,0,0,1,100,240)">
+          <g transform="matrix(1,0,0,1,0,0)">
+            <circle
+              id="key"
+              fill="rgba(34,126,255,1)"
+              transform="translate(-10,-10)"
+              cx="10"
+              cy="10"
+              stroke-width="0"
+              stroke="rgba(0,0,0,1)"
+              r="10"
+            />
+          </g>
+        </g>
+        <g id="node-4" fill="none" transform="matrix(1,0,0,1,240,240)">
+          <g transform="matrix(1,0,0,1,0,0)">
+            <circle
+              id="key"
+              fill="rgba(34,126,255,1)"
+              transform="translate(-10,-10)"
+              cx="10"
+              cy="10"
+              stroke-width="0"
+              stroke="rgba(0,0,0,1)"
+              r="10"
+            />
+          </g>
+        </g>
+      </g>
+      <g transform="matrix(1,0,0,1,250,250)">
+        <path
+          id="g-svg-34"
+          fill="rgba(243,249,255,1)"
+          d="M 0,0 l 20,0 l 0,20 l-20 0 z"
+          fill-opacity="0.5"
+          stroke="rgba(255,0,0,1)"
+          stroke-dasharray="5,5"
+          width="20"
+          height="20"
+          pointer-events="none"
+        />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/packages/g6/__tests__/unit/behaviors/behavior-drag-node.spec.ts
+++ b/packages/g6/__tests__/unit/behaviors/behavior-drag-node.spec.ts
@@ -1,0 +1,50 @@
+import { CommonEvent, type Graph } from '@/src';
+import { behaviorDragNode } from '@@/demo/case';
+import { createDemoGraph } from '@@/utils';
+
+describe('behavior drag node', () => {
+  let graph: Graph;
+
+  beforeAll(async () => {
+    graph = await createDemoGraph(behaviorDragNode, { animation: false });
+  });
+
+  it('default status', async () => {
+    await expect(graph.getCanvas()).toMatchSnapshot(__filename);
+
+    graph.emit(`node:${CommonEvent.DRAG_START}`, { target: { id: 'node-4' } });
+    graph.emit(`node:${CommonEvent.DRAG}`, { dx: 20, dy: 20 });
+    graph.emit(`node:${CommonEvent.DRAG_END}`);
+
+    await expect(graph.getCanvas()).toMatchSnapshot(__filename, '{name}__after-drag');
+  });
+
+  it('hide edges', async () => {
+    graph.setBehaviors([{ type: 'drag-node', hideEdges: 'both' }]);
+    graph.emit(`node:${CommonEvent.DRAG_START}`, { target: { id: 'node-4' } });
+    graph.emit(`node:${CommonEvent.DRAG}`, { dx: 20, dy: 20 });
+    await expect(graph.getCanvas()).toMatchSnapshot(__filename, '{name}__hideEdges-both');
+    graph.emit(`node:${CommonEvent.DRAG_END}`);
+
+    graph.setBehaviors([{ type: 'drag-node', hideEdges: 'in' }]);
+    graph.emit(`node:${CommonEvent.DRAG_START}`, { target: { id: 'node-3' } });
+    graph.emit(`node:${CommonEvent.DRAG}`, { dx: 0, dy: 20 });
+    await expect(graph.getCanvas()).toMatchSnapshot(__filename, '{name}__hideEdges-in');
+    graph.emit(`node:${CommonEvent.DRAG_END}`);
+
+    graph.setBehaviors([{ type: 'drag-node', hideEdges: 'out' }]);
+    graph.emit(`node:${CommonEvent.DRAG_START}`, { target: { id: 'node-3' } });
+    graph.emit(`node:${CommonEvent.DRAG}`, { dx: 0, dy: 20 });
+    await expect(graph.getCanvas()).toMatchSnapshot(__filename, '{name}__hideEdges-out');
+    graph.emit(`node:${CommonEvent.DRAG_END}`);
+  });
+
+  it('shadow', async () => {
+    graph.setBehaviors([{ type: 'drag-node', shadow: true, shadowStroke: 'red', shadowStrokeOpacity: 1 }]);
+    graph.emit(`node:${CommonEvent.DRAG_START}`, { target: { id: 'node-4' } });
+    graph.emit(`node:${CommonEvent.DRAG}`, { dx: 20, dy: 20 });
+    await expect(graph.getCanvas()).toMatchSnapshot(__filename, '{name}__shadow');
+    graph.emit(`node:${CommonEvent.DRAG_END}`);
+    await expect(graph.getCanvas()).toMatchSnapshot(__filename, '{name}__shadow-after-drag');
+  });
+});

--- a/packages/g6/__tests__/unit/runtime/data.spec.ts
+++ b/packages/g6/__tests__/unit/runtime/data.spec.ts
@@ -1,4 +1,4 @@
-import { treeToGraphData } from '@/src';
+import { Utils } from '@/src';
 import { DataController } from '@/src/runtime/data';
 import { reduceDataChanges } from '@/src/utils/change';
 import tree from '@@/dataset/algorithm-category.json';
@@ -547,7 +547,7 @@ describe('DataController', () => {
   it('getParentData getChildrenData', () => {
     const controller = new DataController();
 
-    controller.addData(treeToGraphData(tree));
+    controller.addData(Utils.treeToGraphData(tree));
 
     expect(controller.getParentData('Classification')?.id).toBe(tree.id);
 

--- a/packages/g6/__tests__/unit/spec/optimize.spec.ts
+++ b/packages/g6/__tests__/unit/spec/optimize.spec.ts
@@ -1,11 +1,5 @@
-import type { OptimizeOptions } from '@/src';
-
 describe('spec optimize', () => {
   it('optimize 1', () => {
-    const optimize: OptimizeOptions = {
-      tileFirstRender: true,
-    };
-
-    expect(optimize).toBeTruthy();
+    expect(1).toBe(1);
   });
 });

--- a/packages/g6/__tests__/unit/utils/cache.spec.ts
+++ b/packages/g6/__tests__/unit/utils/cache.spec.ts
@@ -1,8 +1,8 @@
-import { cacheStyle, getCachedStyle } from '@/src/utils/cache';
+import { cacheStyle, getCachedStyle, setCacheStyle } from '@/src/utils/cache';
 import { Circle } from '@antv/g';
 
 describe('cache', () => {
-  it('cacheStyle and ', () => {
+  it('cacheStyle and getCachedStyle and setCacheStyle', () => {
     const circle = new Circle({
       style: {
         r: 10,
@@ -16,5 +16,9 @@ describe('cache', () => {
     circle.style.fill = 'green';
 
     expect(getCachedStyle(circle, 'fill')).toBe('red');
+
+    setCacheStyle(circle, 'fill', 'yellow');
+
+    expect(getCachedStyle(circle, 'fill')).toBe('yellow');
   });
 });

--- a/packages/g6/__tests__/utils/create.ts
+++ b/packages/g6/__tests__/utils/create.ts
@@ -7,7 +7,6 @@ import { resetEntityCounter } from '@antv/g';
 import { Renderer as CanvasRenderer } from '@antv/g-canvas';
 import { Plugin as Plugin3D } from '@antv/g-plugin-3d';
 import { Plugin as PluginControl } from '@antv/g-plugin-control';
-import { Plugin as DragAndDropPlugin } from '@antv/g-plugin-dragndrop';
 import { Renderer as SVGRenderer } from '@antv/g-svg';
 import { Renderer as WebGLRenderer } from '@antv/g-webgl';
 import type { STDTestCase, STDTestCaseContext } from '../demo/types';
@@ -55,7 +54,6 @@ export function createGraphCanvas(
   const context = new OffscreenCanvasContext(offscreenNodeCanvas);
 
   const instance = getRenderer(renderer) as any as IRenderer;
-  instance.registerPlugin(new DragAndDropPlugin({ dragstartDistanceThreshold: 10 }));
   return new Canvas({
     container,
     width,

--- a/packages/g6/__tests__/utils/to-match-svg-snapshot.ts
+++ b/packages/g6/__tests__/utils/to-match-svg-snapshot.ts
@@ -1,3 +1,4 @@
+import { Canvas as LayeredCanvas } from '@/src/runtime/canvas';
 import { Canvas } from '@antv/g';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -97,10 +98,10 @@ export async function toMatchSVGSnapshot(
 }
 
 export async function toMatchSnapshot(
-  gCanvas: Canvas | Canvas[],
+  canvas: LayeredCanvas,
   dir: string,
   format: string = '{name}',
   options: ToMatchSVGSnapshotOptions = {},
 ) {
-  return await toMatchSVGSnapshot(gCanvas, ...getSnapshotDir(dir, format), options);
+  return await toMatchSVGSnapshot(Object.values(canvas.canvas), ...getSnapshotDir(dir, format), options);
 }

--- a/packages/g6/src/behaviors/drag-node.ts
+++ b/packages/g6/src/behaviors/drag-node.ts
@@ -1,0 +1,233 @@
+import type { BaseStyleProps, FederatedMouseEvent } from '@antv/g';
+import { Rect } from '@antv/g';
+import { ID } from '@antv/graphlib';
+import { isFunction } from '@antv/util';
+import { CommonEvent } from '../constants';
+import { RuntimeContext } from '../runtime/types';
+import type { BehaviorEvent, EdgeDirection, Point, PrefixObject } from '../types';
+import { getBBoxSize, getCombinedBBox } from '../utils/bbox';
+import { idOf } from '../utils/id';
+import { subStyleProps } from '../utils/prefix';
+import { subtract } from '../utils/vector';
+import { BaseBehavior, BaseBehaviorOptions } from './base-behavior';
+
+export interface DragNodeOptions extends BaseBehaviorOptions, PrefixObject<BaseStyleProps, 'shadow'> {
+  /**
+   * <zh/> 是否启用拖拽动画
+   *
+   * <en/> Whether to enable drag animation
+   */
+  animation: boolean;
+  /**
+   * <zh/> 是否启用拖拽节点的功能
+   *
+   * <en/> Whether to enable the function of dragging the node
+   */
+  enable?: boolean | ((event: BehaviorEvent<FederatedMouseEvent> | BehaviorEvent<KeyboardEvent>) => boolean);
+  /**
+   * <zh/> 节点选中的状态，启用多选时会基于该状态查找选中的节点
+   *
+   * <en/> The state name of the selected node, when multi-selection is enabled, the selected nodes will be found based on this state
+   */
+  state?: string;
+  /**
+   * <zh/> 拖拽时隐藏的边
+   * - none: 不隐藏
+   * - out: 隐藏以节点为源节点的边
+   * - in: 隐藏以节点为目标节点的边
+   * - both: 隐藏与节点相关的所有边
+   * - all: 隐藏图中所有边
+   *
+   * <en/> Edges hidden during dragging
+   * - none: do not hide
+   * - out: hide the edges with the node as the source node
+   * - in: hide the edges with the node as the target node
+   * - both: hide all edges related to the node
+   * - all: hide all edges in the graph
+   * @description
+   * <zh/> 使用幽灵节点时不会隐藏边
+   *
+   * <en/> Edges will not be hidden when using the drag shadow
+   */
+  hideEdges?: 'none' | 'all' | EdgeDirection;
+  /**
+   * <zh/> 是否启用幽灵节点，即用一个图形代替节点跟随鼠标移动
+   *
+   * <en/> Whether to enable the drag shadow, that is, use a shape to replace the node to follow the mouse movement
+   */
+  shadow?: boolean;
+  /**
+   * <zh/> 完成拖拽时的回调
+   *
+   * <en/> Callback when dragging is completed
+   */
+  onfinish?: (ids: ID[]) => void;
+}
+
+export class DragNode extends BaseBehavior<DragNodeOptions> {
+  static defaultOptions: Partial<DragNodeOptions> = {
+    animation: true,
+    enable: true,
+    state: 'selected',
+    hideEdges: 'none',
+    shadowZIndex: 100,
+    shadowFill: '#F3F9FF',
+    shadowFillOpacity: 0.5,
+    shadowStroke: '#1890FF',
+    shadowStrokeOpacity: 0.9,
+    shadowLineDash: [5, 5],
+  };
+
+  private enable: boolean = false;
+
+  private target: ID[] = [];
+
+  private shadow?: Rect;
+
+  private shadowOrigin: Point = [0, 0];
+
+  private hiddenEdges: ID[] = [];
+
+  private get animation() {
+    if (!this.options.shadow) return false;
+    return this.options.animation;
+  }
+
+  constructor(context: RuntimeContext, options: DragNodeOptions) {
+    super(context, Object.assign({}, DragNode.defaultOptions, options));
+    this.bindEvents();
+  }
+
+  private bindEvents() {
+    const { graph } = this.context;
+    graph.on(`node:${CommonEvent.DRAG_START}`, this.onDragStart);
+    graph.on(`node:${CommonEvent.DRAG}`, this.onDrag);
+    graph.on(`node:${CommonEvent.DRAG_END}`, this.onDragEnd);
+  }
+
+  private getSelectedNodeIDs(currTarget: ID[]) {
+    return Array.from(
+      new Set(
+        this.context.graph
+          .getElementDataByState('node', this.options.state)
+          .map((node) => node.id)
+          .concat(currTarget),
+      ),
+    );
+  }
+
+  private onDragStart = (event: DragEvent) => {
+    this.enable = this.validate(event);
+    if (!this.enable) return;
+
+    this.target = this.getSelectedNodeIDs([event.target.id]);
+    this.hideEdges();
+    if (this.options.shadow) this.createShadow(this.target);
+  };
+
+  private onDrag = (event: DragEvent) => {
+    if (!this.enable) return;
+    const { dx, dy } = event;
+
+    if (this.options.shadow) this.moveShadow([dx, dy]);
+    else this.moveNode(this.target, [dx, dy]);
+  };
+
+  private onDragEnd = () => {
+    this.enable = false;
+    if (this.options.shadow) {
+      if (!this.shadow) return;
+      this.shadow.style.visibility = 'hidden';
+      const { x = 0, y = 0 } = this.shadow.attributes;
+      const [dx, dy] = subtract([+x, +y], this.shadowOrigin);
+      this.moveNode(this.target, [dx, dy]);
+    }
+    this.showEdges();
+    this.options.onfinish?.(this.target);
+    this.target = [];
+  };
+
+  private validate(event: DragEvent) {
+    if (this.destroyed) return false;
+    const { enable } = this.options;
+    if (isFunction(enable)) return enable(event);
+    return !!enable;
+  }
+
+  private moveNode(ids: ID[], offset: Point) {
+    this.context.graph.translateElementBy(Object.fromEntries(ids.map((id) => [id, offset])), this.animation);
+  }
+
+  private moveShadow(offset: Point) {
+    if (!this.shadow) return;
+    const { x = 0, y = 0 } = this.shadow.attributes;
+    const [dx, dy] = offset;
+    this.shadow.attr({ x: +x + dx, y: +y + dy });
+  }
+
+  private createShadow(target: ID[]) {
+    const shadowStyle = subStyleProps(this.options, 'shadow');
+
+    const bbox = getCombinedBBox(target.map((id) => this.context.element!.getElement(id)!.getBounds()));
+    const [x, y] = bbox.min;
+    this.shadowOrigin = [x, y];
+    const [width, height] = getBBoxSize(bbox);
+    const positionStyle = { width, height, x, y };
+
+    if (this.shadow) {
+      this.shadow.attr({
+        ...shadowStyle,
+        ...positionStyle,
+        visibility: 'visible',
+      });
+    } else {
+      this.shadow = new Rect({
+        style: {
+          ...shadowStyle,
+          ...positionStyle,
+          pointerEvents: 'none',
+          // @ts-expect-error $layer is not in the type definition
+          $layer: 'transient',
+        },
+      });
+      this.context.canvas.appendChild(this.shadow);
+    }
+  }
+
+  private showEdges() {
+    if (this.options.shadow || this.hiddenEdges.length === 0) return;
+    this.context.graph.setElementVisibility(this.hiddenEdges, 'visible');
+    this.hiddenEdges = [];
+  }
+
+  private hideEdges() {
+    const { hideEdges, shadow } = this.options;
+    if (hideEdges === 'none' || shadow) return;
+    const { graph } = this.context;
+    let hiddenEdges: ID[] = [];
+    if (hideEdges === 'all') {
+      hiddenEdges = graph.getEdgeData().map((edge) => idOf(edge));
+    } else {
+      const edgeSet = new Set<ID>();
+      this.target.forEach((id) => {
+        graph.getRelatedEdgesData(id, hideEdges).forEach((edge) => edgeSet.add(idOf(edge)));
+      });
+      hiddenEdges = Array.from(edgeSet);
+    }
+    this.hiddenEdges = hiddenEdges;
+    graph.setElementVisibility(hiddenEdges, 'hidden');
+  }
+
+  public destroy() {
+    this.context.graph.off(`node:${CommonEvent.DRAG_START}`, this.onDragStart);
+    this.context.graph.off(`node:${CommonEvent.DRAG}`, this.onDrag);
+    this.context.graph.off(`node:${CommonEvent.DRAG_END}`, this.onDragEnd);
+    this.shadow?.destroy();
+    super.destroy();
+  }
+}
+
+interface DragEvent extends BehaviorEvent<FederatedMouseEvent> {
+  dx: number;
+  dy: number;
+}

--- a/packages/g6/src/behaviors/index.ts
+++ b/packages/g6/src/behaviors/index.ts
@@ -1,7 +1,9 @@
 export { BaseBehavior } from './base-behavior';
 export { DragCanvas } from './drag-canvas';
+export { DragNode } from './drag-node';
 export { ZoomCanvas } from './zoom-canvas';
 
 export type { BaseBehaviorOptions } from './base-behavior';
 export type { DragCanvasOptions } from './drag-canvas';
+export type { DragNodeOptions } from './drag-node';
 export type { ZoomCanvasOptions } from './zoom-canvas';

--- a/packages/g6/src/elements/combos/base-combo.ts
+++ b/packages/g6/src/elements/combos/base-combo.ts
@@ -35,17 +35,19 @@ export abstract class BaseCombo<S extends BaseComboStyleProps = BaseComboStylePr
   public type = 'combo';
 
   static defaultStyleProps: BaseComboStyleProps = {
+    size: 0,
+    padding: 0,
     children: [],
+    droppable: true,
+    draggable: true,
     collapsed: false,
+    collapsedSize: 32,
+    collapsedOrigin: [0.5, 0.5],
     collapsedMarker: true,
     collapsedMarkerFontSize: 12,
     collapsedMarkerTextAlign: 'center',
     collapsedMarkerTextBaseline: 'middle',
     collapsedMarkerType: 'child-count',
-    collapsedOrigin: [0.5, 0.5],
-    collapsedSize: 32,
-    padding: 0,
-    size: 0,
   };
   constructor(options: DisplayObjectConfig<BaseComboStyleProps>) {
     super(deepMix({}, { style: BaseCombo.defaultStyleProps }, options));

--- a/packages/g6/src/elements/nodes/base-node.ts
+++ b/packages/g6/src/elements/nodes/base-node.ts
@@ -58,6 +58,8 @@ export abstract class BaseNode<S extends BaseNodeStyleProps = any> extends BaseS
     x: 0,
     y: 0,
     size: 32,
+    droppable: true,
+    draggable: true,
     port: true,
     ports: [],
     portZIndex: 2,

--- a/packages/g6/src/exports.ts
+++ b/packages/g6/src/exports.ts
@@ -1,0 +1,45 @@
+import { dark, light } from './themes';
+import { idOf } from './utils/id';
+import { treeToGraphData } from './utils/tree';
+
+export { BaseBehavior } from './behaviors';
+export { CanvasEvent, ComboEvent, CommonEvent, ContainerEvent, EdgeEvent, GraphEvent, NodeEvent } from './constants';
+export { BaseCombo } from './elements/combos';
+export { BaseEdge } from './elements/edges';
+export { BaseNode } from './elements/nodes';
+export { getExtension, getExtensions, register } from './registry';
+export { Graph } from './runtime/graph';
+
+export type { BaseBehaviorOptions } from './behaviors';
+export type { BaseComboStyleProps } from './elements/combos';
+export type { BaseEdgeStyleProps } from './elements/edges';
+export type { BaseNodeStyleProps } from './elements/nodes';
+export type {
+  BehaviorOptions,
+  CanvasOptions,
+  ComboData,
+  ComboOptions,
+  EdgeData,
+  EdgeOptions,
+  G6Spec,
+  GraphData,
+  LayoutOptions,
+  NodeData,
+  NodeOptions,
+  PluginOptions,
+  ThemeOptions,
+  ViewportOptions,
+} from './spec';
+export type { Point, Vector2, Vector3 } from './types';
+
+const Utils = {
+  idOf,
+  treeToGraphData,
+};
+
+const Theme = {
+  dark,
+  light,
+};
+
+export { Theme, Utils };

--- a/packages/g6/src/index.ts
+++ b/packages/g6/src/index.ts
@@ -1,36 +1,5 @@
 import './preset';
 
 export const version = '5.0.0';
-export { BaseBehavior } from './behaviors';
-export { CanvasEvent, ComboEvent, CommonEvent, ContainerEvent, EdgeEvent, GraphEvent, NodeEvent } from './constants';
-export { BaseCombo } from './elements/combos';
-export { BaseEdge } from './elements/edges';
-export { BaseNode } from './elements/nodes';
-export { getExtension, getExtensions, register } from './registry';
-export { Graph } from './runtime/graph';
-export { dark, light } from './themes';
-export { idOf } from './utils/id';
-export { treeToGraphData } from './utils/tree';
 
-export type { BaseBehaviorOptions } from './behaviors';
-export type { BaseComboStyleProps } from './elements/combos';
-export type { BaseEdgeStyleProps } from './elements/edges';
-export type { BaseNodeStyleProps } from './elements/nodes';
-export type {
-  BehaviorOptions,
-  CanvasOptions,
-  ComboData,
-  ComboOptions,
-  EdgeData,
-  EdgeOptions,
-  G6Spec,
-  GraphData,
-  LayoutOptions,
-  NodeData,
-  NodeOptions,
-  OptimizeOptions,
-  PluginOptions,
-  ThemeOptions,
-  ViewportOptions,
-} from './spec';
-export type { Point, Vector2, Vector3 } from './types';
+export * from './exports';

--- a/packages/g6/src/index.ts
+++ b/packages/g6/src/index.ts
@@ -9,6 +9,7 @@ export { BaseNode } from './elements/nodes';
 export { getExtension, getExtensions, register } from './registry';
 export { Graph } from './runtime/graph';
 export { dark, light } from './themes';
+export { idOf } from './utils/id';
 export { treeToGraphData } from './utils/tree';
 
 export type { BaseBehaviorOptions } from './behaviors';

--- a/packages/g6/src/registry/build-in.ts
+++ b/packages/g6/src/registry/build-in.ts
@@ -1,5 +1,5 @@
 import { fade, translate } from '../animations';
-import { DragCanvas, ZoomCanvas } from '../behaviors';
+import { DragCanvas, DragNode, ZoomCanvas } from '../behaviors';
 import {
   Circle,
   CircleCombo,
@@ -52,6 +52,7 @@ export const BUILT_IN_EXTENSIONS: ExtensionRegistry = {
   behavior: {
     'zoom-canvas': ZoomCanvas,
     'drag-canvas': DragCanvas,
+    'drag-node': DragNode,
   },
   combo: {
     circle: CircleCombo,

--- a/packages/g6/src/runtime/element.ts
+++ b/packages/g6/src/runtime/element.ts
@@ -771,7 +771,7 @@ export class ElementController {
     delete this.runtimeStyle[id];
   }
 
-  public async setElementsVisibility(ids: ID[], visibility: BaseStyleProps['visibility']) {
+  public async setElementsVisibility(ids: ID[], visibility: BaseStyleProps['visibility'], animation?: boolean) {
     if (ids.length === 0) return null;
 
     const isHide = visibility === 'hidden';
@@ -811,7 +811,7 @@ export class ElementController {
     const tasks: AnimatableTask[] = [];
     iteration.forEach(([elementType, elementIds]) => {
       if (elementIds.length === 0) return;
-      const animator = this.getAnimationExecutor(elementType, isHide ? 'hide' : 'show');
+      const animator = this.getAnimationExecutor(elementType, isHide ? 'hide' : 'show', animation);
       elementIds.forEach((id) => {
         const element = this.getElement(id);
         if (!element) return;

--- a/packages/g6/src/runtime/element.ts
+++ b/packages/g6/src/runtime/element.ts
@@ -3,7 +3,7 @@
 import type { BaseStyleProps, DisplayObject, IAnimation } from '@antv/g';
 import { Group } from '@antv/g';
 import type { ID } from '@antv/graphlib';
-import { groupBy, pick } from '@antv/util';
+import { groupBy, isUndefined, pick } from '@antv/util';
 import { executor as animationExecutor } from '../animations';
 import type { AnimationContext } from '../animations/types';
 import { AnimationType, ChangeTypeEnum, GraphEvent } from '../constants';
@@ -32,10 +32,10 @@ import type {
 } from '../types';
 import { executeAnimatableTasks, inferDefaultValue, withAnimationCallbacks } from '../utils/animation';
 import { deduplicate } from '../utils/array';
-import { cacheStyle, getCachedStyle } from '../utils/cache';
+import { cacheStyle, getCachedStyle, setCacheStyle } from '../utils/cache';
 import { reduceDataChanges } from '../utils/change';
 import { isEmptyData } from '../utils/data';
-import { isVisible, updateStyle } from '../utils/element';
+import { updateStyle } from '../utils/element';
 import type { BaseEvent } from '../utils/event';
 import {
   AnimateEvent,
@@ -792,20 +792,40 @@ export class ElementController {
       ['combo', combos],
     ];
 
-    const show = (id: ID, element: DisplayObject, animator: AnimationExecutor) => {
-      const originalOpacity = getCachedStyle(element, 'opacity') ?? element.style.opacity ?? 1;
-      cacheStyle(element, 'opacity');
+    const cacheOpacity = (element: DisplayObject) => {
+      if (isUndefined(getCachedStyle(element, 'opacity'))) cacheStyle(element, 'opacity');
+    };
 
+    const show = (id: ID, element: DisplayObject, animator: AnimationExecutor) => {
+      const originalOpacity =
+        getCachedStyle(element, 'opacity') ?? element.style.opacity ?? inferDefaultValue('opacity');
+      cacheOpacity(element);
+      // 由于 show 和 hide 的时序存在差异
+      // - show： 立即将元素显示出来，然后执行动画
+      // - hide： 先执行动画，然后隐藏元素
+      // 如果在调用 hide 后立即调用 show，hide 动画完成后会将元素隐藏
+      // 因此需要缓存元素最新的可见性
+      //
+      // Due to the difference in the timing of show and hide
+      // - show: immediately shows the element and then executes the animation
+      // - hide: executes the animation first, and then hides the element
+      // If show is called immediately after hide,it hide the element after hide animation completed
+      // Therefore, the latest visibility of the element needs to be cached
+      setCacheStyle(element, 'visibility', visibility);
       setVisibility(element, visibility);
       return animator(id, element, { ...element.attributes, opacity: 0 }, { opacity: originalOpacity });
     };
 
     const hide = (id: ID, element: DisplayObject, animator: AnimationExecutor) => {
-      const originalOpacity = getCachedStyle(element, 'opacity') ?? element.style.opacity ?? 1;
-      cacheStyle(element, 'opacity');
+      const originalOpacity =
+        getCachedStyle(element, 'opacity') ?? element.style.opacity ?? inferDefaultValue('opacity');
 
+      cacheOpacity(element);
+      setCacheStyle(element, 'visibility', visibility);
       const animation = animator(id, element, { ...element.attributes, opacity: originalOpacity }, { opacity: 0 });
-      return withAnimationCallbacks(animation, { after: () => setVisibility(element, visibility) });
+      return withAnimationCallbacks(animation, {
+        after: () => setVisibility(element, getCachedStyle(element, 'visibility')),
+      });
     };
 
     const tasks: AnimatableTask[] = [];
@@ -814,14 +834,9 @@ export class ElementController {
       const animator = this.getAnimationExecutor(elementType, isHide ? 'hide' : 'show', animation);
       elementIds.forEach((id) => {
         const element = this.getElement(id);
-        if (!element) return;
-        if (!isVisible(element)) {
-          if (isHide) return;
-        } else if (!isHide) return;
-
-        tasks.push(() => {
-          return () => (isHide ? hide : show)(id, element, animator);
-        });
+        if (element) {
+          tasks.push(() => () => (isHide ? hide : show)(id, element, animator));
+        }
       });
     });
 

--- a/packages/g6/src/runtime/graph.ts
+++ b/packages/g6/src/runtime/graph.ts
@@ -607,8 +607,12 @@ export class Graph extends EventEmitter {
     return omit(this.context.element!.getElement(id)!.attributes, ['context']);
   }
 
-  public async setElementVisibility(id: ID | ID[], visibility: BaseStyleProps['visibility']): Promise<void> {
-    await this.context.element!.setElementsVisibility(Array.isArray(id) ? id : [id], visibility);
+  public async setElementVisibility(
+    id: ID | ID[],
+    visibility: BaseStyleProps['visibility'],
+    animation?: boolean,
+  ): Promise<void> {
+    await this.context.element!.setElementsVisibility(Array.isArray(id) ? id : [id], visibility, animation);
   }
 
   public getElementVisibility(id: ID): BaseStyleProps['visibility'] {

--- a/packages/g6/src/types/behavior.ts
+++ b/packages/g6/src/types/behavior.ts
@@ -1,5 +1,6 @@
-import type { FederatedEvent } from '@antv/g';
+import type { DisplayObject, FederatedEvent } from '@antv/g';
 
-export type BehaviorEvent<T extends Event | FederatedEvent = Event> = T & {
+export type BehaviorEvent<T extends Event | FederatedEvent = Event> = Omit<T, 'target'> & {
   targetType: 'canvas' | 'node' | 'edge' | 'combo';
+  target: DisplayObject;
 };

--- a/packages/g6/src/utils/cache.ts
+++ b/packages/g6/src/utils/cache.ts
@@ -31,3 +31,15 @@ export function cacheStyle(element: DisplayObject, name: string | string[]) {
 export function getCachedStyle(element: DisplayObject, name: string) {
   return element.attributes[getStyleCacheKey(name)];
 }
+
+/**
+ * <zh/> 设置缓存的样式
+ *
+ * <en/> Set cached style
+ * @param element - <zh/> 图形元素 | <en/> graphic element
+ * @param name - <zh/> 样式名 | <en/> style name
+ * @param value - <zh/> 样式值 | <en/> style value
+ */
+export function setCacheStyle(element: DisplayObject, name: string, value: any) {
+  element.attributes[getStyleCacheKey(name)] = value;
+}


### PR DESCRIPTION
**默认交互/Default Behavior**
![Mar-07-2024 17-19-55](https://github.com/antvis/G6/assets/25787943/7c442ae5-ee33-41f8-a2b7-edb961bdf6bf)

**幽灵拖拽/Drag Shadow**
![Mar-07-2024 17-18-16](https://github.com/antvis/G6/assets/25787943/2ea111ac-4045-4216-b8b7-16c4697f00eb)

**隐藏边/hideEdges**
![Mar-07-2024 17-18-25](https://github.com/antvis/G6/assets/25787943/7b737079-47ed-4738-87d2-51a3b275a866)

**关闭动画/Disable Animation**
![Mar-07-2024 17-18-31](https://github.com/antvis/G6/assets/25787943/ebc00802-910c-49d9-8241-5c8f3b63878e)
![Mar-07-2024 17-18-45](https://github.com/antvis/G6/assets/25787943/90644b29-3bbe-40c5-8638-a74c9e839f7d)


* 新增 `DragNode` 交互，支持以下能力：
  * 拖拽过程中隐藏边，可配置临边、入边、出边 、所有边
  * 支持幽灵拖拽（Drag Shadow）
* 修复了 show/hide 方法连续调用时导致异常的问题
* 修复了边箭头的绘制问题 https://github.com/antvis/G6/issues/5502

---

* Add `DragNode` behavior, which supports the following capabilities:
  * The edge can be hidden during the dragging process, and 'both', 'in', 'out', and 'all' edges can be configured
  * Support ghost dragging (Drag Shadow)
  * Fixed issue that caused an exception when the show/hide method was called consecutively
  * Fixed issue with drawing edge arrows https://github.com/antvis/G6/issues/5502