### PR TITLE
refactor: toDataURL support export overall mode

### DIFF
--- a/packages/g6/__tests__/demos/graph-to-data-url.ts
+++ b/packages/g6/__tests__/demos/graph-to-data-url.ts
@@ -16,13 +16,14 @@ export const graphToDataURL: TestCase = async (context) => {
   graphToDataURL.form = (panel) => {
     const config = {
       toDataURL: () => {
-        graph.toDataURL().then((url) => {
+        graph.toDataURL({ mode: config.mode } as any).then((url) => {
           navigator.clipboard.writeText(url);
           alert('The data URL has been copied to the clipboard');
         });
       },
+      mode: 'viewport',
       download: async () => {
-        const dataURL = await graph.toDataURL();
+        const dataURL = await graph.toDataURL({ mode: config.mode } as any);
         const [head, content] = dataURL.split(',');
         const contentType = head.match(/:(.*?);/)![1];
 
@@ -43,7 +44,11 @@ export const graphToDataURL: TestCase = async (context) => {
         a.click();
       },
     };
-    return [panel.add(config, 'toDataURL'), panel.add(config, 'download').name('Download')];
+    return [
+      panel.add(config, 'toDataURL'),
+      panel.add(config, 'mode', ['viewport', 'overall']),
+      panel.add(config, 'download').name('Download'),
+    ];
   };
 
   await graph.render();

--- a/packages/g6/__tests__/snapshots/elements/position-combo/default.svg
+++ b/packages/g6/__tests__/snapshots/elements/position-combo/default.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g transform="matrix(0.782568,0,0,0.782568,85.594421,28.822777)">
+  <g transform="matrix(0.781902,0,0,0.781902,85.734138,29.206221)">
     <g fill="none" transform="matrix(1,0,0,1,0,0)">
       <g fill="none" transform="matrix(1,0,0,1,0,0)">
         <g fill="none" transform="matrix(1,0,0,1,210.084839,271.130188)">

--- a/packages/g6/__tests__/snapshots/layouts/combo-layout/combined.svg
+++ b/packages/g6/__tests__/snapshots/layouts/combo-layout/combined.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g transform="matrix(0.202864,0,0,0.202864,235.381668,231.086716)">
+  <g transform="matrix(0.202782,0,0,0.202782,235.387604,231.094391)">
     <g fill="none" transform="matrix(1,0,0,1,0,0)">
       <g fill="none" transform="matrix(1,0,0,1,0,0)">
         <g fill="none" transform="matrix(1,0,0,1,514.073059,93.231476)">

--- a/packages/g6/__tests__/snapshots/layouts/compact-box/left-align.svg
+++ b/packages/g6/__tests__/snapshots/layouts/compact-box/left-align.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g transform="matrix(0.447227,0,0,0.447227,290.250427,170.590347)">
+  <g transform="matrix(0.446828,0,0,0.446828,290.214478,170.773026)">
     <g fill="none" transform="matrix(1,0,0,1,0,0)">
       <g fill="none" transform="matrix(1,0,0,1,0,0)"/>
       <g fill="none" transform="matrix(1,0,0,1,0,0)">

--- a/packages/g6/__tests__/snapshots/layouts/compact-box/top-to-bottom.svg
+++ b/packages/g6/__tests__/snapshots/layouts/compact-box/top-to-bottom.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g transform="matrix(0.570698,0,0,0.570698,127.836365,281.388397)">
+  <g transform="matrix(0.570373,0,0,0.570373,128.048645,281.370483)">
     <g fill="none" transform="matrix(1,0,0,1,0,0)">
       <g fill="none" transform="matrix(1,0,0,1,0,0)"/>
       <g fill="none" transform="matrix(1,0,0,1,0,0)">

--- a/packages/g6/__tests__/snapshots/layouts/dagre/antv-flow-combo.svg
+++ b/packages/g6/__tests__/snapshots/layouts/dagre/antv-flow-combo.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g transform="matrix(0.819672,0,0,0.819672,-6.147559,-25.819664)">
+  <g transform="matrix(0.818331,0,0,0.818331,-5.728308,-25.368242)">
     <g fill="none" transform="matrix(1,0,0,1,0,0)">
       <g fill="none" transform="matrix(1,0,0,1,0,0)">
         <g fill="none" transform="matrix(1,0,0,1,122.500000,400)">

--- a/packages/g6/__tests__/snapshots/layouts/mindmap/h-left.svg
+++ b/packages/g6/__tests__/snapshots/layouts/mindmap/h-left.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g transform="matrix(0.585480,0,0,0.585480,608.934448,282.201416)">
+  <g transform="matrix(0.584795,0,0,0.584795,608.368469,282.163727)">
     <g fill="none" transform="matrix(1,0,0,1,0,0)">
       <g fill="none" transform="matrix(1,0,0,1,0,0)"/>
       <g fill="none" transform="matrix(1,0,0,1,0,0)">

--- a/packages/g6/__tests__/snapshots/layouts/mindmap/h-right.svg
+++ b/packages/g6/__tests__/snapshots/layouts/mindmap/h-right.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g transform="matrix(0.585480,0,0,0.585480,134.332550,282.201416)">
+  <g transform="matrix(0.584795,0,0,0.584795,134.614044,282.163727)">
     <g fill="none" transform="matrix(1,0,0,1,0,0)">
       <g fill="none" transform="matrix(1,0,0,1,0,0)"/>
       <g fill="none" transform="matrix(1,0,0,1,0,0)">

--- a/packages/g6/__tests__/snapshots/plugins/tooltip/edge.svg
+++ b/packages/g6/__tests__/snapshots/plugins/tooltip/edge.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g transform="matrix(0.202407,0,0,0.202407,235.416672,231.129288)">
+  <g transform="matrix(0.202325,0,0,0.202325,235.422577,231.136917)">
     <g fill="none" transform="matrix(1,0,0,1,0,0)">
       <g fill="none" transform="matrix(1,0,0,1,0,0)">
         <g fill="none" transform="matrix(1,0,0,1,514.073059,93.231476)">

--- a/packages/g6/__tests__/snapshots/plugins/tooltip/hover.svg
+++ b/packages/g6/__tests__/snapshots/plugins/tooltip/hover.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g transform="matrix(0.202407,0,0,0.202407,235.416672,231.129288)">
+  <g transform="matrix(0.202325,0,0,0.202325,235.422577,231.136917)">
     <g fill="none" transform="matrix(1,0,0,1,0,0)">
       <g fill="none" transform="matrix(1,0,0,1,0,0)">
         <g fill="none" transform="matrix(1,0,0,1,514.073059,93.231476)">

--- a/packages/g6/__tests__/snapshots/plugins/tooltip/node.svg
+++ b/packages/g6/__tests__/snapshots/plugins/tooltip/node.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g transform="matrix(0.202407,0,0,0.202407,235.416672,231.129288)">
+  <g transform="matrix(0.202325,0,0,0.202325,235.422577,231.136917)">
     <g fill="none" transform="matrix(1,0,0,1,0,0)">
       <g fill="none" transform="matrix(1,0,0,1,0,0)">
         <g fill="none" transform="matrix(1,0,0,1,514.073059,93.231476)">

--- a/packages/g6/__tests__/snapshots/plugins/tooltip/show-tooltip-by-id.svg
+++ b/packages/g6/__tests__/snapshots/plugins/tooltip/show-tooltip-by-id.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g transform="matrix(0.202407,0,0,0.202407,235.416672,231.129288)">
+  <g transform="matrix(0.202325,0,0,0.202325,235.422577,231.136917)">
     <g fill="none" transform="matrix(1,0,0,1,0,0)">
       <g fill="none" transform="matrix(1,0,0,1,0,0)">
         <g fill="none" transform="matrix(1,0,0,1,514.073059,93.231476)">

--- a/packages/g6/__tests__/unit/runtime/graph/graph.spec.ts
+++ b/packages/g6/__tests__/unit/runtime/graph/graph.spec.ts
@@ -313,8 +313,10 @@ describe('Graph', () => {
   });
 
   it('toDataURL', async () => {
-    const url = await graph.toDataURL();
-    expect(url).toBeDefined();
+    expect(await graph.toDataURL()).toBeDefined();
+    expect(await graph.toDataURL({ mode: 'overall' })).toBeDefined();
+    expect((await graph.toDataURL({ type: 'image/jpeg' })).startsWith('data:image/jpeg')).toBe(true);
+    expect((await graph.toDataURL({ type: 'image/png' })).startsWith('data:image/png')).toBe(true);
   });
 
   it('resize', () => {

--- a/packages/g6/src/runtime/canvas.ts
+++ b/packages/g6/src/runtime/canvas.ts
@@ -224,7 +224,7 @@ export class Canvas {
 
   public async toDataURL(options: Partial<DataURLOptions> = {}) {
     const devicePixelRatio = window.devicePixelRatio || 1;
-    const { mode = 'viewport', ..._options } = options;
+    const { mode = 'viewport', ...restOptions } = options;
 
     let startX = 0;
     let startY = 0;
@@ -232,15 +232,12 @@ export class Canvas {
     let height = 0;
 
     if (mode === 'viewport') {
-      width = this.config.width || 0;
-      height = this.config.height || 0;
+      [width, height] = [this.config.width || 0, this.config.height || 0];
     } else if (mode === 'overall') {
       const bounds = this.getBounds();
       const size = getBBoxSize(bounds);
-      startX = bounds.min[0];
-      startY = bounds.min[1];
-      width = size[0];
-      height = size[1];
+      [startX, startY] = bounds.min;
+      [width, height] = size;
     }
 
     const container: HTMLElement = createDOM('<div id="virtual-image"></div>');
@@ -290,7 +287,7 @@ export class Canvas {
 
     return new Promise<string>((resolve) => {
       offscreenCanvas.on(CanvasEvent.AFTER_RENDER, async () => {
-        const url = await contextService.toDataURL(_options);
+        const url = await contextService.toDataURL(restOptions);
         resolve(url);
       });
     });

--- a/packages/g6/src/runtime/canvas.ts
+++ b/packages/g6/src/runtime/canvas.ts
@@ -1,8 +1,8 @@
 import type {
   Cursor,
-  DataURLOptions,
   DisplayObject,
   CanvasConfig as GCanvasConfig,
+  DataURLOptions as GDataURLOptions,
   IAnimation,
   IRenderer,
   PointLike,
@@ -13,12 +13,25 @@ import { Plugin as DragNDropPlugin } from '@antv/g-plugin-dragndrop';
 import { createDOM, isFunction, isString } from '@antv/util';
 import type { CanvasOptions } from '../spec/canvas';
 import type { CanvasLayer } from '../types/canvas';
-import { getCombinedBBox } from '../utils/bbox';
+import { getBBoxSize, getCombinedBBox } from '../utils/bbox';
 
 export interface CanvasConfig
   extends Pick<GCanvasConfig, 'container' | 'devicePixelRatio' | 'width' | 'height' | 'cursor'> {
   renderer?: CanvasOptions['renderer'];
   background?: string;
+}
+
+export interface DataURLOptions extends GDataURLOptions {
+  /**
+   * <zh/> 导出模式
+   *  - viewport: 导出视口内容
+   *  - overall: 导出整个画布
+   *
+   * <en/> export mode
+   *  - viewport: export the content of the viewport
+   *  - overall: export the entire canvas
+   */
+  mode?: 'viewport' | 'overall';
 }
 
 /**
@@ -173,7 +186,7 @@ export class Canvas {
       Object.values(this.canvas)
         .map((canvas) => canvas.document.documentElement)
         .filter((el) => el.childNodes.length > 0)
-        .map((el) => el.getBounds()),
+        .map((el) => el.getRenderBounds()),
     );
   }
 
@@ -211,7 +224,24 @@ export class Canvas {
 
   public async toDataURL(options: Partial<DataURLOptions> = {}) {
     const devicePixelRatio = window.devicePixelRatio || 1;
-    const { width, height } = this.config;
+    const { mode = 'viewport', ..._options } = options;
+
+    let startX = 0;
+    let startY = 0;
+    let width = 0;
+    let height = 0;
+
+    if (mode === 'viewport') {
+      width = this.config.width || 0;
+      height = this.config.height || 0;
+    } else if (mode === 'overall') {
+      const bounds = this.getBounds();
+      const size = getBBoxSize(bounds);
+      startX = bounds.min[0];
+      startY = bounds.min[1];
+      width = size[0];
+      height = size[1];
+    }
 
     const container: HTMLElement = createDOM('<div id="virtual-image"></div>');
 
@@ -244,15 +274,23 @@ export class Canvas {
 
     const camera = this.main.getCamera();
     const offscreenCamera = offscreenCanvas.getCamera();
-    offscreenCamera.setZoom(camera.getZoom());
-    offscreenCamera.setPosition(camera.getPosition());
-    offscreenCamera.setFocalPoint(camera.getFocalPoint());
+
+    if (mode === 'viewport') {
+      offscreenCamera.setZoom(camera.getZoom());
+      offscreenCamera.setPosition(camera.getPosition());
+      offscreenCamera.setFocalPoint(camera.getFocalPoint());
+    } else if (mode === 'overall') {
+      const [x, y, z] = offscreenCamera.getPosition();
+      const [fx, fy, fz] = offscreenCamera.getFocalPoint();
+      offscreenCamera.setPosition([x + startX, y + startY, z]);
+      offscreenCamera.setFocalPoint([fx + startX, fy + startY, fz]);
+    }
 
     const contextService = offscreenCanvas.getContextService();
 
     return new Promise<string>((resolve) => {
       offscreenCanvas.on(CanvasEvent.AFTER_RENDER, async () => {
-        const url = await contextService.toDataURL(options);
+        const url = await contextService.toDataURL(_options);
         resolve(url);
       });
     });

--- a/packages/g6/src/runtime/graph.ts
+++ b/packages/g6/src/runtime/graph.ts
@@ -1,5 +1,5 @@
 import EventEmitter from '@antv/event-emitter';
-import type { AABB, BaseStyleProps, DataURLOptions } from '@antv/g';
+import type { AABB, BaseStyleProps } from '@antv/g';
 import type { ID } from '@antv/graphlib';
 import { debounce, isEqual, isFunction, isNumber, isObject, isString, omit } from '@antv/util';
 import { COMBO_KEY, GraphEvent } from '../constants';
@@ -49,6 +49,7 @@ import { zIndexOf } from '../utils/style';
 import { subtract } from '../utils/vector';
 import { BatchController } from './batch';
 import { BehaviorController } from './behavior';
+import type { DataURLOptions } from './canvas';
 import { Canvas } from './canvas';
 import type { HierarchyKey } from './data';
 import { DataController } from './data';
@@ -1051,6 +1052,21 @@ export class Graph extends EventEmitter {
     else if (elementType === 'combo') this.updateComboData([{ id, style: { collapsed } }]);
   }
 
+  /**
+   * <zh/> 导出画布内容为 DataURL
+   *
+   * <en/> Export canvas content as DataURL
+   * @param options - <zh/> 导出配置 | <en/> export configuration
+   * @param mode
+   * <zh/> 导出模式
+   *  - viewport: 导出视口内容
+   *  - overall: 导出整个画布
+   *
+   * <en/> export mode
+   *  - viewport: export the content of the viewport
+   *  - overall: export the entire canvas
+   * @returns <zh/> DataURL | <en/> DataURL
+   */
   public async toDataURL(options: Partial<DataURLOptions> = {}): Promise<string> {
     return this.context.canvas!.toDataURL(options);
   }


### PR DESCRIPTION

<img width="499" alt="image" src="https://github.com/antvis/G6/assets/25787943/2c1b7421-d76b-4607-84b9-ab4daa12a404">

> Graph

![image](https://github.com/antvis/G6/assets/25787943/a3ad8ca7-a366-42da-8d44-76fee671761d)

> Export

* `toDataURL` 支持导出全图模式

---

* `toDataURL` support export overall mode