### PR TITLE
refactor: adjust element spec

### DIFF
--- a/packages/g6/__tests__/dataset/combo.json
+++ b/packages/g6/__tests__/dataset/combo.json
@@ -1,522 +1,106 @@
 {
   "nodes": [
-    {
-      "id": "0",
-      "style": {
-        "parentId": "a"
-      }
-    },
-    {
-      "id": "1",
-      "style": {
-        "parentId": "a"
-      }
-    },
-    {
-      "id": "2",
-      "style": {
-        "parentId": "a"
-      }
-    },
-    {
-      "id": "3",
-      "style": {
-        "parentId": "a"
-      }
-    },
-    {
-      "id": "4",
-      "style": {
-        "parentId": "a"
-      }
-    },
-    {
-      "id": "5",
-      "style": {
-        "parentId": "a"
-      }
-    },
-    {
-      "id": "6",
-      "style": {
-        "parentId": "a"
-      }
-    },
-    {
-      "id": "7",
-      "style": {
-        "parentId": "a"
-      }
-    },
-    {
-      "id": "8",
-      "style": {
-        "parentId": "a"
-      }
-    },
-    {
-      "id": "9",
-      "style": {
-        "parentId": "a"
-      }
-    },
-    {
-      "id": "10",
-      "style": {
-        "parentId": "a"
-      }
-    },
-    {
-      "id": "11",
-      "style": {
-        "parentId": "a"
-      }
-    },
-    {
-      "id": "12",
-      "style": {
-        "parentId": "a"
-      }
-    },
-    {
-      "id": "13",
-      "style": {
-        "parentId": "a"
-      }
-    },
-    {
-      "id": "14",
-      "style": {
-        "parentId": "a"
-      }
-    },
-    {
-      "id": "15",
-      "style": {
-        "parentId": "a"
-      }
-    },
-    {
-      "id": "16",
-      "style": {
-        "parentId": "b"
-      }
-    },
-    {
-      "id": "17",
-      "style": {
-        "parentId": "b"
-      }
-    },
-    {
-      "id": "18",
-      "style": {
-        "parentId": "b"
-      }
-    },
-    {
-      "id": "19",
-      "style": {
-        "parentId": "b"
-      }
-    },
-    {
-      "id": "20"
-    },
-    {
-      "id": "21"
-    },
-    {
-      "id": "22"
-    },
-    {
-      "id": "23",
-      "style": {
-        "parentId": "c"
-      }
-    },
-    {
-      "id": "24",
-      "style": {
-        "parentId": "a"
-      }
-    },
-    {
-      "id": "25"
-    },
-    {
-      "id": "26"
-    },
-    {
-      "id": "27",
-      "style": {
-        "parentId": "c"
-      }
-    },
-    {
-      "id": "28",
-      "style": {
-        "parentId": "c"
-      }
-    },
-    {
-      "id": "29",
-      "style": {
-        "parentId": "c"
-      }
-    },
-    {
-      "id": "30",
-      "style": {
-        "parentId": "c"
-      }
-    },
-    {
-      "id": "31",
-      "style": {
-        "parentId": "c"
-      }
-    },
-    {
-      "id": "32",
-      "style": {
-        "parentId": "d"
-      }
-    },
-    {
-      "id": "33",
-      "style": {
-        "parentId": "d"
-      }
-    }
+    { "id": "0", "combo": "a" },
+    { "id": "1", "combo": "a" },
+    { "id": "2", "combo": "a" },
+    { "id": "3", "combo": "a" },
+    { "id": "4", "combo": "a" },
+    { "id": "5", "combo": "a" },
+    { "id": "6", "combo": "a" },
+    { "id": "7", "combo": "a" },
+    { "id": "8", "combo": "a" },
+    { "id": "9", "combo": "a" },
+    { "id": "10", "combo": "a" },
+    { "id": "11", "combo": "a" },
+    { "id": "12", "combo": "a" },
+    { "id": "13", "combo": "a" },
+    { "id": "14", "combo": "a" },
+    { "id": "15", "combo": "a" },
+    { "id": "16", "combo": "b" },
+    { "id": "17", "combo": "b" },
+    { "id": "18", "combo": "b" },
+    { "id": "19", "combo": "b" },
+    { "id": "20" },
+    { "id": "21" },
+    { "id": "22" },
+    { "id": "23", "combo": "c" },
+    { "id": "24", "combo": "a" },
+    { "id": "25" },
+    { "id": "26" },
+    { "id": "27", "combo": "c" },
+    { "id": "28", "combo": "c" },
+    { "id": "29", "combo": "c" },
+    { "id": "30", "combo": "c" },
+    { "id": "31", "combo": "c" },
+    { "id": "32", "combo": "d" },
+    { "id": "33", "combo": "d" }
   ],
   "edges": [
-    {
-      "id": "edge-444",
-      "source": "0",
-      "target": "1"
-    },
-    {
-      "id": "edge-123",
-      "source": "0",
-      "target": "2"
-    },
-    {
-      "id": "edge-689",
-      "source": "0",
-      "target": "3"
-    },
-    {
-      "id": "edge-625",
-      "source": "0",
-      "target": "4"
-    },
-    {
-      "id": "edge-110",
-      "source": "0",
-      "target": "5"
-    },
-    {
-      "id": "edge-783",
-      "source": "0",
-      "target": "7"
-    },
-    {
-      "id": "edge-72",
-      "source": "0",
-      "target": "8"
-    },
-    {
-      "id": "edge-165",
-      "source": "0",
-      "target": "9"
-    },
-    {
-      "id": "edge-109",
-      "source": "0",
-      "target": "10"
-    },
-    {
-      "id": "edge-764",
-      "source": "0",
-      "target": "11"
-    },
-    {
-      "id": "edge-596",
-      "source": "0",
-      "target": "13"
-    },
-    {
-      "id": "edge-711",
-      "source": "0",
-      "target": "14"
-    },
-    {
-      "id": "edge-81",
-      "source": "0",
-      "target": "15"
-    },
-    {
-      "id": "edge-810",
-      "source": "0",
-      "target": "16"
-    },
-    {
-      "id": "edge-957",
-      "source": "2",
-      "target": "3"
-    },
-    {
-      "id": "edge-279",
-      "source": "4",
-      "target": "5"
-    },
-    {
-      "id": "edge-83",
-      "source": "4",
-      "target": "6"
-    },
-    {
-      "id": "edge-488",
-      "source": "5",
-      "target": "6"
-    },
-    {
-      "id": "edge-453",
-      "source": "7",
-      "target": "13"
-    },
-    {
-      "id": "edge-523",
-      "source": "8",
-      "target": "14"
-    },
-    {
-      "id": "edge-543",
-      "source": "9",
-      "target": "10"
-    },
-    {
-      "id": "edge-30",
-      "source": "10",
-      "target": "22"
-    },
-    {
-      "id": "edge-146",
-      "source": "10",
-      "target": "14"
-    },
-    {
-      "id": "edge-878",
-      "source": "10",
-      "target": "12"
-    },
-    {
-      "id": "edge-369",
-      "source": "10",
-      "target": "24"
-    },
-    {
-      "id": "edge-179",
-      "source": "10",
-      "target": "21"
-    },
-    {
-      "id": "edge-759",
-      "source": "10",
-      "target": "20"
-    },
-    {
-      "id": "edge-116",
-      "source": "11",
-      "target": "24"
-    },
-    {
-      "id": "edge-940",
-      "source": "11",
-      "target": "22"
-    },
-    {
-      "id": "edge-538",
-      "source": "11",
-      "target": "14"
-    },
-    {
-      "id": "edge-522",
-      "source": "12",
-      "target": "13"
-    },
-    {
-      "id": "edge-73",
-      "source": "16",
-      "target": "17"
-    },
-    {
-      "id": "edge-59",
-      "source": "16",
-      "target": "18"
-    },
-    {
-      "id": "edge-493",
-      "source": "16",
-      "target": "21"
-    },
-    {
-      "id": "edge-162",
-      "source": "16",
-      "target": "22"
-    },
-    {
-      "id": "edge-13",
-      "source": "17",
-      "target": "18"
-    },
-    {
-      "id": "edge-892",
-      "source": "17",
-      "target": "20"
-    },
-    {
-      "id": "edge-722",
-      "source": "18",
-      "target": "19"
-    },
-    {
-      "id": "edge-617",
-      "source": "19",
-      "target": "20"
-    },
-    {
-      "id": "edge-364",
-      "source": "19",
-      "target": "33"
-    },
-    {
-      "id": "edge-926",
-      "source": "19",
-      "target": "22"
-    },
-    {
-      "id": "edge-31",
-      "source": "19",
-      "target": "23"
-    },
-    {
-      "id": "edge-695",
-      "source": "20",
-      "target": "21"
-    },
-    {
-      "id": "edge-286",
-      "source": "21",
-      "target": "22"
-    },
-    {
-      "id": "edge-300",
-      "source": "22",
-      "target": "24"
-    },
-    {
-      "id": "edge-503",
-      "source": "22",
-      "target": "25"
-    },
-    {
-      "id": "edge-509",
-      "source": "22",
-      "target": "26"
-    },
-    {
-      "id": "edge-432",
-      "source": "22",
-      "target": "23"
-    },
-    {
-      "id": "edge-293",
-      "source": "22",
-      "target": "28"
-    },
-    {
-      "id": "edge-785",
-      "source": "22",
-      "target": "30"
-    },
-    {
-      "id": "edge-514",
-      "source": "22",
-      "target": "31"
-    },
-    {
-      "id": "edge-608",
-      "source": "22",
-      "target": "32"
-    },
-    {
-      "id": "edge-946",
-      "source": "22",
-      "target": "33"
-    },
-    {
-      "id": "edge-728",
-      "source": "23",
-      "target": "28"
-    },
-    {
-      "id": "edge-416",
-      "source": "23",
-      "target": "27"
-    },
-    {
-      "id": "edge-14",
-      "source": "23",
-      "target": "29"
-    },
-    {
-      "id": "edge-776",
-      "source": "23",
-      "target": "30"
-    },
-    {
-      "id": "edge-736",
-      "source": "23",
-      "target": "31"
-    },
-    {
-      "id": "edge-508",
-      "source": "23",
-      "target": "33"
-    },
-    {
-      "id": "edge-201",
-      "source": "32",
-      "target": "33"
-    }
+    { "source": "0", "target": "1" },
+    { "source": "0", "target": "2" },
+    { "source": "0", "target": "3" },
+    { "source": "0", "target": "4" },
+    { "source": "0", "target": "5" },
+    { "source": "0", "target": "7" },
+    { "source": "0", "target": "8" },
+    { "source": "0", "target": "9" },
+    { "source": "0", "target": "10" },
+    { "source": "0", "target": "11" },
+    { "source": "0", "target": "13" },
+    { "source": "0", "target": "14" },
+    { "source": "0", "target": "15" },
+    { "source": "0", "target": "16" },
+    { "source": "2", "target": "3" },
+    { "source": "4", "target": "5" },
+    { "source": "4", "target": "6" },
+    { "source": "5", "target": "6" },
+    { "source": "7", "target": "13" },
+    { "source": "8", "target": "14" },
+    { "source": "9", "target": "10" },
+    { "source": "10", "target": "22" },
+    { "source": "10", "target": "14" },
+    { "source": "10", "target": "12" },
+    { "source": "10", "target": "24" },
+    { "source": "10", "target": "21" },
+    { "source": "10", "target": "20" },
+    { "source": "11", "target": "24" },
+    { "source": "11", "target": "22" },
+    { "source": "11", "target": "14" },
+    { "source": "12", "target": "13" },
+    { "source": "16", "target": "17" },
+    { "source": "16", "target": "18" },
+    { "source": "16", "target": "21" },
+    { "source": "16", "target": "22" },
+    { "source": "17", "target": "18" },
+    { "source": "17", "target": "20" },
+    { "source": "18", "target": "19" },
+    { "source": "19", "target": "20" },
+    { "source": "19", "target": "33" },
+    { "source": "19", "target": "22" },
+    { "source": "19", "target": "23" },
+    { "source": "20", "target": "21" },
+    { "source": "21", "target": "22" },
+    { "source": "22", "target": "24" },
+    { "source": "22", "target": "25" },
+    { "source": "22", "target": "26" },
+    { "source": "22", "target": "23" },
+    { "source": "22", "target": "28" },
+    { "source": "22", "target": "30" },
+    { "source": "22", "target": "31" },
+    { "source": "22", "target": "32" },
+    { "source": "22", "target": "33" },
+    { "source": "23", "target": "28" },
+    { "source": "23", "target": "27" },
+    { "source": "23", "target": "29" },
+    { "source": "23", "target": "30" },
+    { "source": "23", "target": "31" },
+    { "source": "23", "target": "33" },
+    { "source": "32", "target": "33" }
   ],
   "combos": [
-    {
-      "id": "a",
-      "data": {
-        "label": "Combo A"
-      }
-    },
-    {
-      "id": "b",
-      "data": {
-        "label": "Combo B"
-      }
-    },
-    {
-      "id": "c",
-      "data": {
-        "label": "Combo D"
-      }
-    },
-    {
-      "id": "d",
-      "data": {
-        "label": "Combo D",
-        "parentId": "b"
-      }
-    }
+    { "id": "a", "data": { "label": "Combo A" } },
+    { "id": "b", "data": { "label": "Combo B" } },
+    { "id": "c", "data": { "label": "Combo D" } },
+    { "id": "d", "combo": "b", "data": { "label": "Combo D" } }
   ]
 }

