### PR TITLE
fix: fix exceptional canvas options when init in dev env

### DIFF
--- a/packages/g6/__tests__/utils/create.ts
+++ b/packages/g6/__tests__/utils/create.ts
@@ -40,6 +40,21 @@ export function createGraphCanvas(
   container.style.height = `${height}px`;
 
   resetEntityCounter();
+
+  let extraOptions = {};
+
+  if (globalThis.process) {
+    const offscreenNodeCanvas = {
+      getContext: () => context,
+    } as unknown as HTMLCanvasElement;
+    const context = new OffscreenCanvasContext(offscreenNodeCanvas);
+    // 下列参数仅在 node 环境下需要传入 / These parameters only need to be passed in the node environment
+    extraOptions = {
+      document: container.ownerDocument,
+      offscreenCanvas: offscreenNodeCanvas,
+    };
+  }
+
   const offscreenNodeCanvas = {
     getContext: () => context,
   } as unknown as HTMLCanvasElement;
@@ -51,9 +66,7 @@ export function createGraphCanvas(
     width,
     height,
     renderer: () => instance,
-    // @ts-expect-error document offscreenCanvas is not in the type definition
-    document: container.ownerDocument,
-    offscreenCanvas: offscreenNodeCanvas,
+    ...extraOptions,
   });
 }
 


### PR DESCRIPTION
* 修复开发环境异常的 Canvas 初始化参数

createGraphCanvas 被同时用于测试环境和开发环境的画布，测试环境在 node 中执行，因此需要传入 document 和 offscreenCanvas，但开发环境是在浏览器中执行，传入这两个参数会导致事件拾取异常。

---

* Fixed abnormal Canvas initialization parameters in the development environment

createGraphCanvas is used as a canvas for both the test environment and the development environment. The test environment is executed in node, so it needs to pass document and offscreenCanvas, but the development environment is executed in the browser, passing these two parameters will cause an event pickup exception.