### PR TITLE
feat: improve diffItems performance

### DIFF
--- a/packages/core/src/element/node.ts
+++ b/packages/core/src/element/node.ts
@@ -34,7 +34,7 @@ const singleNode: ShapeOptions = {
    * @return {Array} 宽高
    */
   getSize(cfg: ModelConfig): number[] {
-    let size: number | number[] = this.mergeStyle?.size || cfg.size || this.getOptions({})!.size || Global.defaultNode.size; // Global.defaultNode.size; //  
+    let size: number | number[] = this.mergeStyle?.size || cfg.size || this.getOptions({})!.size || Global.defaultNode.size; // Global.defaultNode.size; //
 
     // size 是数组，但长度为1，则补长度为2
     if (isArray(size) && size.length === 1) {

--- a/packages/core/src/graph/graph.ts
+++ b/packages/core/src/graph/graph.ts
@@ -1573,8 +1573,10 @@ export default abstract class AbstractGraph extends EventEmitter implements IAbs
     const self = this;
     let item: INode;
     const itemMap: NodeMap = this.get('itemMap');
+    const itemsArray = items[`${type}s`];
+    const itemsToAdd: { type: ITEM_TYPE; model: NodeConfig | EdgeConfig }[] = [];
 
-    each(models, model => {
+    each(models, (model: NodeConfig | EdgeConfig) => {
       item = itemMap[model.id];
       if (item) {
         if (self.get('animate') && type === NODE) {
@@ -1588,10 +1590,23 @@ export default abstract class AbstractGraph extends EventEmitter implements IAbs
 
         self.updateItem(item, model, false);
       } else {
-        item = self.addItem(type, model, false) as any;
+        itemsToAdd.push({ type, model });
       }
-      if (item) (items as { [key: string]: any[] })[`${type}s`].push(item);
+
+      if (item) {
+        itemsArray.push(item);
+      }
     });
+
+    if (itemsToAdd.length) {
+      const items = self.addItems(itemsToAdd, false);
+      for (var i = 0; i < items.length; i++) {
+        const item = items[i];
+        if (item) {
+          itemsArray.push(item);
+        }
+      }
+    }
   }
 
   /**

--- a/packages/pc/src/graph/controller/layout.ts
+++ b/packages/pc/src/graph/controller/layout.ts
@@ -116,7 +116,7 @@ export default class LayoutController extends AbstractLayout {
       layoutCfg.onLayoutEnd = () => {
         graph.emit('aftersublayout', { type: layoutType });
         reslove();
-      }
+      };
 
       // 若用户指定开启 gpu，且当前浏览器支持 webgl，且该算法存在 GPU 版本（目前仅支持 fruchterman 和 gForce），使用 gpu 版本的布局
       if (layoutType && this.isGPU) {
@@ -149,7 +149,7 @@ export default class LayoutController extends AbstractLayout {
       try {
         layoutMethod = new Layout[layoutType](layoutCfg);
         if (this.layoutMethods[order]) {
-          this.layoutMethods[order].destroy()
+          this.layoutMethods[order].destroy();
         }
         this.layoutMethods[order] = layoutMethod;
       } catch (e) {
@@ -189,7 +189,7 @@ export default class LayoutController extends AbstractLayout {
       layoutCfg.onLayoutEnd = () => {
         graph.emit('aftersublayout', { type: layoutType });
         reslove();
-      }
+      };
 
       if (Util.isForce(layoutType)) {
         const { onTick, animate } = layoutCfg;
@@ -340,18 +340,18 @@ export default class LayoutController extends AbstractLayout {
     });
     edges.forEach(edge => {
       const { source, target } = edge;
-      const sourcePosition = positionMap[source]
-      const targetPosition = positionMap[target]
+      const sourcePosition = positionMap[source];
+      const targetPosition = positionMap[target];
       if (!sourcePosition && targetPosition) {
         positionMap[source] = {
           x: targetPosition.x + (Math.random() - 0.5) * 80,
           y: targetPosition.y + (Math.random() - 0.5) * 80
-        }
+        };
       } else if (!targetPosition && sourcePosition) {
         positionMap[target] = {
           x: sourcePosition.x + (Math.random() - 0.5) * 80,
           y: sourcePosition.y + (Math.random() - 0.5) * 80
-        }
+        };
       }
     });
     const width = graph.get('width');
@@ -360,7 +360,7 @@ export default class LayoutController extends AbstractLayout {
       const position = positionMap[node.id] || { x: width / 2 + (Math.random() - 0.5) * 20, y: height / 2 + (Math.random() - 0.5) * 20 };
       node.x = position.x;
       node.y = position.y;
-    })
+    });
   }
 
   public initWithPreset(hasPresetCallback, noPresetCallback): Promise<void> {
@@ -629,7 +629,7 @@ export default class LayoutController extends AbstractLayout {
           });
         });
         resolve();
-      }
+      };
 
       const layoutMethod = new Layout[adjust](layoutCfg);
       layoutMethod.layout({ nodes: layoutNodes });

--- a/packages/pc/tests/unit/element/edge-label-back-spec.ts
+++ b/packages/pc/tests/unit/element/edge-label-back-spec.ts
@@ -124,7 +124,7 @@ describe('text background label', () => {
       graph.updateItem('node3', {
         x: 250,
         y: 200,
-      })
+      });
       setTimeout(() => {
         edge1bgMatrix = edge1bg.getMatrix();
         expect(edge1bgMatrix[0]).toBe(1);
@@ -132,9 +132,9 @@ describe('text background label', () => {
         expect(edge1bgMatrix[7]).toBe(0);
         expect(edge1bg.attr('x')).toBe(258);
         expect(edge1bg.attr('y')).toBe(164);
-        done()
+        done();
       }, 30);
-    }, 100)
+    }, 100);
   });
   it('text background with autoRotate false and clearItemStates', (done) => {
     let edge = graph.getEdges()[0];
@@ -154,7 +154,7 @@ describe('text background label', () => {
       const { x: newX, y: newY } = labelBgShape.attr();
       expect(numberEqual(newX, 226, 2)).toBe(true);
       expect(numberEqual(newY, 166, 2)).toBe(true);
-      done()
+      done();
     }, 16);
   });
 });

--- a/packages/pc/tests/unit/graph/updateLayout-align-spec.ts
+++ b/packages/pc/tests/unit/graph/updateLayout-align-spec.ts
@@ -95,7 +95,7 @@ describe('graph', () => {
       expect(Math.abs(meanCenter.x - point.x) < 10).toBe(true);
       expect(Math.abs(meanCenter.y - point.y) < 10).toBe(true);
       done();
-    })
+    });
     graph.updateLayout(
       {
         type: 'force',

--- a/packages/pc/tests/unit/issues-loop-spec.ts
+++ b/packages/pc/tests/unit/issues-loop-spec.ts
@@ -97,7 +97,7 @@ describe('issues', () => {
       style: {
         lineWidth: 0
       },
-    }
+    };
     const edge = {
       source: '1',
       target: '1',
@@ -107,7 +107,7 @@ describe('issues', () => {
         dist: 20,
         pointPadding: 15,
       },
-    }
+    };
 
     const data = {
       nodes: [node],
@@ -121,23 +121,23 @@ describe('issues', () => {
       fitCenter: true,
     });
 
-    const center = [node.x, node.y]
-    const halfOfWidth = node.size[0] / 2
-    const halfOfHeight = node.size[1] / 2
-    const pointPadding = edge.loopCfg.pointPadding
+    const center = [node.x, node.y];
+    const halfOfWidth = node.size[0] / 2;
+    const halfOfHeight = node.size[1] / 2;
+    const pointPadding = edge.loopCfg.pointPadding;
     graph.data(data);
     graph.render();
     const startPoint = [center[0] + halfOfWidth, center[1] - pointPadding];
     const endPoint = [center[0] + halfOfWidth, center[1] + pointPadding];
 
-    const { edges } = data
-    const currentEdges = edges[0]
+    const { edges } = data;
+    const currentEdges = edges[0];
 
     //@ts-ignore
     expect([currentEdges.startPoint.x, currentEdges.startPoint.y]).toEqual(startPoint);
     //@ts-ignore
     expect([currentEdges.endPoint.x, currentEdges.endPoint.y]).toEqual(endPoint);
-  })
+  });
 
   it('test position top-right calc pointPadding value is ok ', () => {
     const node =
@@ -152,7 +152,7 @@ describe('issues', () => {
       style: {
         lineWidth: 0
       },
-    }
+    };
     const edge = {
       source: '1',
       target: '1',
@@ -162,7 +162,7 @@ describe('issues', () => {
         dist: 20,
         pointPadding: 15,
       },
-    }
+    };
 
     const data = {
       nodes: [node],
@@ -176,26 +176,24 @@ describe('issues', () => {
       fitCenter: true,
     });
 
-
-    const center = [node.x, node.y]
-    const halfOfWidth = node.size[0] / 2
-    const halfOfHeight = node.size[1] / 2
-    const pointPadding = edge.loopCfg.pointPadding
+    const center = [node.x, node.y];
+    const halfOfWidth = node.size[0] / 2;
+    const halfOfHeight = node.size[1] / 2;
+    const pointPadding = edge.loopCfg.pointPadding;
     graph.data(data);
     graph.render();
 
     const startPoint = [center[0] + halfOfWidth - pointPadding, center[1] - halfOfHeight];
     const endPoint = [center[0] + halfOfWidth, center[1] - halfOfHeight + pointPadding];
 
-    const { edges } = data
-    const currentEdges = edges[0]
+    const { edges } = data;
+    const currentEdges = edges[0];
 
     //@ts-ignore
     expect([currentEdges.startPoint.x, currentEdges.startPoint.y]).toEqual(startPoint);
     //@ts-ignore
     expect([currentEdges.endPoint.x, currentEdges.endPoint.y]).toEqual(endPoint);
-  })
-
+  });
 
   it('test unset pointPadding and final pointPadding calc is ok', () => {
     const node =
@@ -210,7 +208,7 @@ describe('issues', () => {
       style: {
         lineWidth: 0
       },
-    }
+    };
     const edge = {
       source: '1',
       target: '1',
@@ -219,7 +217,7 @@ describe('issues', () => {
         position: 'top-right',
         dist: 20,
       },
-    }
+    };
 
     const data = {
       nodes: [node],
@@ -233,25 +231,25 @@ describe('issues', () => {
       fitCenter: true,
     });
 
-    const center = [node.x, node.y]
-    const halfOfWidth = node.size[0] / 2
-    const halfOfHeight = node.size[1] / 2
-    // 预期 pointPadding 为 20 
-    const pointPadding = 20
+    const center = [node.x, node.y];
+    const halfOfWidth = node.size[0] / 2;
+    const halfOfHeight = node.size[1] / 2;
+    // 预期 pointPadding 为 20
+    const pointPadding = 20;
     graph.data(data);
     graph.render();
 
     const startPoint = [center[0] + halfOfWidth - pointPadding, center[1] - halfOfHeight];
     const endPoint = [center[0] + halfOfWidth, center[1] - halfOfHeight + pointPadding];
 
-    const { edges } = data
-    const currentEdges = edges[0]
+    const { edges } = data;
+    const currentEdges = edges[0];
 
     //@ts-ignore
     expect([currentEdges.startPoint.x, currentEdges.startPoint.y]).toEqual(startPoint);
     //@ts-ignore
     expect([currentEdges.endPoint.x, currentEdges.endPoint.y]).toEqual(endPoint);
-  })
+  });
 
   it('test set pointPadding greater than minimum height and width minimum value , final pointPadding calc is ok', () => {
     const node =
@@ -266,7 +264,7 @@ describe('issues', () => {
       style: {
         lineWidth: 0
       },
-    }
+    };
     const edge = {
       source: '1',
       target: '1',
@@ -277,7 +275,7 @@ describe('issues', () => {
         clockwise: true,
         pointPadding: 1000,
       },
-    }
+    };
 
     const data = {
       nodes: [node],
@@ -291,26 +289,25 @@ describe('issues', () => {
       fitCenter: true,
     });
 
-    const center = [node.x, node.y]
-    const halfOfWidth = node.size[0] / 2
-    const halfOfHeight = node.size[1] / 2
+    const center = [node.x, node.y];
+    const halfOfWidth = node.size[0] / 2;
+    const halfOfHeight = node.size[1] / 2;
     // 预期 pointPadding 为 40
-    const pointPadding = 40
+    const pointPadding = 40;
     graph.data(data);
     graph.render();
 
     const startPoint = [center[0] + halfOfWidth - pointPadding, center[1] - halfOfHeight];
     const endPoint = [center[0] + halfOfWidth, center[1] - halfOfHeight + pointPadding];
 
-    const { edges } = data
-    const currentEdges = edges[0]
+    const { edges } = data;
+    const currentEdges = edges[0];
 
     //@ts-ignore
     expect([currentEdges.startPoint.x, currentEdges.startPoint.y]).toEqual(startPoint);
     //@ts-ignore
     expect([currentEdges.endPoint.x, currentEdges.endPoint.y]).toEqual(endPoint);
-  })
-
+  });
 
   it('test set clockwise => true, calc pointPadding is ok', () => {
     const node =
@@ -325,7 +322,7 @@ describe('issues', () => {
       style: {
         lineWidth: 0
       },
-    }
+    };
     const edge = {
       source: '1',
       target: '1',
@@ -336,7 +333,7 @@ describe('issues', () => {
         clockwise: true,
         pointPadding: 1000,
       },
-    }
+    };
 
     const data = {
       nodes: [node],
@@ -350,23 +347,23 @@ describe('issues', () => {
       fitCenter: true,
     });
 
-    const center = [node.x, node.y]
-    const halfOfWidth = node.size[0] / 2
-    const halfOfHeight = node.size[1] / 2
+    const center = [node.x, node.y];
+    const halfOfWidth = node.size[0] / 2;
+    const halfOfHeight = node.size[1] / 2;
     // 预期 pointPadding 为 40
-    const pointPadding = 40
+    const pointPadding = 40;
     graph.data(data);
     graph.render();
 
     const startPoint = [center[0] + halfOfWidth - pointPadding, center[1] - halfOfHeight];
     const endPoint = [center[0] + halfOfWidth, center[1] - halfOfHeight + pointPadding];
 
-    const { edges } = data
-    const currentEdges = edges[0]
+    const { edges } = data;
+    const currentEdges = edges[0];
 
     //@ts-ignore
     expect([currentEdges.startPoint.x, currentEdges.startPoint.y]).toEqual(startPoint);
     //@ts-ignore
     expect([currentEdges.endPoint.x, currentEdges.endPoint.y]).toEqual(endPoint);
-  })
+  });
 });


### PR DESCRIPTION
With a test graph with over 2k nodes we noticed a reduction in the computation time from over 5 seconds to less than 1.

Additionally this PR fixes a bunch of punctuation bits