### PR TITLE
chore: add script to help checkout contributor branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "postinstall": "husky install",
     "prepare": "husky install",
     "build": "turbo build --filter=!@antv/g6-site",
-    "ci": "turbo run ci --filter=!@antv/g6-site"
+    "ci": "turbo run ci --filter=!@antv/g6-site",
+    "contribute": "node ./scripts/contribute.mjs"
   },
   "commitlint": {
     "extends": [

--- a/scripts/contribute.mjs
+++ b/scripts/contribute.mjs
@@ -1,0 +1,114 @@
+import chalk from 'chalk';
+import { execSync } from 'child_process';
+import readline from 'readline';
+
+const rl = readline.createInterface({
+  input: process.stdin,
+  output: process.stdout,
+});
+
+function getCurrentBranch() {
+  try {
+    return execSync('git rev-parse --abbrev-ref HEAD').toString().trim();
+  } catch (error) {
+    console.error('获取当前分支时出错:', error);
+    process.exit(1);
+  }
+}
+
+function checkStagingArea() {
+  try {
+    const status = execSync('git status --porcelain').toString();
+    if (status) {
+      console.error('请在执行操作前清空暂存区:');
+      process.exit(1);
+    }
+  } catch (error) {
+    console.error('检查暂存区时出错:', error);
+    process.exit(1);
+  }
+}
+
+function parseGithubUrl(url) {
+  const regex = /https:\/\/github\.com\/([^/]+)\/([^/]+)\/tree\/([^/]+)\/(.+)/;
+  const match = url.match(regex);
+  if (!match) {
+    throw new Error('无法解析 GitHub URL');
+  }
+  return { username: match[1], repository: match[2], branch: match[3] + '/' + match[4] };
+}
+
+function addRemoteAndCheckoutBranch(username, branch) {
+  const remoteUrl = `https://github.com/${username}/G6.git`;
+  const originalBranch = getCurrentBranch();
+
+  try {
+    console.log(`添加远程源: ${remoteUrl}`);
+    execSync(`git remote add ${username} ${remoteUrl}`);
+    console.log(`获取分支: ${branch}`);
+    execSync(`git fetch ${username}`);
+    console.log(`切换到分支: ${branch}`);
+    execSync(`git checkout -b ${branch} ${username}/${branch}`);
+    console.log(`成功切换到分支: ${branch}`);
+  } catch (error) {
+    console.error('执行 git 命令时出错:', error);
+    process.exit(1);
+  }
+
+  console.log(chalk.bold(chalk.green('已切换到贡献者所在分支')));
+
+  rl.question(
+    `请在完成后执行下一步操作：
+0 - [${chalk.green('推荐')}]移除远程源，${chalk.underline(chalk.red('移除当前分支'))}并切回到 ${chalk.underline(originalBranch)} 分支
+1 - 仅移除远程源
+2 - 不进行任何操作
+`,
+    (answer) => {
+      if (answer === '2') {
+        rl.close();
+        return;
+      }
+
+      if (['', '1', '0'].includes(answer)) {
+        try {
+          execSync(`git remote remove ${username}`);
+          console.log(`移除远程源: ${username}`);
+        } catch (error) {
+          console.error('执行 git 命令时出错:', error);
+          process.exit(1);
+        }
+      }
+
+      if (['', '0'].includes(answer)) {
+        try {
+          execSync(`git checkout ${originalBranch}`);
+          execSync(`git branch -D ${branch}`);
+        } catch (error) {
+          console.error('执行 git 命令时出错:', error);
+          process.exit(1);
+        }
+      }
+
+      rl.close();
+    },
+  );
+}
+
+function startAndConfirmInfo() {
+  rl.question(
+    `请输入 GitHub 分支 URL: \n示例：${chalk.green('https://github.com/contributor/G6/tree/branch/name')}\n> `,
+    (url) => {
+      const { username, branch } = parseGithubUrl(url);
+      console.log(`\n${chalk.red(chalk.bold('即将切换到贡献者所在分支'))}`);
+      console.log(`  贡献者: ${chalk.red(username)}`);
+      console.log(`  分支: ${chalk.red(branch)}`);
+      // 按回车键继续
+      rl.question(`\n按回车键继续...`, () => {
+        addRemoteAndCheckoutBranch(username, branch);
+      });
+    },
+  );
+}
+
+checkStagingArea();
+startAndConfirmInfo();


### PR DESCRIPTION
* 添加了一个脚本用于切换到贡献者所在分支上进行查看

使用方法：
1. 执行 `npm run contribute`
2. 输入贡献者代码分支
> 例如：https://github.com/vaynevayne/G6/tree/feat/minimap
3. 确认后切换到该分支
4. 进行查看与变更
5. 完成/提交后移除远程源并删除分支

<img width="480" alt="image" src="https://github.com/antvis/G6/assets/25787943/82aa1211-b147-49e6-ae8a-450ec6ceea6d">
