### PR TITLE
fix(runtime): 修复 graph 默认宽高被删除后 height width 默认为0 的错误

### DIFF
--- a/packages/g6/src/runtime/graph.ts
+++ b/packages/g6/src/runtime/graph.ts
@@ -139,8 +139,7 @@ export class Graph extends EventEmitter {
     if (theme) this.setTheme(theme);
     if (plugins) this.setPlugins(plugins);
     if (transforms) this.setTransforms(transforms);
-    if (isNumber(width) || isNumber(height))
-      this.setSize(width ?? this.options.width ?? 0, height ?? this.options.height ?? 0);
+    if (isNumber(width) || isNumber(height)) this.setSize(width ?? this.options.width, height ?? this.options.height);
 
     if (zoomRange) this.options.zoomRange = zoomRange;
     if (isNumber(zoom)) this.options.zoom = zoom;
@@ -161,7 +160,7 @@ export class Graph extends EventEmitter {
     return [this.options.width || 0, this.options.height || 0];
   }
 
-  public setSize(width: number, height: number): void {
+  public setSize(width?: number, height?: number): void {
     this.options.width = width;
     this.options.height = height;
   }

--- a/packages/g6/src/runtime/graph.ts
+++ b/packages/g6/src/runtime/graph.ts
@@ -489,8 +489,8 @@ export class Graph extends EventEmitter {
 
       const canvas = new Canvas({
         container: $container!,
-        width: width ?? containerSize[0],
-        height: height ?? containerSize[1],
+        width: width || containerSize[0],
+        height: height || containerSize[1],
         renderer,
       });
 


### PR DESCRIPTION
原因为 原有的默认 height: 400 , width: 600 被删除。 
 setSize 中 当 height 或者 width 被配置时 对 height width 默认为 0 的处理。
 在 Canvas 中的 width ?? containerSize[0] ,height ?? containerSize[1]  中就导致 配置了 height 或者 width ，另一个会为 0 的情况。从而导致报错。