### PR TITLE
refactor(runtime): rename some api name of data controller

### DIFF
--- a/packages/g6/__tests__/unit/runtime/data.spec.ts
+++ b/packages/g6/__tests__/unit/runtime/data.spec.ts
@@ -565,14 +565,14 @@ describe('DataController', () => {
 
     controller.addData(clone(data));
 
-    expect(controller.getElementsData(['node-1'])[0]).toEqual(data.nodes[0]);
+    expect(controller.getElementDataById('node-1')).toEqual(data.nodes[0]);
 
-    expect(controller.getElementsData(['edge-1'])[0]).toEqual(data.edges[0]);
+    expect(controller.getElementDataById('edge-1')).toEqual(data.edges[0]);
 
-    expect(controller.getElementsData(['combo-1'])[0]).toEqual(data.combos[0]);
+    expect(controller.getElementDataById('combo-1')).toEqual(data.combos[0]);
 
     expect(() => {
-      controller.getElementsData(['undefined'])[0];
+      controller.getElementDataById('undefined');
     }).toThrow();
   });
 

--- a/packages/g6/src/runtime/data.ts
+++ b/packages/g6/src/runtime/data.ts
@@ -169,7 +169,7 @@ export class DataController {
   }
 
   public getDescendantsData(id: ID): NodeLikeData[] {
-    const root = this.getElementsData([id])[0] as NodeLikeData;
+    const root = this.getElementDataById(id) as NodeLikeData;
     const data: NodeLikeData[] = [];
     dfs(
       root,
@@ -207,7 +207,7 @@ export class DataController {
    * @param elementType - <zh/> 元素类型 | <en/> element type
    * @returns <zh/> 元素数据 | <en/> element data
    */
-  public getElementData(elementType: ElementType) {
+  public getElementsDataByType(elementType: ElementType) {
     if (elementType === 'node') return this.getNodeData();
     if (elementType === 'edge') return this.getEdgeData();
     if (elementType === 'combo') return this.getComboData();
@@ -218,16 +218,14 @@ export class DataController {
    * <zh/> 根据 ID 获取元素的数据，不用关心元素的类型
    *
    * <en/> Get the data of the element by ID, no need to care about the type of the element
-   * @param ids - <zh/> 元素 ID 数组 | <en/> element ID array
+   * @param id - <zh/> 元素 ID 数组 | <en/> element ID array
    * @returns <zh/> 元素数据 | <en/> data of the element
    */
-  public getElementsData(ids: ID[]): ElementDatum[] {
-    return ids.map((id) => {
-      const type = this.getElementType(id);
-      if (type === 'node') return this.getNodeData([id])[0];
-      else if (type === 'edge') return this.getEdgeData([id])[0];
-      return this.getComboData([id])[0];
-    });
+  public getElementDataById(id: ID): ElementDatum {
+    const type = this.getElementType(id);
+    if (type === 'node') return this.getNodeData([id])[0];
+    else if (type === 'edge') return this.getEdgeData([id])[0];
+    return this.getComboData([id])[0];
   }
 
   /**
@@ -247,12 +245,12 @@ export class DataController {
   }
 
   public getElementDataByState(elementType: ElementType, state: string) {
-    const elementData = this.getElementData(elementType);
+    const elementData = this.getElementsDataByType(elementType);
     return elementData.filter((datum) => datum.states?.includes(state));
   }
 
   public getElementState(id: ID): State[] {
-    return this.getElementsData([id])?.[0]?.states || [];
+    return this.getElementDataById(id)?.states || [];
   }
 
   public hasNode(id: ID) {
@@ -552,7 +550,7 @@ export class DataController {
   }
 
   public getElementPosition(id: ID): Position {
-    const datum = this.getElementsData([id])[0] as NodeLikeData;
+    const datum = this.getElementDataById(id) as NodeLikeData;
     return positionOf(datum);
   }
 

--- a/packages/g6/src/runtime/element.ts
+++ b/packages/g6/src/runtime/element.ts
@@ -71,7 +71,7 @@ export class ElementController {
 
   private forEachElementData(callback: (elementType: ElementType, elementData: ElementData) => void) {
     ELEMENT_TYPES.forEach((elementType) => {
-      const elementData = this.context.model.getElementData(elementType);
+      const elementData = this.context.model.getElementsDataByType(elementType);
       callback(elementType, elementData);
     });
   }

--- a/packages/g6/src/runtime/graph.ts
+++ b/packages/g6/src/runtime/graph.ts
@@ -1413,7 +1413,7 @@ export class Graph extends EventEmitter {
    * @apiCategory element
    */
   public getElementZIndex(id: ID): number {
-    return zIndexOf(this.context.model.getElementsData([id])[0]);
+    return zIndexOf(this.context.model.getElementDataById(id));
   }
 
   /**


### PR DESCRIPTION
* getElementData -> getElementDataById
> 根据 ID 获取该元素数据，而不用考虑元素类型
> Get the element data based on its ID, regardless of the element type

* getElementData -> getElementsDataByType:
> 获取给定类型的所有元素数据
> Gets all element data for a given type