### PR TITLE
refactor: adjust animation logic

### DIFF
--- a/packages/g6/__tests__/demos/transform-process-parallel-edges.ts
+++ b/packages/g6/__tests__/demos/transform-process-parallel-edges.ts
@@ -40,9 +40,7 @@ export const transformProcessParallelEdges: TestCase = async (context) => {
       .name('Mode')
       .onChange((mode: string) => {
         graph.updateTransform({ key: 'process-parallel-edges', mode });
-        graph.removeEdgeData(data.edges.map((edge) => edge.id));
-        graph.addEdgeData(data.edges);
-        graph.render();
+        graph.draw();
       }),
     panel
       .add(

--- a/packages/g6/__tests__/snapshots/animations/element-position/default-200.svg
+++ b/packages/g6/__tests__/snapshots/animations/element-position/default-200.svg
@@ -7,63 +7,63 @@
         <g fill="none" marker-start="false" marker-end="false">
           <g fill="none" marker-start="false" marker-end="false" stroke="transparent" stroke-width="3"/>
           <g>
-            <path fill="none" d="M 254.09135032695497,166.0252643799912 C 242.45869628314762 181.53546977173434,230.82604223934027 197.04567516347748,230.82604223934027 197.04567516347748" stroke-width="1" stroke="rgba(153,173,209,1)"/>
+            <path fill="none" d="M 244.00000052888566,171.0709385070158 L 228.30320686857527,191.99999960333577" stroke-width="1" stroke="rgba(153,173,209,1)"/>
             <path fill="none" d="M 260,200 L 260,200" stroke-width="3" stroke="transparent"/>
           </g>
         </g>
         <g fill="none" marker-start="false" marker-end="false">
           <g fill="none" marker-start="false" marker-end="false" stroke="transparent" stroke-width="3"/>
           <g>
-            <path fill="none" d="M 232.3032046576015,200 C 256.3070939543469 200,280.31098325109224 200,280.31098325109224 200" stroke-width="1" stroke="rgba(153,173,209,1)"/>
+            <path fill="none" d="M 232.30320739746094,200 L 267.6968078613281,200" stroke-width="1" stroke="rgba(153,173,209,1)"/>
             <path fill="none" d="M 260,200 L 260,200" stroke-width="3" stroke="transparent"/>
           </g>
         </g>
         <g fill="none" marker-start="false" marker-end="false">
           <g fill="none" marker-start="false" marker-end="false" stroke="transparent" stroke-width="3"/>
           <g>
-            <path fill="none" d="M 281.78814566935347,197.04567516347748 C 270.1554916255461 181.53546977173434,258.5228375817387 166.0252643799912,258.5228375817387 166.0252643799912" stroke-width="1" stroke="rgba(153,173,209,1)"/>
+            <path fill="none" d="M 271.6968062746716,192.00000118999264 L 256.00000158665654,171.07093692035892" stroke-width="1" stroke="rgba(153,173,209,1)"/>
             <path fill="none" d="M 260,200 L 260,200" stroke-width="3" stroke="transparent"/>
           </g>
         </g>
         <g fill="none" marker-start="false" marker-end="false">
           <g fill="none" marker-start="false" marker-end="false" stroke="transparent" stroke-width="3"/>
           <g>
-            <path fill="none" d="M 281.78814566935347,202.95432483652252 C 270.1554916255461 218.4645302282657,258.5228375817387 233.97473562000883,258.5228375817387 233.97473562000883" stroke-width="1" stroke="rgba(153,173,209,1)"/>
+            <path fill="none" d="M 271.6968062746716,207.99999881000736 L 256.00000158665654,228.92906307964108" stroke-width="1" stroke="rgba(153,173,209,1)"/>
             <path fill="none" d="M 260,200 L 260,200" stroke-width="3" stroke="transparent"/>
           </g>
         </g>
         <g fill="none" marker-start="false" marker-end="false">
           <g fill="none" marker-start="false" marker-end="false" stroke="transparent" stroke-width="3"/>
           <g>
-            <path fill="none" d="M 226.3945549845565,202.95432483652252 C 214.76190094074911 218.4645302282657,203.12924689694177 233.97473562000883,203.12924689694177 233.97473562000883" stroke-width="1" stroke="rgba(153,173,209,1)"/>
+            <path fill="none" d="M 216.3032079263466,208.00000039666423 L 200.6064142660362,228.9290614929842" stroke-width="1" stroke="rgba(153,173,209,1)"/>
             <path fill="none" d="M 260,200 L 260,200" stroke-width="3" stroke="transparent"/>
           </g>
         </g>
         <g fill="none" marker-start="false" marker-end="false">
           <g fill="none" marker-start="false" marker-end="false" stroke="transparent" stroke-width="3"/>
           <g>
-            <path fill="none" d="M 230.82604223934027,202.95432483652252 C 242.45869628314762 218.4645302282657,254.09135032695497 233.97473562000883,254.09135032695497 233.97473562000883" stroke-width="1" stroke="rgba(153,173,209,1)"/>
+            <path fill="none" d="M 228.30320686857527,208.00000039666423 L 244.00000052888566,228.9290614929842" stroke-width="1" stroke="rgba(153,173,209,1)"/>
             <path fill="none" d="M 260,200 L 260,200" stroke-width="3" stroke="transparent"/>
           </g>
         </g>
         <g fill="none" marker-start="false" marker-end="false">
           <g fill="none" marker-start="false" marker-end="false" stroke="transparent" stroke-width="3"/>
           <g>
-            <path fill="none" d="M 286.2196329241372,202.95432483652252 C 297.85228696794456 218.4645302282657,309.48494101175197 233.97473562000883,309.48494101175197 233.97473562000883" stroke-width="1" stroke="rgba(153,173,209,1)"/>
+            <path fill="none" d="M 283.696805216899,208.00000198332114 L 299.39358784950724,228.9290599063273" stroke-width="1" stroke="rgba(153,173,209,1)"/>
             <path fill="none" d="M 260,200 L 260,200" stroke-width="3" stroke="transparent"/>
           </g>
         </g>
         <g fill="none" marker-start="false" marker-end="false">
           <g fill="none" marker-start="false" marker-end="false" stroke="transparent" stroke-width="3"/>
           <g>
-            <path fill="none" d="M 204.606409315203,236.92906045653132 C 228.61029861194837 236.92906045653132,252.61418790869374 236.92906045653132,252.61418790869374 236.92906045653132" stroke-width="1" stroke="rgba(153,173,209,1)"/>
+            <path fill="none" d="M 204.60641479492188,236.92906188964844 L 240,236.92906188964844" stroke-width="1" stroke="rgba(153,173,209,1)"/>
             <path fill="none" d="M 260,200 L 260,200" stroke-width="3" stroke="transparent"/>
           </g>
         </g>
         <g fill="none" marker-start="false" marker-end="false">
           <g fill="none" marker-start="false" marker-end="false" stroke="transparent" stroke-width="3"/>
           <g>
-            <path fill="none" d="M 260,236.92906045653132 C 284.00388929674534 236.92906045653132,308.0077785934907 236.92906045653132,308.0077785934907 236.92906045653132" stroke-width="1" stroke="rgba(153,173,209,1)"/>
+            <path fill="none" d="M 260,236.92906188964844 L 295.3935852050781,236.92906188964844" stroke-width="1" stroke="rgba(153,173,209,1)"/>
             <path fill="none" d="M 260,200 L 260,200" stroke-width="3" stroke="transparent"/>
           </g>
         </g>

--- a/packages/g6/__tests__/snapshots/animations/element-style-position/default-200.svg
+++ b/packages/g6/__tests__/snapshots/animations/element-style-position/default-200.svg
@@ -7,14 +7,14 @@
         <g fill="none" marker-start="false" marker-end="false">
           <g fill="none" marker-start="false" marker-end="false" stroke="transparent" stroke-width="3"/>
           <g>
-            <path fill="none" d="M 60,50 L 190,50" stroke-width="1" stroke="rgba(153,173,209,1)" opacity="0.6307093954346867"/>
+            <path fill="none" d="M 59.380782299466254,53.464234901103076 L 190.61921770053374,101.92935793336957" stroke-width="1" stroke="rgba(153,173,209,1)" opacity="0.6307093954346867"/>
             <path fill="none" d="M 60,50 L 190,50" stroke-width="3" stroke="transparent" opacity="0.6307093954346867"/>
           </g>
         </g>
         <g fill="none" marker-start="false" marker-end="false">
           <g fill="none" marker-start="false" marker-end="false" stroke="transparent" stroke-width="3"/>
           <g>
-            <path fill="none" d="M 193.1430600651442,108.39081014010935 C 162.5 127.6967953423985,131.8569399348558 147.00278054468762,131.8569399348558 147.00278054468762" stroke-width="1" stroke="rgba(153,173,209,1)"/>
+            <path fill="none" d="M 191.405235834402,110.50534683263731 L 133.594764165598,144.88824600183534" stroke-width="1" stroke="rgba(153,173,209,1)"/>
             <path fill="none" d="M 194,58 L 131,142" stroke-width="3" stroke="transparent"/>
           </g>
         </g>

--- a/packages/g6/__tests__/unit/runtime/element.spec.ts
+++ b/packages/g6/__tests__/unit/runtime/element.spec.ts
@@ -155,7 +155,7 @@ describe('ElementController', () => {
 
     const comboStyle = elementController.getElementComputedStyle('combo', combo1);
 
-    expect(comboStyle.childrenNode[0].id).toEqual('node-3');
+    expect(comboStyle.childrenNode[0]).toEqual('node-3');
 
     expect(omit(comboStyle, ['childrenNode', 'childrenData'])).toEqual({
       ...LIGHT_THEME.combo?.style,

--- a/packages/g6/__tests__/unit/transforms/transform-process-parallel-edges.spec.ts
+++ b/packages/g6/__tests__/unit/transforms/transform-process-parallel-edges.spec.ts
@@ -1,7 +1,6 @@
 import { transformProcessParallelEdges } from '@/__tests__/demos';
 import type { Graph } from '@/src';
 import { getParallelEdges, groupByEndpoints, isParallelEdges } from '@/src/transforms/process-parallel-edges';
-import data from '@@/dataset/parallel-edges.json';
 import { createDemoGraph } from '@@/utils';
 
 describe('transform-process-parallel-edges', () => {
@@ -18,9 +17,7 @@ describe('transform-process-parallel-edges', () => {
   it('mode', async () => {
     await expect(graph).toMatchSnapshot(__filename, 'merge-mode');
     graph.updateTransform({ key: 'process-parallel-edges', mode: 'bundle' });
-    graph.removeEdgeData(data.edges.map((edge) => edge.id));
-    graph.addEdgeData(data.edges);
-    graph.render();
+    graph.draw();
     await expect(graph).toMatchSnapshot(__filename, 'bundle-mode');
 
     await expect(graph).toMatchSnapshot(__filename, 'bundle-add-orange-edge__before');

--- a/packages/g6/__tests__/unit/utils/theme.spec.ts
+++ b/packages/g6/__tests__/unit/utils/theme.spec.ts
@@ -1,0 +1,14 @@
+import { register } from '@/src/registry';
+import { themeOf } from '@/src/utils/theme';
+
+describe('theme', () => {
+  it('themeOf', () => {
+    expect(themeOf({})).toEqual({});
+    expect(themeOf({ theme: 'null' })).toEqual({});
+
+    const theme = { node: {} };
+    register('theme', 'light', theme);
+
+    expect(themeOf({ theme: 'light' })).toBe(theme);
+  });
+});

--- a/packages/g6/src/animations/executor.ts
+++ b/packages/g6/src/animations/executor.ts
@@ -1,33 +1,22 @@
 import type { DisplayObject, IAnimation } from '@antv/g';
-import { isString, upperFirst } from '@antv/util';
-import { DEFAULT_ELEMENTS_ANIMATION_OPTIONS } from '../constants';
-import { getExtension } from '../registry';
+import { upperFirst } from '@antv/util';
 import { createAnimationsProxy, inferDefaultValue, preprocessKeyframes } from '../utils/animation';
 import { replaceTranslateInTransform } from '../utils/transform';
 import type { AnimationExecutor } from './types';
 
 /**
- * <zh/> 动画 Spec 执行器
+ * <zh/> 动画语法执行器
  *
- * <en/> Animation Spec Executor
+ * <en/> Animation syntax executor
  * @param element - <zh/> 要执行动画的图形 | <en/> shape to execute animation
- * @param animation - <zh/> 动画 Spec | <en/> animation specification
- * @param commonEffectTiming - <zh/> 动画公共配置 | <en/> common animation configuration
- * @param context - <zh/> 动画执行上下文 | <en/> animation execution context
+ * @param keyframes - <zh/> 动画关键帧 | <en/> animation keyframes
+ * @param options - <zh/> 动画语法 | <en/> animation syntax
  * @returns <zh/> 动画实例 | <en/> animation instance
  */
-export const executor: AnimationExecutor = (element, animation, commonEffectTiming, context) => {
-  if (!animation) return null;
+export const executor: AnimationExecutor = (element, keyframes, options) => {
+  if (!options.length) return null;
 
-  const { animationsFilter = () => true } = context;
-
-  const animations = (isString(animation) ? getExtension('animation', animation) || [] : animation).filter(
-    animationsFilter,
-  );
-  if (animations.length === 0) return null;
-
-  const { originalStyle, modifiedStyle, states } = context;
-
+  const [originalStyle, modifiedStyle] = keyframes;
   /**
    * <zh/> 获取图形关键帧样式
    *
@@ -47,61 +36,50 @@ export const executor: AnimationExecutor = (element, animation, commonEffectTimi
       const styler: (attrs?: Record<string, unknown>) => Record<string, unknown> =
         element?.[name]?.bind(element) || ((attrs) => attrs);
 
-      const fromStyle = styler?.({ ...element.attributes, ...originalStyle }) || {};
-      const toStyle = { ...shape.attributes };
+      const fromStyle = styler?.(originalStyle) || {};
+      const toStyle = styler?.(modifiedStyle) || {};
 
       return { shape, fromStyle, toStyle };
     } else {
       const shape = element;
-      const fromStyle = originalStyle;
-      const toStyle = { ...shape.attributes, ...modifiedStyle };
-      return { shape, fromStyle, toStyle };
+      return { shape, fromStyle: originalStyle, toStyle: modifiedStyle };
     }
   };
 
   let mainResult: IAnimation;
 
-  const subResults = animations
-    .map(({ fields, shape: shapeID, states: enabledStates, ...individualEffectTiming }) => {
-      if (enabledStates === undefined || enabledStates?.some((state) => states.includes(state))) {
-        const keyframeStyle = getKeyframeStyle(shapeID);
-        if (!keyframeStyle) return null;
+  const subResults = options
+    .map(({ fields, shape: shapeID, states: enabledStates, ...effectTiming }) => {
+      const keyframeStyle = getKeyframeStyle(shapeID);
+      if (!keyframeStyle) return null;
 
-        const { shape, fromStyle, toStyle } = keyframeStyle;
+      const { shape, fromStyle, toStyle } = keyframeStyle;
 
-        const keyframes: Keyframe[] = [{}, {}];
+      const keyframes: Keyframe[] = [{}, {}];
 
-        fields.forEach((attr) => {
-          Object.assign(keyframes[0], { [attr]: fromStyle[attr] ?? inferDefaultValue(attr) });
-          Object.assign(keyframes[1], { [attr]: toStyle[attr] ?? inferDefaultValue(attr) });
+      fields.forEach((attr) => {
+        Object.assign(keyframes[0], { [attr]: fromStyle[attr] ?? inferDefaultValue(attr) });
+        Object.assign(keyframes[1], { [attr]: toStyle[attr] ?? inferDefaultValue(attr) });
+      });
+
+      // x/y -> translate
+      if (keyframes.some((keyframe) => Object.keys(keyframe).some((attr) => ['x', 'y', 'z'].includes(attr)))) {
+        const { x = 0, y = 0, z = 0, transform = '' } = shape.attributes || {};
+        keyframes.forEach((keyframe) => {
+          keyframe.transform = replaceTranslateInTransform(
+            (keyframe.x as number) || (x as number),
+            (keyframe.y as number) || (y as number),
+            (keyframe.z as number) || (z as number),
+            transform,
+          );
         });
-
-        const translateAttrs = ['x', 'y', 'z'];
-
-        // x/y -> translate
-        if (keyframes.some((keyframe) => Object.keys(keyframe).some((attr) => translateAttrs.includes(attr)))) {
-          const { x = 0, y = 0, z = 0, transform = '' } = shape.attributes || {};
-          keyframes.forEach((keyframe) => {
-            keyframe.transform = replaceTranslateInTransform(
-              (keyframe.x as number) || (x as number),
-              (keyframe.y as number) || (y as number),
-              (keyframe.z as number) || (z as number),
-              transform,
-            );
-          });
-        }
-
-        const result = shape.animate(preprocessKeyframes(keyframes), {
-          ...DEFAULT_ELEMENTS_ANIMATION_OPTIONS,
-          ...commonEffectTiming,
-          ...individualEffectTiming,
-        });
-
-        if (shapeID === undefined) mainResult = result!;
-
-        return result;
       }
-      return null;
+
+      const result = shape.animate(preprocessKeyframes(keyframes), effectTiming);
+
+      if (shapeID === undefined) mainResult = result!;
+
+      return result;
     })
     .filter(Boolean) as IAnimation[];
 

--- a/packages/g6/src/animations/index.ts
+++ b/packages/g6/src/animations/index.ts
@@ -16,4 +16,4 @@ export const translate = [
   },
 ];
 
-export const comboCollapseExpand = [{ fields: ['x', 'y'] }, { fields: ['r', 'width', 'height'], shape: 'key' }];
+export const comboCollapseExpand = [{ fields: ['childrenNode'] }];

--- a/packages/g6/src/animations/types.ts
+++ b/packages/g6/src/animations/types.ts
@@ -1,22 +1,54 @@
-import type { IAnimation, IAnimationEffectTiming } from '@antv/g';
-import type { Element, State } from '../types';
+import type { IAnimation } from '@antv/g';
+import type { AnimationStage } from '../spec/element/animation';
+import type { Element, ElementType, State } from '../types';
+
+export type STDAnimation = AnimationOptions[];
 
 /**
- * <zh/> 为 string 时，会从注册的动画中获取
+ * <zh/> 元素动画选项
  *
- * <en/> When it is a string, it will be obtained from the registered animation
+ * <en/> Element animation options
  */
-export type Animation = false | string | STDAnimation;
-
-export type STDAnimation = ConfigurableAnimationOptions[];
-
-interface ConfigurableAnimationOptions extends AnimationEffectTiming {
+export interface AnimationOptions extends AnimationEffectTiming {
+  /**
+   * <zh/> 执行动画的字段（样式）名
+   *
+   * <en/> Field (style) name of the animation
+   */
   fields: string[];
+  /**
+   * <zh/> 执行动画的图形，默认为当前元素
+   *
+   * <en/> Shape of the animation, default is the current element
+   */
   shape?: string;
+  /**
+   * <zh/> 参与动画的状态
+   *
+   * <en/> States involved in the animation
+   */
   states?: State[];
 }
 
 export interface AnimationContext {
+  /**
+   * <zh/> 执行动画的元素
+   *
+   * <en/> Element to execute animation
+   */
+  element: Element;
+  /**
+   * <zh/> 元素类型
+   *
+   * <en/> Element type
+   */
+  elementType: ElementType;
+  /**
+   * <zh/> 动画阶段
+   *
+   * <en/> Animation stage
+   */
+  stage: AnimationStage;
   /**
    * <zh/> 动画的源样式
    *
@@ -36,32 +68,61 @@ export interface AnimationContext {
    *
    * <en/> For example, before the element is destroyed, the final state opacity of the element needs to be set to 0
    */
-  modifiedStyle?: Record<string, unknown>;
+  modifiedStyle: Record<string, unknown>;
   /**
-   * <zh/> 动画配置过滤
+   * <zh/> 动画时序配置
    *
-   * <en/> Animation configuration filter
-   * @remarks
-   * <zh/> 某些情况下，需要过滤掉一些动画配置，例如位移动画只会作用于元素根节点图形，不会作用于子图形。这项配置通常用于优化动画性能，避免不必要的动画执行
-   *
-   * <en/> In some cases, it is necessary to filter out some animation configurations. For example, the displacement animation will only affect the root node shape of the element, not the child shape. This configuration is usually used to optimize animation performance and avoid unnecessary animation execution
+   * <en/> Animation effect timing
    */
-  animationsFilter?: (animation: ConfigurableAnimationOptions) => boolean;
-  /**
-   * <zh/> 元素状态
-   *
-   * <en/> Element states
-   */
-  states: State[];
+  // effectTiming: AnimationEffectTiming;
 }
 
-export type AnimationEffectTiming = Partial<
-  Pick<IAnimationEffectTiming, 'duration' | 'delay' | 'easing' | 'iterations' | 'direction' | 'fill'>
->;
+/**
+ * <zh/> 动画效果时序
+ *
+ * <en/> Animation effect timing
+ */
+export interface AnimationEffectTiming {
+  /**
+   * <zh/> 动画延迟时间
+   *
+   * <en/> Animation delay time
+   */
+  delay?: number;
+  /**
+   * <zh/> 动画方向
+   *
+   * <en/> Animation direction
+   */
+  direction?: PlaybackDirection;
+  /**
+   * <zh/> 动画持续时间
+   *
+   * <en/> Animation duration
+   */
+  duration?: number;
+  /**
+   * <zh/> 动画缓动函数
+   *
+   * <en/> Animation easing function
+   */
+  easing?: string;
+  /**
+   * <zh/> 动画结束后的填充模式
+   *
+   * <en/> Fill mode after the animation ends
+   */
+  fill?: FillMode;
+  /**
+   * <zh/> 动画迭代次数
+   *
+   * <en/> Number of iterations of the animation
+   */
+  iterations?: number;
+}
 
 export type AnimationExecutor = (
-  shape: Element,
-  animation: Animation | false,
-  baseEffectTiming: AnimationEffectTiming,
-  context: AnimationContext,
+  element: Element,
+  keyframes: [Record<string, unknown>, Record<string, unknown>],
+  options: STDAnimation,
 ) => IAnimation | null;

--- a/packages/g6/src/behaviors/create-edge.ts
+++ b/packages/g6/src/behaviors/create-edge.ts
@@ -157,7 +157,7 @@ export class CreateEdge extends BaseBehavior<CreateEdgeOptions> {
 
     model.translateNodeTo(ASSIST_NODE_ID, [event.canvas.x, event.canvas.y]);
 
-    await element!.draw({ animation: false, silence: true });
+    await element!.draw({ animation: false, silence: true })?.finished;
   };
 
   private createEdge = (event: IElementEvent) => {
@@ -183,7 +183,7 @@ export class CreateEdge extends BaseBehavior<CreateEdgeOptions> {
 
     this.source = undefined;
 
-    await element!.draw({ animation: false, silence: true });
+    await element!.draw({ animation: false, silence: true })?.finished;
   };
 
   private getSelectedNodeIDs(currTarget: ID[]) {

--- a/packages/g6/src/behaviors/drag-element.ts
+++ b/packages/g6/src/behaviors/drag-element.ts
@@ -268,7 +268,7 @@ export class DragElement extends BaseBehavior<DragElementOptions> {
       }
       model.setParent(id, modifiedParentId, COMBO_KEY);
     });
-    await element?.draw({ animation: true });
+    await element?.draw({ animation: true })?.finished;
   };
 
   /**
@@ -304,7 +304,7 @@ export class DragElement extends BaseBehavior<DragElementOptions> {
     });
 
     if (dropEffect === 'move') ids.forEach((id) => model.refreshComboData(id));
-    await element!.draw({ animation: this.animation });
+    await element!.draw({ animation: this.animation })?.finished;
   }
 
   private moveShadow(offset: Point) {

--- a/packages/g6/src/behaviors/hover-element.ts
+++ b/packages/g6/src/behaviors/hover-element.ts
@@ -77,7 +77,7 @@ export interface HoverElementOptions extends BaseBehaviorOptions {
  */
 export class HoverElement extends BaseBehavior<HoverElementOptions> {
   static defaultOptions: Partial<HoverElementOptions> = {
-    animation: true,
+    animation: false,
     enable: true,
     degree: 0,
     activeState: 'active',

--- a/packages/g6/src/constants/animation.ts
+++ b/packages/g6/src/constants/animation.ts
@@ -1,8 +1,10 @@
-export const DEFAULT_ANIMATION_OPTIONS: KeyframeAnimationOptions = {
+import type { AnimationEffectTiming } from '../animations/types';
+
+export const DEFAULT_ANIMATION_OPTIONS: AnimationEffectTiming = {
   duration: 500,
 };
 
-export const DEFAULT_ELEMENTS_ANIMATION_OPTIONS: KeyframeAnimationOptions = {
+export const DEFAULT_ELEMENTS_ANIMATION_OPTIONS: AnimationEffectTiming = {
   duration: 1000,
   easing: 'cubic-bezier(0.250, 0.460, 0.450, 0.940)',
   iterations: 1,

--- a/packages/g6/src/elements/nodes/base-node.ts
+++ b/packages/g6/src/elements/nodes/base-node.ts
@@ -5,8 +5,8 @@ import type { CategoricalPalette } from '../../palettes/types';
 import type { NodeData } from '../../spec';
 import type {
   BaseElementStyleProps,
+  ID,
   Keyframe,
-  Node,
   NodeBadgeStyleProps,
   NodeLabelStyleProps,
   NodePortStyleProps,
@@ -83,7 +83,7 @@ export interface BaseNodeStyleProps
    *
    * <en/> Only valid in the tree graph
    */
-  childrenNode?: Node[];
+  childrenNode?: ID[];
   /**
    * <zh/> 子节点数据
    *
@@ -393,6 +393,10 @@ export abstract class BaseNode<S extends BaseNodeStyleProps = BaseNodeStyleProps
     });
   }
 
+  protected drawLabelShape(attributes: Required<S>, container: Group): void {
+    this.upsert('label', Label, this.getLabelStyle(attributes), container);
+  }
+
   protected abstract drawKeyShape(attributes: Required<S>, container: Group): DisplayObject | undefined;
 
   public render(attributes = this.parsedAttributes, container: Group = this) {
@@ -416,7 +420,7 @@ export abstract class BaseNode<S extends BaseNodeStyleProps = BaseNodeStyleProps
     this.drawBadgeShapes(attributes, container);
 
     // 5. label
-    this.upsert('label', Label, this.getLabelStyle(attributes), container);
+    this.drawLabelShape(attributes, container);
 
     // 6. ports
     this.drawPortShapes(attributes, container);
@@ -446,13 +450,16 @@ export abstract class BaseNode<S extends BaseNodeStyleProps = BaseNodeStyleProps
    */
   public onDestroy() {}
 
+  protected onframe() {
+    this.drawBadgeShapes(this.parsedAttributes, this);
+    this.drawLabelShape(this.parsedAttributes, this);
+  }
+
   public animate(keyframes: Keyframe[], options?: number | KeyframeAnimationOptions) {
     const result = super.animate(keyframes, options);
 
     if (result) {
-      result.onframe = () => {
-        this.drawBadgeShapes(this.parsedAttributes, this);
-      };
+      result.onframe = () => this.onframe();
     }
 
     return result;

--- a/packages/g6/src/exports.ts
+++ b/packages/g6/src/exports.ts
@@ -103,7 +103,7 @@ export type {
   RandomLayoutOptions,
 } from '@antv/layout';
 export type { PathArray } from '@antv/util';
-export type { AnimationContext, AnimationEffectTiming, AnimationExecutor } from './animations/types';
+export type { AnimationContext, AnimationEffectTiming, AnimationExecutor, AnimationOptions } from './animations/types';
 export type {
   BaseBehaviorOptions,
   BrushSelectOptions,
@@ -150,7 +150,7 @@ export type {
   PolygonStyleProps,
 } from './elements/shapes';
 export type { ContourLabelStyleProps, ContourStyleProps } from './elements/shapes/contour';
-export type { AnimationOptions, BaseLayoutOptions, WebWorkerLayoutOptions } from './layouts/types';
+export type { BaseLayoutOptions, WebWorkerLayoutOptions } from './layouts/types';
 export type { CategoricalPalette } from './palettes/types';
 export type {
   BasePluginOptions,
@@ -183,6 +183,7 @@ export type {
   ViewportOptions,
 } from './spec';
 export type { CustomBehaviorOption } from './spec/behavior';
+export type { AnimationStage } from './spec/element/animation';
 export type { LayoutOptions, STDLayoutOptions, SingleLayoutOptions } from './spec/layout';
 export type { CustomPluginOption } from './spec/plugin';
 export type { BaseTransformOptions } from './transforms';

--- a/packages/g6/src/layouts/types.ts
+++ b/packages/g6/src/layouts/types.ts
@@ -102,7 +102,7 @@ interface DagreLayout extends BaseLayoutOptions, DagreLayoutOptions {
   type: 'dagre';
 }
 
-export interface AnimationOptions {
+interface AnimationOptions {
   /**
    * <zh/> 启用布局动画，对于迭代布局，会在两次迭代之间进行动画过渡
    *

--- a/packages/g6/src/plugins/timebar.ts
+++ b/packages/g6/src/plugins/timebar.ts
@@ -390,7 +390,7 @@ export class Timebar extends BasePlugin<TimebarOptions> {
     });
 
     graph.setData(newData);
-    await element!.draw({ animation: false, silence: true });
+    await element!.draw({ animation: false, silence: true })?.finished;
   }
 
   private hiddenElements(range: number | [number, number]) {

--- a/packages/g6/src/runtime/animation.ts
+++ b/packages/g6/src/runtime/animation.ts
@@ -1,0 +1,111 @@
+import type { IAnimation } from '@antv/g';
+import { executor } from '../animations/executor';
+import type { AnimationContext, AnimationEffectTiming } from '../animations/types';
+import type { AnimationStage } from '../spec/element/animation';
+import type { Element } from '../types';
+import { createAnimationsProxy, getElementAnimationOptions, inferDefaultValue } from '../utils/animation';
+import { getCachedStyle } from '../utils/cache';
+import type { RuntimeContext } from './types';
+
+export class Animation {
+  private context: RuntimeContext;
+
+  constructor(context: RuntimeContext) {
+    this.context = context;
+  }
+
+  private tasks: [AnimationContext, AnimationCallbacks | undefined][] = [];
+
+  private animations: Set<IAnimation> = new Set();
+
+  private getTasks() {
+    const tasks = [...this.tasks];
+    this.tasks = [];
+    return tasks;
+  }
+
+  public add(context: AnimationContext, callbacks?: AnimationCallbacks) {
+    this.tasks.push([context, callbacks]);
+  }
+
+  public animate(localAnimation?: AnimationEffectTiming | boolean, callbacks?: AnimationCallbacks) {
+    callbacks?.before?.();
+
+    const animations = this.getTasks()
+      .map(([{ element, elementType, originalStyle, modifiedStyle, stage }, cb]) => {
+        const options = getElementAnimationOptions(this.context.options, elementType, stage, localAnimation);
+        cb?.before?.();
+
+        const [inferredOriginalStyle, inferredModifiedStyle] = this.inferStyle(element, stage);
+        const animation = executor(
+          element,
+          [
+            { ...originalStyle, ...inferredOriginalStyle },
+            { ...modifiedStyle, ...inferredModifiedStyle },
+          ],
+          options,
+        );
+
+        if (animation) {
+          cb?.beforeAnimate?.(animation);
+          animation.finished.then(() => {
+            cb?.afterAnimate?.(animation);
+            cb?.after?.();
+          });
+        } else cb?.after?.();
+
+        return animation;
+      })
+      .filter(Boolean) as IAnimation[];
+
+    animations.forEach((animation) => this.animations.add(animation));
+
+    const animation = createAnimationsProxy(animations);
+
+    if (animation) {
+      callbacks?.beforeAnimate?.(animation);
+
+      animation.finished.then(() => {
+        callbacks?.afterAnimate?.(animation);
+        callbacks?.after?.();
+      });
+    } else callbacks?.after?.();
+
+    return animation;
+  }
+
+  /**
+   * <zh/> 推断额外的动画样式
+   *
+   * <en/> Infer additional animation styles
+   * @param element - <zh/> 元素 | <en/> element
+   * @param stage - <zh/> 动画阶段 | <en/> animation stage
+   * @returns <zh/> 始态样式与终态样式 | <en/> Initial style and final style
+   */
+  public inferStyle(element: Element, stage: AnimationStage) {
+    if (stage === 'enter') return [{ opacity: 0 }, {}];
+    if (stage === 'exit') return [{}, { opacity: 0 }];
+
+    const getCacheOpacity = () => getCachedStyle(element, 'opacity') ?? inferDefaultValue('opacity');
+    if (stage === 'show') return [{ opacity: 0 }, { opacity: getCacheOpacity() }];
+    if (stage === 'hide') return [{ opacity: getCacheOpacity() }, { opacity: 0 }];
+    return [{}, {}];
+  }
+
+  public stop() {
+    this.animations.forEach((animation) => animation.cancel());
+  }
+
+  public destroy() {
+    this.stop();
+    this.animations.clear();
+    this.tasks = [];
+  }
+}
+
+interface AnimationCallbacks {
+  before?: () => void;
+  beforeAnimate?: (animation: IAnimation) => void;
+  afterAnimate?: (animation: IAnimation) => void;
+  after?: () => void;
+}

--- a/packages/g6/src/runtime/layout.ts
+++ b/packages/g6/src/runtime/layout.ts
@@ -9,7 +9,7 @@ import { getExtension } from '../registry';
 import type { GraphData, NodeData } from '../spec';
 import type { STDLayoutOptions } from '../spec/layout';
 import type { AdaptiveLayout, Combo, Node, TreeData } from '../types';
-import { getAnimation } from '../utils/animation';
+import { getAnimationOptions } from '../utils/animation';
 import { GraphLifeCycleEvent, emit } from '../utils/event';
 import { createTreeStructure } from '../utils/graphlib';
 import { idOf } from '../utils/id';
@@ -31,7 +31,7 @@ export class LayoutController {
 
   private get presetOptions() {
     return {
-      animation: !!getAnimation(this.context.options, true),
+      animation: !!getAnimationOptions(this.context.options, true),
     };
   }
 

--- a/packages/g6/src/runtime/types.ts
+++ b/packages/g6/src/runtime/types.ts
@@ -1,4 +1,5 @@
 import type { GraphOptions } from '../spec';
+import type { Animation } from './animation';
 import type { BatchController } from './batch';
 import type { BehaviorController } from './behavior';
 import type { Canvas } from './canvas';
@@ -51,6 +52,12 @@ export interface RuntimeContext {
    * <en/> Only available after drawing starts
    */
   element?: ElementController;
+  /**
+   * <zh/> 元素动画执行器
+   *
+   * <en/> Element animation executor
+   */
+  animation?: Animation;
   /**
    * <zh/> 视口控制器
    *

--- a/packages/g6/src/runtime/viewport.ts
+++ b/packages/g6/src/runtime/viewport.ts
@@ -2,7 +2,7 @@ import { AABB } from '@antv/g';
 import { clamp, isNumber, pick } from '@antv/util';
 import { AnimationType, GraphEvent } from '../constants';
 import type { FitViewOptions, ID, Point, TransformOptions, Vector2, ViewportAnimationEffectTiming } from '../types';
-import { getAnimation } from '../utils/animation';
+import { getAnimationOptions } from '../utils/animation';
 import { getBBoxSize, getCombinedBBox } from '../utils/bbox';
 import { AnimateEvent, ViewportEvent, emit } from '../utils/event';
 import { parsePadding } from '../utils/padding';
@@ -40,7 +40,7 @@ export class ViewportController {
   }
 
   private getAnimation(animation?: ViewportAnimationEffectTiming) {
-    const finalAnimation = getAnimation(this.context.options, animation);
+    const finalAnimation = getAnimationOptions(this.context.options, animation);
     if (!finalAnimation) return false;
     return pick({ ...finalAnimation }, ['easing', 'duration']) as Exclude<ViewportAnimationEffectTiming, boolean>;
   }

--- a/packages/g6/src/spec/element/animation.ts
+++ b/packages/g6/src/spec/element/animation.ts
@@ -1,16 +1,6 @@
-import type { Animation } from '../../animations/types';
-
-export type AnimationOptions =
-  | false
-  | ({
-      [STAGE in AnimationStage]?: Animation;
-    } & {
-      [key: string]: Animation;
-    });
-
 /**
- * <zh/> 动画阶段
+ * <zh/> 元素动画执行阶段
  *
- * <en/> Animation stage
+ * <en/> Stage of element animation execution
  */
-export type AnimationStage = 'enter' | 'update' | 'exit' | 'visibility' | 'show' | 'hide' | 'collapse' | 'expand';
+export type AnimationStage = 'enter' | 'update' | 'exit' | 'show' | 'hide' | 'collapse' | 'expand' | string;

--- a/packages/g6/src/spec/element/combo.ts
+++ b/packages/g6/src/spec/element/combo.ts
@@ -1,7 +1,8 @@
+import type { AnimationOptions } from '../../animations/types';
 import type { BaseComboStyleProps } from '../../elements/combos';
 import type { CallableObject } from '../../types';
 import type { ComboData } from '../data';
-import type { AnimationOptions } from './animation';
+import type { AnimationStage } from './animation';
 import type { PaletteOptions } from './palette';
 
 /**
@@ -33,7 +34,7 @@ export interface ComboOptions {
    *
    * <en/> Combo animation
    */
-  animation?: AnimationOptions;
+  animation?: false | Record<AnimationStage, false | string | AnimationOptions[]>;
   /**
    * <zh/> 色板
    *
@@ -45,7 +46,7 @@ export interface ComboOptions {
 export interface StaticComboOptions {
   style?: ComboStyle;
   state?: Record<string, ComboStyle>;
-  animation?: AnimationOptions;
+  animation?: false | Record<AnimationStage, false | string | AnimationOptions[]>;
   palette?: PaletteOptions;
 }
 

--- a/packages/g6/src/spec/element/edge.ts
+++ b/packages/g6/src/spec/element/edge.ts
@@ -1,7 +1,8 @@
+import type { AnimationOptions } from '../../animations/types';
 import type { BaseEdgeStyleProps } from '../../elements/edges';
 import type { CallableObject } from '../../types';
 import type { EdgeData } from '../data';
-import type { AnimationOptions } from './animation';
+import type { AnimationStage } from './animation';
 import type { PaletteOptions } from './palette';
 
 /**
@@ -33,7 +34,7 @@ export interface EdgeOptions {
    *
    * <en/> Edge animation
    */
-  animation?: AnimationOptions;
+  animation?: false | Record<AnimationStage, false | string | AnimationOptions[]>;
   /**
    * <zh/> 色板
    *
@@ -45,7 +46,7 @@ export interface EdgeOptions {
 export interface StaticEdgeOptions {
   style?: EdgeStyle;
   state?: Record<string, EdgeStyle>;
-  animation?: AnimationOptions;
+  animation?: false | Record<AnimationStage, false | string | AnimationOptions[]>;
   palette?: PaletteOptions;
 }
 

--- a/packages/g6/src/spec/element/node.ts
+++ b/packages/g6/src/spec/element/node.ts
@@ -1,7 +1,8 @@
+import type { AnimationOptions } from '../../animations/types';
 import type { BaseNodeStyleProps } from '../../elements/nodes';
 import type { CallableObject } from '../../types';
 import type { NodeData } from '../data';
-import type { AnimationOptions } from './animation';
+import type { AnimationStage } from './animation';
 import type { PaletteOptions } from './palette';
 
 /**
@@ -33,7 +34,7 @@ export interface NodeOptions {
    *
    * <en/> Node animation
    */
-  animation?: AnimationOptions;
+  animation?: false | Record<AnimationStage, false | string | AnimationOptions[]>;
   /**
    * <zh/> 色板
    *
@@ -45,7 +46,7 @@ export interface NodeOptions {
 export interface StaticNodeOptions {
   style?: NodeStyle;
   state?: Record<string, NodeStyle>;
-  animation?: AnimationOptions;
+  animation?: false | Record<AnimationStage, false | string | AnimationOptions[]>;
   palette?: PaletteOptions;
 }
 

--- a/packages/g6/src/themes/base.ts
+++ b/packages/g6/src/themes/base.ts
@@ -136,7 +136,8 @@ export function create(tokens: ThemeTokens): Theme {
       animation: {
         enter: 'fade',
         exit: 'fade',
-        visibility: 'fade',
+        show: 'fade',
+        hide: 'fade',
         update: [{ fields: ['x', 'y', 'fill', 'stroke'] }],
       },
     },
@@ -190,11 +191,9 @@ export function create(tokens: ThemeTokens): Theme {
       animation: {
         enter: 'fade',
         exit: 'fade',
-        visibility: 'fade',
-        update: [
-          { fields: ['d', 'stroke'], shape: 'key' },
-          { fields: ['d', 'stroke'], shape: 'halo' },
-        ],
+        show: 'fade',
+        hide: 'fade',
+        update: [{ fields: ['sourceNode', 'targetNode'] }, { fields: ['stroke'], shape: 'key' }],
       },
     },
     combo: {
@@ -253,7 +252,8 @@ export function create(tokens: ThemeTokens): Theme {
       animation: {
         enter: 'fade',
         exit: 'fade',
-        visibility: 'fade',
+        show: 'fade',
+        hide: 'fade',
         expand: 'combo-collapse-expand',
         collapse: 'combo-collapse-expand',
         update: [{ fields: ['x', 'y'] }, { fields: ['size', 'fill', 'stroke'], shape: 'key' }],

--- a/packages/g6/src/transforms/base-transform.ts
+++ b/packages/g6/src/transforms/base-transform.ts
@@ -1,11 +1,12 @@
 import { BaseExtension } from '../registry/extension';
+import type { DrawContext } from '../runtime/element';
 import type { CustomBehaviorOption } from '../spec/behavior';
 import type { DrawData } from './types';
 
 export type BaseTransformOptions = CustomBehaviorOption;
 
 export abstract class BaseTransform<T extends BaseTransformOptions = BaseTransformOptions> extends BaseExtension<T> {
-  public beforeDraw(data: DrawData): DrawData {
+  public beforeDraw(data: DrawData, context: DrawContext): DrawData {
     return data;
   }
 }

--- a/packages/g6/src/transforms/collapse-expand-combo.ts
+++ b/packages/g6/src/transforms/collapse-expand-combo.ts
@@ -1,3 +1,4 @@
+import type { DrawContext } from '../runtime/element';
 import type { ComboData } from '../spec';
 import { getSubgraphRelatedEdges } from '../utils/edge';
 import { idOf } from '../utils/id';
@@ -11,7 +12,9 @@ import type { DrawData } from './types';
  * <en/> Process the collapse and expand of elements
  */
 export class CollapseExpandCombo extends BaseTransform {
-  public beforeDraw(input: DrawData): DrawData {
+  public beforeDraw(input: DrawData, context: DrawContext): DrawData {
+    if (context.stage === 'visibility') return input;
+
     const { model } = this.context;
     const { add, update } = input;
     // combo 添加和更新的顺序为先子后父，因此采用倒序遍历

--- a/packages/g6/src/transforms/process-parallel-edges.ts
+++ b/packages/g6/src/transforms/process-parallel-edges.ts
@@ -219,6 +219,7 @@ export class ProcessParallelEdges extends BaseTransform<ProcessParallelEdgesOpti
           this.cacheMergeStyle.set(idOf(edge), parsedStyle);
           const mergedEdgeData = {
             ...edge,
+            type: 'line',
             style: { ...mergedStyle, ...parsedStyle },
           };
           const element = this.context.element?.getElement(idOf(edge));

--- a/packages/g6/src/transforms/update-related-edge.ts
+++ b/packages/g6/src/transforms/update-related-edge.ts
@@ -1,3 +1,4 @@
+import type { DrawContext } from '../runtime/element';
 import type { ID, NodeLikeData } from '../types';
 import { idOf } from '../utils/id';
 import { BaseTransform } from './base-transform';
@@ -8,7 +9,10 @@ import type { DrawData } from './types';
  * If the node / combo is updated, the connected edge and the combo it is in need to be updated
  */
 export class UpdateRelatedEdge extends BaseTransform {
-  public beforeDraw(input: DrawData): DrawData {
+  public beforeDraw(input: DrawData, context: DrawContext): DrawData {
+    const { stage } = context;
+    if (stage === 'visibility') return input;
+
     const { model } = this.context;
     const {
       update: { nodes, edges, combos },

--- a/packages/g6/src/types/animation.ts
+++ b/packages/g6/src/types/animation.ts
@@ -4,6 +4,4 @@ export type Keyframe = {
   [key: string]: any;
 };
 
-export type AnimatableTask = () => AnimationTask;
-
-export type AnimationTask = () => IAnimation | null;
+export type AnimationTask = () => () => IAnimation | null;

--- a/packages/g6/src/utils/cache.ts
+++ b/packages/g6/src/utils/cache.ts
@@ -53,6 +53,5 @@ export function hasCachedStyle(element: DisplayObject, name: string) {
  * @param value - <zh/> 样式值 | <en/> style value
  */
 export function setCacheStyle(element: DisplayObject, name: string, value: any) {
-  // element.attributes[getStyleCacheKey(name)] = value;
   set(element, [CacheTargetKey, getStyleCacheKey(name)], value);
 }

--- a/packages/g6/src/utils/theme.ts
+++ b/packages/g6/src/utils/theme.ts
@@ -1,0 +1,18 @@
+import { ExtensionCategory } from '../constants';
+import { getExtension } from '../registry';
+import type { GraphOptions } from '../spec';
+
+/**
+ * <zh/> 获取主题配置
+ *
+ * <en/> Get theme options
+ * @param options - <zh/> 图配置项 <en/> graph options
+ * @returns <zh/> 主题配置 <en/> theme options
+ */
+export function themeOf(options: GraphOptions) {
+  const { theme } = options;
+  if (!theme) return {};
+
+  const themeOptions = getExtension(ExtensionCategory.THEME, theme);
+  return themeOptions ?? {};
+}


### PR DESCRIPTION
* 从 Element Controller 中抽取出动画逻辑并置于 Animation  Controller
* 调整 Element.draw 方法值，返回一个 IAnmation 对象
* 调整动画配置逻辑及优先级，具体参考：[动画优先级](https://g6-next.antv.antgroup.com/manual/core-concept/animation#%E5%8A%A8%E7%94%BB%E4%BC%98%E5%85%88%E7%BA%A7)
* 边的路径与组合尺寸的更新在 onframe 中进行

---

* Extract the Animation logic from the Element Controller and put it in the Animation Controller
* Adjust the Element.draw method value, return a IAnmation object 
* Adjust the animation configuration logic and priority, specific reference: [animation priority](https://g6-next.antv.antgroup.com/manual/core-concept/animation#%E5%8A%A8%E7%94%BB%E4%BC%98%E5%85%88%E7%BA%A7)
* The path of the edge and the update of the combined dimensions are carried out in onframe