### PR TITLE
fix(graph): width,height bug fix

### DIFF
--- a/packages/g6/src/runtime/graph.ts
+++ b/packages/g6/src/runtime/graph.ts
@@ -490,8 +490,8 @@ export class Graph extends EventEmitter {
 
       const canvas = new Canvas({
         container: $container!,
-        width: width ?? containerSize[0],
-        height: height ?? containerSize[1],
+        width: width || containerSize[0],
+        height: height || containerSize[1],
         renderer,
       });
 


### PR DESCRIPTION
原因为 
原有的默认 height: 400 , width: 600 被删除。
setSize 中 当 height 或者 width 被配置时 对 height width 默认为 0 的处理。
在 Canvas 中的 width ?? containerSize[0] ,height ?? containerSize[1] 中就导致 配置了 height 或者 width ，另一个会为 0 的情况。从而导致报错。