### PR TITLE
refactor: move type config to element.type

### DIFF
--- a/packages/g6-extension-3d/__tests__/demos/behavior-drag-canvas.ts
+++ b/packages/g6-extension-3d/__tests__/demos/behavior-drag-canvas.ts
@@ -14,8 +14,8 @@ export const behaviorDragCanvas: TestCase = async (context) => {
     renderer,
     data,
     node: {
+      type: 'sphere',
       style: {
-        type: 'sphere',
         materialType: 'phong',
         labelText: '',
         x: (d) => +d.style!.x! + 250,
@@ -24,9 +24,7 @@ export const behaviorDragCanvas: TestCase = async (context) => {
       palette: 'spectral',
     },
     edge: {
-      style: {
-        type: 'line3d',
-      },
+      type: 'line3d',
     },
     behaviors: [
       'drag-canvas-3d',

--- a/packages/g6-extension-3d/__tests__/demos/behavior-observe-canvas.ts
+++ b/packages/g6-extension-3d/__tests__/demos/behavior-observe-canvas.ts
@@ -15,8 +15,8 @@ export const behaviorObserveCanvas: TestCase = async (context) => {
     renderer,
     data,
     node: {
+      type: 'sphere',
       style: {
-        type: 'sphere',
         materialType: 'phong',
         labelText: '',
         x: (d) => +d.style!.x! + 250,
@@ -25,9 +25,7 @@ export const behaviorObserveCanvas: TestCase = async (context) => {
       palette: 'spectral',
     },
     edge: {
-      style: {
-        type: 'line3d',
-      },
+      type: 'line3d',
     },
     behaviors: ['zoom-canvas-3d', { key: 'observe-canvas-3d', type: 'observe-canvas-3d' }],
     plugins: [

--- a/packages/g6-extension-3d/__tests__/demos/behavior-roll-canvas.ts
+++ b/packages/g6-extension-3d/__tests__/demos/behavior-roll-canvas.ts
@@ -14,8 +14,8 @@ export const behaviorRollCanvas: TestCase = async (context) => {
     renderer,
     data,
     node: {
+      type: 'sphere',
       style: {
-        type: 'sphere',
         materialType: 'phong',
         labelText: '',
         x: (d) => +d.style!.x! + 250,
@@ -24,9 +24,7 @@ export const behaviorRollCanvas: TestCase = async (context) => {
       palette: 'spectral',
     },
     edge: {
-      style: {
-        type: 'line3d',
-      },
+      type: 'line3d',
     },
     behaviors: ['roll-canvas-3d'],
     plugins: [

--- a/packages/g6-extension-3d/__tests__/demos/behavior-zoom-canvas.ts
+++ b/packages/g6-extension-3d/__tests__/demos/behavior-zoom-canvas.ts
@@ -14,8 +14,8 @@ export const behaviorZoomCanvas: TestCase = async (context) => {
     renderer,
     data,
     node: {
+      type: 'sphere',
       style: {
-        type: 'sphere',
         materialType: 'phong',
         labelText: '',
         x: (d) => +d.style!.x! + 250,
@@ -24,9 +24,7 @@ export const behaviorZoomCanvas: TestCase = async (context) => {
       palette: 'spectral',
     },
     edge: {
-      style: {
-        type: 'line3d',
-      },
+      type: 'line3d',
     },
     behaviors: ['zoom-canvas-3d'],
     plugins: [

--- a/packages/g6-extension-3d/__tests__/demos/layer-top.ts
+++ b/packages/g6-extension-3d/__tests__/demos/layer-top.ts
@@ -17,8 +17,8 @@ export const layerTop: TestCase = async (context) => {
   data.nodes = nodes.map(({ name, pos, layer }: any) => ({
     id: name,
     data: { layer },
+    type: 'sphere',
     style: {
-      type: 'sphere',
       radius: 10,
       color: colors[layer - 1],
       materialType: 'phong',
@@ -29,8 +29,8 @@ export const layerTop: TestCase = async (context) => {
   new Array(3).fill(0).forEach((_, i) => {
     data.nodes!.push({
       id: `plane-${i + 1}`,
+      type: 'plane',
       style: {
-        type: 'plane',
         size: 1000,
         color: colors[i],
         y: -300 + 300 * i + 10,
@@ -50,12 +50,9 @@ export const layerTop: TestCase = async (context) => {
     y: 100,
     data,
     zoom: 0.4,
-    node: {
-      style: {},
-    },
     edge: {
+      type: 'line3d',
       style: {
-        type: 'line3d',
         lineWidth: 5,
       },
     },

--- a/packages/g6-extension-3d/__tests__/demos/layout-d3-force-3d.ts
+++ b/packages/g6-extension-3d/__tests__/demos/layout-d3-force-3d.ts
@@ -19,8 +19,8 @@ export const layoutD3Force3D: TestCase = async (context) => {
       type: 'd3-force-3d',
     },
     node: {
+      type: 'sphere',
       style: {
-        type: 'sphere',
         materialType: 'phong',
       },
       palette: {
@@ -30,9 +30,7 @@ export const layoutD3Force3D: TestCase = async (context) => {
       },
     },
     edge: {
-      style: {
-        type: 'line3d',
-      },
+      type: 'line3d',
     },
     behaviors: ['observe-canvas-3d', 'zoom-canvas-3d'],
     plugins: [

--- a/packages/g6-extension-3d/__tests__/demos/position.ts
+++ b/packages/g6-extension-3d/__tests__/demos/position.ts
@@ -30,17 +30,15 @@ export const positionValidate: TestCase = async (context) => {
       ],
     },
     node: {
+      type: 'sphere',
       style: {
-        type: 'sphere',
         materialType: 'phong',
         labelText: '',
       },
       palette: 'spectral',
     },
     edge: {
-      style: {
-        type: 'line3d',
-      },
+      type: 'line3d',
     },
     behaviors: ['drag-canvas-3d'],
     plugins: [

--- a/packages/g6-extension-3d/__tests__/demos/shapes.ts
+++ b/packages/g6-extension-3d/__tests__/demos/shapes.ts
@@ -1,47 +1,51 @@
-import { Graph, register } from '@antv/g6';
-import { Capsule, Cone, Cube, Cylinder, Light, Plane, Sphere, Torus, renderer } from '../../src';
+import type { NodeData } from '@antv/g6';
+import { ExtensionCategory, Graph, register } from '@antv/g6';
+import { Capsule, Cone, Cube, Cylinder, Light, ObserveCanvas3D, Plane, Sphere, Torus, renderer } from '../../src';
 
 export const shapes: TestCase = async (context) => {
-  register('plugin', '3d-light', Light);
-  register('node', 'sphere', Sphere);
-  register('node', 'plane', Plane);
-  register('node', 'cylinder', Cylinder);
-  register('node', 'cone', Cone);
-  register('node', 'cube', Cube);
-  register('node', 'capsule', Capsule);
-  register('node', 'torus', Torus);
+  register(ExtensionCategory.PLUGIN, '3d-light', Light);
+  register(ExtensionCategory.NODE, 'sphere', Sphere);
+  register(ExtensionCategory.NODE, 'plane', Plane);
+  register(ExtensionCategory.NODE, 'cylinder', Cylinder);
+  register(ExtensionCategory.NODE, 'cone', Cone);
+  register(ExtensionCategory.NODE, 'cube', Cube);
+  register(ExtensionCategory.NODE, 'capsule', Capsule);
+  register(ExtensionCategory.NODE, 'torus', Torus);
+  register(ExtensionCategory.BEHAVIOR, 'observe-canvas-3d', ObserveCanvas3D);
+
+  const nodes: NodeData[] = [
+    {
+      id: '1',
+      type: 'sphere',
+      style: {
+        texture: 'https://mdn.alipayobjects.com/huamei_qa8qxu/afts/img/A*cdTdTI2bNl8AAAAAAAAAAAAADmJ7AQ/original',
+      },
+    },
+    { id: '2', type: 'plane', style: { size: 50 } },
+    { id: '3', type: 'cylinder' },
+    { id: '4', type: 'cone' },
+    {
+      id: '5',
+      type: 'cube',
+      style: {
+        texture: 'https://gw.alipayobjects.com/mdn/rms_6ae20b/afts/img/A*8TlCRIsKeUkAAAAAAAAAAAAAARQnAQ',
+      },
+    },
+    { id: '6', type: 'capsule' },
+    { id: '7', type: 'torus' },
+  ];
 
   const graph = new Graph({
     ...context,
     renderer,
     data: {
-      nodes: [
-        {
-          id: '1',
-          style: {
-            type: 'sphere',
-            texture: 'https://mdn.alipayobjects.com/huamei_qa8qxu/afts/img/A*cdTdTI2bNl8AAAAAAAAAAAAADmJ7AQ/original',
-          },
-        },
-        { id: '2', style: { type: 'plane', size: 50 } },
-        { id: '3', style: { type: 'cylinder' } },
-        { id: '4', style: { type: 'cone' } },
-        {
-          id: '5',
-          style: {
-            type: 'cube',
-            texture: 'https://gw.alipayobjects.com/mdn/rms_6ae20b/afts/img/A*8TlCRIsKeUkAAAAAAAAAAAAAARQnAQ',
-          },
-        },
-        { id: '6', style: { type: 'capsule' } },
-        { id: '7', style: { type: 'torus' } },
-      ],
+      nodes,
     },
     node: {
       style: {
         materialType: 'phong',
-        x: (_, i) => 100 + (i % 5) * 100,
-        y: (_, i) => 100 + Math.floor(i / 5) * 100,
+        x: (d) => 100 + (nodes.findIndex((n) => n.id === d.id) % 5) * 100,
+        y: (d) => 100 + Math.floor(nodes.findIndex((n) => n.id === d.id) / 5) * 100,
       },
     },
     plugins: [
@@ -52,6 +56,7 @@ export const shapes: TestCase = async (context) => {
         },
       },
     ],
+    behaviors: ['observe-canvas-3d'],
   });
 
   await graph.render();

--- a/packages/g6-extension-3d/__tests__/demos/solar-system.ts
+++ b/packages/g6-extension-3d/__tests__/demos/solar-system.ts
@@ -55,8 +55,8 @@ export const solarSystem: TestCase = async (context) => {
       ],
     },
     node: {
+      type: 'sphere',
       style: {
-        type: 'sphere',
         materialShininess: 0,
         labelText: (d) => d.id,
       },

--- a/packages/g6/__tests__/demos/animation-element-edge-cubic.ts
+++ b/packages/g6/__tests__/demos/animation-element-edge-cubic.ts
@@ -20,8 +20,8 @@ export const animationElementEdgeCubic: TestCase = async (context) => {
       ],
     },
     edge: {
+      type: 'cubic',
       style: {
-        type: 'cubic',
         lineWidth: 2,
         stroke: '#1890FF',
         labelText: 'cubic-edge',

--- a/packages/g6/__tests__/demos/animation-element-edge-quadratic.ts
+++ b/packages/g6/__tests__/demos/animation-element-edge-quadratic.ts
@@ -17,8 +17,8 @@ export const animationElementEdgeQuadratic: TestCase = async (context) => {
       ],
     },
     edge: {
+      type: 'quadratic',
       style: {
-        type: 'quadratic',
         lineWidth: 2,
         stroke: '#1890FF',
         labelText: 'quadratic-edge',

--- a/packages/g6/__tests__/demos/animation-element-state.ts
+++ b/packages/g6/__tests__/demos/animation-element-state.ts
@@ -38,15 +38,15 @@ export const animationElementState: TestCase = async (context) => {
       ],
     },
     node: {
+      type: 'breathing-circle',
       style: {
-        type: 'breathing-circle',
         halo: true,
         haloLineWidth: 5,
       },
     },
     edge: {
+      type: 'fly-line',
       style: {
-        type: 'fly-line',
         lineDash: [10, 10],
       },
     },

--- a/packages/g6/__tests__/demos/combo-expand-collapse.ts
+++ b/packages/g6/__tests__/demos/combo-expand-collapse.ts
@@ -17,7 +17,11 @@ export const comboExpandCollapse: TestCase = async (context) => {
       combos: [
         {
           id: 'combo-1',
-          style: { type: 'rect', parentId: 'combo-2', collapsed: true },
+          type: 'rect',
+          style: {
+            parentId: 'combo-2',
+            collapsed: true,
+          },
         },
         { id: 'combo-2' },
       ],

--- a/packages/g6/__tests__/demos/combo.ts
+++ b/packages/g6/__tests__/demos/combo.ts
@@ -14,7 +14,10 @@ export const combo: TestCase = async (context) => {
     combos: [
       {
         id: 'combo-1',
-        style: { type: 'rect', parentId: 'combo-2' },
+        type: 'rect',
+        style: {
+          parentId: 'combo-2',
+        },
       },
       {
         id: 'combo-2',

--- a/packages/g6/__tests__/demos/element-change-type.ts
+++ b/packages/g6/__tests__/demos/element-change-type.ts
@@ -5,7 +5,7 @@ export const elementChangeType: TestCase = async (context) => {
     ...context,
     data: {
       nodes: [
-        { id: 'node-1', style: { x: 100, y: 100, type: 'rect', color: 'transparent', stroke: '#1783ff' } },
+        { id: 'node-1', type: 'rect', style: { x: 100, y: 100, color: 'transparent', stroke: '#1783ff' } },
         { id: 'node-2', style: { x: 200, y: 100 } },
       ],
       edges: [{ id: 'edge-1', source: 'node-1', target: 'node-2' }],
@@ -22,7 +22,7 @@ export const elementChangeType: TestCase = async (context) => {
     const options = { Circle: 'circle', Rect: 'rect', Diamond: 'diamond', Star: 'star' };
 
     const changeType = (id: string, type: string) => {
-      graph.updateNodeData([{ id, style: { type } }]);
+      graph.updateNodeData([{ id, type }]);
       graph.draw();
     };
 

--- a/packages/g6/__tests__/demos/element-edge-arrow.ts
+++ b/packages/g6/__tests__/demos/element-edge-arrow.ts
@@ -26,8 +26,8 @@ export const elementEdgeArrow: TestCase = async (context) => {
     ...context,
     data,
     edge: {
+      type: 'line', // 👈🏻 Edge shape type.
       style: {
-        type: 'line', // 👈🏻 Edge shape type.
         labelText: (d) => d.id!,
         labelBackground: true,
         endArrow: true,

--- a/packages/g6/__tests__/demos/element-edge-cubic-horizontal.ts
+++ b/packages/g6/__tests__/demos/element-edge-cubic-horizontal.ts
@@ -42,8 +42,8 @@ export const elementEdgeCubicHorizontal: TestCase = async (context) => {
       },
     },
     edge: {
+      type: 'cubic-horizontal', // 👈🏻 Edge shape type.
       style: {
-        type: 'cubic-horizontal', // 👈🏻 Edge shape type.
         labelText: (d) => d.id!,
         labelBackground: true,
         endArrow: true,

--- a/packages/g6/__tests__/demos/element-edge-cubic-vertical.ts
+++ b/packages/g6/__tests__/demos/element-edge-cubic-vertical.ts
@@ -42,8 +42,8 @@ export const elementEdgeCubicVertical: TestCase = async (context) => {
       },
     },
     edge: {
+      type: 'cubic-vertical', // 👈🏻 Edge shape type.
       style: {
-        type: 'cubic-vertical', // 👈🏻 Edge shape type.
         labelText: (d) => d.id!,
         labelBackground: true,
         endArrow: true,

--- a/packages/g6/__tests__/demos/element-edge-cubic.ts
+++ b/packages/g6/__tests__/demos/element-edge-cubic.ts
@@ -36,8 +36,8 @@ export const elementEdgeCubic: TestCase = async (context) => {
     ...context,
     data,
     edge: {
+      type: 'cubic', // 👈🏻 Edge shape type.
       style: {
-        type: 'cubic', // 👈🏻 Edge shape type.
         labelText: (d) => d.id!,
         labelBackground: true,
         endArrow: true,

--- a/packages/g6/__tests__/demos/element-edge-custom-arrow.ts
+++ b/packages/g6/__tests__/demos/element-edge-custom-arrow.ts
@@ -39,8 +39,8 @@ export const elementEdgeCustomArrow: TestCase = async (context) => {
     ...context,
     data,
     edge: {
+      type: 'line', // 👈🏻 Edge shape type.
       style: {
-        type: 'line', // 👈🏻 Edge shape type.
         color: '#F6BD16',
         labelText: (d) => d.id!,
         labelBackground: true,

--- a/packages/g6/__tests__/demos/element-edge-line.ts
+++ b/packages/g6/__tests__/demos/element-edge-line.ts
@@ -36,8 +36,8 @@ export const elementEdgeLine: TestCase = async (context) => {
     ...context,
     data,
     edge: {
+      type: 'line', // 👈🏻 Edge shape type.
       style: {
-        type: 'line', // 👈🏻 Edge shape type.
         labelText: (d) => d.id!,
         labelBackground: true,
         endArrow: true,

--- a/packages/g6/__tests__/demos/element-edge-loop-curve.ts
+++ b/packages/g6/__tests__/demos/element-edge-loop-curve.ts
@@ -78,8 +78,8 @@ export const elementEdgeLoopCurve: TestCase = async (context) => {
     ...context,
     data,
     node: {
+      type: 'rect',
       style: {
-        type: 'rect',
         size: [80, 30],
         labelBackground: true,
         port: (d) => idOf(d).toString().includes('ports'),
@@ -97,8 +97,8 @@ export const elementEdgeLoopCurve: TestCase = async (context) => {
       },
     },
     edge: {
+      type: 'line',
       style: {
-        type: 'line',
         endArrow: true,
         loopPlacement: (d) => d.style!.placement,
       },

--- a/packages/g6/__tests__/demos/element-edge-loop-polyline.ts
+++ b/packages/g6/__tests__/demos/element-edge-loop-polyline.ts
@@ -78,8 +78,8 @@ export const elementEdgeLoopPolyline: TestCase = async (context) => {
     ...context,
     data,
     node: {
+      type: 'rect',
       style: {
-        type: 'rect',
         size: [80, 30],
         port: (d) => idOf(d).toString().includes('ports'),
         portR: 3,
@@ -96,8 +96,8 @@ export const elementEdgeLoopPolyline: TestCase = async (context) => {
       },
     },
     edge: {
+      type: 'polyline',
       style: {
-        type: 'polyline',
         endArrow: true,
         loopPlacement: (d) => d.style!.placement,
       },

--- a/packages/g6/__tests__/demos/element-edge-polyline-animation.ts
+++ b/packages/g6/__tests__/demos/element-edge-polyline-animation.ts
@@ -13,9 +13,7 @@ export const elementEdgePolylineAnimation: TestCase = async (context) => {
     ...context,
     data,
     edge: {
-      style: {
-        type: 'polyline',
-      },
+      type: 'polyline',
     },
     behaviors: [{ type: 'drag-element' }],
   });

--- a/packages/g6/__tests__/demos/element-edge-polyline.ts
+++ b/packages/g6/__tests__/demos/element-edge-polyline.ts
@@ -52,7 +52,8 @@ export const elementEdgePolyline: TestCase = async (context) => {
         },
         {
           id: 'control-point-1',
-          style: { x: 100, y: 175, size: 4, type: 'circle' },
+          type: 'circle',
+          style: { x: 100, y: 175, size: 4 },
         },
         {
           id: 'node-5',
@@ -64,7 +65,8 @@ export const elementEdgePolyline: TestCase = async (context) => {
         },
         {
           id: 'control-point-2',
-          style: { x: 100, y: 300, size: 4, type: 'circle' },
+          type: 'circle',
+          style: { x: 100, y: 300, size: 4 },
         },
         {
           id: 'node-7',
@@ -84,7 +86,8 @@ export const elementEdgePolyline: TestCase = async (context) => {
         },
         {
           id: 'control-point-3',
-          style: { x: 340, y: 390, size: 4, type: 'circle' },
+          type: 'circle',
+          style: { x: 340, y: 390, size: 4 },
         },
       ],
       edges: [
@@ -138,8 +141,8 @@ export const elementEdgePolyline: TestCase = async (context) => {
       ],
     },
     node: {
+      type: (d) => d.type || 'rect',
       style: {
-        type: (d) => d.style?.type || 'rect',
         size: (d) => d.style?.size || [50, 20],
         color: '#f8f8f8',
         stroke: '#8b9baf',
@@ -150,8 +153,8 @@ export const elementEdgePolyline: TestCase = async (context) => {
       },
     },
     edge: {
+      type: 'polyline',
       style: {
-        type: 'polyline',
         color: '#1890FF',
       },
     },

--- a/packages/g6/__tests__/demos/element-edge-port.ts
+++ b/packages/g6/__tests__/demos/element-edge-port.ts
@@ -84,9 +84,6 @@ export const elementEdgePort: TestCase = async (context) => {
         { key: 'right', placement: [1, 0.5], r: 4, stroke: '#31d0c6', fill: '#fff' },
       ],
     },
-    'node-19': {
-      type: 'star',
-    },
   };
 
   const edges: Record<string, any> = {
@@ -124,7 +121,6 @@ export const elementEdgePort: TestCase = async (context) => {
       labelText: 'sourcePort✅ targetPort❓',
     },
     'edge-9': {
-      type: 'cubic',
       sourcePort: 'bottom',
       labelText: 'sourcePort✅ targetPort❓',
     },
@@ -133,18 +129,24 @@ export const elementEdgePort: TestCase = async (context) => {
   const graph = new Graph({
     ...context,
     data: {
-      nodes: Array.from({ length: 20 }).map((_, i) => ({ id: `node-${i}`, style: nodes[`node-${i}`] || {} })),
+      nodes: Array.from({ length: 20 }).map((_, i) => ({
+        id: `node-${i}`,
+        data: { index: i },
+        type: i === 19 ? 'star' : 'circle',
+        style: nodes[`node-${i}`] || {},
+      })),
       edges: Array.from({ length: 10 }).map((_, i) => ({
         id: `edge-${i}`,
         source: `node-${i * 2}`,
         target: `node-${i * 2 + 1}`,
+        type: i === 9 ? 'cubic' : 'line',
         style: edges[`edge-${i}`] || {},
       })),
     },
     node: {
       style: {
-        x: (_, index) => [50, 200, 300, 450][index % 4],
-        y: (_, index) => 50 + Math.floor(index / 4) * 100,
+        x: (d) => [50, 200, 300, 450][(d.data!.index as number) % 4],
+        y: (d) => 50 + Math.floor((d.data!.index as number) / 4) * 100,
         size: 50,
         color: '#f8f8f8',
         stroke: '#8b9baf',

--- a/packages/g6/__tests__/demos/element-edge-quadratic.ts
+++ b/packages/g6/__tests__/demos/element-edge-quadratic.ts
@@ -36,8 +36,8 @@ export const elementEdgeQuadratic: TestCase = async (context) => {
     ...context,
     data,
     edge: {
+      type: 'quadratic', // 👈🏻 Edge shape type.
       style: {
-        type: 'quadratic', // 👈🏻 Edge shape type.
         labelText: (d) => d.id!,
         labelBackground: true,
         endArrow: true,

--- a/packages/g6/__tests__/demos/element-label-oversized.ts
+++ b/packages/g6/__tests__/demos/element-label-oversized.ts
@@ -38,8 +38,8 @@ export const elementLabelOversized: TestCase = async (context) => {
     ...context,
     data,
     node: {
+      type: 'rect',
       style: {
-        type: 'rect',
         x: (d) => d.data!.x as number,
         y: (d) => d.data!.y as number,
         size: (d) => d.data!.size as number,

--- a/packages/g6/__tests__/demos/element-node-circle.ts
+++ b/packages/g6/__tests__/demos/element-node-circle.ts
@@ -20,8 +20,8 @@ export const elementNodeCircle: TestCase = async (context) => {
     ...context,
     data,
     node: {
+      type: 'circle', // 👈🏻 Node shape type.
       style: {
-        type: 'circle', // 👈🏻 Node shape type.
         size: 40,
         labelText: (d) => d.id!,
         iconHeight: 20,

--- a/packages/g6/__tests__/demos/element-node-diamond.ts
+++ b/packages/g6/__tests__/demos/element-node-diamond.ts
@@ -20,8 +20,8 @@ export const elementNodeDiamond: TestCase = async (context) => {
     ...context,
     data,
     node: {
+      type: 'diamond', // 👈🏻 Node shape type.
       style: {
-        type: 'diamond', // 👈🏻 Node shape type.
         size: 40,
         labelText: (d) => d.id!,
         iconWidth: 20,

--- a/packages/g6/__tests__/demos/element-node-ellipse.ts
+++ b/packages/g6/__tests__/demos/element-node-ellipse.ts
@@ -20,8 +20,8 @@ export const elementNodeEllipse: TestCase = async (context) => {
     ...context,
     data,
     node: {
+      type: 'ellipse', // 👈🏻 Node shape type.
       style: {
-        type: 'ellipse', // 👈🏻 Node shape type.
         size: [45, 35],
         labelText: (d) => d.id!,
         iconHeight: 20,

--- a/packages/g6/__tests__/demos/element-node-hexagon.ts
+++ b/packages/g6/__tests__/demos/element-node-hexagon.ts
@@ -20,8 +20,8 @@ export const elementNodeHexagon: TestCase = async (context) => {
     ...context,
     data,
     node: {
+      type: 'hexagon', // 👈🏻 Node shape type.
       style: {
-        type: 'hexagon', // 👈🏻 Node shape type.
         size: 40,
         labelText: (d) => d.id!,
         iconSrc: 'https://gw.alipayobjects.com/zos/basement_prod/012bcf4f-423b-4922-8c24-32a89f8c41ce.svg',

--- a/packages/g6/__tests__/demos/element-node-html.ts
+++ b/packages/g6/__tests__/demos/element-node-html.ts
@@ -14,8 +14,8 @@ export const elementNodeHTML: TestCase = async (context) => {
     ...context,
     data,
     node: {
+      type: 'html', // 👈🏻 Node shape type.
       style: {
-        type: 'html', // 👈🏻 Node shape type.
         size: [240, 80],
         innerHTML: (d: NodeData) => `
 <div style="width: 100%; height: 100%; background: ${d.style!.color}; display: flex; justify-content: center; align-items: center;">

--- a/packages/g6/__tests__/demos/element-node-image.ts
+++ b/packages/g6/__tests__/demos/element-node-image.ts
@@ -20,8 +20,8 @@ export const elementNodeImage: TestCase = async (context) => {
     ...context,
     data,
     node: {
+      type: 'image', // 👈🏻 Node shape type.
       style: {
-        type: 'image', // 👈🏻 Node shape type.
         size: 40,
         labelText: (d) => d.id!,
         src: 'https://gw.alipayobjects.com/mdn/rms_6ae20b/afts/img/A*N4ZMS7gHsUIAAAAAAAAAAABkARQnAQ',

--- a/packages/g6/__tests__/demos/element-node-rect.ts
+++ b/packages/g6/__tests__/demos/element-node-rect.ts
@@ -20,8 +20,8 @@ export const elementNodeRect: TestCase = async (context) => {
     ...context,
     data,
     node: {
+      type: 'rect', // 👈🏻 Node shape type.
       style: {
-        type: 'rect', // 👈🏻 Node shape type.
         radius: 4, // 👈🏻 Set the radius.
         size: 40,
         labelText: (d) => d.id!,

--- a/packages/g6/__tests__/demos/element-node-star.ts
+++ b/packages/g6/__tests__/demos/element-node-star.ts
@@ -20,8 +20,8 @@ export const elementNodeStar: TestCase = async (context) => {
     ...context,
     data,
     node: {
+      type: 'star', // 👈🏻 Node shape type.
       style: {
-        type: 'star', // 👈🏻 Node shape type.
         size: 40,
         labelText: (d) => d.id!,
         iconSrc: 'https://gw.alipayobjects.com/zos/basement_prod/012bcf4f-423b-4922-8c24-32a89f8c41ce.svg',

--- a/packages/g6/__tests__/demos/element-node-triangle.ts
+++ b/packages/g6/__tests__/demos/element-node-triangle.ts
@@ -19,8 +19,8 @@ export const elementNodeTriangle: TestCase = async (context) => {
     ...context,
     data,
     node: {
+      type: 'triangle', // 👈🏻 Node shape type.
       style: {
-        type: 'triangle', // 👈🏻 Node shape type.
         size: 40,
         direction: (d: any) => d.data?.direction,
         labelText: (d) => d.id!,

--- a/packages/g6/__tests__/demos/element-port.ts
+++ b/packages/g6/__tests__/demos/element-port.ts
@@ -24,8 +24,8 @@ export const elementPort: TestCase = async (context) => {
       ],
     },
     node: {
+      type: (d) => (d.id === 'node-1' ? 'circle' : 'rect'),
       style: {
-        type: (d) => (d.id === 'node-1' ? 'circle' : 'rect'),
         size: (d) => (d.id === 'node-1' ? 30 : [50, 150]),
         port: true,
         ports: (d) =>

--- a/packages/g6/__tests__/demos/element-z-index.ts
+++ b/packages/g6/__tests__/demos/element-z-index.ts
@@ -26,14 +26,14 @@ export const elementZIndex: TestCase = async (context) => {
         size: 40,
         labelText: (d) => d.id,
         labelWordWrapWidth: 200,
-        color: (d, index) => ['red', 'green', 'blue'][index],
       },
+      palette: 'tableau',
     },
     combo: {
       style: {
         labelText: (d) => d.id,
-        color: (d, index: number) => ['pink', 'cyan', 'purple', 'orange'][index],
       },
+      palette: 'tableau',
     },
     behaviors: ['drag-element'],
   });

--- a/packages/g6/__tests__/demos/layout-antv-dagre-flow-combo.ts
+++ b/packages/g6/__tests__/demos/layout-antv-dagre-flow-combo.ts
@@ -7,8 +7,8 @@ export const layoutAntVDagreFlowCombo: TestCase = async (context) => {
     autoFit: 'view',
     data,
     node: {
+      type: 'rect',
       style: {
-        type: 'rect',
         size: [60, 30],
         radius: 8,
         labelText: (d) => d.id,
@@ -20,14 +20,14 @@ export const layoutAntVDagreFlowCombo: TestCase = async (context) => {
       },
     },
     edge: {
+      type: 'cubic-vertical',
       style: {
-        type: 'cubic-vertical',
         endArrow: true,
       },
     },
     combo: {
+      type: 'rect',
       style: {
-        type: 'rect',
         radius: 8,
         labelText: (d) => d.id,
         lineDash: 0,

--- a/packages/g6/__tests__/demos/layout-antv-dagre-flow.ts
+++ b/packages/g6/__tests__/demos/layout-antv-dagre-flow.ts
@@ -7,8 +7,8 @@ export const layoutAntVDagreFlow: TestCase = async (context) => {
     autoFit: 'view',
     data,
     node: {
+      type: 'rect',
       style: {
-        type: 'rect',
         size: [60, 30],
         radius: 8,
         labelPlacement: 'center',
@@ -16,8 +16,8 @@ export const layoutAntVDagreFlow: TestCase = async (context) => {
       },
     },
     edge: {
+      type: 'polyline',
       style: {
-        type: 'polyline',
         radius: 20,
         endArrow: true,
         lineWidth: 2,

--- a/packages/g6/__tests__/demos/layout-compact-box-basic.ts
+++ b/packages/g6/__tests__/demos/layout-compact-box-basic.ts
@@ -16,9 +16,7 @@ export const layoutCompactBoxBasic: TestCase = async (context) => {
       },
     },
     edge: {
-      style: {
-        type: 'cubic-horizontal',
-      },
+      type: 'cubic-horizontal',
     },
     layout: {
       type: 'compact-box',

--- a/packages/g6/__tests__/demos/layout-compact-box-left-align.ts
+++ b/packages/g6/__tests__/demos/layout-compact-box-left-align.ts
@@ -20,9 +20,7 @@ export const layoutCompactBoxTopToBottom: TestCase = async (context) => {
       },
     },
     edge: {
-      style: {
-        type: 'cubic-horizontal',
-      },
+      type: 'cubic-horizontal',
     },
     layout: {
       type: 'compact-box',

--- a/packages/g6/__tests__/demos/layout-compact-box-top-to-bottom.ts
+++ b/packages/g6/__tests__/demos/layout-compact-box-top-to-bottom.ts
@@ -21,9 +21,7 @@ export const layoutCompactBoxLeftAlign: TestCase = async (context) => {
       },
     },
     edge: {
-      style: {
-        type: 'cubic-vertical',
-      },
+      type: 'cubic-vertical',
     },
     layout: {
       type: 'compact-box',

--- a/packages/g6/__tests__/demos/layout-dagre.ts
+++ b/packages/g6/__tests__/demos/layout-dagre.ts
@@ -27,8 +27,8 @@ export const layoutDagre: TestCase = async (context) => {
     },
     zoom: 0.8,
     node: {
+      type: 'rect',
       style: {
-        type: 'rect',
         labelText: (d) => d.data!.label as string,
         size: (d) => [d.data!.width, d.data!.height] as [number, number],
       },

--- a/packages/g6/__tests__/demos/layout-dendrogram-basic.ts
+++ b/packages/g6/__tests__/demos/layout-dendrogram-basic.ts
@@ -14,9 +14,7 @@ export const layoutDendrogramBasic: TestCase = async (context) => {
       },
     },
     edge: {
-      style: {
-        type: 'cubic-horizontal',
-      },
+      type: 'cubic-horizontal',
     },
     layout: {
       type: 'dendrogram',

--- a/packages/g6/__tests__/demos/layout-dendrogram-tb.ts
+++ b/packages/g6/__tests__/demos/layout-dendrogram-tb.ts
@@ -21,9 +21,7 @@ export const layoutDendrogramTb: TestCase = async (context) => {
       },
     },
     edge: {
-      style: {
-        type: 'cubic-vertical',
-      },
+      type: 'cubic-vertical',
     },
     layout: {
       type: 'dendrogram',

--- a/packages/g6/__tests__/demos/layout-force-collision.ts
+++ b/packages/g6/__tests__/demos/layout-force-collision.ts
@@ -23,7 +23,7 @@ export const layoutForceCollision: TestCase = async (context) => {
         this.context.layout?.getLayoutInstance().find((layout) => ['d3-force', 'd3-force-3d'].includes(layout?.id)) as
           | D3Force3DLayout
           | D3ForceLayout
-      ).setFixedPosition(0, [...pos]);
+      ).setFixedPosition('0', [...pos]);
     }
   }
 
@@ -75,7 +75,7 @@ function getData(width: number, size = 200) {
   const r = randomUniform(k, k * 4);
   const n = 4;
   return {
-    nodes: Array.from({ length: size }, (_, i) => ({ id: i, data: { r: r(), group: i && (i % n) + 1 } })),
+    nodes: Array.from({ length: size }, (_, i) => ({ id: `${i}`, data: { r: r(), group: i && (i % n) + 1 } })),
     edges: [],
   };
 }

--- a/packages/g6/__tests__/demos/layout-force-collision.ts
+++ b/packages/g6/__tests__/demos/layout-force-collision.ts
@@ -55,7 +55,7 @@ export const layoutForceCollision: TestCase = async (context) => {
     },
     node: {
       style: {
-        size: (d, i) => (i === 0 ? 0 : (d.data!.r as number) * 4),
+        size: (d) => (d.id === '0' ? 0 : (d.data!.r as number) * 4),
       },
       palette: {
         color: 'tableau',

--- a/packages/g6/__tests__/demos/layout-indented.ts
+++ b/packages/g6/__tests__/demos/layout-indented.ts
@@ -23,9 +23,7 @@ export const layoutIndented: TestCase = async (context) => {
     },
     node: { style: { size: 20 } },
     edge: {
-      style: {
-        type: 'polyline',
-      },
+      type: 'polyline',
     },
   };
 

--- a/packages/g6/__tests__/demos/layout-mindmap-h-custom-side.ts
+++ b/packages/g6/__tests__/demos/layout-mindmap-h-custom-side.ts
@@ -24,9 +24,7 @@ export const layoutMindmapHCustomSide: TestCase = async (context) => {
       },
     },
     edge: {
-      style: {
-        type: 'cubic-horizontal',
-      },
+      type: 'cubic-horizontal',
     },
     layout: {
       type: 'mindmap',

--- a/packages/g6/__tests__/demos/layout-mindmap-h-left.ts
+++ b/packages/g6/__tests__/demos/layout-mindmap-h-left.ts
@@ -22,9 +22,7 @@ export const layoutMindmapHLeft: TestCase = async (context) => {
       },
     },
     edge: {
-      style: {
-        type: 'cubic-horizontal',
-      },
+      type: 'cubic-horizontal',
     },
     layout: {
       type: 'mindmap',

--- a/packages/g6/__tests__/demos/layout-mindmap-h-right.ts
+++ b/packages/g6/__tests__/demos/layout-mindmap-h-right.ts
@@ -21,9 +21,7 @@ export const layoutMindmapHRight: TestCase = async (context) => {
       },
     },
     edge: {
-      style: {
-        type: 'cubic-horizontal',
-      },
+      type: 'cubic-horizontal',
     },
     layout: {
       type: 'mindmap',

--- a/packages/g6/__tests__/demos/layout-mindmap-h.ts
+++ b/packages/g6/__tests__/demos/layout-mindmap-h.ts
@@ -23,9 +23,7 @@ export const layoutMindmapH: TestCase = async (context) => {
       },
     },
     edge: {
-      style: {
-        type: 'cubic-horizontal',
-      },
+      type: 'cubic-horizontal',
     },
     layout: {
       type: 'mindmap',

--- a/packages/g6/__tests__/demos/plugin-history.ts
+++ b/packages/g6/__tests__/demos/plugin-history.ts
@@ -17,7 +17,8 @@ export const pluginHistory: TestCase = async (context) => {
       combos: [
         {
           id: 'combo-1',
-          style: { type: 'rect', parentId: 'combo-2', collapsed: true },
+          type: 'rect',
+          style: { parentId: 'combo-2', collapsed: true },
         },
         { id: 'combo-2' },
       ],

--- a/packages/g6/__tests__/demos/plugin-legend.ts
+++ b/packages/g6/__tests__/demos/plugin-legend.ts
@@ -25,15 +25,15 @@ export const pluginLegend: TestCase = async (context) => {
     layout: { type: 'd3force' },
     behaviors: ['drag-canvas', 'drag-element'],
     node: {
+      type: (item: any) => {
+        if (item.data.cluster === 'a') return 'diamond';
+        if (item.data.cluster === 'b') return 'rect';
+        if (item.data.cluster === 'c') return 'triangle';
+        return 'circle';
+      },
       style: {
         labelText: (d) => d.id,
         lineWidth: 0,
-        type: (item: any) => {
-          if (item.data.cluster === 'a') return 'diamond';
-          if (item.data.cluster === 'b') return 'rect';
-          if (item.data.cluster === 'c') return 'triangle';
-          return 'circle';
-        },
         color: (item: any) => {
           if (item.data.cluster === 'a') return 'red';
           if (item.data.cluster === 'b') return 'blue';

--- a/packages/g6/__tests__/snapshots/elements/change-type/change-type.svg
+++ b/packages/g6/__tests__/snapshots/elements/change-type/change-type.svg
@@ -6,8 +6,8 @@
       <g fill="none" transform="matrix(1,0,0,1,0,0)">
         <g fill="none" marker-start="false" marker-end="false" transform="matrix(1,0,0,1,0,0)">
           <g fill="none" marker-start="false" marker-end="false" stroke="transparent" stroke-width="3"/>
-          <g transform="matrix(1,0,0,1,124,100)">
-            <path fill="none" d="M 0,0 L 64,0" stroke-width="1" stroke="rgba(153,173,209,1)"/>
+          <g transform="matrix(1,0,0,1,112,100)">
+            <path fill="none" d="M 0,0 L 76,0" stroke-width="1" stroke="rgba(153,173,209,1)"/>
             <path fill="none" d="M 0,0 L 64,0" stroke-width="3" stroke="transparent"/>
           </g>
         </g>

--- a/packages/g6/__tests__/snapshots/elements/z-index/default.svg
+++ b/packages/g6/__tests__/snapshots/elements/z-index/default.svg
@@ -5,7 +5,7 @@
       <g fill="none" transform="matrix(1,0,0,1,0,0)">
         <g fill="none" transform="matrix(1,0,0,1,150.500000,273)">
           <g transform="matrix(1,0,0,1,0,0)">
-            <circle fill="rgba(255,192,203,1)" transform="translate(-107.64448311567081,-107.64448311567081)" cx="107.64448311567081" cy="107.64448311567081" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="107.64448311567081"/>
+            <circle fill="rgba(78,121,167,1)" transform="translate(-107.64448311567081,-107.64448311567081)" cx="107.64448311567081" cy="107.64448311567081" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="107.64448311567081"/>
           </g>
           <g fill="none" transform="matrix(1,0,0,1,0,107.644485)">
             <g transform="matrix(1,0,0,1,0,0)">
@@ -17,7 +17,7 @@
         </g>
         <g fill="none" transform="matrix(1,0,0,1,350,250)">
           <g transform="matrix(1,0,0,1,0,0)">
-            <circle fill="rgba(255,165,0,1)" transform="translate(-26,-26)" cx="26" cy="26" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="26"/>
+            <circle fill="rgba(118,183,178,1)" transform="translate(-26,-26)" cx="26" cy="26" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="26"/>
           </g>
           <g fill="none" transform="matrix(1,0,0,1,0,26)">
             <g transform="matrix(1,0,0,1,0,0)">
@@ -29,7 +29,7 @@
         </g>
         <g fill="none" transform="matrix(1,0,0,1,150.500000,261.500000)">
           <g transform="matrix(1,0,0,1,0,0)">
-            <circle fill="rgba(0,255,255,1)" transform="translate(-60.148649195139875,-60.148649195139875)" cx="60.148649195139875" cy="60.148649195139875" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="60.148649195139875"/>
+            <circle fill="rgba(242,142,44,1)" transform="translate(-60.148649195139875,-60.148649195139875)" cx="60.148649195139875" cy="60.148649195139875" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="60.148649195139875"/>
           </g>
           <g fill="none" transform="matrix(1,0,0,1,0,60.148647)">
             <g transform="matrix(1,0,0,1,0,0)">
@@ -41,7 +41,7 @@
         </g>
         <g fill="none" transform="matrix(1,0,0,1,150,250)">
           <g transform="matrix(1,0,0,1,0,0)">
-            <circle fill="rgba(128,0,128,1)" transform="translate(-26,-26)" cx="26" cy="26" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="26"/>
+            <circle fill="rgba(225,87,89,1)" transform="translate(-26,-26)" cx="26" cy="26" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="26"/>
           </g>
           <g fill="none" transform="matrix(1,0,0,1,0,26)">
             <g transform="matrix(1,0,0,1,0,0)">
@@ -78,7 +78,7 @@
       <g fill="none" transform="matrix(1,0,0,1,0,0)">
         <g fill="none" transform="matrix(1,0,0,1,50,50)">
           <g transform="matrix(1,0,0,1,0,0)">
-            <circle fill="rgba(255,0,0,1)" transform="translate(-20,-20)" cx="20" cy="20" stroke-width="0" stroke="rgba(0,0,0,1)" r="20"/>
+            <circle fill="rgba(78,121,167,1)" transform="translate(-20,-20)" cx="20" cy="20" stroke-width="0" stroke="rgba(0,0,0,1)" r="20"/>
           </g>
           <g fill="none" transform="matrix(1,0,0,1,0,20)">
             <g transform="matrix(1,0,0,1,0,0)">
@@ -90,7 +90,7 @@
         </g>
         <g fill="none" transform="matrix(1,0,0,1,200,50)">
           <g transform="matrix(1,0,0,1,0,0)">
-            <circle fill="rgba(0,128,0,1)" transform="translate(-20,-20)" cx="20" cy="20" stroke-width="0" stroke="rgba(0,0,0,1)" r="20"/>
+            <circle fill="rgba(242,142,44,1)" transform="translate(-20,-20)" cx="20" cy="20" stroke-width="0" stroke="rgba(0,0,0,1)" r="20"/>
           </g>
           <g fill="none" transform="matrix(1,0,0,1,0,20)">
             <g transform="matrix(1,0,0,1,0,0)">
@@ -102,7 +102,7 @@
         </g>
         <g fill="none" transform="matrix(1,0,0,1,125,150)">
           <g transform="matrix(1,0,0,1,0,0)">
-            <circle fill="rgba(0,0,255,1)" transform="translate(-20,-20)" cx="20" cy="20" stroke-width="0" stroke="rgba(0,0,0,1)" r="20"/>
+            <circle fill="rgba(225,87,89,1)" transform="translate(-20,-20)" cx="20" cy="20" stroke-width="0" stroke="rgba(0,0,0,1)" r="20"/>
           </g>
           <g fill="none" transform="matrix(1,0,0,1,0,20)">
             <g transform="matrix(1,0,0,1,0,0)">

--- a/packages/g6/__tests__/snapshots/elements/z-index/drag-combo-1.svg
+++ b/packages/g6/__tests__/snapshots/elements/z-index/drag-combo-1.svg
@@ -5,7 +5,7 @@
       <g fill="none" transform="matrix(1,0,0,1,0,0)">
         <g fill="none" transform="matrix(1,0,0,1,350,250)">
           <g transform="matrix(1,0,0,1,0,0)">
-            <circle fill="rgba(255,165,0,1)" transform="translate(-26,-26)" cx="26" cy="26" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="26"/>
+            <circle fill="rgba(118,183,178,1)" transform="translate(-26,-26)" cx="26" cy="26" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="26"/>
           </g>
           <g fill="none" transform="matrix(1,0,0,1,0,26)">
             <g transform="matrix(1,0,0,1,0,0)">
@@ -17,7 +17,7 @@
         </g>
         <g fill="none" transform="matrix(1,0,0,1,170.500000,273)">
           <g transform="matrix(1,0,0,1,0,0)">
-            <circle fill="rgba(255,192,203,1)" transform="translate(-107.64448311567081,-107.64448311567081)" cx="107.64448311567081" cy="107.64448311567081" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="107.64448311567081"/>
+            <circle fill="rgba(78,121,167,1)" transform="translate(-107.64448311567081,-107.64448311567081)" cx="107.64448311567081" cy="107.64448311567081" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="107.64448311567081"/>
           </g>
           <g fill="none" transform="matrix(1,0,0,1,0,107.644485)">
             <g transform="matrix(1,0,0,1,0,0)">
@@ -29,7 +29,7 @@
         </g>
         <g fill="none" transform="matrix(1,0,0,1,170.500000,261.500000)">
           <g transform="matrix(1,0,0,1,0,0)">
-            <circle fill="rgba(0,255,255,1)" transform="translate(-60.148649195139875,-60.148649195139875)" cx="60.148649195139875" cy="60.148649195139875" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="60.148649195139875"/>
+            <circle fill="rgba(242,142,44,1)" transform="translate(-60.148649195139875,-60.148649195139875)" cx="60.148649195139875" cy="60.148649195139875" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="60.148649195139875"/>
           </g>
           <g fill="none" transform="matrix(1,0,0,1,0,60.148647)">
             <g transform="matrix(1,0,0,1,0,0)">
@@ -41,7 +41,7 @@
         </g>
         <g fill="none" transform="matrix(1,0,0,1,170,250)">
           <g transform="matrix(1,0,0,1,0,0)">
-            <circle fill="rgba(128,0,128,1)" transform="translate(-26,-26)" cx="26" cy="26" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="26"/>
+            <circle fill="rgba(225,87,89,1)" transform="translate(-26,-26)" cx="26" cy="26" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="26"/>
           </g>
           <g fill="none" transform="matrix(1,0,0,1,0,26)">
             <g transform="matrix(1,0,0,1,0,0)">
@@ -78,7 +78,7 @@
       <g fill="none" transform="matrix(1,0,0,1,0,0)">
         <g fill="none" transform="matrix(1,0,0,1,190,50)">
           <g transform="matrix(1,0,0,1,0,0)">
-            <circle fill="rgba(255,0,0,1)" transform="translate(-20,-20)" cx="20" cy="20" stroke-width="0" stroke="rgba(0,0,0,1)" r="20"/>
+            <circle fill="rgba(78,121,167,1)" transform="translate(-20,-20)" cx="20" cy="20" stroke-width="0" stroke="rgba(0,0,0,1)" r="20"/>
           </g>
           <g fill="none" transform="matrix(1,0,0,1,0,20)">
             <g transform="matrix(1,0,0,1,0,0)">
@@ -90,7 +90,7 @@
         </g>
         <g fill="none" transform="matrix(1,0,0,1,135,150)">
           <g transform="matrix(1,0,0,1,0,0)">
-            <circle fill="rgba(0,128,0,1)" transform="translate(-20,-20)" cx="20" cy="20" stroke-width="0" stroke="rgba(0,0,0,1)" r="20"/>
+            <circle fill="rgba(242,142,44,1)" transform="translate(-20,-20)" cx="20" cy="20" stroke-width="0" stroke="rgba(0,0,0,1)" r="20"/>
           </g>
           <g fill="none" transform="matrix(1,0,0,1,0,20)">
             <g transform="matrix(1,0,0,1,0,0)">
@@ -102,7 +102,7 @@
         </g>
         <g fill="none" transform="matrix(1,0,0,1,200,50)">
           <g transform="matrix(1,0,0,1,0,0)">
-            <circle fill="rgba(0,0,255,1)" transform="translate(-20,-20)" cx="20" cy="20" stroke-width="0" stroke="rgba(0,0,0,1)" r="20"/>
+            <circle fill="rgba(225,87,89,1)" transform="translate(-20,-20)" cx="20" cy="20" stroke-width="0" stroke="rgba(0,0,0,1)" r="20"/>
           </g>
           <g fill="none" transform="matrix(1,0,0,1,0,20)">
             <g transform="matrix(1,0,0,1,0,0)">

--- a/packages/g6/__tests__/snapshots/elements/z-index/drag-combo-2.svg
+++ b/packages/g6/__tests__/snapshots/elements/z-index/drag-combo-2.svg
@@ -5,7 +5,7 @@
       <g fill="none" transform="matrix(1,0,0,1,0,0)">
         <g fill="none" transform="matrix(1,0,0,1,350,250)">
           <g transform="matrix(1,0,0,1,0,0)">
-            <circle fill="rgba(255,165,0,1)" transform="translate(-26,-26)" cx="26" cy="26" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="26"/>
+            <circle fill="rgba(118,183,178,1)" transform="translate(-26,-26)" cx="26" cy="26" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="26"/>
           </g>
           <g fill="none" transform="matrix(1,0,0,1,0,26)">
             <g transform="matrix(1,0,0,1,0,0)">
@@ -17,7 +17,7 @@
         </g>
         <g fill="none" transform="matrix(1,0,0,1,190.500000,273)">
           <g transform="matrix(1,0,0,1,0,0)">
-            <circle fill="rgba(255,192,203,1)" transform="translate(-107.64448311567082,-107.64448311567082)" cx="107.64448311567082" cy="107.64448311567082" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="107.64448311567082"/>
+            <circle fill="rgba(78,121,167,1)" transform="translate(-107.64448311567082,-107.64448311567082)" cx="107.64448311567082" cy="107.64448311567082" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="107.64448311567082"/>
           </g>
           <g fill="none" transform="matrix(1,0,0,1,0,107.644485)">
             <g transform="matrix(1,0,0,1,0,0)">
@@ -29,7 +29,7 @@
         </g>
         <g fill="none" transform="matrix(1,0,0,1,190.500000,261.500000)">
           <g transform="matrix(1,0,0,1,0,0)">
-            <circle fill="rgba(0,255,255,1)" transform="translate(-60.148649195139875,-60.148649195139875)" cx="60.148649195139875" cy="60.148649195139875" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="60.148649195139875"/>
+            <circle fill="rgba(242,142,44,1)" transform="translate(-60.148649195139875,-60.148649195139875)" cx="60.148649195139875" cy="60.148649195139875" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="60.148649195139875"/>
           </g>
           <g fill="none" transform="matrix(1,0,0,1,0,60.148647)">
             <g transform="matrix(1,0,0,1,0,0)">
@@ -41,7 +41,7 @@
         </g>
         <g fill="none" transform="matrix(1,0,0,1,190,250)">
           <g transform="matrix(1,0,0,1,0,0)">
-            <circle fill="rgba(128,0,128,1)" transform="translate(-26,-26)" cx="26" cy="26" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="26"/>
+            <circle fill="rgba(225,87,89,1)" transform="translate(-26,-26)" cx="26" cy="26" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="26"/>
           </g>
           <g fill="none" transform="matrix(1,0,0,1,0,26)">
             <g transform="matrix(1,0,0,1,0,0)">
@@ -78,7 +78,7 @@
       <g fill="none" transform="matrix(1,0,0,1,0,0)">
         <g fill="none" transform="matrix(1,0,0,1,190,50)">
           <g transform="matrix(1,0,0,1,0,0)">
-            <circle fill="rgba(255,0,0,1)" transform="translate(-20,-20)" cx="20" cy="20" stroke-width="0" stroke="rgba(0,0,0,1)" r="20"/>
+            <circle fill="rgba(78,121,167,1)" transform="translate(-20,-20)" cx="20" cy="20" stroke-width="0" stroke="rgba(0,0,0,1)" r="20"/>
           </g>
           <g fill="none" transform="matrix(1,0,0,1,0,20)">
             <g transform="matrix(1,0,0,1,0,0)">
@@ -90,7 +90,7 @@
         </g>
         <g fill="none" transform="matrix(1,0,0,1,135,150)">
           <g transform="matrix(1,0,0,1,0,0)">
-            <circle fill="rgba(0,128,0,1)" transform="translate(-20,-20)" cx="20" cy="20" stroke-width="0" stroke="rgba(0,0,0,1)" r="20"/>
+            <circle fill="rgba(242,142,44,1)" transform="translate(-20,-20)" cx="20" cy="20" stroke-width="0" stroke="rgba(0,0,0,1)" r="20"/>
           </g>
           <g fill="none" transform="matrix(1,0,0,1,0,20)">
             <g transform="matrix(1,0,0,1,0,0)">
@@ -102,7 +102,7 @@
         </g>
         <g fill="none" transform="matrix(1,0,0,1,200,50)">
           <g transform="matrix(1,0,0,1,0,0)">
-            <circle fill="rgba(0,0,255,1)" transform="translate(-20,-20)" cx="20" cy="20" stroke-width="0" stroke="rgba(0,0,0,1)" r="20"/>
+            <circle fill="rgba(225,87,89,1)" transform="translate(-20,-20)" cx="20" cy="20" stroke-width="0" stroke="rgba(0,0,0,1)" r="20"/>
           </g>
           <g fill="none" transform="matrix(1,0,0,1,0,20)">
             <g transform="matrix(1,0,0,1,0,0)">

--- a/packages/g6/__tests__/snapshots/elements/z-index/drag-combo-3.svg
+++ b/packages/g6/__tests__/snapshots/elements/z-index/drag-combo-3.svg
@@ -5,7 +5,7 @@
       <g fill="none" transform="matrix(1,0,0,1,0,0)">
         <g fill="none" transform="matrix(1,0,0,1,350,250)">
           <g transform="matrix(1,0,0,1,0,0)">
-            <circle fill="rgba(255,165,0,1)" transform="translate(-26,-26)" cx="26" cy="26" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="26"/>
+            <circle fill="rgba(118,183,178,1)" transform="translate(-26,-26)" cx="26" cy="26" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="26"/>
           </g>
           <g fill="none" transform="matrix(1,0,0,1,0,26)">
             <g transform="matrix(1,0,0,1,0,0)">
@@ -17,7 +17,7 @@
         </g>
         <g fill="none" transform="matrix(1,0,0,1,210.500000,273)">
           <g transform="matrix(1,0,0,1,0,0)">
-            <circle fill="rgba(255,192,203,1)" transform="translate(-107.64448311567081,-107.64448311567081)" cx="107.64448311567081" cy="107.64448311567081" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="107.64448311567081"/>
+            <circle fill="rgba(78,121,167,1)" transform="translate(-107.64448311567081,-107.64448311567081)" cx="107.64448311567081" cy="107.64448311567081" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="107.64448311567081"/>
           </g>
           <g fill="none" transform="matrix(1,0,0,1,0,107.644485)">
             <g transform="matrix(1,0,0,1,0,0)">
@@ -29,7 +29,7 @@
         </g>
         <g fill="none" transform="matrix(1,0,0,1,210.500000,261.500000)">
           <g transform="matrix(1,0,0,1,0,0)">
-            <circle fill="rgba(0,255,255,1)" transform="translate(-60.148649195139875,-60.148649195139875)" cx="60.148649195139875" cy="60.148649195139875" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="60.148649195139875"/>
+            <circle fill="rgba(242,142,44,1)" transform="translate(-60.148649195139875,-60.148649195139875)" cx="60.148649195139875" cy="60.148649195139875" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="60.148649195139875"/>
           </g>
           <g fill="none" transform="matrix(1,0,0,1,0,60.148647)">
             <g transform="matrix(1,0,0,1,0,0)">
@@ -41,7 +41,7 @@
         </g>
         <g fill="none" transform="matrix(1,0,0,1,210,250)">
           <g transform="matrix(1,0,0,1,0,0)">
-            <circle fill="rgba(128,0,128,1)" transform="translate(-26,-26)" cx="26" cy="26" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="26"/>
+            <circle fill="rgba(225,87,89,1)" transform="translate(-26,-26)" cx="26" cy="26" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="26"/>
           </g>
           <g fill="none" transform="matrix(1,0,0,1,0,26)">
             <g transform="matrix(1,0,0,1,0,0)">
@@ -78,7 +78,7 @@
       <g fill="none" transform="matrix(1,0,0,1,0,0)">
         <g fill="none" transform="matrix(1,0,0,1,190,50)">
           <g transform="matrix(1,0,0,1,0,0)">
-            <circle fill="rgba(255,0,0,1)" transform="translate(-20,-20)" cx="20" cy="20" stroke-width="0" stroke="rgba(0,0,0,1)" r="20"/>
+            <circle fill="rgba(78,121,167,1)" transform="translate(-20,-20)" cx="20" cy="20" stroke-width="0" stroke="rgba(0,0,0,1)" r="20"/>
           </g>
           <g fill="none" transform="matrix(1,0,0,1,0,20)">
             <g transform="matrix(1,0,0,1,0,0)">
@@ -90,7 +90,7 @@
         </g>
         <g fill="none" transform="matrix(1,0,0,1,135,150)">
           <g transform="matrix(1,0,0,1,0,0)">
-            <circle fill="rgba(0,128,0,1)" transform="translate(-20,-20)" cx="20" cy="20" stroke-width="0" stroke="rgba(0,0,0,1)" r="20"/>
+            <circle fill="rgba(242,142,44,1)" transform="translate(-20,-20)" cx="20" cy="20" stroke-width="0" stroke="rgba(0,0,0,1)" r="20"/>
           </g>
           <g fill="none" transform="matrix(1,0,0,1,0,20)">
             <g transform="matrix(1,0,0,1,0,0)">
@@ -102,7 +102,7 @@
         </g>
         <g fill="none" transform="matrix(1,0,0,1,200,50)">
           <g transform="matrix(1,0,0,1,0,0)">
-            <circle fill="rgba(0,0,255,1)" transform="translate(-20,-20)" cx="20" cy="20" stroke-width="0" stroke="rgba(0,0,0,1)" r="20"/>
+            <circle fill="rgba(225,87,89,1)" transform="translate(-20,-20)" cx="20" cy="20" stroke-width="0" stroke="rgba(0,0,0,1)" r="20"/>
           </g>
           <g fill="none" transform="matrix(1,0,0,1,0,20)">
             <g transform="matrix(1,0,0,1,0,0)">

--- a/packages/g6/__tests__/snapshots/elements/z-index/drag-overlap-combo-3.svg
+++ b/packages/g6/__tests__/snapshots/elements/z-index/drag-overlap-combo-3.svg
@@ -5,7 +5,7 @@
       <g fill="none" transform="matrix(1,0,0,1,0,0)">
         <g fill="none" transform="matrix(1,0,0,1,350,250)">
           <g transform="matrix(1,0,0,1,0,0)">
-            <circle fill="rgba(255,165,0,1)" transform="translate(-26,-26)" cx="26" cy="26" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="26"/>
+            <circle fill="rgba(118,183,178,1)" transform="translate(-26,-26)" cx="26" cy="26" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="26"/>
           </g>
           <g fill="none" transform="matrix(1,0,0,1,0,26)">
             <g transform="matrix(1,0,0,1,0,0)">
@@ -17,7 +17,7 @@
         </g>
         <g fill="none" transform="matrix(1,0,0,1,230.500000,273)">
           <g transform="matrix(1,0,0,1,0,0)">
-            <circle fill="rgba(255,192,203,1)" transform="translate(-107.6444831156708,-107.6444831156708)" cx="107.6444831156708" cy="107.6444831156708" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="107.6444831156708"/>
+            <circle fill="rgba(78,121,167,1)" transform="translate(-107.6444831156708,-107.6444831156708)" cx="107.6444831156708" cy="107.6444831156708" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="107.6444831156708"/>
           </g>
           <g fill="none" transform="matrix(1,0,0,1,0,107.644485)">
             <g transform="matrix(1,0,0,1,0,0)">
@@ -29,7 +29,7 @@
         </g>
         <g fill="none" transform="matrix(1,0,0,1,230.500000,261.500000)">
           <g transform="matrix(1,0,0,1,0,0)">
-            <circle fill="rgba(0,255,255,1)" transform="translate(-60.14864919513987,-60.14864919513987)" cx="60.14864919513987" cy="60.14864919513987" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="60.14864919513987"/>
+            <circle fill="rgba(242,142,44,1)" transform="translate(-60.14864919513987,-60.14864919513987)" cx="60.14864919513987" cy="60.14864919513987" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="60.14864919513987"/>
           </g>
           <g fill="none" transform="matrix(1,0,0,1,0,60.148647)">
             <g transform="matrix(1,0,0,1,0,0)">
@@ -41,7 +41,7 @@
         </g>
         <g fill="none" transform="matrix(1,0,0,1,230,250)">
           <g transform="matrix(1,0,0,1,0,0)">
-            <circle fill="rgba(128,0,128,1)" transform="translate(-26,-26)" cx="26" cy="26" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="26"/>
+            <circle fill="rgba(225,87,89,1)" transform="translate(-26,-26)" cx="26" cy="26" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="26"/>
           </g>
           <g fill="none" transform="matrix(1,0,0,1,0,26)">
             <g transform="matrix(1,0,0,1,0,0)">
@@ -78,7 +78,7 @@
       <g fill="none" transform="matrix(1,0,0,1,0,0)">
         <g fill="none" transform="matrix(1,0,0,1,190,50)">
           <g transform="matrix(1,0,0,1,0,0)">
-            <circle fill="rgba(255,0,0,1)" transform="translate(-20,-20)" cx="20" cy="20" stroke-width="0" stroke="rgba(0,0,0,1)" r="20"/>
+            <circle fill="rgba(78,121,167,1)" transform="translate(-20,-20)" cx="20" cy="20" stroke-width="0" stroke="rgba(0,0,0,1)" r="20"/>
           </g>
           <g fill="none" transform="matrix(1,0,0,1,0,20)">
             <g transform="matrix(1,0,0,1,0,0)">
@@ -90,7 +90,7 @@
         </g>
         <g fill="none" transform="matrix(1,0,0,1,135,150)">
           <g transform="matrix(1,0,0,1,0,0)">
-            <circle fill="rgba(0,128,0,1)" transform="translate(-20,-20)" cx="20" cy="20" stroke-width="0" stroke="rgba(0,0,0,1)" r="20"/>
+            <circle fill="rgba(242,142,44,1)" transform="translate(-20,-20)" cx="20" cy="20" stroke-width="0" stroke="rgba(0,0,0,1)" r="20"/>
           </g>
           <g fill="none" transform="matrix(1,0,0,1,0,20)">
             <g transform="matrix(1,0,0,1,0,0)">
@@ -102,7 +102,7 @@
         </g>
         <g fill="none" transform="matrix(1,0,0,1,200,50)">
           <g transform="matrix(1,0,0,1,0,0)">
-            <circle fill="rgba(0,0,255,1)" transform="translate(-20,-20)" cx="20" cy="20" stroke-width="0" stroke="rgba(0,0,0,1)" r="20"/>
+            <circle fill="rgba(225,87,89,1)" transform="translate(-20,-20)" cx="20" cy="20" stroke-width="0" stroke="rgba(0,0,0,1)" r="20"/>
           </g>
           <g fill="none" transform="matrix(1,0,0,1,0,20)">
             <g transform="matrix(1,0,0,1,0,0)">

--- a/packages/g6/__tests__/snapshots/elements/z-index/drag-overlap-combo-4(1).svg
+++ b/packages/g6/__tests__/snapshots/elements/z-index/drag-overlap-combo-4(1).svg
@@ -5,7 +5,7 @@
       <g fill="none" transform="matrix(1,0,0,1,0,0)">
         <g fill="none" transform="matrix(1,0,0,1,230.500000,273)">
           <g transform="matrix(1,0,0,1,0,0)">
-            <circle fill="rgba(255,192,203,1)" transform="translate(-107.6444831156708,-107.6444831156708)" cx="107.6444831156708" cy="107.6444831156708" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="107.6444831156708"/>
+            <circle fill="rgba(78,121,167,1)" transform="translate(-107.6444831156708,-107.6444831156708)" cx="107.6444831156708" cy="107.6444831156708" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="107.6444831156708"/>
           </g>
           <g fill="none" transform="matrix(1,0,0,1,0,107.644485)">
             <g transform="matrix(1,0,0,1,0,0)">
@@ -17,7 +17,7 @@
         </g>
         <g fill="none" transform="matrix(1,0,0,1,230.500000,261.500000)">
           <g transform="matrix(1,0,0,1,0,0)">
-            <circle fill="rgba(0,255,255,1)" transform="translate(-60.14864919513987,-60.14864919513987)" cx="60.14864919513987" cy="60.14864919513987" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="60.14864919513987"/>
+            <circle fill="rgba(242,142,44,1)" transform="translate(-60.14864919513987,-60.14864919513987)" cx="60.14864919513987" cy="60.14864919513987" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="60.14864919513987"/>
           </g>
           <g fill="none" transform="matrix(1,0,0,1,0,60.148647)">
             <g transform="matrix(1,0,0,1,0,0)">
@@ -29,7 +29,7 @@
         </g>
         <g fill="none" transform="matrix(1,0,0,1,230,250)">
           <g transform="matrix(1,0,0,1,0,0)">
-            <circle fill="rgba(128,0,128,1)" transform="translate(-26,-26)" cx="26" cy="26" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="26"/>
+            <circle fill="rgba(225,87,89,1)" transform="translate(-26,-26)" cx="26" cy="26" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="26"/>
           </g>
           <g fill="none" transform="matrix(1,0,0,1,0,26)">
             <g transform="matrix(1,0,0,1,0,0)">
@@ -41,7 +41,7 @@
         </g>
         <g fill="none" transform="matrix(1,0,0,1,330,250)">
           <g transform="matrix(1,0,0,1,0,0)">
-            <circle fill="rgba(255,165,0,1)" transform="translate(-26,-26)" cx="26" cy="26" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="26"/>
+            <circle fill="rgba(118,183,178,1)" transform="translate(-26,-26)" cx="26" cy="26" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="26"/>
           </g>
           <g fill="none" transform="matrix(1,0,0,1,0,26)">
             <g transform="matrix(1,0,0,1,0,0)">
@@ -78,7 +78,7 @@
       <g fill="none" transform="matrix(1,0,0,1,0,0)">
         <g fill="none" transform="matrix(1,0,0,1,190,50)">
           <g transform="matrix(1,0,0,1,0,0)">
-            <circle fill="rgba(255,0,0,1)" transform="translate(-20,-20)" cx="20" cy="20" stroke-width="0" stroke="rgba(0,0,0,1)" r="20"/>
+            <circle fill="rgba(78,121,167,1)" transform="translate(-20,-20)" cx="20" cy="20" stroke-width="0" stroke="rgba(0,0,0,1)" r="20"/>
           </g>
           <g fill="none" transform="matrix(1,0,0,1,0,20)">
             <g transform="matrix(1,0,0,1,0,0)">
@@ -90,7 +90,7 @@
         </g>
         <g fill="none" transform="matrix(1,0,0,1,135,150)">
           <g transform="matrix(1,0,0,1,0,0)">
-            <circle fill="rgba(0,128,0,1)" transform="translate(-20,-20)" cx="20" cy="20" stroke-width="0" stroke="rgba(0,0,0,1)" r="20"/>
+            <circle fill="rgba(242,142,44,1)" transform="translate(-20,-20)" cx="20" cy="20" stroke-width="0" stroke="rgba(0,0,0,1)" r="20"/>
           </g>
           <g fill="none" transform="matrix(1,0,0,1,0,20)">
             <g transform="matrix(1,0,0,1,0,0)">
@@ -102,7 +102,7 @@
         </g>
         <g fill="none" transform="matrix(1,0,0,1,200,50)">
           <g transform="matrix(1,0,0,1,0,0)">
-            <circle fill="rgba(0,0,255,1)" transform="translate(-20,-20)" cx="20" cy="20" stroke-width="0" stroke="rgba(0,0,0,1)" r="20"/>
+            <circle fill="rgba(225,87,89,1)" transform="translate(-20,-20)" cx="20" cy="20" stroke-width="0" stroke="rgba(0,0,0,1)" r="20"/>
           </g>
           <g fill="none" transform="matrix(1,0,0,1,0,20)">
             <g transform="matrix(1,0,0,1,0,0)">

--- a/packages/g6/__tests__/snapshots/elements/z-index/drag-overlap-combo-4(2).svg
+++ b/packages/g6/__tests__/snapshots/elements/z-index/drag-overlap-combo-4(2).svg
@@ -5,7 +5,7 @@
       <g fill="none" transform="matrix(1,0,0,1,0,0)">
         <g fill="none" transform="matrix(1,0,0,1,230.500000,273)">
           <g transform="matrix(1,0,0,1,0,0)">
-            <circle fill="rgba(255,192,203,1)" transform="translate(-107.6444831156708,-107.6444831156708)" cx="107.6444831156708" cy="107.6444831156708" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="107.6444831156708"/>
+            <circle fill="rgba(78,121,167,1)" transform="translate(-107.6444831156708,-107.6444831156708)" cx="107.6444831156708" cy="107.6444831156708" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="107.6444831156708"/>
           </g>
           <g fill="none" transform="matrix(1,0,0,1,0,107.644485)">
             <g transform="matrix(1,0,0,1,0,0)">
@@ -17,7 +17,7 @@
         </g>
         <g fill="none" transform="matrix(1,0,0,1,230.500000,261.500000)">
           <g transform="matrix(1,0,0,1,0,0)">
-            <circle fill="rgba(0,255,255,1)" transform="translate(-60.14864919513987,-60.14864919513987)" cx="60.14864919513987" cy="60.14864919513987" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="60.14864919513987"/>
+            <circle fill="rgba(242,142,44,1)" transform="translate(-60.14864919513987,-60.14864919513987)" cx="60.14864919513987" cy="60.14864919513987" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="60.14864919513987"/>
           </g>
           <g fill="none" transform="matrix(1,0,0,1,0,60.148647)">
             <g transform="matrix(1,0,0,1,0,0)">
@@ -29,7 +29,7 @@
         </g>
         <g fill="none" transform="matrix(1,0,0,1,230,250)">
           <g transform="matrix(1,0,0,1,0,0)">
-            <circle fill="rgba(128,0,128,1)" transform="translate(-26,-26)" cx="26" cy="26" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="26"/>
+            <circle fill="rgba(225,87,89,1)" transform="translate(-26,-26)" cx="26" cy="26" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="26"/>
           </g>
           <g fill="none" transform="matrix(1,0,0,1,0,26)">
             <g transform="matrix(1,0,0,1,0,0)">
@@ -41,7 +41,7 @@
         </g>
         <g fill="none" transform="matrix(1,0,0,1,290,250)">
           <g transform="matrix(1,0,0,1,0,0)">
-            <circle fill="rgba(255,165,0,1)" transform="translate(-26,-26)" cx="26" cy="26" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="26"/>
+            <circle fill="rgba(118,183,178,1)" transform="translate(-26,-26)" cx="26" cy="26" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="26"/>
           </g>
           <g fill="none" transform="matrix(1,0,0,1,0,26)">
             <g transform="matrix(1,0,0,1,0,0)">
@@ -78,7 +78,7 @@
       <g fill="none" transform="matrix(1,0,0,1,0,0)">
         <g fill="none" transform="matrix(1,0,0,1,190,50)">
           <g transform="matrix(1,0,0,1,0,0)">
-            <circle fill="rgba(255,0,0,1)" transform="translate(-20,-20)" cx="20" cy="20" stroke-width="0" stroke="rgba(0,0,0,1)" r="20"/>
+            <circle fill="rgba(78,121,167,1)" transform="translate(-20,-20)" cx="20" cy="20" stroke-width="0" stroke="rgba(0,0,0,1)" r="20"/>
           </g>
           <g fill="none" transform="matrix(1,0,0,1,0,20)">
             <g transform="matrix(1,0,0,1,0,0)">
@@ -90,7 +90,7 @@
         </g>
         <g fill="none" transform="matrix(1,0,0,1,135,150)">
           <g transform="matrix(1,0,0,1,0,0)">
-            <circle fill="rgba(0,128,0,1)" transform="translate(-20,-20)" cx="20" cy="20" stroke-width="0" stroke="rgba(0,0,0,1)" r="20"/>
+            <circle fill="rgba(242,142,44,1)" transform="translate(-20,-20)" cx="20" cy="20" stroke-width="0" stroke="rgba(0,0,0,1)" r="20"/>
           </g>
           <g fill="none" transform="matrix(1,0,0,1,0,20)">
             <g transform="matrix(1,0,0,1,0,0)">
@@ -102,7 +102,7 @@
         </g>
         <g fill="none" transform="matrix(1,0,0,1,200,50)">
           <g transform="matrix(1,0,0,1,0,0)">
-            <circle fill="rgba(0,0,255,1)" transform="translate(-20,-20)" cx="20" cy="20" stroke-width="0" stroke="rgba(0,0,0,1)" r="20"/>
+            <circle fill="rgba(225,87,89,1)" transform="translate(-20,-20)" cx="20" cy="20" stroke-width="0" stroke="rgba(0,0,0,1)" r="20"/>
           </g>
           <g fill="none" transform="matrix(1,0,0,1,0,20)">
             <g transform="matrix(1,0,0,1,0,0)">

--- a/packages/g6/__tests__/snapshots/elements/z-index/drag-overlap-combo-4(3).svg
+++ b/packages/g6/__tests__/snapshots/elements/z-index/drag-overlap-combo-4(3).svg
@@ -5,7 +5,7 @@
       <g fill="none" transform="matrix(1,0,0,1,0,0)">
         <g fill="none" transform="matrix(1,0,0,1,230.500000,273)">
           <g transform="matrix(1,0,0,1,0,0)">
-            <circle fill="rgba(255,192,203,1)" transform="translate(-107.6444831156708,-107.6444831156708)" cx="107.6444831156708" cy="107.6444831156708" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="107.6444831156708"/>
+            <circle fill="rgba(78,121,167,1)" transform="translate(-107.6444831156708,-107.6444831156708)" cx="107.6444831156708" cy="107.6444831156708" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="107.6444831156708"/>
           </g>
           <g fill="none" transform="matrix(1,0,0,1,0,107.644485)">
             <g transform="matrix(1,0,0,1,0,0)">
@@ -17,7 +17,7 @@
         </g>
         <g fill="none" transform="matrix(1,0,0,1,230.500000,261.500000)">
           <g transform="matrix(1,0,0,1,0,0)">
-            <circle fill="rgba(0,255,255,1)" transform="translate(-60.14864919513987,-60.14864919513987)" cx="60.14864919513987" cy="60.14864919513987" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="60.14864919513987"/>
+            <circle fill="rgba(242,142,44,1)" transform="translate(-60.14864919513987,-60.14864919513987)" cx="60.14864919513987" cy="60.14864919513987" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="60.14864919513987"/>
           </g>
           <g fill="none" transform="matrix(1,0,0,1,0,60.148647)">
             <g transform="matrix(1,0,0,1,0,0)">
@@ -29,7 +29,7 @@
         </g>
         <g fill="none" transform="matrix(1,0,0,1,230,250)">
           <g transform="matrix(1,0,0,1,0,0)">
-            <circle fill="rgba(128,0,128,1)" transform="translate(-26,-26)" cx="26" cy="26" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="26"/>
+            <circle fill="rgba(225,87,89,1)" transform="translate(-26,-26)" cx="26" cy="26" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="26"/>
           </g>
           <g fill="none" transform="matrix(1,0,0,1,0,26)">
             <g transform="matrix(1,0,0,1,0,0)">
@@ -41,7 +41,7 @@
         </g>
         <g fill="none" transform="matrix(1,0,0,1,250,250)">
           <g transform="matrix(1,0,0,1,0,0)">
-            <circle fill="rgba(255,165,0,1)" transform="translate(-26,-26)" cx="26" cy="26" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="26"/>
+            <circle fill="rgba(118,183,178,1)" transform="translate(-26,-26)" cx="26" cy="26" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="26"/>
           </g>
           <g fill="none" transform="matrix(1,0,0,1,0,26)">
             <g transform="matrix(1,0,0,1,0,0)">
@@ -78,7 +78,7 @@
       <g fill="none" transform="matrix(1,0,0,1,0,0)">
         <g fill="none" transform="matrix(1,0,0,1,190,50)">
           <g transform="matrix(1,0,0,1,0,0)">
-            <circle fill="rgba(255,0,0,1)" transform="translate(-20,-20)" cx="20" cy="20" stroke-width="0" stroke="rgba(0,0,0,1)" r="20"/>
+            <circle fill="rgba(78,121,167,1)" transform="translate(-20,-20)" cx="20" cy="20" stroke-width="0" stroke="rgba(0,0,0,1)" r="20"/>
           </g>
           <g fill="none" transform="matrix(1,0,0,1,0,20)">
             <g transform="matrix(1,0,0,1,0,0)">
@@ -90,7 +90,7 @@
         </g>
         <g fill="none" transform="matrix(1,0,0,1,135,150)">
           <g transform="matrix(1,0,0,1,0,0)">
-            <circle fill="rgba(0,128,0,1)" transform="translate(-20,-20)" cx="20" cy="20" stroke-width="0" stroke="rgba(0,0,0,1)" r="20"/>
+            <circle fill="rgba(242,142,44,1)" transform="translate(-20,-20)" cx="20" cy="20" stroke-width="0" stroke="rgba(0,0,0,1)" r="20"/>
           </g>
           <g fill="none" transform="matrix(1,0,0,1,0,20)">
             <g transform="matrix(1,0,0,1,0,0)">
@@ -102,7 +102,7 @@
         </g>
         <g fill="none" transform="matrix(1,0,0,1,200,50)">
           <g transform="matrix(1,0,0,1,0,0)">
-            <circle fill="rgba(0,0,255,1)" transform="translate(-20,-20)" cx="20" cy="20" stroke-width="0" stroke="rgba(0,0,0,1)" r="20"/>
+            <circle fill="rgba(225,87,89,1)" transform="translate(-20,-20)" cx="20" cy="20" stroke-width="0" stroke="rgba(0,0,0,1)" r="20"/>
           </g>
           <g fill="none" transform="matrix(1,0,0,1,0,20)">
             <g transform="matrix(1,0,0,1,0,0)">

--- a/packages/g6/__tests__/snapshots/elements/z-index/drag-overlap-node-1.svg
+++ b/packages/g6/__tests__/snapshots/elements/z-index/drag-overlap-node-1.svg
@@ -5,7 +5,7 @@
       <g fill="none" transform="matrix(1,0,0,1,0,0)">
         <g fill="none" transform="matrix(1,0,0,1,150.500000,273)">
           <g transform="matrix(1,0,0,1,0,0)">
-            <circle fill="rgba(255,192,203,1)" transform="translate(-107.64448311567081,-107.64448311567081)" cx="107.64448311567081" cy="107.64448311567081" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="107.64448311567081"/>
+            <circle fill="rgba(78,121,167,1)" transform="translate(-107.64448311567081,-107.64448311567081)" cx="107.64448311567081" cy="107.64448311567081" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="107.64448311567081"/>
           </g>
           <g fill="none" transform="matrix(1,0,0,1,0,107.644485)">
             <g transform="matrix(1,0,0,1,0,0)">
@@ -17,7 +17,7 @@
         </g>
         <g fill="none" transform="matrix(1,0,0,1,350,250)">
           <g transform="matrix(1,0,0,1,0,0)">
-            <circle fill="rgba(255,165,0,1)" transform="translate(-26,-26)" cx="26" cy="26" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="26"/>
+            <circle fill="rgba(118,183,178,1)" transform="translate(-26,-26)" cx="26" cy="26" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="26"/>
           </g>
           <g fill="none" transform="matrix(1,0,0,1,0,26)">
             <g transform="matrix(1,0,0,1,0,0)">
@@ -29,7 +29,7 @@
         </g>
         <g fill="none" transform="matrix(1,0,0,1,150.500000,261.500000)">
           <g transform="matrix(1,0,0,1,0,0)">
-            <circle fill="rgba(0,255,255,1)" transform="translate(-60.148649195139875,-60.148649195139875)" cx="60.148649195139875" cy="60.148649195139875" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="60.148649195139875"/>
+            <circle fill="rgba(242,142,44,1)" transform="translate(-60.148649195139875,-60.148649195139875)" cx="60.148649195139875" cy="60.148649195139875" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="60.148649195139875"/>
           </g>
           <g fill="none" transform="matrix(1,0,0,1,0,60.148647)">
             <g transform="matrix(1,0,0,1,0,0)">
@@ -41,7 +41,7 @@
         </g>
         <g fill="none" transform="matrix(1,0,0,1,150,250)">
           <g transform="matrix(1,0,0,1,0,0)">
-            <circle fill="rgba(128,0,128,1)" transform="translate(-26,-26)" cx="26" cy="26" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="26"/>
+            <circle fill="rgba(225,87,89,1)" transform="translate(-26,-26)" cx="26" cy="26" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="26"/>
           </g>
           <g fill="none" transform="matrix(1,0,0,1,0,26)">
             <g transform="matrix(1,0,0,1,0,0)">
@@ -78,7 +78,7 @@
       <g fill="none" transform="matrix(1,0,0,1,0,0)">
         <g fill="none" transform="matrix(1,0,0,1,200,50)">
           <g transform="matrix(1,0,0,1,0,0)">
-            <circle fill="rgba(0,128,0,1)" transform="translate(-20,-20)" cx="20" cy="20" stroke-width="0" stroke="rgba(0,0,0,1)" r="20"/>
+            <circle fill="rgba(242,142,44,1)" transform="translate(-20,-20)" cx="20" cy="20" stroke-width="0" stroke="rgba(0,0,0,1)" r="20"/>
           </g>
           <g fill="none" transform="matrix(1,0,0,1,0,20)">
             <g transform="matrix(1,0,0,1,0,0)">
@@ -90,7 +90,7 @@
         </g>
         <g fill="none" transform="matrix(1,0,0,1,125,150)">
           <g transform="matrix(1,0,0,1,0,0)">
-            <circle fill="rgba(0,0,255,1)" transform="translate(-20,-20)" cx="20" cy="20" stroke-width="0" stroke="rgba(0,0,0,1)" r="20"/>
+            <circle fill="rgba(225,87,89,1)" transform="translate(-20,-20)" cx="20" cy="20" stroke-width="0" stroke="rgba(0,0,0,1)" r="20"/>
           </g>
           <g fill="none" transform="matrix(1,0,0,1,0,20)">
             <g transform="matrix(1,0,0,1,0,0)">
@@ -102,7 +102,7 @@
         </g>
         <g fill="none" transform="matrix(1,0,0,1,190,50)">
           <g transform="matrix(1,0,0,1,0,0)">
-            <circle fill="rgba(255,0,0,1)" transform="translate(-20,-20)" cx="20" cy="20" stroke-width="0" stroke="rgba(0,0,0,1)" r="20"/>
+            <circle fill="rgba(78,121,167,1)" transform="translate(-20,-20)" cx="20" cy="20" stroke-width="0" stroke="rgba(0,0,0,1)" r="20"/>
           </g>
           <g fill="none" transform="matrix(1,0,0,1,0,20)">
             <g transform="matrix(1,0,0,1,0,0)">

--- a/packages/g6/__tests__/snapshots/elements/z-index/drag-overlap-node-2.svg
+++ b/packages/g6/__tests__/snapshots/elements/z-index/drag-overlap-node-2.svg
@@ -5,7 +5,7 @@
       <g fill="none" transform="matrix(1,0,0,1,0,0)">
         <g fill="none" transform="matrix(1,0,0,1,150.500000,273)">
           <g transform="matrix(1,0,0,1,0,0)">
-            <circle fill="rgba(255,192,203,1)" transform="translate(-107.64448311567081,-107.64448311567081)" cx="107.64448311567081" cy="107.64448311567081" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="107.64448311567081"/>
+            <circle fill="rgba(78,121,167,1)" transform="translate(-107.64448311567081,-107.64448311567081)" cx="107.64448311567081" cy="107.64448311567081" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="107.64448311567081"/>
           </g>
           <g fill="none" transform="matrix(1,0,0,1,0,107.644485)">
             <g transform="matrix(1,0,0,1,0,0)">
@@ -17,7 +17,7 @@
         </g>
         <g fill="none" transform="matrix(1,0,0,1,350,250)">
           <g transform="matrix(1,0,0,1,0,0)">
-            <circle fill="rgba(255,165,0,1)" transform="translate(-26,-26)" cx="26" cy="26" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="26"/>
+            <circle fill="rgba(118,183,178,1)" transform="translate(-26,-26)" cx="26" cy="26" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="26"/>
           </g>
           <g fill="none" transform="matrix(1,0,0,1,0,26)">
             <g transform="matrix(1,0,0,1,0,0)">
@@ -29,7 +29,7 @@
         </g>
         <g fill="none" transform="matrix(1,0,0,1,150.500000,261.500000)">
           <g transform="matrix(1,0,0,1,0,0)">
-            <circle fill="rgba(0,255,255,1)" transform="translate(-60.148649195139875,-60.148649195139875)" cx="60.148649195139875" cy="60.148649195139875" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="60.148649195139875"/>
+            <circle fill="rgba(242,142,44,1)" transform="translate(-60.148649195139875,-60.148649195139875)" cx="60.148649195139875" cy="60.148649195139875" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="60.148649195139875"/>
           </g>
           <g fill="none" transform="matrix(1,0,0,1,0,60.148647)">
             <g transform="matrix(1,0,0,1,0,0)">
@@ -41,7 +41,7 @@
         </g>
         <g fill="none" transform="matrix(1,0,0,1,150,250)">
           <g transform="matrix(1,0,0,1,0,0)">
-            <circle fill="rgba(128,0,128,1)" transform="translate(-26,-26)" cx="26" cy="26" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="26"/>
+            <circle fill="rgba(225,87,89,1)" transform="translate(-26,-26)" cx="26" cy="26" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="26"/>
           </g>
           <g fill="none" transform="matrix(1,0,0,1,0,26)">
             <g transform="matrix(1,0,0,1,0,0)">
@@ -78,7 +78,7 @@
       <g fill="none" transform="matrix(1,0,0,1,0,0)">
         <g fill="none" transform="matrix(1,0,0,1,125,150)">
           <g transform="matrix(1,0,0,1,0,0)">
-            <circle fill="rgba(0,0,255,1)" transform="translate(-20,-20)" cx="20" cy="20" stroke-width="0" stroke="rgba(0,0,0,1)" r="20"/>
+            <circle fill="rgba(225,87,89,1)" transform="translate(-20,-20)" cx="20" cy="20" stroke-width="0" stroke="rgba(0,0,0,1)" r="20"/>
           </g>
           <g fill="none" transform="matrix(1,0,0,1,0,20)">
             <g transform="matrix(1,0,0,1,0,0)">
@@ -90,7 +90,7 @@
         </g>
         <g fill="none" transform="matrix(1,0,0,1,190,50)">
           <g transform="matrix(1,0,0,1,0,0)">
-            <circle fill="rgba(255,0,0,1)" transform="translate(-20,-20)" cx="20" cy="20" stroke-width="0" stroke="rgba(0,0,0,1)" r="20"/>
+            <circle fill="rgba(78,121,167,1)" transform="translate(-20,-20)" cx="20" cy="20" stroke-width="0" stroke="rgba(0,0,0,1)" r="20"/>
           </g>
           <g fill="none" transform="matrix(1,0,0,1,0,20)">
             <g transform="matrix(1,0,0,1,0,0)">
@@ -102,7 +102,7 @@
         </g>
         <g fill="none" transform="matrix(1,0,0,1,135,150)">
           <g transform="matrix(1,0,0,1,0,0)">
-            <circle fill="rgba(0,128,0,1)" transform="translate(-20,-20)" cx="20" cy="20" stroke-width="0" stroke="rgba(0,0,0,1)" r="20"/>
+            <circle fill="rgba(242,142,44,1)" transform="translate(-20,-20)" cx="20" cy="20" stroke-width="0" stroke="rgba(0,0,0,1)" r="20"/>
           </g>
           <g fill="none" transform="matrix(1,0,0,1,0,20)">
             <g transform="matrix(1,0,0,1,0,0)">

--- a/packages/g6/__tests__/snapshots/elements/z-index/drag-overlap-node-3.svg
+++ b/packages/g6/__tests__/snapshots/elements/z-index/drag-overlap-node-3.svg
@@ -5,7 +5,7 @@
       <g fill="none" transform="matrix(1,0,0,1,0,0)">
         <g fill="none" transform="matrix(1,0,0,1,150.500000,273)">
           <g transform="matrix(1,0,0,1,0,0)">
-            <circle fill="rgba(255,192,203,1)" transform="translate(-107.64448311567081,-107.64448311567081)" cx="107.64448311567081" cy="107.64448311567081" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="107.64448311567081"/>
+            <circle fill="rgba(78,121,167,1)" transform="translate(-107.64448311567081,-107.64448311567081)" cx="107.64448311567081" cy="107.64448311567081" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="107.64448311567081"/>
           </g>
           <g fill="none" transform="matrix(1,0,0,1,0,107.644485)">
             <g transform="matrix(1,0,0,1,0,0)">
@@ -17,7 +17,7 @@
         </g>
         <g fill="none" transform="matrix(1,0,0,1,350,250)">
           <g transform="matrix(1,0,0,1,0,0)">
-            <circle fill="rgba(255,165,0,1)" transform="translate(-26,-26)" cx="26" cy="26" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="26"/>
+            <circle fill="rgba(118,183,178,1)" transform="translate(-26,-26)" cx="26" cy="26" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="26"/>
           </g>
           <g fill="none" transform="matrix(1,0,0,1,0,26)">
             <g transform="matrix(1,0,0,1,0,0)">
@@ -29,7 +29,7 @@
         </g>
         <g fill="none" transform="matrix(1,0,0,1,150.500000,261.500000)">
           <g transform="matrix(1,0,0,1,0,0)">
-            <circle fill="rgba(0,255,255,1)" transform="translate(-60.148649195139875,-60.148649195139875)" cx="60.148649195139875" cy="60.148649195139875" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="60.148649195139875"/>
+            <circle fill="rgba(242,142,44,1)" transform="translate(-60.148649195139875,-60.148649195139875)" cx="60.148649195139875" cy="60.148649195139875" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="60.148649195139875"/>
           </g>
           <g fill="none" transform="matrix(1,0,0,1,0,60.148647)">
             <g transform="matrix(1,0,0,1,0,0)">
@@ -41,7 +41,7 @@
         </g>
         <g fill="none" transform="matrix(1,0,0,1,150,250)">
           <g transform="matrix(1,0,0,1,0,0)">
-            <circle fill="rgba(128,0,128,1)" transform="translate(-26,-26)" cx="26" cy="26" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="26"/>
+            <circle fill="rgba(225,87,89,1)" transform="translate(-26,-26)" cx="26" cy="26" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="26"/>
           </g>
           <g fill="none" transform="matrix(1,0,0,1,0,26)">
             <g transform="matrix(1,0,0,1,0,0)">
@@ -78,7 +78,7 @@
       <g fill="none" transform="matrix(1,0,0,1,0,0)">
         <g fill="none" transform="matrix(1,0,0,1,190,50)">
           <g transform="matrix(1,0,0,1,0,0)">
-            <circle fill="rgba(255,0,0,1)" transform="translate(-20,-20)" cx="20" cy="20" stroke-width="0" stroke="rgba(0,0,0,1)" r="20"/>
+            <circle fill="rgba(78,121,167,1)" transform="translate(-20,-20)" cx="20" cy="20" stroke-width="0" stroke="rgba(0,0,0,1)" r="20"/>
           </g>
           <g fill="none" transform="matrix(1,0,0,1,0,20)">
             <g transform="matrix(1,0,0,1,0,0)">
@@ -90,7 +90,7 @@
         </g>
         <g fill="none" transform="matrix(1,0,0,1,135,150)">
           <g transform="matrix(1,0,0,1,0,0)">
-            <circle fill="rgba(0,128,0,1)" transform="translate(-20,-20)" cx="20" cy="20" stroke-width="0" stroke="rgba(0,0,0,1)" r="20"/>
+            <circle fill="rgba(242,142,44,1)" transform="translate(-20,-20)" cx="20" cy="20" stroke-width="0" stroke="rgba(0,0,0,1)" r="20"/>
           </g>
           <g fill="none" transform="matrix(1,0,0,1,0,20)">
             <g transform="matrix(1,0,0,1,0,0)">
@@ -102,7 +102,7 @@
         </g>
         <g fill="none" transform="matrix(1,0,0,1,200,50)">
           <g transform="matrix(1,0,0,1,0,0)">
-            <circle fill="rgba(0,0,255,1)" transform="translate(-20,-20)" cx="20" cy="20" stroke-width="0" stroke="rgba(0,0,0,1)" r="20"/>
+            <circle fill="rgba(225,87,89,1)" transform="translate(-20,-20)" cx="20" cy="20" stroke-width="0" stroke="rgba(0,0,0,1)" r="20"/>
           </g>
           <g fill="none" transform="matrix(1,0,0,1,0,20)">
             <g transform="matrix(1,0,0,1,0,0)">

--- a/packages/g6/__tests__/snapshots/layouts/d3-force-collision/default.svg
+++ b/packages/g6/__tests__/snapshots/layouts/d3-force-collision/default.svg
@@ -5,1002 +5,1002 @@
       <g fill="none" transform="matrix(1,0,0,1,0,0)"/>
       <g fill="none" transform="matrix(1,0,0,1,0,0)"/>
       <g fill="none" transform="matrix(1,0,0,1,0,0)">
-        <g fill="none" transform="matrix(1,0,0,1,251.676529,241.929504)">
+        <g fill="none" transform="matrix(1,0,0,1,246.714172,242.248032)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(89,161,79,1)" cx="0" cy="0" stroke-width="0" stroke="rgba(0,0,0,1)" r="0"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,118.770576,311.387970)">
+        <g fill="none" transform="matrix(1,0,0,1,162.812241,363.455170)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(242,142,44,1)" transform="translate(-11.548454853771354,-11.548454853771354)" cx="11.548454853771354" cy="11.548454853771354" stroke-width="0" stroke="rgba(0,0,0,1)" r="11.548454853771354"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,109.385254,130.987961)">
+        <g fill="none" transform="matrix(1,0,0,1,76.460617,287.584015)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(225,87,89,1)" transform="translate(-7.322682280657036,-7.322682280657036)" cx="7.322682280657036" cy="7.322682280657036" stroke-width="0" stroke="rgba(0,0,0,1)" r="7.322682280657036"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,291.232330,381.916412)">
+        <g fill="none" transform="matrix(1,0,0,1,346.505249,360.367004)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(118,183,178,1)" transform="translate(-18.096909707542707,-18.096909707542707)" cx="18.096909707542707" cy="18.096909707542707" stroke-width="0" stroke="rgba(0,0,0,1)" r="18.096909707542707"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,107.685966,203.818787)">
+        <g fill="none" transform="matrix(1,0,0,1,94.125381,276.964142)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(78,121,167,1)" transform="translate(-13.871137134428375,-13.871137134428375)" cx="13.871137134428375" cy="13.871137134428375" stroke-width="0" stroke="rgba(0,0,0,1)" r="13.871137134428375"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,483.794495,249.796509)">
+        <g fill="none" transform="matrix(1,0,0,1,391.934326,406.065186)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(242,142,44,1)" transform="translate(-9.645364561314071,-9.645364561314071)" cx="9.645364561314071" cy="9.645364561314071" stroke-width="0" stroke="rgba(0,0,0,1)" r="9.645364561314071"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,272.911713,395.483276)">
+        <g fill="none" transform="matrix(1,0,0,1,290.196747,435.637787)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(225,87,89,1)" transform="translate(-5.419591988199741,-5.419591988199741)" cx="5.419591988199741" cy="5.419591988199741" stroke-width="0" stroke="rgba(0,0,0,1)" r="5.419591988199741"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,113.278702,233.175644)">
+        <g fill="none" transform="matrix(1,0,0,1,111.654282,211.683334)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(118,183,178,1)" transform="translate(-16.19381941508541,-16.19381941508541)" cx="16.19381941508541" cy="16.19381941508541" stroke-width="0" stroke="rgba(0,0,0,1)" r="16.19381941508541"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,372.409485,317.580109)">
+        <g fill="none" transform="matrix(1,0,0,1,384.211456,261.157013)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(78,121,167,1)" transform="translate(-11.96804684197108,-11.96804684197108)" cx="11.96804684197108" cy="11.96804684197108" stroke-width="0" stroke="rgba(0,0,0,1)" r="11.96804684197108"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,130.950836,326.024811)">
+        <g fill="none" transform="matrix(1,0,0,1,114.724312,270.503571)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(242,142,44,1)" transform="translate(-7.74227426885675,-7.74227426885675)" cx="7.74227426885675" cy="7.74227426885675" stroke-width="0" stroke="rgba(0,0,0,1)" r="7.74227426885675"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,210.923203,115.714897)">
+        <g fill="none" transform="matrix(1,0,0,1,267.585114,92.161911)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(225,87,89,1)" transform="translate(-18.51650169574242,-18.51650169574242)" cx="18.51650169574242" cy="18.51650169574242" stroke-width="0" stroke="rgba(0,0,0,1)" r="18.51650169574242"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,140.361496,394.774048)">
+        <g fill="none" transform="matrix(1,0,0,1,53.396919,363.075836)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(118,183,178,1)" transform="translate(-14.290729122628143,-14.290729122628143)" cx="14.290729122628143" cy="14.290729122628143" stroke-width="0" stroke="rgba(0,0,0,1)" r="14.290729122628143"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,96.455330,182.947830)">
+        <g fill="none" transform="matrix(1,0,0,1,88.758537,169.497101)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(78,121,167,1)" transform="translate(-10.06495654951376,-10.06495654951376)" cx="10.06495654951376" cy="10.06495654951376" stroke-width="0" stroke="rgba(0,0,0,1)" r="10.06495654951376"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,202.086105,67.508759)">
+        <g fill="none" transform="matrix(1,0,0,1,280.508575,72.095871)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(242,142,44,1)" transform="translate(-5.839183976399482,-5.839183976399482)" cx="5.839183976399482" cy="5.839183976399482" stroke-width="0" stroke="rgba(0,0,0,1)" r="5.839183976399482"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,168.705399,382.976288)">
+        <g fill="none" transform="matrix(1,0,0,1,268.299316,412.879272)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(225,87,89,1)" transform="translate(-16.6134114032851,-16.6134114032851)" cx="16.6134114032851" cy="16.6134114032851" stroke-width="0" stroke="rgba(0,0,0,1)" r="16.6134114032851"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,121.125008,146.435745)">
+        <g fill="none" transform="matrix(1,0,0,1,149.113892,126.831711)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(118,183,178,1)" transform="translate(-12.387638830170822,-12.387638830170822)" cx="12.387638830170822" cy="12.387638830170822" stroke-width="0" stroke="rgba(0,0,0,1)" r="12.387638830170822"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,268.275055,369.407349)">
+        <g fill="none" transform="matrix(1,0,0,1,228.233551,374.625732)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(78,121,167,1)" transform="translate(-8.161866257056545,-8.161866257056545)" cx="8.161866257056545" cy="8.161866257056545" stroke-width="0" stroke="rgba(0,0,0,1)" r="8.161866257056545"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,112.232132,268.105865)">
+        <g fill="none" transform="matrix(1,0,0,1,104.552147,245.960159)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(242,142,44,1)" transform="translate(-18.93609368394216,-18.93609368394216)" cx="18.93609368394216" cy="18.93609368394216" stroke-width="0" stroke="rgba(0,0,0,1)" r="18.93609368394216"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,391.022430,192.017380)">
+        <g fill="none" transform="matrix(1,0,0,1,412.406464,154.044250)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(225,87,89,1)" transform="translate(-14.710321110827884,-14.710321110827884)" cx="14.710321110827884" cy="14.710321110827884" stroke-width="0" stroke="rgba(0,0,0,1)" r="14.710321110827884"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,238.586792,423.088593)">
+        <g fill="none" transform="matrix(1,0,0,1,262.994690,440.146088)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(118,183,178,1)" transform="translate(-10.4845485377135,-10.4845485377135)" cx="10.4845485377135" cy="10.4845485377135" stroke-width="0" stroke="rgba(0,0,0,1)" r="10.4845485377135"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,125.287498,194.359116)">
+        <g fill="none" transform="matrix(1,0,0,1,124.497681,163.805206)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(78,121,167,1)" transform="translate(-6.258775964599224,-6.258775964599224)" cx="6.258775964599224" cy="6.258775964599224" stroke-width="0" stroke="rgba(0,0,0,1)" r="6.258775964599224"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,393.635620,223.434189)">
+        <g fill="none" transform="matrix(1,0,0,1,388.623779,209.887543)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(242,142,44,1)" transform="translate(-17.03300339148484,-17.03300339148484)" cx="17.03300339148484" cy="17.03300339148484" stroke-width="0" stroke="rgba(0,0,0,1)" r="17.03300339148484"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,152.946777,356.713135)">
+        <g fill="none" transform="matrix(1,0,0,1,129.543228,316.247681)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(225,87,89,1)" transform="translate(-12.807230818370563,-12.807230818370563)" cx="12.807230818370563" cy="12.807230818370563" stroke-width="0" stroke="rgba(0,0,0,1)" r="12.807230818370563"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,256.745544,73.258713)">
+        <g fill="none" transform="matrix(1,0,0,1,292.745239,78.751945)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(118,183,178,1)" transform="translate(-8.581458245256286,-8.581458245256286)" cx="8.581458245256286" cy="8.581458245256286" stroke-width="0" stroke="rgba(0,0,0,1)" r="8.581458245256286"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,374.084381,348.762390)">
+        <g fill="none" transform="matrix(1,0,0,1,366.788116,391.687561)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(78,121,167,1)" transform="translate(-19.355685672141902,-19.355685672141902)" cx="19.355685672141902" cy="19.355685672141902" stroke-width="0" stroke="rgba(0,0,0,1)" r="19.355685672141902"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,119.750671,173.773956)">
+        <g fill="none" transform="matrix(1,0,0,1,111.300453,180.594803)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(242,142,44,1)" transform="translate(-15.129913099027519,-15.129913099027519)" cx="15.129913099027519" cy="15.129913099027519" stroke-width="0" stroke="rgba(0,0,0,1)" r="15.129913099027519"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,443.004181,158.579422)">
+        <g fill="none" transform="matrix(1,0,0,1,437.753265,151.179932)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(225,87,89,1)" transform="translate(-10.904140525913348,-10.904140525913348)" cx="10.904140525913348" cy="10.904140525913348" stroke-width="0" stroke="rgba(0,0,0,1)" r="10.904140525913348"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,147.160355,375.257446)">
+        <g fill="none" transform="matrix(1,0,0,1,341.557281,386.881348)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(118,183,178,1)" transform="translate(-6.678367952798965,-6.678367952798965)" cx="6.678367952798965" cy="6.678367952798965" stroke-width="0" stroke="rgba(0,0,0,1)" r="6.678367952798965"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,175.115494,115.637085)">
+        <g fill="none" transform="matrix(1,0,0,1,176.978653,116.814697)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(78,121,167,1)" transform="translate(-17.45259537968458,-17.45259537968458)" cx="17.45259537968458" cy="17.45259537968458" stroke-width="0" stroke="rgba(0,0,0,1)" r="17.45259537968458"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,342.270203,354.714325)">
+        <g fill="none" transform="matrix(1,0,0,1,372.971344,298.463287)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(242,142,44,1)" transform="translate(-13.226822806570198,-13.226822806570198)" cx="13.226822806570198" cy="13.226822806570198" stroke-width="0" stroke="rgba(0,0,0,1)" r="13.226822806570198"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,92.898659,248.032211)">
+        <g fill="none" transform="matrix(1,0,0,1,88.165588,219.960876)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(225,87,89,1)" transform="translate(-9.001050233456027,-9.001050233456027)" cx="9.001050233456027" cy="9.001050233456027" stroke-width="0" stroke="rgba(0,0,0,1)" r="9.001050233456027"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,324.196136,71.988632)">
+        <g fill="none" transform="matrix(1,0,0,1,303.686554,104.549889)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(118,183,178,1)" transform="translate(-19.775277660341644,-19.775277660341644)" cx="19.775277660341644" cy="19.775277660341644" stroke-width="0" stroke="rgba(0,0,0,1)" r="19.775277660341644"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,253.079910,401.694000)">
+        <g fill="none" transform="matrix(1,0,0,1,247.071060,388.908295)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(78,121,167,1)" transform="translate(-15.54950508722726,-15.54950508722726)" cx="15.54950508722726" cy="15.54950508722726" stroke-width="0" stroke="rgba(0,0,0,1)" r="15.54950508722726"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,126.159477,123.549759)">
+        <g fill="none" transform="matrix(1,0,0,1,125.692543,127.076538)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(242,142,44,1)" transform="translate(-11.32373251411309,-11.32373251411309)" cx="11.32373251411309" cy="11.32373251411309" stroke-width="0" stroke="rgba(0,0,0,1)" r="11.32373251411309"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,400.641022,303.926422)">
+        <g fill="none" transform="matrix(1,0,0,1,377.154755,278.662354)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(225,87,89,1)" transform="translate(-7.097959940998706,-7.097959940998706)" cx="7.097959940998706" cy="7.097959940998706" stroke-width="0" stroke="rgba(0,0,0,1)" r="7.097959940998706"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,124.162025,367.225800)">
+        <g fill="none" transform="matrix(1,0,0,1,112.857895,386.303528)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(118,183,178,1)" transform="translate(-17.872187367884322,-17.872187367884322)" cx="17.872187367884322" cy="17.872187367884322" stroke-width="0" stroke="rgba(0,0,0,1)" r="17.872187367884322"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,291.832520,82.748268)">
+        <g fill="none" transform="matrix(1,0,0,1,248.520493,50.384232)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(78,121,167,1)" transform="translate(-13.646414794769939,-13.646414794769939)" cx="13.646414794769939" cy="13.646414794769939" stroke-width="0" stroke="rgba(0,0,0,1)" r="13.646414794769939"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,285.318848,441.528961)">
+        <g fill="none" transform="matrix(1,0,0,1,377.418396,418.319489)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(242,142,44,1)" transform="translate(-9.420642221655768,-9.420642221655768)" cx="9.420642221655768" cy="9.420642221655768" stroke-width="0" stroke="rgba(0,0,0,1)" r="9.420642221655768"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,64.811180,231.414780)">
+        <g fill="none" transform="matrix(1,0,0,1,70.415184,253.898254)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(225,87,89,1)" transform="translate(-5.194869648541385,-5.194869648541385)" cx="5.194869648541385" cy="5.194869648541385" stroke-width="0" stroke="rgba(0,0,0,1)" r="5.194869648541385"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,310.900909,105.111786)">
+        <g fill="none" transform="matrix(1,0,0,1,348.730988,146.362534)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(118,183,178,1)" transform="translate(-15.969097075427001,-15.969097075427001)" cx="15.969097075427001" cy="15.969097075427001" stroke-width="0" stroke="rgba(0,0,0,1)" r="15.969097075427001"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,235.787964,380.734711)">
+        <g fill="none" transform="matrix(1,0,0,1,233.684174,412.502411)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(78,121,167,1)" transform="translate(-11.74332450231283,-11.74332450231283)" cx="11.74332450231283" cy="11.74332450231283" stroke-width="0" stroke="rgba(0,0,0,1)" r="11.74332450231283"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,94.907700,130.839813)">
+        <g fill="none" transform="matrix(1,0,0,1,156.194199,145.280716)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(242,142,44,1)" transform="translate(-7.517551929198447,-7.517551929198447)" cx="7.517551929198447" cy="7.517551929198447" stroke-width="0" stroke="rgba(0,0,0,1)" r="7.517551929198447"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,381.227753,288.495239)">
+        <g fill="none" transform="matrix(1,0,0,1,406.031952,240.422958)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(225,87,89,1)" transform="translate(-18.291779356084064,-18.291779356084064)" cx="18.291779356084064" cy="18.291779356084064" stroke-width="0" stroke="rgba(0,0,0,1)" r="18.291779356084064"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,153.853317,329.952576)">
+        <g fill="none" transform="matrix(1,0,0,1,144.197296,380.851868)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(118,183,178,1)" transform="translate(-14.06600678296968,-14.06600678296968)" cx="14.06600678296968" cy="14.06600678296968" stroke-width="0" stroke="rgba(0,0,0,1)" r="14.06600678296968"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,268.877563,86.675095)">
+        <g fill="none" transform="matrix(1,0,0,1,267.820679,63.867165)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(78,121,167,1)" transform="translate(-9.84023420985551,-9.84023420985551)" cx="9.84023420985551" cy="9.84023420985551" stroke-width="0" stroke="rgba(0,0,0,1)" r="9.84023420985551"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,320.624878,393.806305)">
+        <g fill="none" transform="matrix(1,0,0,1,301.440155,381.513855)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(242,142,44,1)" transform="translate(-5.614461636741126,-5.614461636741126)" cx="5.614461636741126" cy="5.614461636741126" stroke-width="0" stroke="rgba(0,0,0,1)" r="5.614461636741126"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,83.224815,221.244293)">
+        <g fill="none" transform="matrix(1,0,0,1,83.605148,195.235947)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(225,87,89,1)" transform="translate(-16.388689063626742,-16.388689063626742)" cx="16.388689063626742" cy="16.388689063626742" stroke-width="0" stroke="rgba(0,0,0,1)" r="16.388689063626742"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,353.782196,153.178314)">
+        <g fill="none" transform="matrix(1,0,0,1,369.818268,127.942657)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(118,183,178,1)" transform="translate(-12.162916490512572,-12.162916490512572)" cx="12.162916490512572" cy="12.162916490512572" stroke-width="0" stroke="rgba(0,0,0,1)" r="12.162916490512572"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,191.172562,373.439178)">
+        <g fill="none" transform="matrix(1,0,0,1,168.979691,381.883148)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(78,121,167,1)" transform="translate(-7.937143917397975,-7.937143917397975)" cx="7.937143917397975" cy="7.937143917397975" stroke-width="0" stroke="rgba(0,0,0,1)" r="7.937143917397975"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,180.434448,56.279003)">
+        <g fill="none" transform="matrix(1,0,0,1,188.081558,82.579872)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(242,142,44,1)" transform="translate(-18.711371344283805,-18.711371344283805)" cx="18.711371344283805" cy="18.711371344283805" stroke-width="0" stroke="rgba(0,0,0,1)" r="18.711371344283805"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,397.700623,324.871033)">
+        <g fill="none" transform="matrix(1,0,0,1,398.042480,283.513641)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(225,87,89,1)" transform="translate(-14.485598771169634,-14.485598771169634)" cx="14.485598771169634" cy="14.485598771169634" stroke-width="0" stroke="rgba(0,0,0,1)" r="14.485598771169634"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,52.385117,260.882324)">
+        <g fill="none" transform="matrix(1,0,0,1,34.389008,275.678986)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(118,183,178,1)" transform="translate(-10.259826198055038,-10.259826198055038)" cx="10.259826198055038" cy="10.259826198055038" stroke-width="0" stroke="rgba(0,0,0,1)" r="10.259826198055038"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,335.023651,94.795494)">
+        <g fill="none" transform="matrix(1,0,0,1,352.989014,121.267204)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(78,121,167,1)" transform="translate(-6.034053624940867,-6.034053624940867)" cx="6.034053624940867" cy="6.034053624940867" stroke-width="0" stroke="rgba(0,0,0,1)" r="6.034053624940867"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,281.995667,415.585236)">
+        <g fill="none" transform="matrix(1,0,0,1,300.224274,403.585266)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(242,142,44,1)" transform="translate(-16.808281051826697,-16.808281051826697)" cx="16.808281051826697" cy="16.808281051826697" stroke-width="0" stroke="rgba(0,0,0,1)" r="16.808281051826697"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,142.792847,158.612747)">
+        <g fill="none" transform="matrix(1,0,0,1,136.409286,148.228302)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(225,87,89,1)" transform="translate(-12.5825084787121,-12.5825084787121)" cx="12.5825084787121" cy="12.5825084787121" stroke-width="0" stroke="rgba(0,0,0,1)" r="12.5825084787121"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,347.429474,134.110764)">
+        <g fill="none" transform="matrix(1,0,0,1,380.371521,233.791672)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(118,183,178,1)" transform="translate(-8.35673590559793,-8.35673590559793)" cx="8.35673590559793" cy="8.35673590559793" stroke-width="0" stroke="rgba(0,0,0,1)" r="8.35673590559793"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,80.123329,353.424561)">
+        <g fill="none" transform="matrix(1,0,0,1,137.015930,347.184631)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(78,121,167,1)" transform="translate(-19.13096333248376,-19.13096333248376)" cx="19.13096333248376" cy="19.13096333248376" stroke-width="0" stroke="rgba(0,0,0,1)" r="19.13096333248376"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,195.036652,86.463264)">
+        <g fill="none" transform="matrix(1,0,0,1,208.526855,109.070869)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(242,142,44,1)" transform="translate(-14.905190759369162,-14.905190759369162)" cx="14.905190759369162" cy="14.905190759369162" stroke-width="0" stroke="rgba(0,0,0,1)" r="14.905190759369162"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,363.005371,402.067780)">
+        <g fill="none" transform="matrix(1,0,0,1,354.440765,433.526123)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(225,87,89,1)" transform="translate(-10.679418186254992,-10.679418186254992)" cx="10.679418186254992" cy="10.679418186254992" stroke-width="0" stroke="rgba(0,0,0,1)" r="10.679418186254992"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,136.127121,187.710342)">
+        <g fill="none" transform="matrix(1,0,0,1,73.262756,215.506989)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(118,183,178,1)" transform="translate(-6.453645613140395,-6.453645613140395)" cx="6.453645613140395" cy="6.453645613140395" stroke-width="0" stroke="rgba(0,0,0,1)" r="6.453645613140395"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,381.719604,161.759750)">
+        <g fill="none" transform="matrix(1,0,0,1,380.636719,154.988495)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(78,121,167,1)" transform="translate(-17.227873040026225,-17.227873040026225)" cx="17.227873040026225" cy="17.227873040026225" stroke-width="0" stroke="rgba(0,0,0,1)" r="17.227873040026225"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,211.176071,379.385956)">
+        <g fill="none" transform="matrix(1,0,0,1,186.654373,368.599701)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(242,142,44,1)" transform="translate(-13.002100466912054,-13.002100466912054)" cx="13.002100466912054" cy="13.002100466912054" stroke-width="0" stroke="rgba(0,0,0,1)" r="13.002100466912054"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,254.001480,97.743904)">
+        <g fill="none" transform="matrix(1,0,0,1,242.671631,102.959351)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(225,87,89,1)" transform="translate(-8.776327893797458,-8.776327893797458)" cx="8.776327893797458" cy="8.776327893797458" stroke-width="0" stroke="rgba(0,0,0,1)" r="8.776327893797458"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,426.540558,306.737640)">
+        <g fill="none" transform="matrix(1,0,0,1,399.614075,317.330719)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(118,183,178,1)" transform="translate(-19.550555320683287,-19.550555320683287)" cx="19.550555320683287" cy="19.550555320683287" stroke-width="0" stroke="rgba(0,0,0,1)" r="19.550555320683287"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,110.628220,336.857605)">
+        <g fill="none" transform="matrix(1,0,0,1,89.826950,336.060516)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(78,121,167,1)" transform="translate(-15.324782747569117,-15.324782747569117)" cx="15.324782747569117" cy="15.324782747569117" stroke-width="0" stroke="rgba(0,0,0,1)" r="15.324782747569117"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,273.251068,63.173290)">
+        <g fill="none" transform="matrix(1,0,0,1,295.931061,35.154373)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(242,142,44,1)" transform="translate(-11.09901017445452,-11.09901017445452)" cx="11.09901017445452" cy="11.09901017445452" stroke-width="0" stroke="rgba(0,0,0,1)" r="11.09901017445452"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,266.674408,384.051941)">
+        <g fill="none" transform="matrix(1,0,0,1,288.849152,424.126373)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(225,87,89,1)" transform="translate(-6.87323760134035,-6.87323760134035)" cx="6.87323760134035" cy="6.87323760134035" stroke-width="0" stroke="rgba(0,0,0,1)" r="6.87323760134035"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,92.691292,155.563690)">
+        <g fill="none" transform="matrix(1,0,0,1,106.342690,148.365936)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(118,183,178,1)" transform="translate(-17.64746502822618,-17.64746502822618)" cx="17.64746502822618" cy="17.64746502822618" stroke-width="0" stroke="rgba(0,0,0,1)" r="17.64746502822618"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,414.747223,245.076401)">
+        <g fill="none" transform="matrix(1,0,0,1,372.123047,184.385071)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(78,121,167,1)" transform="translate(-13.421692455111582,-13.421692455111582)" cx="13.421692455111582" cy="13.421692455111582" stroke-width="0" stroke="rgba(0,0,0,1)" r="13.421692455111582"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,134.371384,342.411591)">
+        <g fill="none" transform="matrix(1,0,0,1,113.769592,331.306549)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(242,142,44,1)" transform="translate(-9.195919881997412,-9.195919881997412)" cx="9.195919881997412" cy="9.195919881997412" stroke-width="0" stroke="rgba(0,0,0,1)" r="9.195919881997412"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,229.836166,82.386887)">
+        <g fill="none" transform="matrix(1,0,0,1,226.455765,79.351715)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(225,87,89,1)" transform="translate(-19.970147308882815,-19.970147308882815)" cx="19.970147308882815" cy="19.970147308882815" stroke-width="0" stroke="rgba(0,0,0,1)" r="19.970147308882815"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,440.645264,366.837891)">
+        <g fill="none" transform="matrix(1,0,0,1,408.221832,351.472443)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(118,183,178,1)" transform="translate(-15.744374735768645,-15.744374735768645)" cx="15.744374735768645" cy="15.744374735768645" stroke-width="0" stroke="rgba(0,0,0,1)" r="15.744374735768645"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,82.031372,269.427063)">
+        <g fill="none" transform="matrix(1,0,0,1,69.694580,270.625549)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(78,121,167,1)" transform="translate(-11.518602162654474,-11.518602162654474)" cx="11.518602162654474" cy="11.518602162654474" stroke-width="0" stroke="rgba(0,0,0,1)" r="11.518602162654474"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,321.852264,125.612885)">
+        <g fill="none" transform="matrix(1,0,0,1,312.517914,130.078461)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(242,142,44,1)" transform="translate(-7.292829589539878,-7.292829589539878)" cx="7.292829589539878" cy="7.292829589539878" stroke-width="0" stroke="rgba(0,0,0,1)" r="7.292829589539878"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,208.951553,432.354614)">
+        <g fill="none" transform="matrix(1,0,0,1,206.380249,424.117798)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(225,87,89,1)" transform="translate(-18.067057016425707,-18.067057016425707)" cx="18.067057016425707" cy="18.067057016425707" stroke-width="0" stroke="rgba(0,0,0,1)" r="18.067057016425707"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,149.324875,133.116959)">
+        <g fill="none" transform="matrix(1,0,0,1,150.305466,100.758095)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(118,183,178,1)" transform="translate(-13.841284443311537,-13.841284443311537)" cx="13.841284443311537" cy="13.841284443311537" stroke-width="0" stroke="rgba(0,0,0,1)" r="13.841284443311537"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,432.524231,259.272095)">
+        <g fill="none" transform="matrix(1,0,0,1,413.385284,200.296768)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(78,121,167,1)" transform="translate(-9.61551187019694,-9.61551187019694)" cx="9.61551187019694" cy="9.61551187019694" stroke-width="0" stroke="rgba(0,0,0,1)" r="9.61551187019694"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,104.360962,356.212006)">
+        <g fill="none" transform="matrix(1,0,0,1,128.382965,370.058228)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(242,142,44,1)" transform="translate(-5.3897392970827696,-5.3897392970827696)" cx="5.3897392970827696" cy="5.3897392970827696" stroke-width="0" stroke="rgba(0,0,0,1)" r="5.3897392970827696"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,247.016617,50.624142)">
+        <g fill="none" transform="matrix(1,0,0,1,261.234955,16.508713)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(225,87,89,1)" transform="translate(-16.1639667239686,-16.1639667239686)" cx="16.1639667239686" cy="16.1639667239686" stroke-width="0" stroke="rgba(0,0,0,1)" r="16.1639667239686"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,308.988708,405.916534)">
+        <g fill="none" transform="matrix(1,0,0,1,277.624847,386.041565)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(118,183,178,1)" transform="translate(-11.938194150854002,-11.938194150854002)" cx="11.938194150854002" cy="11.938194150854002" stroke-width="0" stroke="rgba(0,0,0,1)" r="11.938194150854002"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,86.767967,197.506790)">
+        <g fill="none" transform="matrix(1,0,0,1,81.689728,153.535629)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(78,121,167,1)" transform="translate(-7.712421577739832,-7.712421577739832)" cx="7.712421577739832" cy="7.712421577739832" stroke-width="0" stroke="rgba(0,0,0,1)" r="7.712421577739832"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,416.225037,170.382080)">
+        <g fill="none" transform="matrix(1,0,0,1,432.792633,180.042465)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(242,142,44,1)" transform="translate(-18.48664900462566,-18.48664900462566)" cx="18.48664900462566" cy="18.48664900462566" stroke-width="0" stroke="rgba(0,0,0,1)" r="18.48664900462566"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,223.732330,403.620026)">
+        <g fill="none" transform="matrix(1,0,0,1,216.245270,393.437897)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(225,87,89,1)" transform="translate(-14.260876431511065,-14.260876431511065)" cx="14.260876431511065" cy="14.260876431511065" stroke-width="0" stroke="rgba(0,0,0,1)" r="14.260876431511065"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,125.067093,89.342438)">
+        <g fill="none" transform="matrix(1,0,0,1,127.228714,106.100815)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(118,183,178,1)" transform="translate(-10.035103858396894,-10.035103858396894)" cx="10.035103858396894" cy="10.035103858396894" stroke-width="0" stroke="rgba(0,0,0,1)" r="10.035103858396894"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,413.715851,336.125092)">
+        <g fill="none" transform="matrix(1,0,0,1,419.086060,333.002808)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(78,121,167,1)" transform="translate(-5.809331285282298,-5.809331285282298)" cx="5.809331285282298" cy="5.809331285282298" stroke-width="0" stroke="rgba(0,0,0,1)" r="5.809331285282298"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,69.828194,294.714508)">
+        <g fill="none" transform="matrix(1,0,0,1,53.894279,293.983887)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(242,142,44,1)" transform="translate(-16.583558712168127,-16.583558712168127)" cx="16.583558712168127" cy="16.583558712168127" stroke-width="0" stroke="rgba(0,0,0,1)" r="16.583558712168127"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,295.930084,57.370274)">
+        <g fill="none" transform="matrix(1,0,0,1,292.238861,58.344814)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(225,87,89,1)" transform="translate(-12.357786139053957,-12.357786139053957)" cx="12.357786139053957" cy="12.357786139053957" stroke-width="0" stroke="rgba(0,0,0,1)" r="12.357786139053957"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,197.376617,455.821991)">
+        <g fill="none" transform="matrix(1,0,0,1,190.079727,444.485291)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(118,183,178,1)" transform="translate(-8.13201356593936,-8.13201356593936)" cx="8.13201356593936" cy="8.13201356593936" stroke-width="0" stroke="rgba(0,0,0,1)" r="8.13201356593936"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,101.819061,105.937645)">
+        <g fill="none" transform="matrix(1,0,0,1,99.186752,112.574287)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(78,121,167,1)" transform="translate(-18.90624099282519,-18.90624099282519)" cx="18.90624099282519" cy="18.90624099282519" stroke-width="0" stroke="rgba(0,0,0,1)" r="18.90624099282519"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,417.931854,203.299866)">
+        <g fill="none" transform="matrix(1,0,0,1,399.770874,180.335892)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(242,142,44,1)" transform="translate(-14.68046841971102,-14.68046841971102)" cx="14.68046841971102" cy="14.68046841971102" stroke-width="0" stroke="rgba(0,0,0,1)" r="14.68046841971102"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,133.976318,418.405304)">
+        <g fill="none" transform="matrix(1,0,0,1,161.008789,398.352325)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(225,87,89,1)" transform="translate(-10.454695846596422,-10.454695846596422)" cx="10.454695846596422" cy="10.454695846596422" stroke-width="0" stroke="rgba(0,0,0,1)" r="10.454695846596422"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,368.538147,141.797043)">
+        <g fill="none" transform="matrix(1,0,0,1,341.505554,105.805702)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(118,183,178,1)" transform="translate(-6.228923273482252,-6.228923273482252)" cx="6.228923273482252" cy="6.228923273482252" stroke-width="0" stroke="rgba(0,0,0,1)" r="6.228923273482252"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,409.018585,358.314972)">
+        <g fill="none" transform="matrix(1,0,0,1,366.117126,331.517273)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(78,121,167,1)" transform="translate(-17.00315070036808,-17.00315070036808)" cx="17.00315070036808" cy="17.00315070036808" stroke-width="0" stroke="rgba(0,0,0,1)" r="17.00315070036808"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,71.207993,247.713120)">
+        <g fill="none" transform="matrix(1,0,0,1,74.475021,236.485367)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(242,142,44,1)" transform="translate(-12.777378127253485,-12.777378127253485)" cx="12.777378127253485" cy="12.777378127253485" stroke-width="0" stroke="rgba(0,0,0,1)" r="12.777378127253485"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,428.105621,146.197266)">
+        <g fill="none" transform="matrix(1,0,0,1,421.493744,133.087662)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(225,87,89,1)" transform="translate(-8.551605554139314,-8.551605554139314)" cx="8.551605554139314" cy="8.551605554139314" stroke-width="0" stroke="rgba(0,0,0,1)" r="8.551605554139314"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,163.568054,418.559174)">
+        <g fill="none" transform="matrix(1,0,0,1,169.263290,426.926544)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(118,183,178,1)" transform="translate(-19.325832981025144,-19.325832981025144)" cx="19.325832981025144" cy="19.325832981025144" stroke-width="0" stroke="rgba(0,0,0,1)" r="19.325832981025144"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,144.564224,104.770523)">
+        <g fill="none" transform="matrix(1,0,0,1,128.771393,81.152283)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(78,121,167,1)" transform="translate(-15.100060407910973,-15.100060407910973)" cx="15.100060407910973" cy="15.100060407910973" stroke-width="0" stroke="rgba(0,0,0,1)" r="15.100060407910973"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,438.522186,278.904480)">
+        <g fill="none" transform="matrix(1,0,0,1,420.485718,295.433899)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(242,142,44,1)" transform="translate(-10.87428783479595,-10.87428783479595)" cx="10.87428783479595" cy="10.87428783479595" stroke-width="0" stroke="rgba(0,0,0,1)" r="10.87428783479595"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,64.336807,272.167328)">
+        <g fill="none" transform="matrix(1,0,0,1,81.766075,257.123016)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(225,87,89,1)" transform="translate(-6.64851526168178,-6.64851526168178)" cx="6.64851526168178" cy="6.64851526168178" stroke-width="0" stroke="rgba(0,0,0,1)" r="6.64851526168178"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,316.465759,35.736389)">
+        <g fill="none" transform="matrix(1,0,0,1,320.477539,49.507751)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(118,183,178,1)" transform="translate(-17.42274268856761,-17.42274268856761)" cx="17.42274268856761" cy="17.42274268856761" stroke-width="0" stroke="rgba(0,0,0,1)" r="17.42274268856761"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,348.423584,383.454742)">
+        <g fill="none" transform="matrix(1,0,0,1,300.078430,363.391541)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(78,121,167,1)" transform="translate(-13.19697011545344,-13.19697011545344)" cx="13.19697011545344" cy="13.19697011545344" stroke-width="0" stroke="rgba(0,0,0,1)" r="13.19697011545344"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,48.544468,128.120331)">
+        <g fill="none" transform="matrix(1,0,0,1,66.521027,146.907227)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(242,142,44,1)" transform="translate(-8.971197542339269,-8.971197542339269)" cx="8.971197542339269" cy="8.971197542339269" stroke-width="0" stroke="rgba(0,0,0,1)" r="8.971197542339269"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,442.634277,227.096771)">
+        <g fill="none" transform="matrix(1,0,0,1,436.592255,217.960144)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(225,87,89,1)" transform="translate(-19.745424969224246,-19.745424969224246)" cx="19.745424969224246" cy="19.745424969224246" stroke-width="0" stroke="rgba(0,0,0,1)" r="19.745424969224246"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,194.185074,402.178558)">
+        <g fill="none" transform="matrix(1,0,0,1,186.828186,396.983734)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(118,183,178,1)" transform="translate(-15.519652396110075,-15.519652396110075)" cx="15.519652396110075" cy="15.519652396110075" stroke-width="0" stroke="rgba(0,0,0,1)" r="15.519652396110075"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,200.535645,20.193020)">
+        <g fill="none" transform="matrix(1,0,0,1,196.938675,24.474867)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(78,121,167,1)" transform="translate(-11.293879822995905,-11.293879822995905)" cx="11.293879822995905" cy="11.293879822995905" stroke-width="0" stroke="rgba(0,0,0,1)" r="11.293879822995905"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,365.840668,373.514282)">
+        <g fill="none" transform="matrix(1,0,0,1,359.061157,416.532257)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(242,142,44,1)" transform="translate(-7.068107249881734,-7.068107249881734)" cx="7.068107249881734" cy="7.068107249881734" stroke-width="0" stroke="rgba(0,0,0,1)" r="7.068107249881734"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,43.559559,234.619598)">
+        <g fill="none" transform="matrix(1,0,0,1,47.760216,251.285980)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(225,87,89,1)" transform="translate(-17.842334676767564,-17.842334676767564)" cx="17.842334676767564" cy="17.842334676767564" stroke-width="0" stroke="rgba(0,0,0,1)" r="17.842334676767564"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,339.002747,113.843231)">
+        <g fill="none" transform="matrix(1,0,0,1,331.764435,122.344124)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(118,183,178,1)" transform="translate(-13.616562103653393,-13.616562103653393)" cx="13.616562103653393" cy="13.616562103653393" stroke-width="0" stroke="rgba(0,0,0,1)" r="13.616562103653393"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,258.090607,425.952606)">
+        <g fill="none" transform="matrix(1,0,0,1,247.599121,428.257355)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(78,121,167,1)" transform="translate(-9.39078953053837,-9.39078953053837)" cx="9.39078953053837" cy="9.39078953053837" stroke-width="0" stroke="rgba(0,0,0,1)" r="9.39078953053837"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,158.254990,49.404144)">
+        <g fill="none" transform="matrix(1,0,0,1,183.908585,59.046082)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(242,142,44,1)" transform="translate(-5.1650169574242,-5.1650169574242)" cx="5.1650169574242" cy="5.1650169574242" stroke-width="0" stroke="rgba(0,0,0,1)" r="5.1650169574242"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,412.238373,274.380280)">
+        <g fill="none" transform="matrix(1,0,0,1,424.604858,269.003998)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(225,87,89,1)" transform="translate(-15.93924438431003,-15.93924438431003)" cx="15.93924438431003" cy="15.93924438431003" stroke-width="0" stroke="rgba(0,0,0,1)" r="15.93924438431003"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,49.593517,356.963257)">
+        <g fill="none" transform="matrix(1,0,0,1,96.205215,362.165466)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(118,183,178,1)" transform="translate(-11.71347181119586,-11.71347181119586)" cx="11.71347181119586" cy="11.71347181119586" stroke-width="0" stroke="rgba(0,0,0,1)" r="11.71347181119586"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,269.793518,44.987862)">
+        <g fill="none" transform="matrix(1,0,0,1,252.571350,71.097900)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(78,121,167,1)" transform="translate(-7.487699238081689,-7.487699238081689)" cx="7.487699238081689" cy="7.487699238081689" stroke-width="0" stroke="rgba(0,0,0,1)" r="7.487699238081689"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,337.598907,415.434906)">
+        <g fill="none" transform="matrix(1,0,0,1,334.496948,410.698853)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(242,142,44,1)" transform="translate(-18.26192666496752,-18.26192666496752)" cx="18.26192666496752" cy="18.26192666496752" stroke-width="0" stroke="rgba(0,0,0,1)" r="18.26192666496752"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,57.033623,205.927017)">
+        <g fill="none" transform="matrix(1,0,0,1,53.361843,220.051025)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(225,87,89,1)" transform="translate(-14.036154091852495,-14.036154091852495)" cx="14.036154091852495" cy="14.036154091852495" stroke-width="0" stroke="rgba(0,0,0,1)" r="14.036154091852495"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,444.444153,138.012512)">
+        <g fill="none" transform="matrix(1,0,0,1,457.600372,145.369965)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(118,183,178,1)" transform="translate(-9.810381518738325,-9.810381518738325)" cx="9.810381518738325" cy="9.810381518738325" stroke-width="0" stroke="rgba(0,0,0,1)" r="9.810381518738325"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,101.272156,366.211975)">
+        <g fill="none" transform="matrix(1,0,0,1,94.474297,400.726837)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(78,121,167,1)" transform="translate(-5.584608945624154,-5.584608945624154)" cx="5.584608945624154" cy="5.584608945624154" stroke-width="0" stroke="rgba(0,0,0,1)" r="5.584608945624154"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,214.659500,49.561150)">
+        <g fill="none" transform="matrix(1,0,0,1,203.542984,51.241173)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(242,142,44,1)" transform="translate(-16.358836372509984,-16.358836372509984)" cx="16.358836372509984" cy="16.358836372509984" stroke-width="0" stroke="rgba(0,0,0,1)" r="16.358836372509984"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,453.001709,324.036499)">
+        <g fill="none" transform="matrix(1,0,0,1,431.113708,316.635101)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(225,87,89,1)" transform="translate(-12.133063799395813,-12.133063799395813)" cx="12.133063799395813" cy="12.133063799395813" stroke-width="0" stroke="rgba(0,0,0,1)" r="12.133063799395813"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,51.727856,278.659058)">
+        <g fill="none" transform="matrix(1,0,0,1,19.634737,286.086792)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(118,183,178,1)" transform="translate(-7.90729122628079,-7.90729122628079)" cx="7.90729122628079" cy="7.90729122628079" stroke-width="0" stroke="rgba(0,0,0,1)" r="7.90729122628079"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,358.767334,88.404625)">
+        <g fill="none" transform="matrix(1,0,0,1,334.982422,82.391983)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(78,121,167,1)" transform="translate(-18.68151865316662,-18.68151865316662)" cx="18.68151865316662" cy="18.68151865316662" stroke-width="0" stroke="rgba(0,0,0,1)" r="18.68151865316662"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,322.554230,373.973938)">
+        <g fill="none" transform="matrix(1,0,0,1,321.426208,380.827911)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(242,142,44,1)" transform="translate(-14.45574608005245,-14.45574608005245)" cx="14.45574608005245" cy="14.45574608005245" stroke-width="0" stroke="rgba(0,0,0,1)" r="14.45574608005245"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,77.467110,132.358124)">
+        <g fill="none" transform="matrix(1,0,0,1,81.753365,135.645294)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(225,87,89,1)" transform="translate(-10.22997350693828,-10.22997350693828)" cx="10.22997350693828" cy="10.22997350693828" stroke-width="0" stroke="rgba(0,0,0,1)" r="10.22997350693828"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,417.182800,223.968689)">
+        <g fill="none" transform="matrix(1,0,0,1,411.034332,215.642441)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(118,183,178,1)" transform="translate(-6.004200933824109,-6.004200933824109)" cx="6.004200933824109" cy="6.004200933824109" stroke-width="0" stroke="rgba(0,0,0,1)" r="6.004200933824109"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,139.326645,445.078125)">
+        <g fill="none" transform="matrix(1,0,0,1,137.018738,410.862427)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(78,121,167,1)" transform="translate(-16.77842836070994,-16.77842836070994)" cx="16.77842836070994" cy="16.77842836070994" stroke-width="0" stroke="rgba(0,0,0,1)" r="16.77842836070994"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,286.792145,34.410313)">
+        <g fill="none" transform="matrix(1,0,0,1,273.298218,42.423763)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(242,142,44,1)" transform="translate(-12.552655787594915,-12.552655787594915)" cx="12.552655787594915" cy="12.552655787594915" stroke-width="0" stroke="rgba(0,0,0,1)" r="12.552655787594915"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,377.748718,434.181793)">
+        <g fill="none" transform="matrix(1,0,0,1,373.219757,435.500305)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(225,87,89,1)" transform="translate(-8.326883214480745,-8.326883214480745)" cx="8.326883214480745" cy="8.326883214480745" stroke-width="0" stroke="rgba(0,0,0,1)" r="8.326883214480745"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,37.100624,179.498611)">
+        <g fill="none" transform="matrix(1,0,0,1,31.006758,182.048523)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(118,183,178,1)" transform="translate(-19.101110641366574,-19.101110641366574)" cx="19.101110641366574" cy="19.101110641366574" stroke-width="0" stroke="rgba(0,0,0,1)" r="19.101110641366574"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,366.444305,120.865616)">
+        <g fill="none" transform="matrix(1,0,0,1,361.772400,102.398209)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(78,121,167,1)" transform="translate(-14.875338068252404,-14.875338068252404)" cx="14.875338068252404" cy="14.875338068252404" stroke-width="0" stroke="rgba(0,0,0,1)" r="14.875338068252404"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,235.221817,443.459473)">
+        <g fill="none" transform="matrix(1,0,0,1,230.691116,438.817596)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(242,142,44,1)" transform="translate(-10.649565495138233,-10.649565495138233)" cx="10.649565495138233" cy="10.649565495138233" stroke-width="0" stroke="rgba(0,0,0,1)" r="10.649565495138233"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,195.862244,37.072163)">
+        <g fill="none" transform="matrix(1,0,0,1,173.466812,62.581242)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(225,87,89,1)" transform="translate(-6.42379292202321,-6.42379292202321)" cx="6.42379292202321" cy="6.42379292202321" stroke-width="0" stroke="rgba(0,0,0,1)" r="6.42379292202321"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,459.141144,259.985840)">
+        <g fill="none" transform="matrix(1,0,0,1,453.719879,253.349121)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(118,183,178,1)" transform="translate(-17.19802034890904,-17.19802034890904)" cx="17.19802034890904" cy="17.19802034890904" stroke-width="0" stroke="rgba(0,0,0,1)" r="17.19802034890904"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,99.172409,297.030670)">
+        <g fill="none" transform="matrix(1,0,0,1,107.808838,302.603241)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(78,121,167,1)" transform="translate(-12.97224777579487,-12.97224777579487)" cx="12.97224777579487" cy="12.97224777579487" stroke-width="0" stroke="rgba(0,0,0,1)" r="12.97224777579487"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,339.342133,47.965675)">
+        <g fill="none" transform="matrix(1,0,0,1,309.219025,73.128281)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(242,142,44,1)" transform="translate(-8.7464752026807,-8.7464752026807)" cx="8.7464752026807" cy="8.7464752026807" stroke-width="0" stroke="rgba(0,0,0,1)" r="8.7464752026807"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,308.577637,468.620483)">
+        <g fill="none" transform="matrix(1,0,0,1,285.701050,459.519928)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(225,87,89,1)" transform="translate(-19.52070262956653,-19.52070262956653)" cx="19.52070262956653" cy="19.52070262956653" stroke-width="0" stroke="rgba(0,0,0,1)" r="19.52070262956653"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,71.410439,180.493805)">
+        <g fill="none" transform="matrix(1,0,0,1,63.484905,170.814072)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(118,183,178,1)" transform="translate(-15.294930056452358,-15.294930056452358)" cx="15.294930056452358" cy="15.294930056452358" stroke-width="0" stroke="rgba(0,0,0,1)" r="15.294930056452358"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,464.100800,164.300766)">
+        <g fill="none" transform="matrix(1,0,0,1,458.676422,166.036682)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(78,121,167,1)" transform="translate(-11.069157483337335,-11.069157483337335)" cx="11.069157483337335" cy="11.069157483337335" stroke-width="0" stroke="rgba(0,0,0,1)" r="11.069157483337335"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,162.781021,444.644165)">
+        <g fill="none" transform="matrix(1,0,0,1,144.207031,433.303253)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(242,142,44,1)" transform="translate(-6.843384910223165,-6.843384910223165)" cx="6.843384910223165" cy="6.843384910223165" stroke-width="0" stroke="rgba(0,0,0,1)" r="6.843384910223165"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,158.693512,27.220074)">
+        <g fill="none" transform="matrix(1,0,0,1,172.002594,38.878452)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(225,87,89,1)" transform="translate(-17.617612337108994,-17.617612337108994)" cx="17.617612337108994" cy="17.617612337108994" stroke-width="0" stroke="rgba(0,0,0,1)" r="17.617612337108994"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,432.540344,339.041656)">
+        <g fill="none" transform="matrix(1,0,0,1,436.263000,341.439392)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(118,183,178,1)" transform="translate(-13.391839763994824,-13.391839763994824)" cx="13.391839763994824" cy="13.391839763994824" stroke-width="0" stroke="rgba(0,0,0,1)" r="13.391839763994824"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,36.320442,271.634094)">
+        <g fill="none" transform="matrix(1,0,0,1,32.519463,210.116638)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(78,121,167,1)" transform="translate(-9.166067190880653,-9.166067190880653)" cx="9.166067190880653" cy="9.166067190880653" stroke-width="0" stroke="rgba(0,0,0,1)" r="9.166067190880653"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,395.169769,101.056183)">
+        <g fill="none" transform="matrix(1,0,0,1,394.508301,90.854156)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(242,142,44,1)" transform="translate(-19.94029461776563,-19.94029461776563)" cx="19.94029461776563" cy="19.94029461776563" stroke-width="0" stroke="rgba(0,0,0,1)" r="19.94029461776563"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,308.988007,433.469757)">
+        <g fill="none" transform="matrix(1,0,0,1,310.235260,434.403595)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(225,87,89,1)" transform="translate(-15.71452204465146,-15.71452204465146)" cx="15.71452204465146" cy="15.71452204465146" stroke-width="0" stroke="rgba(0,0,0,1)" r="15.71452204465146"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,84.318390,81.169502)">
+        <g fill="none" transform="matrix(1,0,0,1,78.693115,90.242241)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(118,183,178,1)" transform="translate(-11.48874947153729,-11.48874947153729)" cx="11.48874947153729" cy="11.48874947153729" stroke-width="0" stroke="rgba(0,0,0,1)" r="11.48874947153729"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,467.481720,237.242157)">
+        <g fill="none" transform="matrix(1,0,0,1,431.078735,244.290680)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(78,121,167,1)" transform="translate(-7.262976898423119,-7.262976898423119)" cx="7.262976898423119" cy="7.262976898423119" stroke-width="0" stroke="rgba(0,0,0,1)" r="7.262976898423119"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,108.439659,399.351624)">
+        <g fill="none" transform="matrix(1,0,0,1,77.113846,384.812561)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(242,142,44,1)" transform="translate(-18.03720432530895,-18.03720432530895)" cx="18.03720432530895" cy="18.03720432530895" stroke-width="0" stroke="rgba(0,0,0,1)" r="18.03720432530895"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,262.363892,24.988831)">
+        <g fill="none" transform="matrix(1,0,0,1,290.565552,10.901441)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(225,87,89,1)" transform="translate(-13.811431752194778,-13.811431752194778)" cx="13.811431752194778" cy="13.811431752194778" stroke-width="0" stroke="rgba(0,0,0,1)" r="13.811431752194778"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,364.373474,422.251892)">
+        <g fill="none" transform="matrix(1,0,0,1,335.109009,438.447205)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(118,183,178,1)" transform="translate(-9.585659179079755,-9.585659179079755)" cx="9.585659179079755" cy="9.585659179079755" stroke-width="0" stroke="rgba(0,0,0,1)" r="9.585659179079755"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,117.246422,294.626434)">
+        <g fill="none" transform="matrix(1,0,0,1,111.644714,284.754059)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(78,121,167,1)" transform="translate(-5.359886605965585,-5.359886605965585)" cx="5.359886605965585" cy="5.359886605965585" stroke-width="0" stroke="rgba(0,0,0,1)" r="5.359886605965585"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,405.023621,137.861771)">
+        <g fill="none" transform="matrix(1,0,0,1,397.941345,126.653503)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(242,142,44,1)" transform="translate(-16.134114032851414,-16.134114032851414)" cx="16.134114032851414" cy="16.134114032851414" stroke-width="0" stroke="rgba(0,0,0,1)" r="16.134114032851414"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,181.467957,444.078003)">
+        <g fill="none" transform="matrix(1,0,0,1,174.952866,457.534576)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(225,87,89,1)" transform="translate(-11.908341459737244,-11.908341459737244)" cx="11.908341459737244" cy="11.908341459737244" stroke-width="0" stroke="rgba(0,0,0,1)" r="11.908341459737244"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,183.758133,30.054035)">
+        <g fill="none" transform="matrix(1,0,0,1,227.522629,52.008987)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(118,183,178,1)" transform="translate(-7.6825688866230735,-7.6825688866230735)" cx="7.6825688866230735" cy="7.6825688866230735" stroke-width="0" stroke="rgba(0,0,0,1)" r="7.6825688866230735"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,462.709045,295.339172)">
+        <g fill="none" transform="matrix(1,0,0,1,449.597656,292.459076)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(78,121,167,1)" transform="translate(-18.456796313508903,-18.456796313508903)" cx="18.456796313508903" cy="18.456796313508903" stroke-width="0" stroke="rgba(0,0,0,1)" r="18.456796313508903"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,86.092850,320.764526)">
+        <g fill="none" transform="matrix(1,0,0,1,81.252434,307.909790)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(242,142,44,1)" transform="translate(-14.23102374039388,-14.23102374039388)" cx="14.23102374039388" cy="14.23102374039388" stroke-width="0" stroke="rgba(0,0,0,1)" r="14.23102374039388"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,383.297272,73.749077)">
+        <g fill="none" transform="matrix(1,0,0,1,363.247589,77.642143)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(225,87,89,1)" transform="translate(-10.00525116727971,-10.00525116727971)" cx="10.00525116727971" cy="10.00525116727971" stroke-width="0" stroke="rgba(0,0,0,1)" r="10.00525116727971"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,366.921570,386.372101)">
+        <g fill="none" transform="matrix(1,0,0,1,388.802460,342.261292)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(118,183,178,1)" transform="translate(-5.779478594165539,-5.779478594165539)" cx="5.779478594165539" cy="5.779478594165539" stroke-width="0" stroke="rgba(0,0,0,1)" r="5.779478594165539"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,58.807438,151.352371)">
+        <g fill="none" transform="matrix(1,0,0,1,41.266850,148.050003)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(78,121,167,1)" transform="translate(-16.55370602105137,-16.55370602105137)" cx="16.55370602105137" cy="16.55370602105137" stroke-width="0" stroke="rgba(0,0,0,1)" r="16.55370602105137"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,484.684448,228.015396)">
+        <g fill="none" transform="matrix(1,0,0,1,482.778381,248.103714)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(242,142,44,1)" transform="translate(-12.327933447937198,-12.327933447937198)" cx="12.327933447937198" cy="12.327933447937198" stroke-width="0" stroke="rgba(0,0,0,1)" r="12.327933447937198"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,94.051285,377.581390)">
+        <g fill="none" transform="matrix(1,0,0,1,109.913773,348.019592)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(225,87,89,1)" transform="translate(-8.102160874822175,-8.102160874822175)" cx="8.102160874822175" cy="8.102160874822175" stroke-width="0" stroke="rgba(0,0,0,1)" r="8.102160874822175"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,230.501801,18.218882)">
+        <g fill="none" transform="matrix(1,0,0,1,227.556549,25.535391)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(118,183,178,1)" transform="translate(-18.876388301708005,-18.876388301708005)" cx="18.876388301708005" cy="18.876388301708005" stroke-width="0" stroke="rgba(0,0,0,1)" r="18.876388301708005"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,386.381104,380.413147)">
+        <g fill="none" transform="matrix(1,0,0,1,379.212769,360.231506)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(78,121,167,1)" transform="translate(-14.650615728593834,-14.650615728593834)" cx="14.650615728593834" cy="14.650615728593834" stroke-width="0" stroke="rgba(0,0,0,1)" r="14.650615728593834"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,32.852962,208.593002)">
+        <g fill="none" transform="matrix(1,0,0,1,56.962547,195.946655)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(242,142,44,1)" transform="translate(-10.424843155479664,-10.424843155479664)" cx="10.424843155479664" cy="10.424843155479664" stroke-width="0" stroke="rgba(0,0,0,1)" r="10.424843155479664"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,386.682770,125.076225)">
+        <g fill="none" transform="matrix(1,0,0,1,380.165741,112.680443)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(225,87,89,1)" transform="translate(-6.1990705823654935,-6.1990705823654935)" cx="6.1990705823654935" cy="6.1990705823654935" stroke-width="0" stroke="rgba(0,0,0,1)" r="6.1990705823654935"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,261.320557,452.050049)">
+        <g fill="none" transform="matrix(1,0,0,1,246.211853,461.576660)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(118,183,178,1)" transform="translate(-16.973298009251323,-16.973298009251323)" cx="16.973298009251323" cy="16.973298009251323" stroke-width="0" stroke="rgba(0,0,0,1)" r="16.973298009251323"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,107.655609,74.923607)">
+        <g fill="none" transform="matrix(1,0,0,1,101.056114,81.089279)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(78,121,167,1)" transform="translate(-12.7475254361363,-12.7475254361363)" cx="12.7475254361363" cy="12.7475254361363" stroke-width="0" stroke="rgba(0,0,0,1)" r="12.7475254361363"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,473.174194,320.112793)">
+        <g fill="none" transform="matrix(1,0,0,1,451.601898,319.227936)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(242,142,44,1)" transform="translate(-8.52175286302213,-8.52175286302213)" cx="8.52175286302213" cy="8.52175286302213" stroke-width="0" stroke="rgba(0,0,0,1)" r="8.52175286302213"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,53.139297,326.313049)">
+        <g fill="none" transform="matrix(1,0,0,1,55.946556,329.737915)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(225,87,89,1)" transform="translate(-19.29598028990796,-19.29598028990796)" cx="19.29598028990796" cy="19.29598028990796" stroke-width="0" stroke="rgba(0,0,0,1)" r="19.29598028990796"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,297.860474,9.190269)">
+        <g fill="none" transform="matrix(1,0,0,1,318.630585,17.255302)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(118,183,178,1)" transform="translate(-15.070207716793789,-15.070207716793789)" cx="15.070207716793789" cy="15.070207716793789" stroke-width="0" stroke="rgba(0,0,0,1)" r="15.070207716793789"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,353.879364,439.554840)">
+        <g fill="none" transform="matrix(1,0,0,1,348.244690,454.022034)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(78,121,167,1)" transform="translate(-10.844435143679618,-10.844435143679618)" cx="10.844435143679618" cy="10.844435143679618" stroke-width="0" stroke="rgba(0,0,0,1)" r="10.844435143679618"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,38.638500,140.084824)">
+        <g fill="none" transform="matrix(1,0,0,1,40.304634,124.977516)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(242,142,44,1)" transform="translate(-6.618662570564595,-6.618662570564595)" cx="6.618662570564595" cy="6.618662570564595" stroke-width="0" stroke="rgba(0,0,0,1)" r="6.618662570564595"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,429.640259,115.285393)">
+        <g fill="none" transform="matrix(1,0,0,1,444.589935,121.681107)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(225,87,89,1)" transform="translate(-17.392889997450425,-17.392889997450425)" cx="17.392889997450425" cy="17.392889997450425" stroke-width="0" stroke="rgba(0,0,0,1)" r="17.392889997450425"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,113.562683,430.007385)">
+        <g fill="none" transform="matrix(1,0,0,1,124.914711,438.312653)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(118,183,178,1)" transform="translate(-13.167117424336254,-13.167117424336254)" cx="13.167117424336254" cy="13.167117424336254" stroke-width="0" stroke="rgba(0,0,0,1)" r="13.167117424336254"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,114.646301,54.458092)">
+        <g fill="none" transform="matrix(1,0,0,1,113.036034,63.074062)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(78,121,167,1)" transform="translate(-8.941344851222084,-8.941344851222084)" cx="8.941344851222084" cy="8.941344851222084" stroke-width="0" stroke="rgba(0,0,0,1)" r="8.941344851222084"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,417.947845,393.810913)">
+        <g fill="none" transform="matrix(1,0,0,1,435.157593,374.416565)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(242,142,44,1)" transform="translate(-19.715572278107913,-19.715572278107913)" cx="19.715572278107913" cy="19.715572278107913" stroke-width="0" stroke="rgba(0,0,0,1)" r="19.715572278107913"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,36.134621,296.089111)">
+        <g fill="none" transform="matrix(1,0,0,1,26.734200,311.069977)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(225,87,89,1)" transform="translate(-15.489799704993743,-15.489799704993743)" cx="15.489799704993743" cy="15.489799704993743" stroke-width="0" stroke="rgba(0,0,0,1)" r="15.489799704993743"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,391.137512,54.040745)">
+        <g fill="none" transform="matrix(1,0,0,1,379.306091,63.756882)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(118,183,178,1)" transform="translate(-11.26402713187872,-11.26402713187872)" cx="11.26402713187872" cy="11.26402713187872" stroke-width="0" stroke="rgba(0,0,0,1)" r="11.26402713187872"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,284.595062,457.689331)">
+        <g fill="none" transform="matrix(1,0,0,1,279.029175,433.898773)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(78,121,167,1)" transform="translate(-7.0382545587645495,-7.0382545587645495)" cx="7.0382545587645495" cy="7.0382545587645495" stroke-width="0" stroke="rgba(0,0,0,1)" r="7.0382545587645495"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,65.225845,107.280701)">
+        <g fill="none" transform="matrix(1,0,0,1,62.634712,115.247406)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(242,142,44,1)" transform="translate(-17.81248198565038,-17.81248198565038)" cx="17.81248198565038" cy="17.81248198565038" stroke-width="0" stroke="rgba(0,0,0,1)" r="17.81248198565038"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,476.895172,203.415771)">
+        <g fill="none" transform="matrix(1,0,0,1,468.667664,226.572281)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(225,87,89,1)" transform="translate(-13.586709412536209,-13.586709412536209)" cx="13.586709412536209" cy="13.586709412536209" stroke-width="0" stroke="rgba(0,0,0,1)" r="13.586709412536209"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,61.048492,374.420258)">
+        <g fill="none" transform="matrix(1,0,0,1,76.004456,356.410217)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(118,183,178,1)" transform="translate(-9.360936839422038,-9.360936839422038)" cx="9.360936839422038" cy="9.360936839422038" stroke-width="0" stroke="rgba(0,0,0,1)" r="9.360936839422038"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,279.776093,18.065399)">
+        <g fill="none" transform="matrix(1,0,0,1,279.907166,26.481712)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(78,121,167,1)" transform="translate(-5.135164266307015,-5.135164266307015)" cx="5.135164266307015" cy="5.135164266307015" stroke-width="0" stroke="rgba(0,0,0,1)" r="5.135164266307015"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,387.486511,412.076813)">
+        <g fill="none" transform="matrix(1,0,0,1,400.477844,382.088287)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(242,142,44,1)" transform="translate(-15.909391693192845,-15.909391693192845)" cx="15.909391693192845" cy="15.909391693192845" stroke-width="0" stroke="rgba(0,0,0,1)" r="15.909391693192845"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,16.375605,223.238373)">
+        <g fill="none" transform="matrix(1,0,0,1,27.180239,230.221878)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(225,87,89,1)" transform="translate(-11.683619120078674,-11.683619120078674)" cx="11.683619120078674" cy="11.683619120078674" stroke-width="0" stroke="rgba(0,0,0,1)" r="11.683619120078674"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,381.353088,137.605759)">
+        <g fill="none" transform="matrix(1,0,0,1,419.404541,117.157867)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(118,183,178,1)" transform="translate(-7.457846546964504,-7.457846546964504)" cx="7.457846546964504" cy="7.457846546964504" stroke-width="0" stroke="rgba(0,0,0,1)" r="7.457846546964504"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,220.371002,468.095215)">
+        <g fill="none" transform="matrix(1,0,0,1,211.155533,460.007263)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(78,121,167,1)" transform="translate(-18.232073973850333,-18.232073973850333)" cx="18.232073973850333" cy="18.232073973850333" stroke-width="0" stroke="rgba(0,0,0,1)" r="18.232073973850333"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,166.316833,85.557556)">
+        <g fill="none" transform="matrix(1,0,0,1,156.760193,73.867462)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(242,142,44,1)" transform="translate(-14.006301400736163,-14.006301400736163)" cx="14.006301400736163" cy="14.006301400736163" stroke-width="0" stroke="rgba(0,0,0,1)" r="14.006301400736163"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,454.677917,345.759888)">
+        <g fill="none" transform="matrix(1,0,0,1,458.711182,336.033478)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(225,87,89,1)" transform="translate(-9.78052882762114,-9.78052882762114)" cx="9.78052882762114" cy="9.78052882762114" stroke-width="0" stroke="rgba(0,0,0,1)" r="9.78052882762114"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,23.670639,279.210999)">
+        <g fill="none" transform="matrix(1,0,0,1,32.158970,290.801941)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(118,183,178,1)" transform="translate(-5.5547562545069695,-5.5547562545069695)" cx="5.5547562545069695" cy="5.5547562545069695" stroke-width="0" stroke="rgba(0,0,0,1)" r="5.5547562545069695"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,363.627747,53.873520)">
+        <g fill="none" transform="matrix(1,0,0,1,353.954346,53.074871)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(78,121,167,1)" transform="translate(-16.32898368139365,-16.32898368139365)" cx="16.32898368139365" cy="16.32898368139365" stroke-width="0" stroke="rgba(0,0,0,1)" r="16.32898368139365"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,332.602173,447.964539)">
+        <g fill="none" transform="matrix(1,0,0,1,325.310730,457.745117)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(242,142,44,1)" transform="translate(-12.103211108278629,-12.103211108278629)" cx="12.103211108278629" cy="12.103211108278629" stroke-width="0" stroke="rgba(0,0,0,1)" r="12.103211108278629"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,17.818794,198.243103)">
+        <g fill="none" transform="matrix(1,0,0,1,16.004108,214.239441)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(225,87,89,1)" transform="translate(-7.877438535163606,-7.877438535163606)" cx="7.877438535163606" cy="7.877438535163606" stroke-width="0" stroke="rgba(0,0,0,1)" r="7.877438535163606"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,448.059113,189.218170)">
+        <g fill="none" transform="matrix(1,0,0,1,466.869934,194.480865)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(118,183,178,1)" transform="translate(-18.651665962050288,-18.651665962050288)" cx="18.651665962050288" cy="18.651665962050288" stroke-width="0" stroke="rgba(0,0,0,1)" r="18.651665962050288"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,76.889458,392.069305)">
+        <g fill="none" transform="matrix(1,0,0,1,106.592705,417.791443)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(78,121,167,1)" transform="translate(-14.425893388935265,-14.425893388935265)" cx="14.425893388935265" cy="14.425893388935265" stroke-width="0" stroke="rgba(0,0,0,1)" r="14.425893388935265"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,207.830215,0.152866)">
+        <g fill="none" transform="matrix(1,0,0,1,206.651581,5.451481)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(242,142,44,1)" transform="translate(-10.200120815821947,-10.200120815821947)" cx="10.200120815821947" cy="10.200120815821947" stroke-width="0" stroke="rgba(0,0,0,1)" r="10.200120815821947"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,331.614532,392.216583)">
+        <g fill="none" transform="matrix(1,0,0,1,364.380737,446.713837)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(225,87,89,1)" transform="translate(-5.974348242706924,-5.974348242706924)" cx="5.974348242706924" cy="5.974348242706924" stroke-width="0" stroke="rgba(0,0,0,1)" r="5.974348242706924"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,16.162527,255.493591)">
+        <g fill="none" transform="matrix(1,0,0,1,13.966545,258.161743)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(118,183,178,1)" transform="translate(-16.7485756695919,-16.7485756695919)" cx="16.7485756695919" cy="16.7485756695919" stroke-width="0" stroke="rgba(0,0,0,1)" r="16.7485756695919"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,423.794708,86.037827)">
+        <g fill="none" transform="matrix(1,0,0,1,425.981232,98.354057)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(78,121,167,1)" transform="translate(-12.522803096478583,-12.522803096478583)" cx="12.522803096478583" cy="12.522803096478583" stroke-width="0" stroke="rgba(0,0,0,1)" r="12.522803096478583"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,277.622162,471.296021)">
+        <g fill="none" transform="matrix(1,0,0,1,265.170898,478.156250)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(242,142,44,1)" transform="translate(-8.29703052336356,-8.29703052336356)" cx="8.29703052336356" cy="8.29703052336356" stroke-width="0" stroke="rgba(0,0,0,1)" r="8.29703052336356"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,140.463257,65.083977)">
+        <g fill="none" transform="matrix(1,0,0,1,136.464951,47.873669)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(225,87,89,1)" transform="translate(-19.071257950250242,-19.071257950250242)" cx="19.071257950250242" cy="19.071257950250242" stroke-width="0" stroke="rgba(0,0,0,1)" r="19.071257950250242"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,487.980988,273.806580)">
+        <g fill="none" transform="matrix(1,0,0,1,477.570496,274.636627)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(118,183,178,1)" transform="translate(-14.845485377135219,-14.845485377135219)" cx="14.845485377135219" cy="14.845485377135219" stroke-width="0" stroke="rgba(0,0,0,1)" r="14.845485377135219"/>
           </g>

--- a/packages/g6/__tests__/unit/elements/change-type.spec.ts
+++ b/packages/g6/__tests__/unit/elements/change-type.spec.ts
@@ -19,8 +19,8 @@ describe('element change type', () => {
 
   it('change type', async () => {
     graph.updateNodeData([
-      { id: 'node-1', style: { type: 'circle' } },
-      { id: 'node-2', style: { type: 'diamond' } },
+      { id: 'node-1', type: 'circle' },
+      { id: 'node-2', type: 'diamond' },
     ]);
 
     await graph.draw();

--- a/packages/g6/__tests__/unit/elements/combo.spec.ts
+++ b/packages/g6/__tests__/unit/elements/combo.spec.ts
@@ -75,8 +75,8 @@ describe('combo', () => {
       graph.updateComboData([
         {
           id: 'combo-1',
+          type: 'rect',
           style: {
-            type: 'rect',
             collapsed: false,
           },
         },
@@ -87,8 +87,8 @@ describe('combo', () => {
       graph.updateComboData([
         {
           id: 'combo-1',
+          type: 'rect',
           style: {
-            type: 'rect',
             collapsed: true,
             collapsedOrigin,
             collapsedMarker: false,

--- a/packages/g6/__tests__/unit/elements/override-methods.spec.ts
+++ b/packages/g6/__tests__/unit/elements/override-methods.spec.ts
@@ -25,7 +25,7 @@ describe('element override methods', () => {
 
     const graph = createGraph({
       data: {
-        nodes: [{ id: 'node-1', style: { type: 'custom-circle' } }],
+        nodes: [{ id: 'node-1', type: 'custom-circle' }],
       },
     });
 

--- a/packages/g6/__tests__/unit/runtime/element.spec.ts
+++ b/packages/g6/__tests__/unit/runtime/element.spec.ts
@@ -31,7 +31,6 @@ describe('ElementController', () => {
       node: {
         style: {
           fill: (datum) => ((datum?.data?.value as number) > 100 ? 'red' : 'blue'),
-          border: (datum: any, index: number) => (index % 2 === 0 ? 0 : 10),
         },
         state: {
           selected: {
@@ -106,9 +105,9 @@ describe('ElementController', () => {
     expect(elementController.getPaletteStyle(edge2Id)[paletteKey]).toBe(BUILT_IN_PALETTES.oranges.at(-2));
     expect(elementController.getPaletteStyle('combo-1')[paletteKey]).toBe(BUILT_IN_PALETTES.blues[0]);
 
-    expect(elementController.getDefaultStyle('node-1')).toEqual({ fill: 'blue', border: 0 });
-    expect(elementController.getDefaultStyle('node-2')).toEqual({ fill: 'red', border: 10 });
-    expect(elementController.getDefaultStyle('node-3')).toEqual({ fill: 'red', border: 0 });
+    expect(elementController.getDefaultStyle('node-1')).toEqual({ fill: 'blue' });
+    expect(elementController.getDefaultStyle('node-2')).toEqual({ fill: 'red' });
+    expect(elementController.getDefaultStyle('node-3')).toEqual({ fill: 'red' });
     expect(elementController.getDefaultStyle(edge1Id)).toEqual({});
     expect(elementController.getDefaultStyle('combo-1')).toEqual({});
 
@@ -123,11 +122,9 @@ describe('ElementController', () => {
 
     expect(elementController.getElementComputedStyle('node', node1)).toEqual({
       ...LIGHT_THEME.node?.style,
-      type: 'circle',
       fill: 'blue',
       stroke: 'pink',
       lineWidth: 1,
-      border: 0,
       // from palette
       color: BUILT_IN_PALETTES.spectral[0],
       x: 100,
@@ -136,9 +133,7 @@ describe('ElementController', () => {
 
     expect(elementController.getElementComputedStyle('node', node2)).toEqual({
       ...LIGHT_THEME.node?.style,
-      type: 'circle',
       fill: 'red',
-      border: 10,
       // from palette
       color: BUILT_IN_PALETTES.spectral[1],
       x: 150,
@@ -148,8 +143,6 @@ describe('ElementController', () => {
     expect(elementController.getElementComputedStyle('node', node3)).toEqual({
       ...LIGHT_THEME.node?.style,
       ...LIGHT_THEME.node?.state?.selected,
-      type: 'circle',
-      border: 0,
       parentId: 'combo-1',
       states: ['selected'],
       // from state
@@ -162,7 +155,6 @@ describe('ElementController', () => {
 
     expect(omit(elementController.getElementComputedStyle('edge', edge1), ['sourceNode', 'targetNode'])).toEqual({
       ...LIGHT_THEME.edge?.style,
-      type: 'line',
       color: BUILT_IN_PALETTES.oranges.at(-1),
     });
 
@@ -170,7 +162,6 @@ describe('ElementController', () => {
       ...LIGHT_THEME.edge?.style,
       ...LIGHT_THEME.edge?.state?.active,
       ...LIGHT_THEME.edge?.state?.selected,
-      type: 'line',
       lineWidth: 4,
       stroke: 'red',
       states: ['active', 'selected'],
@@ -183,7 +174,6 @@ describe('ElementController', () => {
 
     expect(omit(comboStyle, ['childrenNode', 'childrenData'])).toEqual({
       ...LIGHT_THEME.combo?.style,
-      type: 'circle',
       color: BUILT_IN_PALETTES.blues[0],
     });
   });

--- a/packages/g6/__tests__/unit/utils/edge.spec.ts
+++ b/packages/g6/__tests__/unit/utils/edge.spec.ts
@@ -1,3 +1,4 @@
+import type { ID } from '@/src';
 import { Rect } from '@/src/elements';
 import {
   getCubicPath,
@@ -12,7 +13,6 @@ import {
   parseCurvePosition,
 } from '@/src/utils/edge';
 import { AABB, Line } from '@antv/g';
-import type { ID } from '@antv/graphlib';
 
 describe('edge', () => {
   describe('getLabelPositionStyle', () => {

--- a/packages/g6/__tests__/unit/utils/id.spec.ts
+++ b/packages/g6/__tests__/unit/utils/id.spec.ts
@@ -3,7 +3,6 @@ import { idOf, idsOf, parentIdOf } from '@/src/utils/id';
 describe('id', () => {
   it('idOf', () => {
     expect(idOf({ id: '1' })).toBe('1');
-    expect(idOf({ id: 1 })).toBe(1);
     expect(idOf({ source: 'node-1', target: 'edge-1' })).toBe(`node-1-edge-1`);
     expect(() => idOf({})).toThrow();
   });

--- a/packages/g6/__tests__/unit/utils/style.spec.ts
+++ b/packages/g6/__tests__/unit/utils/style.spec.ts
@@ -20,7 +20,7 @@ describe('style', () => {
       fill: (data: any) => (data.data.type === 'B' ? 'green' : 'red'),
     };
 
-    const computedStyle = computeElementCallbackStyle(style, { datum, index: 0, elementData: [datum] });
+    const computedStyle = computeElementCallbackStyle(style, { datum });
 
     expect(computedStyle).toEqual({
       stroke: 'blue',
@@ -34,7 +34,7 @@ describe('style', () => {
       };
     };
 
-    expect(computeElementCallbackStyle(style1, { datum, index: 0, elementData: [datum] })).toEqual({
+    expect(computeElementCallbackStyle(style1, { datum })).toEqual({
       fill: 'red',
     });
   });

--- a/packages/g6/src/behaviors/brush-select.ts
+++ b/packages/g6/src/behaviors/brush-select.ts
@@ -6,11 +6,10 @@ import { getAllElementState, transformEdgeState } from '../utils/behaviors/utils
 import { Shortcut } from '../utils/shortcut';
 import { BaseBehavior } from './base-behavior';
 
-import type { ID } from '@antv/graphlib';
 import type { Graph } from '../runtime/graph';
 import type { RuntimeContext } from '../runtime/types';
 import type { NodeStyle } from '../spec/element/node';
-import type { ElementType, IPointerEvent, Point, Points, State } from '../types';
+import type { ElementType, ID, IPointerEvent, Point, Points, State } from '../types';
 import type { ShortcutKey } from '../utils/shortcut';
 import type { BaseBehaviorOptions } from './base-behavior';
 

--- a/packages/g6/src/behaviors/click-element.ts
+++ b/packages/g6/src/behaviors/click-element.ts
@@ -1,9 +1,8 @@
-import type { ID } from '@antv/graphlib';
 import { isFunction } from '@antv/util';
 import { CommonEvent } from '../constants';
 import { ELEMENT_TYPES } from '../constants/element';
 import type { RuntimeContext } from '../runtime/types';
-import type { Element, ElementType, IPointerEvent, State } from '../types';
+import type { Element, ElementType, ID, IPointerEvent, State } from '../types';
 import { idsOf } from '../utils/id';
 import { getElementNthDegreeIds } from '../utils/relation';
 import type { ShortcutKey } from '../utils/shortcut';

--- a/packages/g6/src/behaviors/collapse-expand.ts
+++ b/packages/g6/src/behaviors/collapse-expand.ts
@@ -1,8 +1,7 @@
-import type { ID } from '@antv/graphlib';
 import { isFunction } from '@antv/util';
 import { CommonEvent } from '../constants';
 import type { RuntimeContext } from '../runtime/types';
-import type { IPointerEvent } from '../types';
+import type { ID, IPointerEvent } from '../types';
 import { isElement } from '../utils/element';
 import type { BaseBehaviorOptions } from './base-behavior';
 import { BaseBehavior } from './base-behavior';

--- a/packages/g6/src/behaviors/create-edge.ts
+++ b/packages/g6/src/behaviors/create-edge.ts
@@ -1,10 +1,9 @@
-import type { ID } from '@antv/graphlib';
 import { isFunction, uniqueId } from '@antv/util';
 import { CommonEvent } from '../constants';
 import type { RuntimeContext } from '../runtime/types';
 import type { EdgeData } from '../spec';
 import type { EdgeStyle } from '../spec/element/edge';
-import type { Element, IPointerEvent } from '../types';
+import type { Element, ID, IPointerEvent } from '../types';
 import type { BaseBehaviorOptions } from './base-behavior';
 import { BaseBehavior } from './base-behavior';
 

--- a/packages/g6/src/behaviors/drag-element-force.ts
+++ b/packages/g6/src/behaviors/drag-element-force.ts
@@ -1,6 +1,5 @@
-import type { ID } from '@antv/graphlib';
 import type { D3Force3DLayout, D3ForceLayout } from '@antv/layout';
-import type { Element, IDragEvent, Point } from '../types';
+import type { Element, ID, IDragEvent, Point } from '../types';
 import { idOf } from '../utils/id';
 import { add } from '../utils/vector';
 import type { DragElementOptions } from './drag-element';

--- a/packages/g6/src/behaviors/drag-element.ts
+++ b/packages/g6/src/behaviors/drag-element.ts
@@ -1,10 +1,9 @@
 import type { BaseStyleProps } from '@antv/g';
 import { Rect } from '@antv/g';
-import type { ID } from '@antv/graphlib';
 import { isFunction } from '@antv/util';
 import { COMBO_KEY, CommonEvent } from '../constants';
 import type { RuntimeContext } from '../runtime/types';
-import type { EdgeDirection, Element, IDragEvent, Point, PrefixObject } from '../types';
+import type { EdgeDirection, Element, ID, IDragEvent, Point, PrefixObject } from '../types';
 import { getBBoxSize, getCombinedBBox } from '../utils/bbox';
 import { idOf } from '../utils/id';
 import { subStyleProps } from '../utils/prefix';

--- a/packages/g6/src/behaviors/focus-element.ts
+++ b/packages/g6/src/behaviors/focus-element.ts
@@ -1,8 +1,7 @@
-import type { ID } from '@antv/graphlib';
 import { isFunction } from '@antv/util';
 import { CommonEvent } from '../constants';
 import type { RuntimeContext } from '../runtime/types';
-import type { Element, IPointerEvent, ViewportAnimationEffectTiming } from '../types';
+import type { Element, ID, IPointerEvent, ViewportAnimationEffectTiming } from '../types';
 import type { BaseBehaviorOptions } from './base-behavior';
 import { BaseBehavior } from './base-behavior';
 

--- a/packages/g6/src/behaviors/hover-element.ts
+++ b/packages/g6/src/behaviors/hover-element.ts
@@ -1,9 +1,8 @@
-import type { ID } from '@antv/graphlib';
 import { isFunction } from '@antv/util';
 import { CommonEvent } from '../constants';
 import { ELEMENT_TYPES } from '../constants/element';
 import type { RuntimeContext } from '../runtime/types';
-import type { Element, ElementType, IPointerEvent, State } from '../types';
+import type { Element, ElementType, ID, IPointerEvent, State } from '../types';
 import { idsOf } from '../utils/id';
 import { getElementNthDegreeIds } from '../utils/relation';
 import type { BaseBehaviorOptions } from './base-behavior';

--- a/packages/g6/src/behaviors/lasso-select.ts
+++ b/packages/g6/src/behaviors/lasso-select.ts
@@ -4,9 +4,8 @@ import { getAllElementState } from '../utils/behaviors/utils';
 import { pointsToPath } from '../utils/path';
 import { BrushSelect, DEFAULT_STYLE } from './brush-select';
 
-import type { ID } from '@antv/graphlib';
 import type { RuntimeContext } from '../runtime/types';
-import type { IPointerEvent, Points, State } from '../types';
+import type { ID, IPointerEvent, Points, State } from '../types';
 import type { BrushSelectOptions } from './brush-select';
 
 const SHOW_PATH_ID = 'g6-lasso-select-path-id';

--- a/packages/g6/src/elements/nodes/base-node.ts
+++ b/packages/g6/src/elements/nodes/base-node.ts
@@ -1,12 +1,12 @@
 import type { DisplayObject, DisplayObjectConfig, Group } from '@antv/g';
 import { Circle as GCircle } from '@antv/g';
-import type { ID } from '@antv/graphlib';
 import { deepMix, isEmpty } from '@antv/util';
 import type { CategoricalPalette } from '../../palettes/types';
 import type { NodeData } from '../../spec';
 import type {
   BadgePlacement,
   BaseElementStyleProps,
+  ID,
   Keyframe,
   LabelPlacement,
   Node,

--- a/packages/g6/src/exports.ts
+++ b/packages/g6/src/exports.ts
@@ -73,6 +73,7 @@ export type {
   Edge,
   Element,
   IAnimateEvent,
+  ID,
   IDragEvent,
   IElementLifeCycleEvent,
   IEvent,

--- a/packages/g6/src/plugins/hull/index.ts
+++ b/packages/g6/src/plugins/hull/index.ts
@@ -1,9 +1,8 @@
-import type { ID } from '@antv/graphlib';
 import { PathArray, isEqual, isFunction } from '@antv/util';
 import hull from 'hull.js';
 import { GraphEvent } from '../../constants';
 import type { RuntimeContext } from '../../runtime/types';
-import type { CallableValue, Point } from '../../types';
+import type { CallableValue, ID, Point } from '../../types';
 import type { ElementLifeCycleEvent } from '../../utils/event';
 import { idOf } from '../../utils/id';
 import { positionOf } from '../../utils/position';

--- a/packages/g6/src/plugins/legend.ts
+++ b/packages/g6/src/plugins/legend.ts
@@ -197,7 +197,8 @@ export class Legend extends BasePlugin<LegendOptions> {
       data.forEach((item) => {
         const { id } = item;
         const value = get(item, ['data', getField(item)]);
-        const { color = '#1783ff', type: marker = 'circle' } = getElementStyle(type, item);
+        const marker = element?.getElementType(type, item) || 'circle';
+        const { color = '#1783ff' } = getElementStyle(type, item);
         if (id && value && value.replace(/\s+/g, '')) {
           this.setFieldMap(value, id, type);
           if (!items[value]) {

--- a/packages/g6/src/plugins/legend.ts
+++ b/packages/g6/src/plugins/legend.ts
@@ -1,10 +1,9 @@
 import type { CategoryOptions } from '@antv/component';
 import { Category, Layout, Selection } from '@antv/component';
-import type { ID } from '@antv/graphlib';
 import { get, isFunction } from '@antv/util';
 import { GraphEvent } from '../constants';
 import type { RuntimeContext } from '../runtime/types';
-import type { ElementDatum, ElementType, State } from '../types';
+import type { ElementDatum, ElementType, ID, State } from '../types';
 import type { CardinalPlacement } from '../types/placement';
 import type { BasePluginOptions } from './base-plugin';
 import { BasePlugin } from './base-plugin';
@@ -199,7 +198,7 @@ export class Legend extends BasePlugin<LegendOptions> {
         const { id } = item;
         const value = get(item, ['data', getField(item)]);
         const { color = '#1783ff', type: marker = 'circle' } = getElementStyle(type, item);
-        if ((id || id === 0) && value && value.replace(/\s+/g, '')) {
+        if (id && value && value.replace(/\s+/g, '')) {
           this.setFieldMap(value, id, type);
           if (!items[value]) {
             items[value] = {

--- a/packages/g6/src/runtime/data.ts
+++ b/packages/g6/src/runtime/data.ts
@@ -1,4 +1,4 @@
-import { Graph as GraphLib, ID } from '@antv/graphlib';
+import { Graph as GraphLib } from '@antv/graphlib';
 import { isEqual, isUndefined } from '@antv/util';
 import { COMBO_KEY, ChangeType, TREE_KEY } from '../constants';
 import type { ComboData, EdgeData, GraphData, NodeData } from '../spec';
@@ -9,6 +9,7 @@ import type {
   DataRemoved,
   DataUpdated,
   ElementDatum,
+  ID,
   NodeLikeData,
   PartialEdgeData,
   PartialGraphData,

--- a/packages/g6/src/runtime/element.ts
+++ b/packages/g6/src/runtime/element.ts
@@ -2,7 +2,7 @@
 /* eslint-disable jsdoc/require-param */
 import type { BaseStyleProps, DisplayObject, IAnimation } from '@antv/g';
 import { Group } from '@antv/g';
-import { groupBy, isEmpty } from '@antv/util';
+import { groupBy, isEmpty, isString } from '@antv/util';
 import { executor as animationExecutor } from '../animations';
 import type { AnimationContext } from '../animations/types';
 import { AnimationType, ChangeType, GraphEvent } from '../constants';
@@ -64,7 +64,8 @@ export class ElementController {
     }
   }
 
-  private emit(event: BaseEvent) {
+  private emit(event: BaseEvent, context: DrawContext) {
+    if (context.silence) return;
     emit(this.context.graph, event);
   }
 
@@ -73,6 +74,17 @@ export class ElementController {
       const elementData = this.context.model.getElementData(elementType);
       callback(elementType, elementData);
     });
+  }
+
+  public getElementType(elementType: ElementType, datum: ElementDatum) {
+    const { options } = this.context;
+    const userDefinedType = options[elementType]?.type || datum.type;
+
+    if (!userDefinedType) {
+      return { node: 'circle', edge: 'line', combo: 'circle' }[elementType];
+    }
+    if (isString(userDefinedType)) return userDefinedType;
+    return userDefinedType(datum as any);
   }
 
   private getTheme(elementType: ElementType) {
@@ -125,7 +137,7 @@ export class ElementController {
    *
    * <en/> compute default style of single element
    */
-  private computedElementDefaultStyle(elementType: ElementType, context: StyleIterationContext) {
+  private computeElementDefaultStyle(elementType: ElementType, context: StyleIterationContext) {
     const { options } = this.context;
     const defaultStyle = options[elementType]?.style || {};
     this.defaultStyle[idOf(context.datum)] = computeElementCallbackStyle(defaultStyle as any, context);
@@ -135,8 +147,8 @@ export class ElementController {
     this.forEachElementData((elementType, elementData) => {
       elementData
         .filter((datum) => ids === undefined || ids.includes(idOf(datum)))
-        .forEach((datum, index) => {
-          this.computedElementDefaultStyle(elementType, { datum, index, elementData });
+        .forEach((datum) => {
+          this.computeElementDefaultStyle(elementType, { datum });
         });
     });
   }
@@ -189,9 +201,9 @@ export class ElementController {
     this.forEachElementData((elementType, elementData) => {
       elementData
         .filter((datum) => ids === undefined || ids.includes(idOf(datum)))
-        .forEach((datum, index) => {
+        .forEach((datum) => {
           const states = this.getElementState(idOf(datum));
-          this.computeElementStatesStyle(elementType, states, { datum, index, elementData });
+          this.computeElementStatesStyle(elementType, states, { datum });
         });
     });
   }
@@ -309,10 +321,6 @@ export class ElementController {
       Object.assign(style, { childrenNode, childrenData });
     }
 
-    if (!style.type) {
-      style.type = { node: 'circle', edge: 'line', combo: 'circle' }[elementType];
-    }
-
     return style;
   }
 
@@ -344,14 +352,22 @@ export class ElementController {
             before: () =>
               this.emit(
                 new GraphLifeCycleEvent(GraphEvent.BEFORE_DRAW, { dataChanges, animation: drawContext.animation }),
+                drawContext,
               ),
             beforeAnimate: (animation) =>
-              this.emit(new AnimateEvent(GraphEvent.BEFORE_ANIMATE, AnimationType.DRAW, animation, drawData)),
+              this.emit(
+                new AnimateEvent(GraphEvent.BEFORE_ANIMATE, AnimationType.DRAW, animation, drawData),
+                drawContext,
+              ),
             afterAnimate: (animation) =>
-              this.emit(new AnimateEvent(GraphEvent.AFTER_ANIMATE, AnimationType.DRAW, animation, drawData)),
+              this.emit(
+                new AnimateEvent(GraphEvent.AFTER_ANIMATE, AnimationType.DRAW, animation, drawData),
+                drawContext,
+              ),
             after: () =>
               this.emit(
                 new GraphLifeCycleEvent(GraphEvent.AFTER_DRAW, { dataChanges, animation: drawContext.animation }),
+                drawContext,
               ),
           },
     )?.finished;
@@ -415,17 +431,17 @@ export class ElementController {
   }
 
   private createElement(elementType: ElementType, datum: ElementDatum, context: DrawContext) {
-    const { animator } = context;
     const id = idOf(datum);
     const currentShape = this.getElement(id);
     if (currentShape) return () => null;
-    const { type, ...style } = this.getElementComputedStyle(elementType, datum);
+    const type = this.getElementType(elementType, datum);
+    const style = this.getElementComputedStyle(elementType, datum);
 
     // get shape constructor
     const Ctor = getExtension(elementType, type);
     if (!Ctor) return () => null;
 
-    this.emit(new ElementLifeCycleEvent(GraphEvent.BEFORE_ELEMENT_CREATE, elementType, datum));
+    this.emit(new ElementLifeCycleEvent(GraphEvent.BEFORE_ELEMENT_CREATE, elementType, datum), context);
 
     const shape = this.container[elementType].appendChild(
       new Ctor({
@@ -440,10 +456,11 @@ export class ElementController {
     this.shapeTypeMap[id] = type;
     this.elementMap[id] = shape;
 
+    const { animation, animator } = context;
     return () =>
-      withAnimationCallbacks(animator?.(id, shape, { ...shape.attributes, opacity: 0 }) || null, {
+      withAnimationCallbacks(animation ? animator?.(id, shape, { ...shape.attributes, opacity: 0 }) : null, {
         after: () => {
-          this.emit(new ElementLifeCycleEvent(GraphEvent.AFTER_ELEMENT_CREATE, elementType, datum));
+          this.emit(new ElementLifeCycleEvent(GraphEvent.AFTER_ELEMENT_CREATE, elementType, datum), context);
           shape.onCreate();
         },
       });
@@ -495,20 +512,21 @@ export class ElementController {
     const shape = this.getElement(id);
     if (!shape) return () => null;
 
-    this.emit(new ElementLifeCycleEvent(GraphEvent.BEFORE_ELEMENT_UPDATE, elementType, datum));
+    this.emit(new ElementLifeCycleEvent(GraphEvent.BEFORE_ELEMENT_UPDATE, elementType, datum), context);
     const afterUpdate = () => {
-      this.emit(new ElementLifeCycleEvent(GraphEvent.AFTER_ELEMENT_UPDATE, elementType, datum));
+      this.emit(new ElementLifeCycleEvent(GraphEvent.AFTER_ELEMENT_UPDATE, elementType, datum), context);
       shape.onUpdate();
     };
 
-    const { type, ...style } = this.getElementComputedStyle(elementType, datum);
+    const type = this.getElementType(elementType, datum);
+    const style = this.getElementComputedStyle(elementType, datum);
 
     // 如果类型不同，需要先销毁原有元素，再创建新元素
     // If the type is different, you need to destroy the original element first, and then create a new element
     if (this.shapeTypeMap[id] !== type) {
+      this.destroyElement(elementType, datum, { animation: false, silence: true })();
+      this.createElement(elementType, datum, { animation: false, silence: true })();
       return () => {
-        this.destroyElement(elementType, datum, { ...context, animation: false })();
-        this.createElement(elementType, datum, { ...context, animation: false })();
         afterUpdate();
         return null;
       };
@@ -527,7 +545,7 @@ export class ElementController {
         updateStyle(shape, { visibility: 'visible' });
         return () =>
           withAnimationCallbacks(
-            animator?.(id, shape, { ...shape.attributes, opacity: 0 }, { opacity: originalOpacity }) || null,
+            animator?.(id, shape, { ...shape.attributes, opacity: 0 }, { opacity: originalOpacity }),
             { after: afterUpdate },
           );
       }
@@ -535,7 +553,7 @@ export class ElementController {
       else if (style.visibility === 'hidden') {
         return () =>
           withAnimationCallbacks(
-            animator?.(id, shape, { ...shape.attributes, opacity: originalOpacity }, { opacity: 0 }) || null,
+            animator?.(id, shape, { ...shape.attributes, opacity: originalOpacity }, { opacity: 0 }),
             {
               after: () => {
                 updateStyle(shape, { visibility: this.latestElementVisibilityMap.get(shape) });
@@ -549,8 +567,19 @@ export class ElementController {
     const originalStyle = { ...shape.attributes };
     updateStyle(shape, style);
 
+    // 如果边的端点节点已经销毁，则更新端点节点
+    // If the endpoint node of the edge has been destroyed, update the endpoint node
+    if (elementType === 'edge') {
+      if (originalStyle.sourceNode.destroyed) {
+        originalStyle.sourceNode = style.sourceNode;
+      }
+      if (originalStyle.targetNode.destroyed) {
+        originalStyle.targetNode = style.targetNode;
+      }
+    }
+
     return () =>
-      withAnimationCallbacks(animator?.(id, shape, originalStyle) || null, {
+      withAnimationCallbacks(animator?.(id, shape, originalStyle), {
         after: afterUpdate,
       });
   }
@@ -582,20 +611,17 @@ export class ElementController {
     const element = this.elementMap[id];
     if (!element) return () => null;
 
-    this.emit(new ElementLifeCycleEvent(GraphEvent.BEFORE_ELEMENT_DESTROY, elementType, datum));
+    this.emit(new ElementLifeCycleEvent(GraphEvent.BEFORE_ELEMENT_DESTROY, elementType, datum), context);
 
-    return () => {
-      const result = animator?.(id, element, { ...element.attributes }, { opacity: 0 }) || null;
-      withAnimationCallbacks(result, {
+    return () =>
+      withAnimationCallbacks(animator?.(id, element, { ...element.attributes }, { opacity: 0 }), {
         after: () => {
           this.clearElement(id);
           element.destroy();
           element.onDestroy();
-          this.emit(new ElementLifeCycleEvent(GraphEvent.AFTER_ELEMENT_DESTROY, elementType, datum));
+          this.emit(new ElementLifeCycleEvent(GraphEvent.AFTER_ELEMENT_DESTROY, elementType, datum), context);
         },
       });
-      return result;
-    };
   }
 
   private getDestroyTasks(data: ProcedureData, context: Omit<DrawContext, 'animator'>): AnimatableTask[] {
@@ -606,11 +632,11 @@ export class ElementController {
       ['node', nodes],
     ];
 
-    const { animation, stage } = context;
+    const { animation, stage = 'exit' } = context;
     const tasks: AnimatableTask[] = [];
     iteration.forEach(([elementType, elementData]) => {
       if (elementData.size === 0) return [];
-      const animator = this.getAnimationExecutor(elementType, stage || 'exit', animation);
+      const animator = this.getAnimationExecutor(elementType, stage, animation);
       elementData.forEach((datum) =>
         tasks.push(() => this.destroyElement(elementType, datum, { ...context, animator })),
       );

--- a/packages/g6/src/runtime/element.ts
+++ b/packages/g6/src/runtime/element.ts
@@ -2,7 +2,6 @@
 /* eslint-disable jsdoc/require-param */
 import type { BaseStyleProps, DisplayObject, IAnimation } from '@antv/g';
 import { Group } from '@antv/g';
-import type { ID } from '@antv/graphlib';
 import { groupBy, isEmpty } from '@antv/util';
 import { executor as animationExecutor } from '../animations';
 import type { AnimationContext } from '../animations/types';
@@ -21,6 +20,7 @@ import type {
   ElementData,
   ElementDatum,
   ElementType,
+  ID,
   Node,
   State,
   StyleIterationContext,

--- a/packages/g6/src/runtime/graph.ts
+++ b/packages/g6/src/runtime/graph.ts
@@ -1,6 +1,5 @@
 import EventEmitter from '@antv/event-emitter';
 import type { AABB, BaseStyleProps } from '@antv/g';
-import type { ID } from '@antv/graphlib';
 import { debounce, isArray, isEqual, isFunction, isNumber, isObject, isString, omit } from '@antv/util';
 import { COMBO_KEY, GraphEvent } from '../constants';
 import type { Plugin } from '../plugins/types';
@@ -30,6 +29,7 @@ import type {
   ElementDatum,
   ElementType,
   FitViewOptions,
+  ID,
   IEvent,
   NodeLikeData,
   PartialEdgeData,

--- a/packages/g6/src/runtime/layout.ts
+++ b/packages/g6/src/runtime/layout.ts
@@ -8,7 +8,7 @@ import { COMBO_KEY, GraphEvent, TREE_KEY } from '../constants';
 import { getExtension } from '../registry';
 import type { EdgeData, NodeData } from '../spec';
 import type { STDLayoutOptions } from '../spec/layout';
-import type { Combo, Node, PartialGraphData, TreeData } from '../types';
+import type { Combo, ID, Node, PartialGraphData, TreeData } from '../types';
 import { getAnimation } from '../utils/animation';
 import { isVisible } from '../utils/element';
 import { GraphLifeCycleEvent, emit } from '../utils/event';
@@ -292,7 +292,7 @@ export class LayoutController {
     const nodeSize: number | ((node: LayoutGraphlibNode) => number) =
       (options?.nodeSize as number) ??
       ((node) => {
-        const nodeElement = element?.getElement<Node | Combo>(node.id);
+        const nodeElement = element?.getElement<Node | Combo>(node.id as string);
         const { size } = nodeElement?.attributes || {};
         return Math.max(...parseSize(size));
       });
@@ -327,7 +327,7 @@ export class LayoutController {
     const { nodes, edges } = layoutData;
     const dataToUpdate: Required<PartialGraphData> = { nodes: [], edges: [], combos: [] };
     nodes.forEach(({ id, data: { x, y, z = 0 } }) => {
-      dataToUpdate.nodes.push({ id, style: { x, y, z } });
+      dataToUpdate.nodes.push({ id: id as ID, style: { x, y, z } });
     });
 
     edges.forEach(({ id, data: { points = [], controlPoints = points.slice(1, points.length - 1) } }) => {
@@ -338,7 +338,7 @@ export class LayoutController {
       if (controlPoints?.length) {
         // points 的第一个点是起点，最后一个点是终点，中间的点是控制点
         // The first point of points is the starting point, and the last point is the end point, and the middle point is the control point
-        dataToUpdate.edges.push({ id, style: { controlPoints: controlPoints.map(parsePoint) } });
+        dataToUpdate.edges.push({ id: id as ID, style: { controlPoints: controlPoints.map(parsePoint) } });
       }
     });
 

--- a/packages/g6/src/runtime/viewport.ts
+++ b/packages/g6/src/runtime/viewport.ts
@@ -1,8 +1,7 @@
 import { AABB } from '@antv/g';
-import type { ID } from '@antv/graphlib';
 import { clamp, isNumber, pick } from '@antv/util';
 import { AnimationType, GraphEvent } from '../constants';
-import type { FitViewOptions, Point, TransformOptions, Vector2, ViewportAnimationEffectTiming } from '../types';
+import type { FitViewOptions, ID, Point, TransformOptions, Vector2, ViewportAnimationEffectTiming } from '../types';
 import { getAnimation } from '../utils/animation';
 import { getBBoxSize, getCombinedBBox } from '../utils/bbox';
 import { AnimateEvent, ViewportEvent, emit } from '../utils/event';

--- a/packages/g6/src/spec/data.ts
+++ b/packages/g6/src/spec/data.ts
@@ -25,24 +25,97 @@ export interface GraphData {
 }
 
 export interface NodeData {
+  /**
+   * <zh/> 节点 ID
+   *
+   * <en/> Node ID
+   */
   id: ID;
+  /**
+   * <zh/> 节点类型
+   *
+   * <en/> Node type
+   */
+  type?: string;
+  /**
+   * <zh/> 节点数据
+   *
+   * <en/> Node data
+   */
   data?: Record<string, unknown>;
+  /**
+   * <zh/> 节点样式
+   *
+   * <en/> Node style
+   */
   style?: NodeStyle;
   [key: string]: unknown;
 }
 
 export interface ComboData {
+  /**
+   * <zh/> Combo ID
+   *
+   * <en/> Combo ID
+   */
   id: ID;
+  /**
+   * <zh/> Combo 类型
+   *
+   * <en/> Combo type
+   */
+  type?: string;
+  /**
+   * <zh/> Combo 数据
+   *
+   * <en/> Combo data
+   */
   data?: Record<string, unknown>;
+  /**
+   * <zh/> Combo 样式
+   *
+   * <en/> Combo style
+   */
   style?: ComboStyle;
   [key: string]: unknown;
 }
 
 export interface EdgeData {
+  /**
+   * <zh/> 边 ID
+   *
+   * <en/> Edge ID
+   */
   id?: ID;
+  /**
+   * <zh/> 边源节点 ID
+   *
+   * <en/> Source node ID
+   */
   source: ID;
+  /**
+   * <zh/> 边目标节点 ID
+   *
+   * <en/> Target node ID
+   */
   target: ID;
+  /**
+   * <zh/> 边类型
+   *
+   * <en/> Edge type
+   */
+  type?: string;
+  /**
+   * <zh/> 边数据
+   *
+   * <en/> Edge data
+   */
   data?: Record<string, unknown>;
+  /**
+   * <zh/> 边样式
+   *
+   * <en/> Edge style
+   */
   style?: EdgeStyle;
   [key: string]: unknown;
 }

--- a/packages/g6/src/spec/data.ts
+++ b/packages/g6/src/spec/data.ts
@@ -1,4 +1,4 @@
-import type { ID } from '@antv/graphlib';
+import type { ID } from '../types';
 import type { ComboStyle } from './element/combo';
 import type { EdgeStyle } from './element/edge';
 import type { NodeStyle } from './element/node';

--- a/packages/g6/src/spec/element/base.ts
+++ b/packages/g6/src/spec/element/base.ts
@@ -1,6 +1,0 @@
-export interface BaseElementStyle {
-  /** <zh/> 元素类型 | <en/> Element type */
-  type?: string;
-  /** <zh/> 初始状态 | <en/> Initial state */
-  states?: string[];
-}

--- a/packages/g6/src/spec/element/combo.ts
+++ b/packages/g6/src/spec/element/combo.ts
@@ -1,9 +1,8 @@
 import type { BaseComboStyleProps } from '../../elements/combos';
-import type { ID } from '../../types';
+import type { ID, State } from '../../types';
 import type { CallableObject } from '../../types/callable';
-import type { NodeData } from '../data';
+import type { ComboData } from '../data';
 import type { AnimationOptions } from './animation';
-import type { BaseElementStyle } from './base';
 import type { PaletteOptions } from './palette';
 
 /**
@@ -13,17 +12,23 @@ import type { PaletteOptions } from './palette';
  */
 export interface ComboOptions {
   /**
+   * <zh/> Combo 类型
+   *
+   * <en/> Combo type
+   */
+  type?: string | ((datum: ComboData) => string);
+  /**
    * <zh/> Combo 样式
    *
    * <en/> Combo style
    */
-  style?: CallableObject<ComboStyle, NodeData>;
+  style?: CallableObject<ComboStyle, ComboData>;
   /**
    * <zh/> Combo 状态样式
    *
    * <en/> Combo state style
    */
-  state?: Record<string, CallableObject<ComboStyle, NodeData>>;
+  state?: Record<string, CallableObject<ComboStyle, ComboData>>;
   /**
    * <zh/> Combo 动画
    *
@@ -45,7 +50,13 @@ export interface StaticComboOptions {
   palette?: PaletteOptions;
 }
 
-export interface ComboStyle extends BaseElementStyle, Partial<BaseComboStyleProps> {
+export interface ComboStyle extends Partial<BaseComboStyleProps> {
+  /**
+   * <zh/> 初始状态
+   *
+   * <en/> Initial state
+   */
+  states?: State[];
   children?: ID[];
   [key: string]: any;
 }

--- a/packages/g6/src/spec/element/combo.ts
+++ b/packages/g6/src/spec/element/combo.ts
@@ -1,5 +1,5 @@
-import type { ID } from '@antv/graphlib';
 import type { BaseComboStyleProps } from '../../elements/combos';
+import type { ID } from '../../types';
 import type { CallableObject } from '../../types/callable';
 import type { NodeData } from '../data';
 import type { AnimationOptions } from './animation';

--- a/packages/g6/src/spec/element/edge.ts
+++ b/packages/g6/src/spec/element/edge.ts
@@ -1,8 +1,8 @@
 import type { BaseEdgeStyleProps } from '../../elements/edges';
+import { State } from '../../types';
 import type { CallableObject } from '../../types/callable';
 import type { EdgeData } from '../data';
 import type { AnimationOptions } from './animation';
-import type { BaseElementStyle } from './base';
 import type { PaletteOptions } from './palette';
 
 /**
@@ -11,6 +11,12 @@ import type { PaletteOptions } from './palette';
  * <en/> Edge spec
  */
 export interface EdgeOptions {
+  /**
+   * <zh/> 边类型
+   *
+   * <en/> Edge type
+   */
+  type?: string | ((datum: EdgeData) => string);
   /**
    * <zh/> 边样式
    *
@@ -44,6 +50,12 @@ export interface StaticEdgeOptions {
   palette?: PaletteOptions;
 }
 
-export interface EdgeStyle extends BaseElementStyle, Partial<BaseEdgeStyleProps> {
+export interface EdgeStyle extends Partial<BaseEdgeStyleProps> {
+  /**
+   * <zh/> 初始状态
+   *
+   * <en/> Initial state
+   */
+  states?: State[];
   [key: string]: any;
 }

--- a/packages/g6/src/spec/element/node.ts
+++ b/packages/g6/src/spec/element/node.ts
@@ -1,5 +1,5 @@
-import type { ID } from '@antv/graphlib';
 import type { BaseNodeStyleProps } from '../../elements/nodes';
+import type { ID } from '../../types';
 import type { CallableObject } from '../../types/callable';
 import type { NodeData } from '../data';
 import type { AnimationOptions } from './animation';

--- a/packages/g6/src/spec/element/node.ts
+++ b/packages/g6/src/spec/element/node.ts
@@ -1,9 +1,8 @@
 import type { BaseNodeStyleProps } from '../../elements/nodes';
-import type { ID } from '../../types';
+import type { ID, State } from '../../types';
 import type { CallableObject } from '../../types/callable';
 import type { NodeData } from '../data';
 import type { AnimationOptions } from './animation';
-import type { BaseElementStyle } from './base';
 import type { PaletteOptions } from './palette';
 
 /**
@@ -12,6 +11,12 @@ import type { PaletteOptions } from './palette';
  * <en/> Node spec
  */
 export interface NodeOptions {
+  /**
+   * <zh/> 节点类型
+   *
+   * <en/> Node type
+   */
+  type?: string | ((datum: NodeData) => string);
   /**
    * <zh/> 节点样式
    *
@@ -45,7 +50,18 @@ export interface StaticNodeOptions {
   palette?: PaletteOptions;
 }
 
-export interface NodeStyle extends BaseElementStyle, Partial<BaseNodeStyleProps> {
+export interface NodeStyle extends Partial<BaseNodeStyleProps> {
+  /**
+   * <zh/> 初始状态
+   *
+   * <en/> Initial state
+   */
+  states?: State[];
+  /**
+   * <zh/> 子节点 ID (树图专用)
+   *
+   * <en/> Child node ID (for tree graph)
+   */
   children?: ID[];
   [key: string]: any;
 }

--- a/packages/g6/src/transforms/arrange-draw-order.ts
+++ b/packages/g6/src/transforms/arrange-draw-order.ts
@@ -1,5 +1,5 @@
-import type { ID } from '@antv/graphlib';
 import type { ComboData } from '../spec';
+import type { ID } from '../types';
 import { idOf } from '../utils/id';
 import { BaseTransform } from './base-transform';
 import type { DrawData } from './types';

--- a/packages/g6/src/transforms/process-parallel-edges.ts
+++ b/packages/g6/src/transforms/process-parallel-edges.ts
@@ -1,9 +1,8 @@
 import type { PathStyleProps } from '@antv/g';
-import type { ID } from '@antv/graphlib';
 import { deepMix, isBoolean, isEmpty } from '@antv/util';
 import type { RuntimeContext } from '../runtime/types';
 import type { EdgeData } from '../spec';
-import type { ElementDatum, ElementType, LoopPlacement, NodeLikeData } from '../types';
+import type { ElementDatum, ElementType, ID, LoopPlacement, NodeLikeData } from '../types';
 import { groupByChangeType, reduceDataChanges } from '../utils/change';
 import { idOf } from '../utils/id';
 import type { BaseTransformOptions } from './base-transform';

--- a/packages/g6/src/transforms/process-parallel-edges.ts
+++ b/packages/g6/src/transforms/process-parallel-edges.ts
@@ -152,9 +152,7 @@ export class ProcessParallelEdges extends BaseTransform<ProcessParallelEdgesOpti
       arcEdges.forEach((edge, i, edgeArr) => {
         const computeStyle = () => {
           const length = edgeArr.length;
-          const style: EdgeData['style'] = {
-            type: CUBIC_EDGE_TYPE,
-          };
+          const style: EdgeData['style'] = {};
           if (edge.source === edge.target) {
             const len = CUBIC_LOOP_PLACEMENTS.length;
             style.loopPlacement = CUBIC_LOOP_PLACEMENTS[i % len];
@@ -171,7 +169,8 @@ export class ProcessParallelEdges extends BaseTransform<ProcessParallelEdgesOpti
           return style;
         };
 
-        const mergedEdgeData = deepMix(edge, { style: computeStyle() });
+        const mergedEdgeData = deepMix(edge, { type: CUBIC_EDGE_TYPE, style: computeStyle() });
+
         const element = this.context.element?.getElement(idOf(edge));
         if (element) reassignTo('update', 'edge', mergedEdgeData);
         else reassignTo('add', 'edge', mergedEdgeData);

--- a/packages/g6/src/transforms/types.ts
+++ b/packages/g6/src/transforms/types.ts
@@ -1,5 +1,5 @@
-import { ID } from '@antv/graphlib';
 import type { ComboData, EdgeData, NodeData } from '../spec';
+import type { ID } from '../types';
 import type { BaseTransform, BaseTransformOptions } from './base-transform';
 
 export type BuiltInTransformOptions = BaseTransformOptions;

--- a/packages/g6/src/transforms/update-related-edge.ts
+++ b/packages/g6/src/transforms/update-related-edge.ts
@@ -1,5 +1,4 @@
-import type { ID } from '@antv/graphlib';
-import type { NodeLikeData } from '../types';
+import type { ID, NodeLikeData } from '../types';
 import { idOf } from '../utils/id';
 import { BaseTransform } from './base-transform';
 import type { DrawData } from './types';

--- a/packages/g6/src/types/callable.ts
+++ b/packages/g6/src/types/callable.ts
@@ -27,7 +27,7 @@ export type CallableValue<Returns, Param = Returns> = Returns | ((args: Param) =
  * }
  */
 export type CallableObject<Obj extends Record<string, unknown>, T> =
-  | ((datum: T, index: number, data: T[]) => Obj)
+  | ((datum: T) => Obj)
   | {
-      [K in keyof Obj]: Obj[K] | ((datum: T, index: number, data: T[]) => NonNullable<Obj[K]>);
+      [K in keyof Obj]: Obj[K] | ((datum: T) => NonNullable<Obj[K]>);
     };

--- a/packages/g6/src/types/data.ts
+++ b/packages/g6/src/types/data.ts
@@ -1,5 +1,5 @@
-import type { ID } from '@antv/graphlib';
 import type { ComboData, EdgeData, NodeData } from '../spec/data';
+import type { ID } from '../types';
 
 export type DataID = {
   nodes?: ID[];

--- a/packages/g6/src/types/id.ts
+++ b/packages/g6/src/types/id.ts
@@ -1,0 +1,1 @@
+export type ID = string;

--- a/packages/g6/src/types/index.ts
+++ b/packages/g6/src/types/index.ts
@@ -9,6 +9,7 @@ export type * from './element';
 export type * from './enum';
 export type * from './event';
 export type * from './graphlib';
+export type * from './id';
 export type * from './node';
 export type * from './padding';
 export type * from './placement';

--- a/packages/g6/src/types/style.ts
+++ b/packages/g6/src/types/style.ts
@@ -1,4 +1,4 @@
-import type { ElementData, ElementDatum } from './data';
+import type { ElementDatum } from './data';
 
 /**
  * <zh/> 样式计算迭代上下文
@@ -7,6 +7,4 @@ import type { ElementData, ElementDatum } from './data';
  */
 export type StyleIterationContext = {
   datum: ElementDatum;
-  index: number;
-  elementData: ElementData;
 };

--- a/packages/g6/src/utils/animation.ts
+++ b/packages/g6/src/utils/animation.ts
@@ -182,7 +182,7 @@ type Callbacks = {
  * @param callbacks - <zh/> 回调函数 | <en/> callback function
  * @returns <zh/> 动画对象 | <en/> animation object
  */
-export function withAnimationCallbacks(animation: IAnimation | null, callbacks: Callbacks) {
+export function withAnimationCallbacks(animation: IAnimation | null | undefined, callbacks: Callbacks) {
   callbacks.before?.();
   if (animation) {
     callbacks.beforeAnimate?.(animation);
@@ -193,7 +193,7 @@ export function withAnimationCallbacks(animation: IAnimation | null, callbacks: 
   } else {
     callbacks.after?.();
   }
-  return animation;
+  return animation || null;
 }
 
 /**

--- a/packages/g6/src/utils/behaviors/brush.ts
+++ b/packages/g6/src/utils/behaviors/brush.ts
@@ -1,8 +1,7 @@
 import { isPointInPolygon } from '../point';
 
-import type { ID } from '@antv/graphlib';
 import type { Graph } from '../../runtime/graph';
-import type { Point, Points } from '../../types';
+import type { ID, Point, Points } from '../../types';
 
 /**
  * <zh/> 元素中心是否在 rect 中

--- a/packages/g6/src/utils/behaviors/lasso.ts
+++ b/packages/g6/src/utils/behaviors/lasso.ts
@@ -2,9 +2,8 @@ import { AABB } from '@antv/g';
 import { getLinesIntersection } from '../line';
 import { isPointInPolygon } from '../point';
 
-import type { ID } from '@antv/graphlib';
 import type { Graph } from '../../runtime/graph';
-import type { Points } from '../../types';
+import type { ID, Points } from '../../types';
 import type { LineSegment } from '../line';
 
 /**

--- a/packages/g6/src/utils/behaviors/utils.ts
+++ b/packages/g6/src/utils/behaviors/utils.ts
@@ -1,8 +1,8 @@
 import { isFunction } from '@antv/util';
 
-import type { ID } from '@antv/graphlib';
 import type { States } from '../../behaviors/types';
 import type { Graph } from '../../runtime/graph';
+import type { ID } from '../../types';
 
 /**
  * <zh/> 获取所有元素状态.

--- a/packages/g6/src/utils/change.ts
+++ b/packages/g6/src/utils/change.ts
@@ -1,7 +1,6 @@
-import type { ID } from '@antv/graphlib';
 import { groupBy } from '@antv/util';
 import { ChangeType } from '../constants';
-import type { DataAdded, DataChange, DataChanges, DataRemoved, DataUpdated } from '../types';
+import type { DataAdded, DataChange, DataChanges, DataRemoved, DataUpdated, ID } from '../types';
 import { idOf } from './id';
 
 /**

--- a/packages/g6/src/utils/edge.ts
+++ b/packages/g6/src/utils/edge.ts
@@ -1,5 +1,4 @@
 import type { AABB } from '@antv/g';
-import type { ID } from '@antv/graphlib';
 import type { PathArray } from '@antv/util';
 import { isEqual, isNumber } from '@antv/util';
 import type { EdgeData } from '../spec';
@@ -7,6 +6,7 @@ import type {
   EdgeKey,
   EdgeLabelPlacement,
   EdgeLabelStyleProps,
+  ID,
   LoopPlacement,
   Node,
   Point,

--- a/packages/g6/src/utils/id.ts
+++ b/packages/g6/src/utils/id.ts
@@ -1,7 +1,6 @@
-import type { ID } from '@antv/graphlib';
 import { isNumber, isString } from '@antv/util';
 import type { ComboData, EdgeData, GraphData, NodeData } from '../spec';
-import type { DataID } from '../types';
+import type { DataID, ID } from '../types';
 import { isEdgeData } from './is';
 
 /**

--- a/packages/g6/src/utils/palette.ts
+++ b/packages/g6/src/utils/palette.ts
@@ -1,8 +1,8 @@
-import type { ID } from '@antv/graphlib';
 import { groupBy, isFunction, isNumber, isString } from '@antv/util';
 import type { CategoricalPalette } from '../palettes/types';
 import { getExtension } from '../registry';
 import type { PaletteOptions, STDPaletteOptions } from '../spec/element/palette';
+import type { ID } from '../types';
 import type { ElementData, ElementDatum } from '../types/data';
 import { idOf } from './id';
 

--- a/packages/g6/src/utils/relation.ts
+++ b/packages/g6/src/utils/relation.ts
@@ -1,6 +1,5 @@
-import type { ID } from '@antv/graphlib';
 import type { Graph } from '../runtime/graph';
-import type { ElementType } from '../types';
+import type { ElementType, ID } from '../types';
 import { idOf } from './id';
 import { bfs } from './traverse';
 

--- a/packages/g6/src/utils/style.ts
+++ b/packages/g6/src/utils/style.ts
@@ -14,13 +14,13 @@ export function computeElementCallbackStyle(
   callableStyle: CallableObject<Record<string, unknown>, ElementDatum>,
   context: StyleIterationContext,
 ) {
-  const { datum, index, elementData } = context;
+  const { datum } = context;
 
-  if (isFunction(callableStyle)) return callableStyle(datum, index, elementData);
+  if (isFunction(callableStyle)) return callableStyle(datum);
 
   return Object.fromEntries(
     Object.entries(callableStyle).map(([key, style]) => {
-      if (isFunction(style)) return [key, style(datum, index, elementData)];
+      if (isFunction(style)) return [key, style(datum)];
       return [key, style];
     }),
   );


### PR DESCRIPTION
* 使用内部定义的 `ID` 类型代替 `graphlib` 导出的 `ID` 类型
* 调整元素 `type` 配置位置，不再位于 `style` 下
* 调整回调参数，移除 `index` 和 `datum[]`，目前仅提供 `data` 参数
```ts
{
  nodes: [
    { id: 'node-1', type: 'rect' }
  ],
  node: {
    type: 'rect',
    style: {
      size: (data) => data.data.size
    }
  }
}
```