### PR TITLE
fix: fix setNode/setEdge/setCombo not effect, getRenderBounds not correct

### DIFF
--- a/packages/g6/__tests__/snapshots/elements/position-combo/default.svg
+++ b/packages/g6/__tests__/snapshots/elements/position-combo/default.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g transform="matrix(0.781902,0,0,0.781902,85.734138,29.206221)">
+  <g transform="matrix(0.782568,0,0,0.782568,85.594421,28.822777)">
     <g fill="none" transform="matrix(1,0,0,1,0,0)">
       <g fill="none" transform="matrix(1,0,0,1,0,0)">
         <g fill="none" transform="matrix(1,0,0,1,210.084839,271.130188)">

--- a/packages/g6/__tests__/snapshots/layouts/combo-layout/combined.svg
+++ b/packages/g6/__tests__/snapshots/layouts/combo-layout/combined.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g transform="matrix(0.202782,0,0,0.202782,235.387604,231.094391)">
+  <g transform="matrix(0.202864,0,0,0.202864,235.381668,231.086716)">
     <g fill="none" transform="matrix(1,0,0,1,0,0)">
       <g fill="none" transform="matrix(1,0,0,1,0,0)">
         <g fill="none" transform="matrix(1,0,0,1,514.073059,93.231476)">

--- a/packages/g6/__tests__/snapshots/layouts/compact-box/left-align.svg
+++ b/packages/g6/__tests__/snapshots/layouts/compact-box/left-align.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g transform="matrix(0.446828,0,0,0.446828,290.214478,170.773026)">
+  <g transform="matrix(0.447227,0,0,0.447227,290.250427,170.590347)">
     <g fill="none" transform="matrix(1,0,0,1,0,0)">
       <g fill="none" transform="matrix(1,0,0,1,0,0)"/>
       <g fill="none" transform="matrix(1,0,0,1,0,0)">

--- a/packages/g6/__tests__/snapshots/layouts/compact-box/top-to-bottom.svg
+++ b/packages/g6/__tests__/snapshots/layouts/compact-box/top-to-bottom.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g transform="matrix(0.570373,0,0,0.570373,128.048645,281.370483)">
+  <g transform="matrix(0.570698,0,0,0.570698,127.836365,281.388397)">
     <g fill="none" transform="matrix(1,0,0,1,0,0)">
       <g fill="none" transform="matrix(1,0,0,1,0,0)"/>
       <g fill="none" transform="matrix(1,0,0,1,0,0)">

--- a/packages/g6/__tests__/snapshots/layouts/dagre/antv-flow-combo.svg
+++ b/packages/g6/__tests__/snapshots/layouts/dagre/antv-flow-combo.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g transform="matrix(0.818331,0,0,0.818331,-5.728308,-25.368242)">
+  <g transform="matrix(0.819672,0,0,0.819672,-6.147559,-25.819664)">
     <g fill="none" transform="matrix(1,0,0,1,0,0)">
       <g fill="none" transform="matrix(1,0,0,1,0,0)">
         <g fill="none" transform="matrix(1,0,0,1,122.500000,400)">

--- a/packages/g6/__tests__/snapshots/layouts/mindmap/h-left.svg
+++ b/packages/g6/__tests__/snapshots/layouts/mindmap/h-left.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g transform="matrix(0.584795,0,0,0.584795,608.368469,282.163727)">
+  <g transform="matrix(0.585480,0,0,0.585480,608.934448,282.201416)">
     <g fill="none" transform="matrix(1,0,0,1,0,0)">
       <g fill="none" transform="matrix(1,0,0,1,0,0)"/>
       <g fill="none" transform="matrix(1,0,0,1,0,0)">

--- a/packages/g6/__tests__/snapshots/layouts/mindmap/h-right.svg
+++ b/packages/g6/__tests__/snapshots/layouts/mindmap/h-right.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g transform="matrix(0.584795,0,0,0.584795,134.614044,282.163727)">
+  <g transform="matrix(0.585480,0,0,0.585480,134.332550,282.201416)">
     <g fill="none" transform="matrix(1,0,0,1,0,0)">
       <g fill="none" transform="matrix(1,0,0,1,0,0)"/>
       <g fill="none" transform="matrix(1,0,0,1,0,0)">