--- a/packages/g6/__tests__/dataset/dagre-combo.json
+++ b/packages/g6/__tests__/dataset/dagre-combo.json
@@ -4,14 +4,14 @@
     { "id": "1" },
     { "id": "2" },
     { "id": "3" },
-    { "id": "4", "style": { "parentId": "A" } },
-    { "id": "5", "style": { "parentId": "B" } },
-    { "id": "6", "style": { "parentId": "A" } },
-    { "id": "7", "style": { "parentId": "C" } },
-    { "id": "8", "style": { "parentId": "C" } },
-    { "id": "9", "style": { "parentId": "A" } },
-    { "id": "10", "style": { "parentId": "B" } },
-    { "id": "11", "style": { "parentId": "B" } }
+    { "id": "4", "combo": "A" },
+    { "id": "5", "combo": "B" },
+    { "id": "6", "combo": "A" },
+    { "id": "7", "combo": "C" },
+    { "id": "8", "combo": "C" },
+    { "id": "9", "combo": "A" },
+    { "id": "10", "combo": "B" },
+    { "id": "11", "combo": "B" }
   ],
   "edges": [
     { "id": "edge-102", "source": "0", "target": "1" },

--- a/packages/g6/__tests__/demos/behavior-brush-select.ts
+++ b/packages/g6/__tests__/demos/behavior-brush-select.ts
@@ -5,10 +5,10 @@ export const behaviorBrushSelect: TestCase = async (context) => {
     ...context,
     data: {
       nodes: [
-        { id: 'node1', style: { x: 150, y: 250, lineWidth: 0, parentId: 'combo1' } },
-        { id: 'node2', style: { x: 250, y: 200, lineWidth: 0, parentId: 'combo1' } },
-        { id: 'node3', style: { x: 350, y: 250, lineWidth: 0, parentId: 'combo1' } },
-        { id: 'node4', style: { x: 250, y: 300, lineWidth: 0, parentId: 'combo1' } },
+        { id: 'node1', combo: 'combo1', style: { x: 150, y: 250, lineWidth: 0 } },
+        { id: 'node2', combo: 'combo1', style: { x: 250, y: 200, lineWidth: 0 } },
+        { id: 'node3', combo: 'combo1', style: { x: 350, y: 250, lineWidth: 0 } },
+        { id: 'node4', combo: 'combo1', style: { x: 250, y: 300, lineWidth: 0 } },
       ],
       edges: [
         {

--- a/packages/g6/__tests__/demos/behavior-create-edge.ts
+++ b/packages/g6/__tests__/demos/behavior-create-edge.ts
@@ -5,9 +5,9 @@ export const behaviorCreateEdge: TestCase = async (context) => {
     ...context,
     data: {
       nodes: [
-        { id: 'node1', style: { x: 250, y: 150, parentId: 'combo1' } },
-        { id: 'node2', style: { x: 350, y: 150, parentId: 'combo1' } },
-        { id: 'node3', style: { x: 250, y: 300, parentId: 'combo2' } },
+        { id: 'node1', combo: 'combo1', style: { x: 250, y: 150 } },
+        { id: 'node2', combo: 'combo1', style: { x: 350, y: 150 } },
+        { id: 'node3', combo: 'combo2', style: { x: 250, y: 300 } },
       ],
       edges: [],
       combos: [

--- a/packages/g6/__tests__/demos/behavior-drag-element.ts
+++ b/packages/g6/__tests__/demos/behavior-drag-element.ts
@@ -6,9 +6,9 @@ export const behaviorDragNode: TestCase = async (context) => {
     data: {
       nodes: [
         { id: 'node-1', style: { x: 100, y: 100 } },
-        { id: 'node-2', style: { x: 200, y: 100, parentId: 'combo-1' } },
+        { id: 'node-2', combo: 'combo-1', style: { x: 200, y: 100 } },
         { id: 'node-3', style: { x: 100, y: 200 } },
-        { id: 'node-4', style: { x: 200, y: 200, parentId: 'combo-1' } },
+        { id: 'node-4', combo: 'combo-1', style: { x: 200, y: 200 } },
       ],
       edges: [
         { source: 'node-1', target: 'node-2' },

--- a/packages/g6/__tests__/demos/behavior-focus-element.ts
+++ b/packages/g6/__tests__/demos/behavior-focus-element.ts
@@ -6,9 +6,9 @@ export const behaviorFocusElement: TestCase = async (context) => {
     data: {
       nodes: [
         { id: 'node-1', style: { x: 100, y: 100 } },
-        { id: 'node-2', style: { x: 200, y: 100, parentId: 'combo-1' } },
+        { id: 'node-2', combo: 'combo-1', style: { x: 200, y: 100 } },
         { id: 'node-3', style: { x: 100, y: 200 } },
-        { id: 'node-4', style: { x: 200, y: 200, parentId: 'combo-1' } },
+        { id: 'node-4', combo: 'combo-1', style: { x: 200, y: 200 } },
       ],
       edges: [
         { source: 'node-1', target: 'node-2' },

--- a/packages/g6/__tests__/demos/behavior-lasso-select.ts
+++ b/packages/g6/__tests__/demos/behavior-lasso-select.ts
@@ -5,10 +5,10 @@ export const behaviorLassoSelect: TestCase = async (context) => {
     ...context,
     data: {
       nodes: [
-        { id: 'node1', style: { x: 150, y: 250, lineWidth: 0, parentId: 'combo1' } },
-        { id: 'node2', style: { x: 250, y: 200, lineWidth: 0, parentId: 'combo1' } },
-        { id: 'node3', style: { x: 350, y: 250, lineWidth: 0, parentId: 'combo1' } },
-        { id: 'node4', style: { x: 250, y: 300, lineWidth: 0, parentId: 'combo1' } },
+        { id: 'node1', combo: 'combo1', style: { x: 150, y: 250, lineWidth: 0 } },
+        { id: 'node2', combo: 'combo1', style: { x: 250, y: 200, lineWidth: 0 } },
+        { id: 'node3', combo: 'combo1', style: { x: 350, y: 250, lineWidth: 0 } },
+        { id: 'node4', combo: 'combo1', style: { x: 250, y: 300, lineWidth: 0 } },
       ],
       edges: [
         {

--- a/packages/g6/__tests__/demos/combo-expand-collapse.ts
+++ b/packages/g6/__tests__/demos/combo-expand-collapse.ts
@@ -6,9 +6,9 @@ export const comboExpandCollapse: TestCase = async (context) => {
     ...context,
     data: {
       nodes: [
-        { id: 'node-1', style: { parentId: 'combo-2', x: 120, y: 100 } },
-        { id: 'node-2', style: { parentId: 'combo-1', x: 300, y: 200 } },
-        { id: 'node-3', style: { parentId: 'combo-1', x: 200, y: 300 } },
+        { id: 'node-1', combo: 'combo-2', style: { x: 120, y: 100 } },
+        { id: 'node-2', combo: 'combo-1', style: { x: 300, y: 200 } },
+        { id: 'node-3', combo: 'combo-1', style: { x: 200, y: 300 } },
       ],
       edges: [
         { id: 'edge-1', source: 'node-1', target: 'node-2' },
@@ -18,8 +18,8 @@ export const comboExpandCollapse: TestCase = async (context) => {
         {
           id: 'combo-1',
           type: 'rect',
+          combo: 'combo-2',
           style: {
-            parentId: 'combo-2',
             collapsed: true,
           },
         },

--- a/packages/g6/__tests__/demos/combo.ts
+++ b/packages/g6/__tests__/demos/combo.ts
@@ -3,9 +3,9 @@ import { Graph } from '@/src';
 export const combo: TestCase = async (context) => {
   const data = {
     nodes: [
-      { id: 'node-1', data: {}, style: { parentId: 'combo-2', x: 120, y: 100 } },
-      { id: 'node-2', data: {}, style: { parentId: 'combo-1', x: 300, y: 200 } },
-      { id: 'node-3', data: {}, style: { parentId: 'combo-1', x: 200, y: 300 } },
+      { id: 'node-1', combo: 'combo-2', style: { x: 120, y: 100 } },
+      { id: 'node-2', combo: 'combo-1', style: { x: 300, y: 200 } },
+      { id: 'node-3', combo: 'combo-1', style: { x: 200, y: 300 } },
     ],
     edges: [
       { id: 'edge-1', source: 'node-1', target: 'node-2' },
@@ -15,9 +15,7 @@ export const combo: TestCase = async (context) => {
       {
         id: 'combo-1',
         type: 'rect',
-        style: {
-          parentId: 'combo-2',
-        },
+        combo: 'combo-2',
       },
       {
         id: 'combo-2',
@@ -133,7 +131,8 @@ export const combo: TestCase = async (context) => {
           graph.addNodeData([
             {
               id: 'node-4',
-              style: { parentId: 'combo-2', x: 100, y: 200, fill: 'pink' },
+              combo: 'combo-2',
+              style: { x: 100, y: 200, fill: 'pink' },
             },
           ]);
         }

--- a/packages/g6/__tests__/demos/element-position-combo.ts
+++ b/packages/g6/__tests__/demos/element-position-combo.ts
@@ -5,16 +5,12 @@ export const elementPositionCombo: TestCase = async (context) => {
     ...context,
     data: {
       nodes: [
-        { id: 'node-1', style: { x: 100, y: 150, parentId: 'combo-1' } },
-        { id: 'node-2', style: { x: 200, y: 150, parentId: 'combo-1' } },
-        { id: 'node-3', style: { x: 400, y: 200, parentId: 'combo-2' } },
-        { id: 'node-4', style: { x: 150, y: 300, parentId: 'combo-3' } },
+        { id: 'node-1', combo: 'combo-1', style: { x: 100, y: 150 } },
+        { id: 'node-2', combo: 'combo-1', style: { x: 200, y: 150 } },
+        { id: 'node-3', combo: 'combo-2', style: { x: 400, y: 200 } },
+        { id: 'node-4', combo: 'combo-3', style: { x: 150, y: 300 } },
       ],
-      combos: [
-        { id: 'combo-1', style: { parentId: 'combo-2' } },
-        { id: 'combo-2' },
-        { id: 'combo-3', style: { parentId: 'combo-1' } },
-      ],
+      combos: [{ id: 'combo-1', combo: 'combo-2' }, { id: 'combo-2' }, { id: 'combo-3', combo: 'combo-1' }],
     },
     node: {
       style: {

--- a/packages/g6/__tests__/demos/element-z-index.ts
+++ b/packages/g6/__tests__/demos/element-z-index.ts
@@ -16,8 +16,8 @@ export const elementZIndex: TestCase = async (context) => {
       ],
       combos: [
         { id: 'combo-1', style: { x: 50, y: 250 } },
-        { id: 'combo-2', style: { x: 50, y: 250, parentId: 'combo-1' } },
-        { id: 'combo-3', style: { x: 150, y: 250, parentId: 'combo-2' } },
+        { id: 'combo-2', combo: 'combo-1', style: { x: 50, y: 250 } },
+        { id: 'combo-3', combo: 'combo-2', style: { x: 150, y: 250 } },
         { id: 'combo-4', style: { x: 350, y: 250 } },
       ],
     },

--- a/packages/g6/__tests__/demos/layout-antv-dagre-flow-combo.ts
+++ b/packages/g6/__tests__/demos/layout-antv-dagre-flow-combo.ts
@@ -16,7 +16,7 @@ export const layoutAntVDagreFlowCombo: TestCase = async (context) => {
         ports: [{ placement: 'top' }, { placement: 'bottom' }],
       },
       palette: {
-        field: (d) => d.style?.parentId,
+        field: (d) => d.combo,
       },
     },
     edge: {

--- a/packages/g6/__tests__/demos/layout-combo-combined.ts
+++ b/packages/g6/__tests__/demos/layout-combo-combined.ts
@@ -21,6 +21,11 @@ export const layoutComboCombined: TestCase = async (context) => {
         return { stroke: color || '#99ADD1', lineWidth: size || 1 };
       },
     },
+    combo: {
+      style: {
+        labelText: (d) => d.id,
+      },
+    },
     behaviors: ['drag-element', 'drag-canvas', 'zoom-canvas'],
     autoFit: 'view',
   });

--- a/packages/g6/__tests__/demos/layout-dendrogram-basic.ts
+++ b/packages/g6/__tests__/demos/layout-dendrogram-basic.ts
@@ -9,7 +9,7 @@ export const layoutDendrogramBasic: TestCase = async (context) => {
     node: {
       style: {
         labelText: (d) => d.id,
-        labelPlacement: (model) => (model.style!.children?.length ? 'left' : 'right'),
+        labelPlacement: (model) => (model.children?.length ? 'left' : 'right'),
         ports: [{ placement: 'right' }, { placement: 'left' }],
       },
     },

--- a/packages/g6/__tests__/demos/layout-dendrogram-tb.ts
+++ b/packages/g6/__tests__/demos/layout-dendrogram-tb.ts
@@ -8,7 +8,7 @@ export const layoutDendrogramTb: TestCase = async (context) => {
     data: treeToGraphData(data),
     node: {
       style: (model) => {
-        const hasChildren = !!model.style!.children?.length;
+        const hasChildren = !!model.children?.length;
         return {
           labelMaxWidth: 200,
           labelPlacement: hasChildren ? 'right' : 'bottom',

--- a/packages/g6/__tests__/demos/plugin-history.ts
+++ b/packages/g6/__tests__/demos/plugin-history.ts
@@ -6,9 +6,9 @@ export const pluginHistory: TestCase = async (context) => {
     ...context,
     data: {
       nodes: [
-        { id: 'node-1', style: { parentId: 'combo-2', x: 120, y: 100 } },
-        { id: 'node-2', style: { parentId: 'combo-1', x: 300, y: 200 } },
-        { id: 'node-3', style: { parentId: 'combo-1', x: 200, y: 300 } },
+        { id: 'node-1', combo: 'combo-2', style: { x: 120, y: 100 } },
+        { id: 'node-2', combo: 'combo-1', style: { x: 300, y: 200 } },
+        { id: 'node-3', combo: 'combo-1', style: { x: 200, y: 300 } },
       ],
       edges: [
         { id: 'edge-1', source: 'node-1', target: 'node-2' },
@@ -18,7 +18,8 @@ export const pluginHistory: TestCase = async (context) => {
         {
           id: 'combo-1',
           type: 'rect',
-          style: { parentId: 'combo-2', collapsed: true },
+          combo: 'combo-2',
+          style: { collapsed: true },
         },
         { id: 'combo-2' },
       ],

--- a/packages/g6/__tests__/snapshots/layouts/combo-layout/combined.svg
+++ b/packages/g6/__tests__/snapshots/layouts/combo-layout/combined.svg
@@ -1,26 +1,54 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g transform="matrix(0.618237,0,0,0.618237,235.918900,206.720840)">
+  <g transform="matrix(0.562748,0,0,0.562748,237.182755,225.857666)">
     <g fill="none" transform="matrix(1,0,0,1,0,0)">
       <g fill="none" transform="matrix(1,0,0,1,0,0)">
         <g fill="none" transform="matrix(1,0,0,1,53.982624,309.341858)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(253,253,253,1)" transform="translate(-154.80771720105744,-154.80771720105744)" cx="154.80771720105744" cy="154.80771720105744" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="154.80771720105744"/>
           </g>
+          <g fill="none" transform="matrix(1,0,0,1,0,154.807724)">
+            <g transform="matrix(1,0,0,1,0,0)">
+              <text fill="rgba(0,0,0,0.8509803921568627)" dominant-baseline="central" paint-order="stroke" dx="0.5" dy="11.5px" font-size="12" text-anchor="middle" font-weight="400">
+                a
+              </text>
+            </g>
+          </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,196.021637,-86.306732)">
+        <g fill="none" transform="matrix(1,0,0,1,-9.803416,-140.453995)">
           <g transform="matrix(1,0,0,1,0,0)">
-            <circle fill="rgba(253,253,253,1)" transform="translate(-79.07117047318826,-79.07117047318826)" cx="79.07117047318826" cy="79.07117047318826" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="79.07117047318826"/>
+            <circle fill="rgba(253,253,253,1)" transform="translate(-260.8939637431703,-260.8939637431703)" cx="260.8939637431703" cy="260.8939637431703" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="260.8939637431703"/>
+          </g>
+          <g fill="none" transform="matrix(1,0,0,1,0,260.893951)">
+            <g transform="matrix(1,0,0,1,0,0)">
+              <text fill="rgba(0,0,0,0.8509803921568627)" dominant-baseline="central" paint-order="stroke" dx="0.5" dy="11.5px" font-size="12" text-anchor="middle" font-weight="400">
+                b
+              </text>
+            </g>
           </g>
         </g>
         <g fill="none" transform="matrix(1,0,0,1,32.902729,-248.026672)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(253,253,253,1)" transform="translate(-76.11450356931611,-76.11450356931611)" cx="76.11450356931611" cy="76.11450356931611" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="76.11450356931611"/>
           </g>
+          <g fill="none" transform="matrix(1,0,0,1,0,76.114502)">
+            <g transform="matrix(1,0,0,1,0,0)">
+              <text fill="rgba(0,0,0,0.8509803921568627)" dominant-baseline="central" paint-order="stroke" dx="0.5" dy="11.5px" font-size="12" text-anchor="middle" font-weight="400">
+                c
+              </text>
+            </g>
+          </g>
         </g>
         <g fill="none" transform="matrix(1,0,0,1,-175.009796,-210.482574)">
           <g transform="matrix(1,0,0,1,0,0)">
             <circle fill="rgba(253,253,253,1)" transform="translate(-50.61867244406949,-50.61867244406949)" cx="50.61867244406949" cy="50.61867244406949" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="50.61867244406949"/>
+          </g>
+          <g fill="none" transform="matrix(1,0,0,1,0,50.618671)">
+            <g transform="matrix(1,0,0,1,0,0)">
+              <text fill="rgba(0,0,0,0.8509803921568627)" dominant-baseline="central" paint-order="stroke" dx="0.5" dy="11.5px" font-size="12" text-anchor="middle" font-weight="400">
+                d
+              </text>
+            </g>
           </g>
         </g>
       </g>

--- a/packages/g6/__tests__/snapshots/plugins/tooltip/edge.svg
+++ b/packages/g6/__tests__/snapshots/plugins/tooltip/edge.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g transform="matrix(0.621685,0,0,0.621685,239.763260,207.364517)">
+  <g transform="matrix(0.578130,0,0,0.578130,240.480438,235.702255)">
     <g fill="none" transform="matrix(1,0,0,1,0,0)">
       <g fill="none" transform="matrix(1,0,0,1,0,0)">
         <g fill="none" transform="matrix(1,0,0,1,59.975552,299.578186)">
@@ -8,9 +8,9 @@
             <circle fill="rgba(253,253,253,1)" transform="translate(-157.5815347908568,-157.5815347908568)" cx="157.5815347908568" cy="157.5815347908568" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="157.5815347908568"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,191.033539,-90.805405)">
+        <g fill="none" transform="matrix(1,0,0,1,-13.241203,-145.255371)">
           <g transform="matrix(1,0,0,1,0,0)">
-            <circle fill="rgba(253,253,253,1)" transform="translate(-81.52453985707301,-81.52453985707301)" cx="81.52453985707301" cy="81.52453985707301" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="81.52453985707301"/>
+            <circle fill="rgba(253,253,253,1)" transform="translate(-262.4422902950179,-262.4422902950179)" cx="262.4422902950179" cy="262.4422902950179" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="262.4422902950179"/>
           </g>
         </g>
         <g fill="none" transform="matrix(1,0,0,1,38.174038,-241.067780)">

--- a/packages/g6/__tests__/snapshots/plugins/tooltip/hover.svg
+++ b/packages/g6/__tests__/snapshots/plugins/tooltip/hover.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g transform="matrix(0.621685,0,0,0.621685,239.763260,207.364517)">
+  <g transform="matrix(0.578130,0,0,0.578130,240.480438,235.702255)">
     <g fill="none" transform="matrix(1,0,0,1,0,0)">
       <g fill="none" transform="matrix(1,0,0,1,0,0)">
         <g fill="none" transform="matrix(1,0,0,1,59.975552,299.578186)">
@@ -8,9 +8,9 @@
             <circle fill="rgba(253,253,253,1)" transform="translate(-157.5815347908568,-157.5815347908568)" cx="157.5815347908568" cy="157.5815347908568" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="157.5815347908568"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,191.033539,-90.805405)">
+        <g fill="none" transform="matrix(1,0,0,1,-13.241203,-145.255371)">
           <g transform="matrix(1,0,0,1,0,0)">
-            <circle fill="rgba(253,253,253,1)" transform="translate(-81.52453985707301,-81.52453985707301)" cx="81.52453985707301" cy="81.52453985707301" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="81.52453985707301"/>
+            <circle fill="rgba(253,253,253,1)" transform="translate(-262.4422902950179,-262.4422902950179)" cx="262.4422902950179" cy="262.4422902950179" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="262.4422902950179"/>
           </g>
         </g>
         <g fill="none" transform="matrix(1,0,0,1,38.174038,-241.067780)">

--- a/packages/g6/__tests__/snapshots/plugins/tooltip/node.svg
+++ b/packages/g6/__tests__/snapshots/plugins/tooltip/node.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g transform="matrix(0.621685,0,0,0.621685,239.763260,207.364517)">
+  <g transform="matrix(0.578130,0,0,0.578130,240.480438,235.702255)">
     <g fill="none" transform="matrix(1,0,0,1,0,0)">
       <g fill="none" transform="matrix(1,0,0,1,0,0)">
         <g fill="none" transform="matrix(1,0,0,1,59.975552,299.578186)">
@@ -8,9 +8,9 @@
             <circle fill="rgba(253,253,253,1)" transform="translate(-157.5815347908568,-157.5815347908568)" cx="157.5815347908568" cy="157.5815347908568" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="157.5815347908568"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,191.033539,-90.805405)">
+        <g fill="none" transform="matrix(1,0,0,1,-13.241203,-145.255371)">
           <g transform="matrix(1,0,0,1,0,0)">
-            <circle fill="rgba(253,253,253,1)" transform="translate(-81.52453985707301,-81.52453985707301)" cx="81.52453985707301" cy="81.52453985707301" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="81.52453985707301"/>
+            <circle fill="rgba(253,253,253,1)" transform="translate(-262.4422902950179,-262.4422902950179)" cx="262.4422902950179" cy="262.4422902950179" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="262.4422902950179"/>
           </g>
         </g>
         <g fill="none" transform="matrix(1,0,0,1,38.174038,-241.067780)">

--- a/packages/g6/__tests__/snapshots/plugins/tooltip/show-tooltip-by-id.svg
+++ b/packages/g6/__tests__/snapshots/plugins/tooltip/show-tooltip-by-id.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g transform="matrix(0.621685,0,0,0.621685,239.763260,207.364517)">
+  <g transform="matrix(0.578130,0,0,0.578130,240.480438,235.702255)">
     <g fill="none" transform="matrix(1,0,0,1,0,0)">
       <g fill="none" transform="matrix(1,0,0,1,0,0)">
         <g fill="none" transform="matrix(1,0,0,1,59.975552,299.578186)">
@@ -8,9 +8,9 @@
             <circle fill="rgba(253,253,253,1)" transform="translate(-157.5815347908568,-157.5815347908568)" cx="157.5815347908568" cy="157.5815347908568" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="157.5815347908568"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1,0,0,1,191.033539,-90.805405)">
+        <g fill="none" transform="matrix(1,0,0,1,-13.241203,-145.255371)">
           <g transform="matrix(1,0,0,1,0,0)">
-            <circle fill="rgba(253,253,253,1)" transform="translate(-81.52453985707301,-81.52453985707301)" cx="81.52453985707301" cy="81.52453985707301" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="81.52453985707301"/>
+            <circle fill="rgba(253,253,253,1)" transform="translate(-262.4422902950179,-262.4422902950179)" cx="262.4422902950179" cy="262.4422902950179" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="262.4422902950179"/>
           </g>
         </g>
         <g fill="none" transform="matrix(1,0,0,1,38.174038,-241.067780)">

--- a/packages/g6/__tests__/unit/plugins/tooltip.spec.ts
+++ b/packages/g6/__tests__/unit/plugins/tooltip.spec.ts
@@ -1,5 +1,5 @@
 import { pluginTooltip } from '@/__tests__/demos';
-import type { Tooltip } from '@/src';
+import { idOf, type Tooltip } from '@/src';
 import { createDemoGraph } from '@@/utils';
 
 describe('plugin tooltip', () => {
@@ -19,7 +19,7 @@ describe('plugin tooltip', () => {
 
   it('edge', async () => {
     const graph = await createDemoGraph(pluginTooltip);
-    graph.emit('edge:click', { targetType: 'edge', target: { id: 'edge-444' } });
+    graph.emit('edge:click', { targetType: 'edge', target: { id: idOf({ source: '0', target: '1' }) } });
     await expect(graph).toMatchSnapshot(__filename, 'edge');
     graph.destroy();
   });

--- a/packages/g6/__tests__/unit/runtime/data.spec.ts
+++ b/packages/g6/__tests__/unit/runtime/data.spec.ts
@@ -8,8 +8,8 @@ import { clone } from '@antv/util';
 const data = {
   nodes: [
     { id: 'node-1', data: { value: 1 }, style: { fill: 'red' } },
-    { id: 'node-2', data: { value: 2 }, style: { fill: 'green', parentId: 'combo-1' } },
-    { id: 'node-3', data: { value: 3 }, style: { fill: 'blue', parentId: 'combo-1' } },
+    { id: 'node-2', data: { value: 2 }, combo: 'combo-1', style: { fill: 'green' } },
+    { id: 'node-3', data: { value: 3 }, combo: 'combo-1', style: { fill: 'blue' } },
   ],
   edges: [
     { id: 'edge-1', source: 'node-1', target: 'node-2', data: { weight: 1 }, style: {} },
@@ -73,17 +73,17 @@ describe('DataController', () => {
 
     controller.addNodeData([]);
 
-    controller.addNodeData([{ id: 'node-5', data: { value: 5 }, style: { fill: 'black', parentId: 'combo-2' } }]);
+    controller.addNodeData([{ id: 'node-5', data: { value: 5 }, combo: 'combo-2', style: { fill: 'black' } }]);
 
     controller.addEdgeData([{ id: 'edge-3', source: 'node-1', target: 'node-5', data: { weight: 3 } }]);
 
     expect(controller.getData()).toEqual({
       nodes: [
         { id: 'node-1', data: { value: 1 }, style: { fill: 'red' } },
-        { id: 'node-2', data: { value: 2 }, style: { fill: 'green', parentId: 'combo-1' } },
-        { id: 'node-3', data: { value: 3 }, style: { fill: 'blue', parentId: 'combo-1' } },
+        { id: 'node-2', data: { value: 2 }, combo: 'combo-1', style: { fill: 'green' } },
+        { id: 'node-3', data: { value: 3 }, combo: 'combo-1', style: { fill: 'blue' } },
         { id: 'node-4', data: { value: 4 }, style: { fill: 'yellow' } },
-        { id: 'node-5', data: { value: 5 }, style: { fill: 'black', parentId: 'combo-2' } },
+        { id: 'node-5', data: { value: 5 }, combo: 'combo-2', style: { fill: 'black' } },
       ],
       edges: [
         { id: 'edge-1', source: 'node-1', target: 'node-2', data: { weight: 1 }, style: {} },
@@ -127,9 +127,9 @@ describe('DataController', () => {
 
     controller.addComboData([{ id: 'combo-2' }]);
 
-    controller.updateNodeData([{ id: 'node-1', data: { value: 666 }, style: { parentId: 'combo-2' } }]);
+    controller.updateNodeData([{ id: 'node-1', data: { value: 666 }, combo: 'combo-2' }]);
 
-    controller.updateNodeData([{ id: 'node-2', style: { parentId: 'combo-2' } }]);
+    controller.updateNodeData([{ id: 'node-2', combo: 'combo-2' }]);
 
     controller.updateEdgeData([{ id: 'edge-2', data: { weight: 666 } }]);
 
@@ -137,9 +137,9 @@ describe('DataController', () => {
 
     expect(controller.getData()).toEqual({
       nodes: [
-        { id: 'node-1', data: { value: 666 }, style: { fill: 'pink', lineWidth: 2, parentId: 'combo-2' } },
-        { id: 'node-2', data: { value: 2 }, style: { fill: 'green', parentId: 'combo-2' } },
-        { id: 'node-3', data: { value: 3 }, style: { fill: 'blue', parentId: 'combo-1' } },
+        { id: 'node-1', data: { value: 666 }, combo: 'combo-2', style: { fill: 'pink', lineWidth: 2 } },
+        { id: 'node-2', data: { value: 2 }, combo: 'combo-2', style: { fill: 'green' } },
+        { id: 'node-3', data: { value: 3 }, combo: 'combo-1', style: { fill: 'blue' } },
       ],
       edges: [
         { id: 'edge-1', source: 'node-1', target: 'node-2', data: { weight: 678 }, style: {} },
@@ -191,8 +191,8 @@ describe('DataController', () => {
   it('updateComboData', () => {
     const data = {
       nodes: [
-        { id: 'node-1', style: { x: 50, y: 50, parentId: 'combo-1' } },
-        { id: 'node-2', style: { x: 100, y: 100, parentId: 'combo-1' } },
+        { id: 'node-1', combo: 'combo-1', style: { x: 50, y: 50 } },
+        { id: 'node-2', combo: 'combo-1', style: { x: 100, y: 100 } },
       ],
       combos: [
         {
@@ -214,8 +214,8 @@ describe('DataController', () => {
 
     expect(controller.getData()).toEqual({
       nodes: [
-        { id: 'node-1', data: {}, style: { x: 50, y: 50, parentId: 'combo-1' } },
-        { id: 'node-2', data: {}, style: { x: 100, y: 100, parentId: 'combo-1' } },
+        { id: 'node-1', data: {}, combo: 'combo-1', style: { x: 50, y: 50 } },
+        { id: 'node-2', data: {}, combo: 'combo-1', style: { x: 100, y: 100 } },
       ],
       edges: [],
       combos: [
@@ -228,8 +228,8 @@ describe('DataController', () => {
 
     expect(controller.getData()).toEqual({
       nodes: [
-        { id: 'node-1', data: {}, style: { x: 50, y: 50, parentId: 'combo-1' } },
-        { id: 'node-2', data: {}, style: { x: 100, y: 100, parentId: 'combo-1' } },
+        { id: 'node-1', data: {}, combo: 'combo-1', style: { x: 50, y: 50 } },
+        { id: 'node-2', data: {}, combo: 'combo-1', style: { x: 100, y: 100 } },
       ],
       edges: [],
       combos: [
@@ -245,14 +245,14 @@ describe('DataController', () => {
     const controller = new DataController();
 
     controller.addData({
-      nodes: [{ id: 'node-1', style: { parentId: 'combo-1' } }],
+      nodes: [{ id: 'node-1', combo: 'combo-1' }],
       combos: [{ id: 'combo-1' }],
     });
 
     controller.translateComboBy('combo-1', [100, 100]);
 
     expect(controller.getData()).toEqual({
-      nodes: [{ id: 'node-1', data: {}, style: { parentId: 'combo-1', x: 100, y: 100, z: 0 } }],
+      nodes: [{ id: 'node-1', data: {}, combo: 'combo-1', style: { x: 100, y: 100, z: 0 } }],
       combos: [{ id: 'combo-1', data: {}, style: { x: 100, y: 100, z: 0 } }],
       edges: [],
     });
@@ -264,8 +264,8 @@ describe('DataController', () => {
     controller.addData({
       nodes: [
         { id: 'node-1' },
-        { id: 'node-2', style: { y: 50, fill: 'green', parentId: 'combo-1' } },
-        { id: 'node-3', style: { x: 100, y: 100, fill: 'blue', parentId: 'combo-1' } },
+        { id: 'node-2', combo: 'combo-1', style: { y: 50, fill: 'green' } },
+        { id: 'node-3', combo: 'combo-1', style: { x: 100, y: 100, fill: 'blue' } },
       ],
       combos: [{ id: 'combo-1' }],
     });
@@ -274,8 +274,8 @@ describe('DataController', () => {
 
     expect(controller.getNodeData()).toEqual([
       { id: 'node-1', data: {}, style: {} },
-      { id: 'node-2', data: {}, style: { x: 66, y: 117, z: 0, fill: 'green', parentId: 'combo-1' } },
-      { id: 'node-3', data: {}, style: { x: 166, y: 167, z: 0, fill: 'blue', parentId: 'combo-1' } },
+      { id: 'node-2', combo: 'combo-1', data: {}, style: { x: 66, y: 117, z: 0, fill: 'green' } },
+      { id: 'node-3', combo: 'combo-1', data: {}, style: { x: 166, y: 167, z: 0, fill: 'blue' } },
     ]);
   });
 
@@ -300,8 +300,8 @@ describe('DataController', () => {
 
     controller.addData({
       nodes: [
-        { id: 'node-1', style: { parentId: 'combo-1' } },
-        { id: 'node-2', style: { parentId: 'combo-1', x: 10, y: 10 } },
+        { id: 'node-1', combo: 'combo-1' },
+        { id: 'node-2', combo: 'combo-1', style: { x: 10, y: 10 } },
       ],
       combos: [{ id: 'combo-1' }],
     });
@@ -310,8 +310,8 @@ describe('DataController', () => {
 
     expect(controller.getData()).toEqual({
       nodes: [
-        { id: 'node-1', data: {}, style: { parentId: 'combo-1', x: 100, y: 100, z: 0 } },
-        { id: 'node-2', data: {}, style: { parentId: 'combo-1', x: 110, y: 110, z: 0 } },
+        { id: 'node-1', data: {}, combo: 'combo-1', style: { x: 100, y: 100, z: 0 } },
+        { id: 'node-2', data: {}, combo: 'combo-1', style: { x: 110, y: 110, z: 0 } },
       ],
       combos: [{ id: 'combo-1', data: {}, style: { x: 100, y: 100, z: 0 } }],
       edges: [],
@@ -331,8 +331,8 @@ describe('DataController', () => {
 
     expect(controller.getData()).toEqual({
       nodes: [
-        { id: 'node-2', data: { value: 2 }, style: { fill: 'green', parentId: 'combo-1' } },
-        { id: 'node-3', data: { value: 3 }, style: { fill: 'blue', parentId: 'combo-1' } },
+        { id: 'node-2', data: { value: 2 }, combo: 'combo-1', style: { fill: 'green' } },
+        { id: 'node-3', data: { value: 3 }, combo: 'combo-1', style: { fill: 'blue' } },
       ],
       edges: [{ id: 'edge-2', source: 'node-2', target: 'node-3', data: { weight: 2 }, style: {} }],
       combos: [{ id: 'combo-1', data: {}, style: {} }],
@@ -342,8 +342,8 @@ describe('DataController', () => {
 
     expect(controller.getData()).toEqual({
       nodes: [
-        { id: 'node-2', data: { value: 2 }, style: { fill: 'green', parentId: undefined } },
-        { id: 'node-3', data: { value: 3 }, style: { fill: 'blue', parentId: undefined } },
+        { id: 'node-2', data: { value: 2 }, combo: undefined, style: { fill: 'green' } },
+        { id: 'node-3', data: { value: 3 }, combo: undefined, style: { fill: 'blue' } },
       ],
       edges: [{ id: 'edge-2', source: 'node-2', target: 'node-3', data: { weight: 2 }, style: {} }],
       combos: [],
@@ -355,8 +355,8 @@ describe('DataController', () => {
 
     expect(controller.getData()).toEqual({
       nodes: [
-        { id: 'node-2', data: { value: 2 }, style: { fill: 'green', parentId: undefined } },
-        { id: 'node-3', data: { value: 3 }, style: { fill: 'blue', parentId: undefined } },
+        { id: 'node-2', data: { value: 2 }, combo: undefined, style: { fill: 'green', combo: undefined } },
+        { id: 'node-3', data: { value: 3 }, combo: undefined, style: { fill: 'blue' } },
       ],
       edges: [],
       combos: [],
@@ -367,7 +367,7 @@ describe('DataController', () => {
     controller.removeNodeData(['node-2']);
 
     expect(controller.getData()).toEqual({
-      nodes: [{ id: 'node-3', data: { value: 3 }, style: { fill: 'blue', parentId: undefined } }],
+      nodes: [{ id: 'node-3', data: { value: 3 }, combo: undefined, style: { fill: 'blue' } }],
       edges: [],
       combos: [],
     });
@@ -385,8 +385,8 @@ describe('DataController', () => {
     expect(controller.getData()).toEqual({
       nodes: [
         { id: 'node-1', data: { value: 1 }, style: { fill: 'red' } },
-        { id: 'node-2', data: { value: 2 }, style: { fill: 'green', parentId: undefined } },
-        { id: 'node-3', data: { value: 3 }, style: { fill: 'blue', parentId: undefined } },
+        { id: 'node-2', data: { value: 2 }, combo: undefined, style: { fill: 'green' } },
+        { id: 'node-3', data: { value: 3 }, combo: undefined, style: { fill: 'blue' } },
       ],
       edges: [
         { id: 'edge-1', source: 'node-1', target: 'node-2', data: { weight: 1 }, style: {} },
@@ -401,12 +401,12 @@ describe('DataController', () => {
   it('removeComboData with children', () => {
     const data = {
       nodes: [
-        { id: 'node-1', data: {}, style: { parentId: 'combo-1' } },
-        { id: 'node-2', data: {}, style: { parentId: 'combo-1' } },
-        { id: 'node-3', data: {}, style: { parentId: 'combo-1' } },
+        { id: 'node-1', data: {}, combo: 'combo-1' },
+        { id: 'node-2', data: {}, combo: 'combo-1' },
+        { id: 'node-3', data: {}, combo: 'combo-1' },
       ],
       combos: [
-        { id: 'combo-1', data: {}, style: { parentId: 'combo-2' } },
+        { id: 'combo-1', data: {}, combo: 'combo-2' },
         { id: 'combo-2', data: {}, style: {} },
       ],
     };
@@ -424,9 +424,9 @@ describe('DataController', () => {
 
     expect(controller.getData()).toEqual({
       nodes: [
-        { id: 'node-1', data: {}, style: { parentId: 'combo-2' } },
-        { id: 'node-2', data: {}, style: { parentId: 'combo-2' } },
-        { id: 'node-3', data: {}, style: { parentId: 'combo-2' } },
+        { id: 'node-1', data: {}, style: {}, combo: 'combo-2' },
+        { id: 'node-2', data: {}, style: {}, combo: 'combo-2' },
+        { id: 'node-3', data: {}, style: {}, combo: 'combo-2' },
       ],
       edges: [],
       combos: [{ id: 'combo-2', data: {}, style: {} }],
@@ -440,7 +440,7 @@ describe('DataController', () => {
 
     controller.setData({
       nodes: [
-        { id: 'node-3', data: { value: 3 }, style: { fill: 'pink', parentId: 'combo-2' } },
+        { id: 'node-3', data: { value: 3 }, combo: 'combo-2', style: { fill: 'pink' } },
         { id: 'node-4', data: { value: 4 }, style: { fill: 'yellow' } },
       ],
       combos: [{ id: 'combo-2' }],
@@ -451,8 +451,8 @@ describe('DataController', () => {
     expect(changes).toEqual([
       { value: { id: 'combo-1', data: {}, style: {} }, type: 'ComboAdded' },
       { value: { id: 'node-1', data: { value: 1 }, style: { fill: 'red' } }, type: 'NodeAdded' },
-      { value: { id: 'node-2', data: { value: 2 }, style: { fill: 'green', parentId: 'combo-1' } }, type: 'NodeAdded' },
-      { value: { id: 'node-3', data: { value: 3 }, style: { fill: 'blue', parentId: 'combo-1' } }, type: 'NodeAdded' },
+      { value: { id: 'node-2', data: { value: 2 }, combo: 'combo-1', style: { fill: 'green' } }, type: 'NodeAdded' },
+      { value: { id: 'node-3', data: { value: 3 }, combo: 'combo-1', style: { fill: 'blue' } }, type: 'NodeAdded' },
       // 新增子元素后更新 combo / update combo after add child
       {
         value: { id: 'combo-1', data: {}, style: {} },
@@ -475,8 +475,8 @@ describe('DataController', () => {
       { value: { id: 'combo-2' }, type: 'ComboAdded' },
       { value: { id: 'node-4', data: { value: 4 }, style: { fill: 'yellow' } }, type: 'NodeAdded' },
       {
-        value: { id: 'node-3', data: { value: 3 }, style: { fill: 'pink', parentId: 'combo-2' } },
-        original: { id: 'node-3', data: { value: 3 }, style: { fill: 'blue', parentId: 'combo-1' } },
+        value: { id: 'node-3', data: { value: 3 }, combo: 'combo-2', style: { fill: 'pink' } },
+        original: { id: 'node-3', data: { value: 3 }, combo: 'combo-1', style: { fill: 'blue' } },
         type: 'NodeUpdated',
       },
       // 移动节点后更新 combo / update combo after move node
@@ -495,7 +495,7 @@ describe('DataController', () => {
       },
       { value: { id: 'node-1', data: { value: 1 }, style: { fill: 'red' } }, type: 'NodeRemoved' },
       {
-        value: { id: 'node-2', data: { value: 2 }, style: { fill: 'green', parentId: 'combo-1' } },
+        value: { id: 'node-2', data: { value: 2 }, combo: 'combo-1', style: { fill: 'green' } },
         type: 'NodeRemoved',
       },
       // 移除节点后更新 combo / update combo after remove node
@@ -510,7 +510,7 @@ describe('DataController', () => {
     expect(reduceDataChanges(changes)).toEqual([
       {
         type: 'NodeAdded',
-        value: { id: 'node-3', data: { value: 3 }, style: { fill: 'pink', parentId: 'combo-2' } },
+        value: { id: 'node-3', data: { value: 3 }, combo: 'combo-2', style: { fill: 'pink' } },
       },
       { value: { id: 'combo-2', data: {}, style: {} }, type: 'ComboAdded' },
       { value: { id: 'node-4', data: { value: 4 }, style: { fill: 'yellow' } }, type: 'NodeAdded' },
@@ -522,7 +522,7 @@ describe('DataController', () => {
 
     controller.addData({
       nodes: [
-        { id: 'node-3', data: { value: 3 }, style: { fill: 'pink', parentId: 'combo-2' } },
+        { id: 'node-3', data: { value: 3 }, combo: 'combo-2', style: { fill: 'pink' } },
         { id: 'node-4', data: { value: 4 }, style: { fill: 'yellow' } },
       ],
       combos: [{ id: 'combo-2' }],
@@ -534,7 +534,7 @@ describe('DataController', () => {
       { value: { id: 'combo-2', data: {}, style: {} }, type: 'ComboAdded' },
       {
         type: 'NodeAdded',
-        value: { id: 'node-3', data: { value: 3 }, style: { fill: 'pink', parentId: 'combo-2' } },
+        value: { id: 'node-3', data: { value: 3 }, combo: 'combo-2', style: { fill: 'pink' } },
       },
       { value: { id: 'node-4', data: { value: 4 }, style: { fill: 'yellow' } }, type: 'NodeAdded' },
     ]);
@@ -548,7 +548,7 @@ describe('DataController', () => {
 
       controller.setData({
         nodes: [
-          { id: 'node-3', data: { value: 3 }, style: { fill: 'pink', parentId: 'combo-2' } },
+          { id: 'node-3', data: { value: 3 }, combo: 'combo-2', style: { fill: 'pink' } },
           { id: 'node-4', data: { value: 4 }, style: { fill: 'yellow' } },
         ],
         combos: [{ id: 'combo-2' }],
@@ -641,28 +641,28 @@ describe('DataController', () => {
 
     expect(controller.getChildrenData('combo-1')).toEqual(data.nodes.slice(1));
 
-    controller.updateNodeData([{ id: 'node-1', style: { parentId: 'combo-1' } }]);
+    controller.updateNodeData([{ id: 'node-1', combo: 'combo-1' }]);
 
     expect(controller.getChildrenData('combo-1')?.sort((a, b) => (a.id < b.id ? -1 : 1))).toEqual([
-      { id: 'node-1', data: { value: 1 }, style: { fill: 'red', parentId: 'combo-1' } },
-      { id: 'node-2', data: { value: 2 }, style: { fill: 'green', parentId: 'combo-1' } },
-      { id: 'node-3', data: { value: 3 }, style: { fill: 'blue', parentId: 'combo-1' } },
+      { id: 'node-1', data: { value: 1 }, combo: 'combo-1', style: { fill: 'red' } },
+      { id: 'node-2', data: { value: 2 }, combo: 'combo-1', style: { fill: 'green' } },
+      { id: 'node-3', data: { value: 3 }, combo: 'combo-1', style: { fill: 'blue' } },
     ]);
 
     controller.addComboData([{ id: 'combo-2' }]);
 
     controller.updateNodeData([
-      { id: 'node-2', style: { parentId: 'combo-2' } },
-      { id: 'node-3', style: { parentId: 'combo-2' } },
+      { id: 'node-2', combo: 'combo-2' },
+      { id: 'node-3', combo: 'combo-2' },
     ]);
 
     expect(controller.getChildrenData('combo-1')).toEqual([
-      { id: 'node-1', data: { value: 1 }, style: { fill: 'red', parentId: 'combo-1' } },
+      { id: 'node-1', data: { value: 1 }, combo: 'combo-1', style: { fill: 'red' } },
     ]);
 
     expect(controller.getChildrenData('combo-2')).toEqual([
-      { id: 'node-2', data: { value: 2 }, style: { fill: 'green', parentId: 'combo-2' } },
-      { id: 'node-3', data: { value: 3 }, style: { fill: 'blue', parentId: 'combo-2' } },
+      { id: 'node-2', data: { value: 2 }, combo: 'combo-2', style: { fill: 'green' } },
+      { id: 'node-3', data: { value: 3 }, combo: 'combo-2', style: { fill: 'blue' } },
     ]);
   });
 
@@ -673,7 +673,7 @@ describe('DataController', () => {
 
     expect(controller.getParentData('node-1', 'combo')).toEqual(undefined);
 
-    controller.updateNodeData([{ id: 'node-1', style: { parentId: 'combo-1' } }]);
+    controller.updateNodeData([{ id: 'node-1', combo: 'combo-1' }]);
 
     expect(controller.getParentData('node-1', 'combo')).toEqual(data.combos[0]);
 
@@ -710,14 +710,14 @@ describe('DataController', () => {
     controller.addData(clone(data));
 
     expect(controller.getNeighborNodesData('node-1')).toEqual([
-      { id: 'node-2', data: { value: 2 }, style: { fill: 'green', parentId: 'combo-1' } },
+      { id: 'node-2', data: { value: 2 }, combo: 'combo-1', style: { fill: 'green' } },
     ]);
 
     controller.addEdgeData([{ id: 'edge-3', source: 'node-1', target: 'node-3', data: { weight: 3 } }]);
 
     expect(controller.getNeighborNodesData('node-1')).toEqual([
-      { id: 'node-2', data: { value: 2 }, style: { fill: 'green', parentId: 'combo-1' } },
-      { id: 'node-3', data: { value: 3 }, style: { fill: 'blue', parentId: 'combo-1' } },
+      { id: 'node-2', data: { value: 2 }, combo: 'combo-1', style: { fill: 'green' } },
+      { id: 'node-3', data: { value: 3 }, combo: 'combo-1', style: { fill: 'blue' } },
     ]);
   });
 

--- a/packages/g6/__tests__/unit/runtime/element.spec.ts
+++ b/packages/g6/__tests__/unit/runtime/element.spec.ts
@@ -14,7 +14,7 @@ describe('ElementController', () => {
         nodes: [
           { id: 'node-1', style: { x: 100, y: 100, fill: 'red', stroke: 'pink', lineWidth: 1 }, data: { value: 100 } },
           { id: 'node-2', style: { x: 150, y: 100 }, data: { value: 150 } },
-          { id: 'node-3', style: { x: 125, y: 150, parentId: 'combo-1', states: ['selected'] }, data: { value: 150 } },
+          { id: 'node-3', combo: 'combo-1', style: { x: 125, y: 150, states: ['selected'] }, data: { value: 150 } },
         ],
         edges: [
           { id: 'edge-1', source: 'node-1', target: 'node-2', data: { weight: 250 } },
@@ -132,7 +132,6 @@ describe('ElementController', () => {
     expect(elementController.getElementComputedStyle('node', node3)).toEqual({
       ...LIGHT_THEME.node?.style,
       ...LIGHT_THEME.node?.state?.selected,
-      parentId: 'combo-1',
       states: ['selected'],
       // from state
       fill: 'purple',
@@ -167,11 +166,7 @@ describe('ElementController', () => {
 
   it('runtime', async () => {
     graph.setData({
-      nodes: [
-        { id: 'node-1' },
-        { id: 'node-2', style: { parentId: 'combo-1' } },
-        { id: 'node-3', style: { parentId: 'combo-1' } },
-      ],
+      nodes: [{ id: 'node-1' }, { id: 'node-2', combo: 'combo-1' }, { id: 'node-3', combo: 'combo-1' }],
       edges: [
         { source: 'node-1', target: 'node-2' },
         { source: 'node-2', target: 'node-3' },

--- a/packages/g6/__tests__/unit/runtime/graph/graph.spec.ts
+++ b/packages/g6/__tests__/unit/runtime/graph/graph.spec.ts
@@ -145,8 +145,8 @@ describe('Graph', () => {
 
     graph.addComboData([{ id: 'combo-1', style: {} }]);
     graph.addNodeData([
-      { id: 'node-3', style: { parentId: 'combo-1' } },
-      { id: 'node-4', style: { parentId: 'combo-1' } },
+      { id: 'node-3', combo: 'combo-1' },
+      { id: 'node-4', combo: 'combo-1' },
     ]);
     graph.addEdgeData([{ id: 'edge-2', source: 'node-3', target: 'node-4' }]);
     expect(graph.getNodeData().map(idOf)).toEqual(['node-1', 'node-2', 'node-3', 'node-4']);
@@ -161,8 +161,8 @@ describe('Graph', () => {
     expect(graph.getNodeData()).toEqual([
       { id: 'node-1', data: {}, style: {} },
       { id: 'node-2', data: {}, style: {} },
-      { id: 'node-3', data: {}, style: { x: 100, y: 100, parentId: 'combo-1' } },
-      { id: 'node-4', data: {}, style: { parentId: 'combo-1' } },
+      { id: 'node-3', data: {}, combo: 'combo-1', style: { x: 100, y: 100 } },
+      { id: 'node-4', data: {}, combo: 'combo-1', style: {} },
     ]);
     expect(graph.getEdgeData().map(idOf)).toEqual(['edge-1', 'edge-2']);
     expect(graph.getComboData()).toEqual([{ id: 'combo-1', data: {}, style: { stroke: 'red' } }]);

--- a/packages/g6/__tests__/unit/spec/data.spec.ts
+++ b/packages/g6/__tests__/unit/spec/data.spec.ts
@@ -18,9 +18,9 @@ describe('spec data', () => {
           data: {
             value: 1,
           },
+          combo: 'combo-1',
           style: {
             collapsed: true,
-            parentId: 'combo-1',
             fill: 'red',
           },
         },
@@ -38,9 +38,9 @@ describe('spec data', () => {
           data: {
             value: 1,
           },
+          combo: 'combo-1',
+          collapsed: true,
           style: {
-            collapsed: true,
-            parentId: 'combo-1',
             fill: 'red',
           },
         },
@@ -51,8 +51,8 @@ describe('spec data', () => {
           data: {
             value: 1,
           },
+          collapsed: true,
           style: {
-            collapsed: true,
             fill: 'red',
           },
         },

--- a/packages/g6/__tests__/unit/spec/element/node.spec.ts
+++ b/packages/g6/__tests__/unit/spec/element/node.spec.ts
@@ -13,8 +13,6 @@ describe('spec element node', () => {
         ],
       },
       style: {
-        collapsed: (data: any) => data.style?.collapsed || false,
-        parentId: '1',
         x: 1,
         y: 1,
       },

--- a/packages/g6/__tests__/unit/utils/edge.spec.ts
+++ b/packages/g6/__tests__/unit/utils/edge.spec.ts
@@ -237,8 +237,8 @@ describe('edge', () => {
      */
     const data = {
       nodes: [
-        { id: 'node-1', style: { parentId: 'combo-1' } },
-        { id: 'node-2', style: { parentId: 'combo-1' } },
+        { id: 'node-1', combo: 'combo-1' },
+        { id: 'node-2', combo: 'combo-1' },
         { id: 'node-3' },
         { id: 'node-4' },
         { id: 'node-5' },

--- a/packages/g6/__tests__/unit/utils/id.spec.ts
+++ b/packages/g6/__tests__/unit/utils/id.spec.ts
@@ -8,7 +8,7 @@ describe('id', () => {
   });
 
   it('parentIdOf', () => {
-    expect(parentIdOf({ style: { parentId: '1' } })).toBe('1');
+    expect(parentIdOf({ combo: '1' })).toBe('1');
     expect(parentIdOf({})).toBeUndefined();
   });
 

--- a/packages/g6/__tests__/unit/utils/relation.spec.ts
+++ b/packages/g6/__tests__/unit/utils/relation.spec.ts
@@ -7,14 +7,7 @@ describe('relation', () => {
   beforeAll(() => {
     graph = new Graph({
       data: {
-        nodes: [
-          { id: '1', style: { parentId: 'combo1' } },
-          { id: '2' },
-          { id: '3' },
-          { id: '4' },
-          { id: '5' },
-          { id: '6' },
-        ],
+        nodes: [{ id: '1', combo: 'combo1' }, { id: '2' }, { id: '3' }, { id: '4' }, { id: '5' }, { id: '6' }],
         edges: [
           { source: '1', target: '2' },
           { source: '1', target: '3' },

--- a/packages/g6/__tests__/unit/utils/tree.spec.ts
+++ b/packages/g6/__tests__/unit/utils/tree.spec.ts
@@ -11,9 +11,7 @@ describe('tree', () => {
       nodes: [
         {
           id: 'root',
-          style: {
-            children: ['child'],
-          },
+          children: ['child'],
         },
         { id: 'child' },
       ],
@@ -31,7 +29,8 @@ describe('tree', () => {
       nodes: [
         {
           id: 'root',
-          style: { fill: 'red', children: ['child'] },
+          children: ['child'],
+          style: { fill: 'red' },
           data: { value: 10 },
         },
         { id: 'child', style: { fill: 'green' }, data: { value: 1 } },
@@ -59,7 +58,8 @@ describe('tree', () => {
       nodes: [
         {
           id: 'root',
-          style: { fill: 'red', children: ['child'] },
+          children: ['child'],
+          style: { fill: 'red' },
           data: { value: 10 },
         },
         { id: 'child', style: { fill: 'green' }, data: { value: 1 } },

--- a/packages/g6/src/elements/nodes/base-node.ts
+++ b/packages/g6/src/elements/nodes/base-node.ts
@@ -5,7 +5,6 @@ import type { CategoricalPalette } from '../../palettes/types';
 import type { NodeData } from '../../spec';
 import type {
   BaseElementStyleProps,
-  ID,
   Keyframe,
   Node,
   NodeBadgeStyleProps,
@@ -69,23 +68,9 @@ export interface BaseNodeStyleProps
    */
   size?: Size;
   /**
-   * <zh/> 父节点 id
+   * <zh/> 当前节点/组合是否展开
    *
-   * <en/> The id of the parent node/combo
-   * @remarks
-   * <zh/> 仅在树图中生效
-   *
-   * <en/> Only valid in the tree graph
-   */
-  parentId?: ID;
-  /**
-   * <zh/> 是否收起
-   *
-   * <en/> Indicates whether the node is collapsed
-   * @remarks
-   * <zh/> 仅在树图中生效
-   *
-   * <en/> Only valid in the tree graph
+   * <en/> Whether the current node/combo is expanded
    */
   collapsed?: boolean;
   /**

--- a/packages/g6/src/spec/data.ts
+++ b/packages/g6/src/spec/data.ts
@@ -1,4 +1,4 @@
-import type { ID } from '../types';
+import type { ID, State } from '../types';
 import type { ComboStyle } from './element/combo';
 import type { EdgeStyle } from './element/edge';
 import type { NodeStyle } from './element/node';
@@ -41,6 +41,10 @@ export interface NodeData {
    * <zh/> 节点数据
    *
    * <en/> Node data
+   * @remarks
+   * <zh/> 用于存储节点的自定义数据，可以在样式映射中通过回调函数获取
+   *
+   * <en/> Used to store custom data of the node, which can be obtained through callback functions in the style mapping
    */
   data?: Record<string, unknown>;
   /**
@@ -49,6 +53,28 @@ export interface NodeData {
    * <en/> Node style
    */
   style?: NodeStyle;
+  /**
+   * <zh/> 节点初始状态
+   *
+   * <en/> Initial state of the node
+   */
+  states?: State[];
+  /**
+   * <zh/> 所属组合 ID
+   *
+   * <en/> ID of the combo to which the node belongs
+   */
+  combo?: ID;
+  /**
+   * <zh/> 子节点 ID
+   *
+   * <en/> Child node ID
+   * @remarks
+   * <zh/> 适用于树图结构
+   *
+   * <en/> Suitable for tree graph structure
+   */
+  children?: ID[];
   [key: string]: unknown;
 }
 
@@ -69,6 +95,10 @@ export interface ComboData {
    * <zh/> Combo 数据
    *
    * <en/> Combo data
+   * @remarks
+   * <zh/> 用于存储 Combo 的自定义数据，可以在样式映射中通过回调函数获取
+   *
+   * <en/> Used to store custom data of the Combo, which can be obtained through callback functions in the style mapping
    */
   data?: Record<string, unknown>;
   /**
@@ -77,6 +107,18 @@ export interface ComboData {
    * <en/> Combo style
    */
   style?: ComboStyle;
+  /**
+   * <zh/> 组合初始状态
+   *
+   * <en/> Initial state of the combo
+   */
+  states?: State[];
+  /**
+   * <zh/> 所属组合 ID
+   *
+   * <en/> ID of the combo to which the combo belongs
+   */
+  combo?: ID;
   [key: string]: unknown;
 }
 
@@ -109,6 +151,10 @@ export interface EdgeData {
    * <zh/> 边数据
    *
    * <en/> Edge data
+   * @remarks
+   * <zh/> 用于存储边的自定义数据，可以在样式映射中通过回调函数获取
+   *
+   * <en/> Used to store custom data of the edge, which can be obtained through callback functions in the style mapping
    */
   data?: Record<string, unknown>;
   /**
@@ -117,5 +163,11 @@ export interface EdgeData {
    * <en/> Edge style
    */
   style?: EdgeStyle;
+  /**
+   * <zh/> 边初始状态
+   *
+   * <en/> Initial state of the edge
+   */
+  states?: State[];
   [key: string]: unknown;
 }

--- a/packages/g6/src/spec/element/combo.ts
+++ b/packages/g6/src/spec/element/combo.ts
@@ -1,6 +1,5 @@
 import type { BaseComboStyleProps } from '../../elements/combos';
-import type { ID, State } from '../../types';
-import type { CallableObject } from '../../types/callable';
+import type { CallableObject } from '../../types';
 import type { ComboData } from '../data';
 import type { AnimationOptions } from './animation';
 import type { PaletteOptions } from './palette';
@@ -12,25 +11,25 @@ import type { PaletteOptions } from './palette';
  */
 export interface ComboOptions {
   /**
-   * <zh/> Combo 类型
+   * <zh/> 组合类型
    *
    * <en/> Combo type
    */
   type?: string | ((datum: ComboData) => string);
   /**
-   * <zh/> Combo 样式
+   * <zh/> 组合样式
    *
    * <en/> Combo style
    */
   style?: CallableObject<ComboStyle, ComboData>;
   /**
-   * <zh/> Combo 状态样式
+   * <zh/> 组合状态样式
    *
    * <en/> Combo state style
    */
   state?: Record<string, CallableObject<ComboStyle, ComboData>>;
   /**
-   * <zh/> Combo 动画
+   * <zh/> 组合动画
    *
    * <en/> Combo animation
    */
@@ -51,12 +50,5 @@ export interface StaticComboOptions {
 }
 
 export interface ComboStyle extends Partial<BaseComboStyleProps> {
-  /**
-   * <zh/> 初始状态
-   *
-   * <en/> Initial state
-   */
-  states?: State[];
-  children?: ID[];
   [key: string]: any;
 }

--- a/packages/g6/src/spec/element/edge.ts
+++ b/packages/g6/src/spec/element/edge.ts
@@ -1,6 +1,5 @@
 import type { BaseEdgeStyleProps } from '../../elements/edges';
-import { State } from '../../types';
-import type { CallableObject } from '../../types/callable';
+import type { CallableObject } from '../../types';
 import type { EdgeData } from '../data';
 import type { AnimationOptions } from './animation';
 import type { PaletteOptions } from './palette';
@@ -51,11 +50,5 @@ export interface StaticEdgeOptions {
 }
 
 export interface EdgeStyle extends Partial<BaseEdgeStyleProps> {
-  /**
-   * <zh/> 初始状态
-   *
-   * <en/> Initial state
-   */
-  states?: State[];
   [key: string]: any;
 }

--- a/packages/g6/src/spec/element/node.ts
+++ b/packages/g6/src/spec/element/node.ts
@@ -1,6 +1,5 @@
 import type { BaseNodeStyleProps } from '../../elements/nodes';
-import type { ID, State } from '../../types';
-import type { CallableObject } from '../../types/callable';
+import type { CallableObject } from '../../types';
 import type { NodeData } from '../data';
 import type { AnimationOptions } from './animation';
 import type { PaletteOptions } from './palette';
@@ -51,17 +50,5 @@ export interface StaticNodeOptions {
 }
 
 export interface NodeStyle extends Partial<BaseNodeStyleProps> {
-  /**
-   * <zh/> 初始状态
-   *
-   * <en/> Initial state
-   */
-  states?: State[];
-  /**
-   * <zh/> 子节点 ID (树图专用)
-   *
-   * <en/> Child node ID (for tree graph)
-   */
-  children?: ID[];
   [key: string]: any;
 }

--- a/packages/g6/src/transforms/arrange-draw-order.ts
+++ b/packages/g6/src/transforms/arrange-draw-order.ts
@@ -15,21 +15,27 @@ export class ArrangeDrawOrder extends BaseTransform {
 
     const combosToAdd = input.add.combos;
 
-    const order: [ID, ComboData, number][] = [];
-    combosToAdd.forEach((combo, id) => {
-      const ancestors = model.getAncestorsData(id, 'combo');
-      const path = ancestors.map((ancestor) => idOf(ancestor)).reverse();
-      // combo 的 zIndex 为距离根 combo 的深度
-      // The zIndex of the combo is the depth from the root combo
-      order.push([id, combo, path.length]);
-    });
+    const arrangeCombo = (combos: Map<string, ComboData>): Map<string, ComboData> => {
+      // id, data, zIndex
+      const order: [ID, ComboData, number][] = [];
+      combos.forEach((combo, id) => {
+        const ancestors = model.getAncestorsData(id, 'combo');
+        const path = ancestors.map((ancestor) => idOf(ancestor)).reverse();
+        // combo 的 zIndex 为距离根 combo 的深度
+        // The zIndex of the combo is the depth from the root combo
+        order.push([id, combo, path.length]);
+      });
 
-    input.add.combos = new Map(
-      order
-        // 基于 zIndex 降序排序，优先绘制子 combo / Sort based on zIndex in descending order, draw child combo first
-        .sort(([, , zIndex1], [, , zIndex2]) => zIndex2 - zIndex1)
-        .map(([id, datum]) => [id, datum]),
-    );
+      return new Map(
+        order
+          // 基于 zIndex 降序排序，优先绘制子 combo / Sort based on zIndex in descending order, draw child combo first
+          .sort(([, , zIndex1], [, , zIndex2]) => zIndex2 - zIndex1)
+          .map(([id, datum]) => [id, datum]),
+      );
+    };
+
+    input.add.combos = arrangeCombo(combosToAdd);
+    input.update.combos = arrangeCombo(input.update.combos);
 
     return input;
   }

--- a/packages/g6/src/utils/id.ts
+++ b/packages/g6/src/utils/id.ts
@@ -25,7 +25,7 @@ export function idOf(data: Partial<NodeData | EdgeData | ComboData>): ID {
  * @returns <zh/> 节点/Combo 的父节点 ID | <en/> parent id of node/combo
  */
 export function parentIdOf(data: Partial<NodeData | ComboData>) {
-  return data.style?.parentId;
+  return data.combo;
 }
 
 export function idsOf(data: GraphData, flat: true): ID[];

--- a/packages/g6/src/utils/layout.ts
+++ b/packages/g6/src/utils/layout.ts
@@ -147,14 +147,14 @@ export function layoutAdapter(
       const { nodes = [], edges = [], combos = [] } = data;
       const nodesToLayout: LayoutNodeData[] = nodes.map((datum) => {
         const id = idOf(datum);
-        const { data, style } = datum;
+        const { data, style, combo } = datum;
         return {
           id,
           data: {
             ...data,
             // antv-dagre 会读取 data.parentId
             // antv-dagre will read data.parentId
-            ...(style?.parentId ? { parentId: style.parentId } : {}),
+            ...(combo ? { parentId: combo } : {}),
           },
           style: { ...style },
         };

--- a/packages/g6/src/utils/tree.ts
+++ b/packages/g6/src/utils/tree.ts
@@ -19,9 +19,9 @@ type TreeDataGetter = {
 export function treeToGraphData(treeData: TreeData, getter?: TreeDataGetter): GraphData {
   const {
     getNodeData = (datum: TreeData) => {
-      if (!datum.children) return datum;
-      const { children, style = {}, ...restDatum } = datum;
-      return { style: { ...style, children: children.map((child) => child.id) }, ...restDatum } as NodeData;
+      if (!datum.children) return datum as NodeData;
+      const { children, ...restDatum } = datum;
+      return { ...restDatum, children: children.map((child) => child.id) } as NodeData;
     },
     getEdgeData = (source: TreeData, target: TreeData) => ({ source: source.id, target: target.id }),
     getChildren = (datum: TreeData) => datum.children || [],


### PR DESCRIPTION
* 修复 `ArrangeDrawOrder` 未考虑组合更新的情况
* 将 `states` `children` `parentId` 属性从 style 提升至上一级
* `parentId` 重命名为 `combo`

---

* Fix to ArrangeDrawOrder not considering combo updates 
* Elevates `states`, `children`, `parentId` property from style to the next level 
* `parentId` to `combo`