### PR TITLE
fix(graph): fix issue that toDataURL export blank image

### DIFF
--- a/packages/g6-extension-3d/src/renderer.ts
+++ b/packages/g6-extension-3d/src/renderer.ts
@@ -4,7 +4,7 @@ import { Renderer as WebGLRenderer } from '@antv/g-webgl';
 import type { CanvasOptions } from '@antv/g6';
 
 export const renderer: CanvasOptions['renderer'] = (layer) => {
-  if (layer === 'label' || layer === 'transientLabel') {
+  if (layer === 'label') {
     return new CanvasRenderer();
   }
 

--- a/packages/g6/__tests__/demos/graph-to-data-url.ts
+++ b/packages/g6/__tests__/demos/graph-to-data-url.ts
@@ -1,0 +1,51 @@
+import { Graph } from '@/src';
+
+export const graphToDataURL: TestCase = async (context) => {
+  const graph = new Graph({
+    ...context,
+    data: {
+      nodes: [
+        { id: 'node-1', style: { x: 50, y: 50, color: 'purple', halo: true, labelText: 'node-1' } },
+        { id: 'node-2', style: { x: 100, y: 50, color: 'pink', halo: true, labelText: 'node-2' } },
+      ],
+      edges: [{ id: 'edge-1', source: 'node-1', target: 'node-2', style: { color: 'orange', lineWidth: 2 } }],
+    },
+    behaviors: ['zoom-canvas', 'drag-canvas', 'drag-element'],
+  });
+
+  graphToDataURL.form = (panel) => {
+    const config = {
+      toDataURL: () => {
+        graph.toDataURL().then((url) => {
+          navigator.clipboard.writeText(url);
+          alert('The data URL has been copied to the clipboard');
+        });
+      },
+      download: async () => {
+        const dataURL = await graph.toDataURL();
+        const [head, content] = dataURL.split(',');
+        const contentType = head.match(/:(.*?);/)![1];
+
+        const bstr = atob(content);
+        let length = bstr.length;
+        const u8arr = new Uint8Array(length);
+
+        while (length--) {
+          u8arr[length] = bstr.charCodeAt(length);
+        }
+
+        const blob = new Blob([u8arr], { type: contentType });
+
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = 'graph.png';
+        a.click();
+      },
+    };
+    return [panel.add(config, 'toDataURL'), panel.add(config, 'download').name('Download')];
+  };
+
+  await graph.render();
+  return graph;
+};

--- a/packages/g6/__tests__/demos/index.ts
+++ b/packages/g6/__tests__/demos/index.ts
@@ -48,6 +48,7 @@ export * from './element-position-combo';
 export * from './element-state';
 export * from './element-visibility';
 export * from './element-z-index';
+export * from './graph-to-data-url';
 export * from './layout-antv-dagre-flow';
 export * from './layout-antv-dagre-flow-combo';
 export * from './layout-circular-basic';

--- a/packages/g6/src/types/canvas.ts
+++ b/packages/g6/src/types/canvas.ts
@@ -1,1 +1,1 @@
-export type CanvasLayer = 'background' | 'main' | 'label' | 'transient' | 'transientLabel';
+export type CanvasLayer = 'background' | 'main' | 'label' | 'transient';


### PR DESCRIPTION

<img width="1258" alt="image" src="https://github.com/antvis/G6/assets/25787943/2388e47f-e8e4-45f2-8622-318313a46e0d">


* 修复 `toDataURL` 导出图片空白的问题

> 目前提供了导出视口区域的内容，后续提供完整图内容的导出

---

* Fixed 'toDataURL' export image blank issue

> At present, the content of the exported viewport area is provided, and the export of the complete graph content is provided in the future