--- a/packages/g6/__tests__/snapshots/plugins/bubble-sets/element-position-update.svg
+++ b/packages/g6/__tests__/snapshots/plugins/bubble-sets/element-position-update.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g transform="matrix(0.738356,0,0,0.738356,82.873093,65.570839)">
+  <g transform="matrix(0.738356,0,0,0.738356,82.873093,65.048737)">
     <g fill="none" transform="matrix(1,0,0,1,0,0)">
       <g fill="none" transform="matrix(1,0,0,1,0,0)"/>
       <g fill="none" transform="matrix(1,0,0,1,0,0)">

--- a/packages/g6/__tests__/snapshots/plugins/bubble-sets/options-update.svg
+++ b/packages/g6/__tests__/snapshots/plugins/bubble-sets/options-update.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g transform="matrix(0.738356,0,0,0.738356,82.873093,65.570839)">
+  <g transform="matrix(0.738356,0,0,0.738356,82.873093,65.048737)">
     <g fill="none" transform="matrix(1,0,0,1,0,0)">
       <g fill="none" transform="matrix(1,0,0,1,0,0)"/>
       <g fill="none" transform="matrix(1,0,0,1,0,0)">

--- a/packages/g6/__tests__/snapshots/plugins/tooltip/edge.svg
+++ b/packages/g6/__tests__/snapshots/plugins/tooltip/edge.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g transform="matrix(0.202325,0,0,0.202325,235.422577,231.136917)">
+  <g transform="matrix(0.202407,0,0,0.202407,235.416672,231.129288)">
     <g fill="none" transform="matrix(1,0,0,1,0,0)">
       <g fill="none" transform="matrix(1,0,0,1,0,0)">
         <g fill="none" transform="matrix(1,0,0,1,514.073059,93.231476)">

--- a/packages/g6/__tests__/snapshots/plugins/tooltip/hover.svg
+++ b/packages/g6/__tests__/snapshots/plugins/tooltip/hover.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g transform="matrix(0.202325,0,0,0.202325,235.422577,231.136917)">
+  <g transform="matrix(0.202407,0,0,0.202407,235.416672,231.129288)">
     <g fill="none" transform="matrix(1,0,0,1,0,0)">
       <g fill="none" transform="matrix(1,0,0,1,0,0)">
         <g fill="none" transform="matrix(1,0,0,1,514.073059,93.231476)">

--- a/packages/g6/__tests__/snapshots/plugins/tooltip/node.svg
+++ b/packages/g6/__tests__/snapshots/plugins/tooltip/node.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g transform="matrix(0.202325,0,0,0.202325,235.422577,231.136917)">
+  <g transform="matrix(0.202407,0,0,0.202407,235.416672,231.129288)">
     <g fill="none" transform="matrix(1,0,0,1,0,0)">
       <g fill="none" transform="matrix(1,0,0,1,0,0)">
         <g fill="none" transform="matrix(1,0,0,1,514.073059,93.231476)">

--- a/packages/g6/__tests__/snapshots/plugins/tooltip/show-tooltip-by-id.svg
+++ b/packages/g6/__tests__/snapshots/plugins/tooltip/show-tooltip-by-id.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g transform="matrix(0.202325,0,0,0.202325,235.422577,231.136917)">
+  <g transform="matrix(0.202407,0,0,0.202407,235.416672,231.129288)">
     <g fill="none" transform="matrix(1,0,0,1,0,0)">
       <g fill="none" transform="matrix(1,0,0,1,0,0)">
         <g fill="none" transform="matrix(1,0,0,1,514.073059,93.231476)">

