### PR TITLE
feat(runtime): add getPluginInstance API

### DIFF
--- a/packages/g6/__tests__/unit/runtime/graph/get-plugin-instantce.spec.ts
+++ b/packages/g6/__tests__/unit/runtime/graph/get-plugin-instantce.spec.ts
@@ -1,0 +1,35 @@
+import { BasePlugin, register } from '@/src';
+import { createGraph } from '@@/utils';
+
+describe('getPluginInstance', () => {
+  it('getPluginInstance', async () => {
+    const fn = jest.fn();
+
+    class CustomPlugin extends BasePlugin<any> {
+      // plugin api
+      api() {
+        fn();
+      }
+    }
+
+    register('plugin', 'custom', CustomPlugin);
+    const graph = await createGraph({
+      plugins: [
+        {
+          key: 'custom-plugin',
+          type: 'custom',
+        },
+      ],
+    });
+
+    await graph.draw();
+
+    const plugin = graph.getPluginInstance<CustomPlugin>('custom-plugin');
+    expect(plugin instanceof CustomPlugin).toBe(true);
+    plugin.api();
+    expect(fn).toHaveBeenCalled();
+
+    const undefinedPlugin = graph.getPluginInstance<CustomPlugin>('undefined-plugin');
+    expect(undefinedPlugin).toBe(undefined);
+  });
+});

--- a/packages/g6/src/runtime/graph.ts
+++ b/packages/g6/src/runtime/graph.ts
@@ -3,6 +3,7 @@ import type { AABB, BaseStyleProps, DataURLOptions } from '@antv/g';
 import type { ID } from '@antv/graphlib';
 import { debounce, isEqual, isFunction, isNumber, isObject, isString, omit } from '@antv/util';
 import { COMBO_KEY, GraphEvent } from '../constants';
+import type { Plugin } from '../plugins/types';
 import { getExtension } from '../registry';
 import type {
   BehaviorOptions,
@@ -274,6 +275,17 @@ export class Graph extends EventEmitter {
    */
   public getPlugins(): PluginOptions {
     return this.options.plugins || [];
+  }
+
+  /**
+   * <zh/> 获取插件实例
+   *
+   * <en/> Get plugin instance
+   * @param key - <zh/> 插件 key | <en/> plugin key
+   * @returns <zh/> 插件实例 | <en/> plugin instance
+   */
+  public getPluginInstance<T extends Plugin>(key: string) {
+    return this.context.plugin!.getPluginInstance(key) as unknown as T;
   }
 
   public getData(): GraphData {

--- a/packages/g6/src/runtime/plugin.ts
+++ b/packages/g6/src/runtime/plugin.ts
@@ -14,4 +14,8 @@ export class PluginController extends ExtensionController<BasePlugin<CustomPlugi
   public setPlugins(plugins: PluginOptions) {
     this.setExtensions(plugins);
   }
+
+  public getPluginInstance(key: string) {
+    return this.extensionMap[key];
+  }
 }


### PR DESCRIPTION
* 新增 `getPluginInstance` API，用于获取插件实例并提供插件 API 调用

---

* Added `getPluginInstance` API to get plug-in instances and provide plug-in API calls

```ts
const graph = new Graph({
  // ...
 plugin: [{key: 'history', type: 'history'}]
});

const history = graph.getPluginInstance<History>('history');

history.undo();
```