--- a/packages/g6/__tests__/snapshots/runtime/viewport/with-lineWidth.svg
+++ b/packages/g6/__tests__/snapshots/runtime/viewport/with-lineWidth.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
+  <defs/>
+  <g transform="matrix(3.200000,0,0,3.200000,-550.000061,-550.000061)">
+    <g fill="none" transform="matrix(1,0,0,1,0,0)">
+      <g fill="none" transform="matrix(1,0,0,1,0,0)"/>
+      <g fill="none" transform="matrix(1,0,0,1,0,0)"/>
+      <g fill="none" transform="matrix(1,0,0,1,0,0)">
+        <g fill="none" transform="matrix(1,0,0,1,200,250)">
+          <g transform="matrix(1,0,0,1,0,0)">
+            <circle fill="rgba(212,65,76,1)" transform="translate(-25,-25)" cx="25" cy="25" stroke-width="5" stroke="rgba(255,192,203,1)" r="25"/>
+          </g>
+        </g>
+        <g fill="none" transform="matrix(1,0,0,1,300,250)">
+          <g transform="matrix(1,0,0,1,0,0)">
+            <circle fill="rgba(47,54,61,1)" transform="translate(-25,-25)" cx="25" cy="25" stroke-width="5" stroke="rgba(255,192,203,1)" r="25"/>
+          </g>
+        </g>
+        <g fill="none" transform="matrix(1,0,0,1,250,200)">
+          <g transform="matrix(1,0,0,1,0,0)">
+            <circle fill="rgba(47,54,61,1)" transform="translate(-25,-25)" cx="25" cy="25" stroke-width="5" stroke="rgba(255,192,203,1)" r="25"/>
+          </g>
+        </g>
+        <g fill="none" transform="matrix(1,0,0,1,250,300)">
+          <g transform="matrix(1,0,0,1,0,0)">
+            <circle fill="rgba(47,54,61,1)" transform="translate(-25,-25)" cx="25" cy="25" stroke-width="5" stroke="rgba(255,192,203,1)" r="25"/>
+          </g>
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/packages/g6/__tests__/unit/runtime/viewport.spec.ts
+++ b/packages/g6/__tests__/unit/runtime/viewport.spec.ts
@@ -229,3 +229,29 @@ describe('Viewport Fit with AutoFit and Padding with Animation', () => {
     await expect(graph).toMatchSnapshot(__filename, 'auto-fit-with-padding-animation');
   });
 });
+
+describe('Viewport Fit with lineWidth', () => {
+  let graph: Graph;
+  beforeAll(async () => {
+    graph = await createDemoGraph(viewportFit, { padding: 10 });
+  });
+
+  afterAll(() => {
+    graph.destroy();
+  });
+
+  it('default', async () => {
+    graph.setNode({
+      ...graph.getOptions().node,
+      style: {
+        size: 50,
+        lineWidth: 5,
+        stroke: 'pink',
+        color: (d: any) => (d.id === '1' ? '#d4414c' : '#2f363d'),
+      },
+    });
+    await graph.draw();
+    await graph.fitView();
+    await expect(graph).toMatchSnapshot(__filename, 'with-lineWidth');
+  });
+});

--- a/packages/g6/__tests__/unit/utils/change.spec.ts
+++ b/packages/g6/__tests__/unit/utils/change.spec.ts
@@ -32,4 +32,17 @@ describe('change', () => {
       },
     ]);
   });
+
+  it('reduceDataChanges with Updated and Removed', () => {
+    expect(
+      reduceDataChanges([
+        {
+          type: 'NodeUpdated',
+          value: { id: 'node-3', style: { fill: 'pink' } },
+          original: { id: 'node-3', style: { fill: 'red' } },
+        },
+        { type: 'NodeRemoved', value: { id: 'node-3' } },
+      ]),
+    ).toEqual([{ type: 'NodeRemoved', value: { id: 'node-3' } }]);
+  });
 });

--- a/packages/g6/__tests__/utils/to-match-svg-snapshot.ts
+++ b/packages/g6/__tests__/utils/to-match-svg-snapshot.ts
@@ -1,5 +1,6 @@
 import type { Graph, IAnimateEvent } from '@/src';
 import type { Canvas, IAnimation } from '@antv/g';
+import chalk from 'chalk';
 import * as fs from 'fs';
 import * as path from 'path';
 import format from 'xml-formatter';
@@ -76,8 +77,11 @@ export async function toMatchSVGSnapshot(
 
       // Perverse actual file.
       if (actual) fs.writeFileSync(actualPath, actual);
+
+      const formatPath = (p: string) => p.split('/g6/')[1];
       return {
-        message: () => `mismatch ${namePath}`,
+        message: () =>
+          `mismatch: \n expected: ${chalk.green(formatPath(expectedPath))}\n received: ${chalk.red(formatPath(actualPath))}`,
         pass: false,
       };
     }

--- a/packages/g6/src/runtime/canvas.ts
+++ b/packages/g6/src/runtime/canvas.ts
@@ -187,7 +187,7 @@ export class Canvas {
       Object.values(this.canvas)
         .map((canvas) => canvas.document.documentElement)
         .filter((el) => el.childNodes.length > 0)
-        .map((el) => el.getRenderBounds()),
+        .map((el) => el.getBounds()),
     );
   }
 

--- a/packages/g6/src/runtime/data.ts
+++ b/packages/g6/src/runtime/data.ts
@@ -417,6 +417,24 @@ export class DataController {
     });
   }
 
+  /**
+   * <zh/> 将所有数据提交到变更记录中以进行重绘
+   *
+   * <en/> Submit all data to the change record for redrawing
+   */
+  public refreshData() {
+    const { nodes, edges, combos } = this.getData();
+    nodes.forEach((node) => {
+      this.pushChange({ value: node, original: node, type: ChangeType.NodeUpdated });
+    });
+    edges.forEach((edge) => {
+      this.pushChange({ value: edge, original: edge, type: ChangeType.EdgeUpdated });
+    });
+    combos.forEach((combo) => {
+      this.pushChange({ value: combo, original: combo, type: ChangeType.ComboUpdated });
+    });
+  }
+
   public syncNodeDatum(datum: PartialNodeLikeData<NodeData>) {
     const { model } = this;
 

--- a/packages/g6/src/runtime/graph.ts
+++ b/packages/g6/src/runtime/graph.ts
@@ -176,14 +176,17 @@ export class Graph extends EventEmitter {
 
   public setNode(node: NodeOptions): void {
     this.options.node = node;
+    this.context.model.refreshData();
   }
 
   public setEdge(edge: EdgeOptions): void {
     this.options.edge = edge;
+    this.context.model.refreshData();
   }
 
   public setCombo(combo: ComboOptions): void {
     this.options.combo = combo;
+    this.context.model.refreshData();
   }
 
   public getTheme(): ThemeOptions {

--- a/packages/g6/src/utils/change.ts
+++ b/packages/g6/src/utils/change.ts
@@ -34,13 +34,18 @@ export function reduceDataChanges(changes: DataChange[]): DataChange[] {
       else if (results.Updated.has(id)) {
         const { original } = results.Updated.get(id)!;
         results.Updated.set(id, { type, value, original } as DataUpdated);
+      } else if (results.Removed.has(id)) {
+        // 如果存在 Removed，不做任何操作
+        // If there is a Removed operation, do nothing
       } else results.Updated.set(id, change);
     } else if (type === 'NodeRemoved' || type === 'EdgeRemoved' || type === 'ComboRemoved') {
       // 如果存在 Added 或者 Updated 的操作，删除 Removed 操作
       // If there is an Added or Updated operation, delete the Removed operation
-      if (results.Added.has(id) || results.Updated.has(id)) {
+      if (results.Added.has(id)) {
         results.Added.delete(id);
+      } else if (results.Updated.has(id)) {
         results.Updated.delete(id);
+        results.Removed.set(id, change);
       } else {
         results.Removed.set(id, change);
       }


### PR DESCRIPTION
* 修复调用 setNode/setEdge/setCombo 后下次绘制不生效的问题
> 主要原因是仅修改了 options, 没有提交更新任务

* 修正了 `reduceDataChanges`  在已有更新任务后提交删除任务时的逻辑错误
* 使用 getBounds 代替 getRenderBounds，因为后者在计算带有 `lineWidth` `stroke` 的 `Path` 时存在较大误差
> 使用 getBounds 会导致当元素设置了 lineWidth 的情况下执行 `fitView` 或者 `autoFit` 会出现边界溢出的问题，需要配合设置 `padding` 避免

---
* Fixed an issue where the next draw does not take effect after calling setNode/setEdge/setCombo
> The main reason is that only options are modified and no update task is submitted

* Fixed a logical error in `reduceDataChanges` when submitting a deleted task after an existing update task
* Use getBounds instead of getRenderBounds because the latter has a large error in calculating a `Path` with `lineWidth` `stroke`
> The use of getBounds causes boundary overflow problems when executing `fitView` or `autoFit` when the element has a lineWidth set, which needs to be avoided with the padding set