### PR TITLE
feat(elements): support control whether to execute draw methods

### DIFF
--- a/packages/g6/__tests__/demos/combo.ts
+++ b/packages/g6/__tests__/demos/combo.ts
@@ -1,6 +1,6 @@
 import { Graph } from '@/src';
 
-export const combo: TestCase = async (context) => {
+export const elementCombo: TestCase = async (context) => {
   const data = {
     nodes: [
       { id: 'node-1', combo: 'combo-2', style: { x: 120, y: 100 } },
@@ -46,66 +46,22 @@ export const combo: TestCase = async (context) => {
   const COMBO_TYPE = ['circle', 'rect'];
   const COLLAPSED_MARKER_TYPE = ['child-count', 'descendant-count', 'node-count', 'custom'];
 
-  combo.form = (panel) => {
+  elementCombo.form = (panel) => {
     const config: Record<string, any> = {
       combo2Type: 'circle',
       collapsedMarker: true,
       collapsedMarkerType: 'child-count',
       collapseCombo1: () => {
-        graph.updateComboData([
-          {
-            id: 'combo-1',
-            style: {
-              collapsed: true,
-              collapsedMarker: config.collapsedMarker,
-              collapsedMarkerType:
-                config.collapsedMarkerType === 'custom'
-                  ? (children) => children.length.toString() + 'nodes'
-                  : config.collapsedMarkerType,
-            },
-          },
-        ]);
-        graph.render();
+        graph.collapseElement('combo-1');
       },
       expandCombo1: () => {
-        graph.updateComboData([
-          {
-            id: 'combo-1',
-            style: {
-              collapsed: false,
-              collapsedMarker: config.collapsedMarker,
-            },
-          },
-        ]);
-        graph.render();
+        graph.expandElement('combo-1');
       },
       collapseCombo2: () => {
-        graph.updateComboData([
-          {
-            id: 'combo-2',
-            style: {
-              collapsed: true,
-              collapsedMarker: config.collapsedMarker,
-              collapsedMarkerType:
-                config.collapsedMarkerType === 'custom'
-                  ? (children) => children.length.toString() + 'nodes'
-                  : config.collapsedMarkerType,
-            },
-          },
-        ]);
-        graph.render();
+        graph.collapseElement('combo-2');
       },
       expandCombo2: () => {
-        graph.updateComboData([
-          {
-            id: 'combo-2',
-            style: {
-              collapsed: false,
-              collapsedMarker: config.collapsedMarker,
-            },
-          },
-        ]);
-        graph.render();
+        graph.expandElement('combo-2');
       },
       addRemoveNode: async () => {
         const node4 = graph.getNodeData('node-4');

--- a/packages/g6/__tests__/demos/element-node-image.ts
+++ b/packages/g6/__tests__/demos/element-node-image.ts
@@ -11,6 +11,7 @@ export const elementNodeImage: TestCase = async (context) => {
         size: 40,
         labelText: (d) => d.id!,
         src: 'https://gw.alipayobjects.com/mdn/rms_6ae20b/afts/img/A*N4ZMS7gHsUIAAAAAAAAAAABkARQnAQ',
+        iconSrc: '',
         haloStroke: '#227eff',
       },
       state: {

--- a/packages/g6/__tests__/demos/index.ts
+++ b/packages/g6/__tests__/demos/index.ts
@@ -17,7 +17,7 @@ export { behaviorHoverActivate } from './behavior-hover-activate';
 export { behaviorLassoSelect } from './behavior-lasso-select';
 export { behaviorScrollCanvas } from './behavior-scroll-canvas';
 export { behaviorZoomCanvas } from './behavior-zoom-canvas';
-export { combo } from './combo';
+export { elementCombo } from './combo';
 export { commonGraph } from './common-graph';
 export { controllerViewport } from './controller-viewport';
 export { elementChangeType } from './element-change-type';

--- a/packages/g6/__tests__/snapshots/behaviors/collapse-expand-combo/expand-combo-1-1000.svg
+++ b/packages/g6/__tests__/snapshots/behaviors/collapse-expand-combo/expand-combo-1-1000.svg
@@ -7,7 +7,7 @@
           <g>
             <circle fill="rgba(153,173,209,1)" class="key" stroke-dasharray="0,0" stroke-width="1" fill-opacity="0.04" stroke="rgba(153,173,209,1)" r="199.8406863177741"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,0,199.840683)">
+          <g fill="none" class="label" transform="matrix(1,0,0,1,0,195.439865)">
             <g>
               <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" dy="11.5px" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="middle" font-weight="400">
                 combo-2

--- a/packages/g6/__tests__/snapshots/elements/nodes/circle/default.svg
+++ b/packages/g6/__tests__/snapshots/elements/nodes/circle/default.svg
@@ -14,7 +14,7 @@
               </text>
             </g>
           </g>
-          <g fill="none" class="icon" width="32" height="32" x="0" y="0">
+          <g fill="none" class="icon" width="32" height="32">
             <g>
               <text fill="rgba(255,255,255,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="icon" text-anchor="middle" width="32" height="32" font-size="20" font-family="iconfont">
                 
@@ -36,7 +36,7 @@
               </text>
             </g>
           </g>
-          <g fill="none" class="icon" width="32" height="32" x="0" y="0">
+          <g fill="none" class="icon" width="32" height="32">
             <g>
               <text fill="rgba(255,255,255,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="icon" text-anchor="middle" width="32" height="32" font-size="20" font-family="iconfont">
                 
@@ -55,7 +55,7 @@
               </text>
             </g>
           </g>
-          <g fill="none" class="icon" width="32" height="32" x="0" y="0">
+          <g fill="none" class="icon" width="32" height="32">
             <g>
               <text fill="rgba(255,255,255,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="icon" text-anchor="middle" width="32" height="32" font-size="20" font-family="iconfont">
                 
@@ -110,7 +110,7 @@
               </text>
             </g>
           </g>
-          <g fill="none" class="icon" width="20" height="20" x="0" y="0">
+          <g fill="none" class="icon" width="20" height="20">
             <g>
               <image fill="rgba(255,255,255,1)" preserveAspectRatio="none" x="-10" y="-10" href="https://gw.alipayobjects.com/zos/basement_prod/012bcf4f-423b-4922-8c24-32a89f8c41ce.svg" class="icon" width="20" height="20" font-family="iconfont"/>
             </g>
@@ -127,7 +127,7 @@
               </text>
             </g>
           </g>
-          <g fill="none" class="icon" width="32" height="32" x="0" y="0">
+          <g fill="none" class="icon" width="32" height="32">
             <g>
               <text fill="rgba(255,255,255,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="icon" text-anchor="middle" width="32" height="32" font-size="20" font-family="iconfont">
                 
@@ -161,7 +161,7 @@
               </text>
             </g>
           </g>
-          <g fill="none" class="icon" width="32" height="32" x="0" y="0">
+          <g fill="none" class="icon" width="32" height="32">
             <g>
               <text fill="rgba(255,255,255,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="icon" text-anchor="middle" width="32" height="32" font-size="20" font-family="iconfont">
                 
@@ -183,7 +183,7 @@
               </text>
             </g>
           </g>
-          <g fill="none" class="icon" width="32" height="32" x="0" y="0">
+          <g fill="none" class="icon" width="32" height="32">
             <g>
               <text fill="rgba(255,255,255,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="icon" text-anchor="middle" width="32" height="32" font-size="20" font-family="iconfont">
                 
@@ -202,7 +202,7 @@
               </text>
             </g>
           </g>
-          <g fill="none" class="icon" width="32" height="32" x="0" y="0">
+          <g fill="none" class="icon" width="32" height="32">
             <g>
               <text fill="rgba(255,255,255,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="icon" text-anchor="middle" width="32" height="32" font-size="20" font-family="iconfont">
                 
@@ -221,7 +221,7 @@
               </text>
             </g>
           </g>
-          <g fill="none" class="icon" width="32" height="32" x="0" y="0">
+          <g fill="none" class="icon" width="32" height="32">
             <g>
               <text fill="rgba(255,255,255,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="icon" text-anchor="middle" width="32" height="32" font-size="20" opacity="0.85" font-family="iconfont">
                 
@@ -240,7 +240,7 @@
               </text>
             </g>
           </g>
-          <g fill="none" class="icon" width="32" height="32" x="0" y="0">
+          <g fill="none" class="icon" width="32" height="32">
             <g>
               <text fill="rgba(27,50,79,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="icon" text-anchor="middle" width="32" height="32" font-size="20" opacity="0.25" font-family="iconfont">
                 

--- a/packages/g6/__tests__/snapshots/elements/nodes/diamond/default.svg
+++ b/packages/g6/__tests__/snapshots/elements/nodes/diamond/default.svg
@@ -14,7 +14,7 @@
               </text>
             </g>
           </g>
-          <g fill="none" class="icon" x="0" y="0">
+          <g fill="none" class="icon">
             <g>
               <text fill="rgba(255,255,255,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="icon" text-anchor="middle" font-size="20" font-family="iconfont">
                 
@@ -36,7 +36,7 @@
               </text>
             </g>
           </g>
-          <g fill="none" class="icon" x="0" y="0">
+          <g fill="none" class="icon">
             <g>
               <text fill="rgba(255,255,255,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="icon" text-anchor="middle" font-size="20" font-family="iconfont">
                 
@@ -55,7 +55,7 @@
               </text>
             </g>
           </g>
-          <g fill="none" class="icon" x="0" y="0">
+          <g fill="none" class="icon">
             <g>
               <text fill="rgba(255,255,255,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="icon" text-anchor="middle" font-size="20" font-family="iconfont">
                 
@@ -110,7 +110,7 @@
               </text>
             </g>
           </g>
-          <g fill="none" class="icon" x="0" y="0" width="20" height="20">
+          <g fill="none" class="icon" width="20" height="20">
             <g>
               <image fill="rgba(255,255,255,1)" preserveAspectRatio="none" x="-10" y="-10" href="https://gw.alipayobjects.com/zos/basement_prod/012bcf4f-423b-4922-8c24-32a89f8c41ce.svg" class="icon" width="20" height="20" font-family="iconfont"/>
             </g>
@@ -127,7 +127,7 @@
               </text>
             </g>
           </g>
-          <g fill="none" class="icon" x="0" y="0">
+          <g fill="none" class="icon">
             <g>
               <text fill="rgba(255,255,255,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="icon" text-anchor="middle" font-size="20" font-family="iconfont">
                 
@@ -161,7 +161,7 @@
               </text>
             </g>
           </g>
-          <g fill="none" class="icon" x="0" y="0">
+          <g fill="none" class="icon">
             <g>
               <text fill="rgba(255,255,255,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="icon" text-anchor="middle" font-size="20" font-family="iconfont">
                 
@@ -183,7 +183,7 @@
               </text>
             </g>
           </g>
-          <g fill="none" class="icon" x="0" y="0">
+          <g fill="none" class="icon">
             <g>
               <text fill="rgba(255,255,255,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="icon" text-anchor="middle" font-size="20" font-family="iconfont">
                 
@@ -202,7 +202,7 @@
               </text>
             </g>
           </g>
-          <g fill="none" class="icon" x="0" y="0">
+          <g fill="none" class="icon">
             <g>
               <text fill="rgba(255,255,255,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="icon" text-anchor="middle" font-size="20" font-family="iconfont">
                 
@@ -221,7 +221,7 @@
               </text>
             </g>
           </g>
-          <g fill="none" class="icon" x="0" y="0">
+          <g fill="none" class="icon">
             <g>
               <text fill="rgba(255,255,255,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="icon" text-anchor="middle" font-size="20" opacity="0.85" font-family="iconfont">
                 
@@ -240,7 +240,7 @@
               </text>
             </g>
           </g>
-          <g fill="none" class="icon" x="0" y="0">
+          <g fill="none" class="icon">
             <g>
               <text fill="rgba(27,50,79,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="icon" text-anchor="middle" font-size="20" opacity="0.25" font-family="iconfont">
                 

--- a/packages/g6/__tests__/snapshots/elements/nodes/donut/default.svg
+++ b/packages/g6/__tests__/snapshots/elements/nodes/donut/default.svg
@@ -17,7 +17,7 @@
           <g>
             <path fill="rgba(255,165,0,1)" d="M -20,0 A 20 20 0 1 1 20 0 A 20 20 0 1 1 -20 0 Z M 12,0 A 12 12 0 1 0 -12 0 A 12 12 0 1 0 12 0 Z" class="round0" stroke-width="2"/>
           </g>
-          <g fill="none" class="icon" width="20" height="20" x="0" y="0">
+          <g fill="none" class="icon" width="20" height="20">
             <g>
               <text fill="rgba(255,255,255,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="icon" text-anchor="middle" width="20" height="20" font-size="20" font-family="iconfont">
                 
@@ -45,7 +45,7 @@
           <g>
             <path fill="rgba(0,128,0,1)" d="M 1.2246467991473533e-15,10 L 2.4492935982947065e-15,20 A 20 20 0 0 1 -4.898587196589413e-15 -20 L -2.4492935982947065e-15,-10 A 10 10 0 0 0 1.2246467991473533e-15 10 Z" class="round1"/>
           </g>
-          <g fill="none" class="icon" width="20" height="20" x="0" y="0">
+          <g fill="none" class="icon" width="20" height="20">
             <g>
               <text fill="rgba(255,255,255,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="icon" text-anchor="middle" width="20" height="20" font-size="20" font-family="iconfont">
                 
@@ -73,7 +73,7 @@
           <g>
             <path fill="rgba(225,87,89,1)" d="M 1.2246467991473533e-15,10 L 2.4492935982947065e-15,20 A 20 20 0 0 1 -4.898587196589413e-15 -20 L -2.4492935982947065e-15,-10 A 10 10 0 0 0 1.2246467991473533e-15 10 Z" class="round2"/>
           </g>
-          <g fill="none" class="icon" width="20" height="20" x="0" y="0">
+          <g fill="none" class="icon" width="20" height="20">
             <g>
               <text fill="rgba(255,255,255,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="icon" text-anchor="middle" width="20" height="20" font-size="20" font-family="iconfont">
                 
@@ -137,7 +137,7 @@
           <g>
             <path fill="rgba(225,87,89,1)" d="M -8.660254037844386,5.000000000000004 L -17.32050807568877,10.000000000000009 A 20 20 0 0 1 -4.898587196589413e-15 -20 L -2.4492935982947065e-15,-10 A 10 10 0 0 0 -8.660254037844386 5.000000000000004 Z" class="round2"/>
           </g>
-          <g fill="none" class="icon" width="20" height="20" x="0" y="0">
+          <g fill="none" class="icon" width="20" height="20">
             <g>
               <text fill="rgba(255,255,255,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="icon" text-anchor="middle" width="20" height="20" font-size="20" font-family="iconfont">
                 
@@ -177,7 +177,7 @@
           <g>
             <path fill="rgba(242,142,44,1)" d="M 1.2288829066471412,-9.924205096719357 L 2.4577658132942823,-19.848410193438713 A 20 20 0 1 1 -4.898587196589413e-15 -20 L -2.4492935982947065e-15,-10 A 10 10 0 1 0 1.2288829066471412 -9.924205096719357 Z" class="round1"/>
           </g>
-          <g fill="none" class="icon" width="20" height="20" x="0" y="0">
+          <g fill="none" class="icon" width="20" height="20">
             <g>
               <text fill="rgba(255,255,255,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="icon" text-anchor="middle" width="20" height="20" font-size="20" font-family="iconfont">
                 
@@ -205,7 +205,7 @@
           <g>
             <path fill="rgba(242,142,44,1)" d="M -1.228882906647149,-9.924205096719357 L -2.457765813294298,-19.848410193438713 A 20 20 0 0 1 -4.898587196589413e-15 -20 L -2.4492935982947065e-15,-10 A 10 10 0 0 0 -1.228882906647149 -9.924205096719357 Z" class="round1"/>
           </g>
-          <g fill="none" class="icon" width="20" height="20" x="0" y="0">
+          <g fill="none" class="icon" width="20" height="20">
             <g>
               <text fill="rgba(255,255,255,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="icon" text-anchor="middle" width="20" height="20" font-size="20" font-family="iconfont">
                 
@@ -233,7 +233,7 @@
           <g>
             <path fill="rgba(225,87,89,1)" d="M 1.2246467991473533e-15,10 L 2.4492935982947065e-15,20 A 20 20 0 0 1 -4.898587196589413e-15 -20 L -2.4492935982947065e-15,-10 A 10 10 0 0 0 1.2246467991473533e-15 10 Z" class="round2" stroke-width="1" stroke="rgba(255,255,255,1)"/>
           </g>
-          <g fill="none" class="icon" width="20" height="20" x="0" y="0">
+          <g fill="none" class="icon" width="20" height="20">
             <g>
               <text fill="rgba(255,255,255,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="icon" text-anchor="middle" width="20" height="20" font-size="20" font-family="iconfont">
                 
@@ -258,7 +258,7 @@
           <g>
             <path fill="rgba(0,128,0,1)" d="M 0,0 L 2.4492935982947065e-15,20 A 20 20 0 0 1 -4.898587196589413e-15 -20 L 0,0 A 0 0 0 0 0 0 0 Z" class="round1" opacity="0.25"/>
           </g>
-          <g fill="none" class="icon" width="20" height="20" x="0" y="0">
+          <g fill="none" class="icon" width="20" height="20">
             <g>
               <text fill="rgba(255,255,255,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="icon" text-anchor="middle" width="20" height="20" font-size="20" opacity="0.85" font-family="iconfont">
                 
@@ -283,7 +283,7 @@
           <g>
             <path fill="rgba(255,0,0,1)" d="M 1.2246467991473533e-15,10 L 2.4492935982947065e-15,20 A 20 20 0 0 1 -4.898587196589413e-15 -20 L -2.4492935982947065e-15,-10 A 10 10 0 0 0 1.2246467991473533e-15 10 Z" class="round1" opacity="0.06"/>
           </g>
-          <g fill="none" class="icon" width="20" height="20" x="0" y="0">
+          <g fill="none" class="icon" width="20" height="20">
             <g>
               <text fill="rgba(27,50,79,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="icon" text-anchor="middle" width="20" height="20" font-size="20" opacity="0.25" font-family="iconfont">
                 

--- a/packages/g6/__tests__/snapshots/elements/nodes/ellipse/default.svg
+++ b/packages/g6/__tests__/snapshots/elements/nodes/ellipse/default.svg
@@ -14,7 +14,7 @@
               </text>
             </g>
           </g>
-          <g fill="none" class="icon" width="20" height="20" x="0" y="0">
+          <g fill="none" class="icon" width="20" height="20">
             <g>
               <text fill="rgba(255,255,255,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="icon" text-anchor="middle" width="20" height="20" font-size="17.5" font-family="iconfont">
                 
@@ -36,7 +36,7 @@
               </text>
             </g>
           </g>
-          <g fill="none" class="icon" width="20" height="20" x="0" y="0">
+          <g fill="none" class="icon" width="20" height="20">
             <g>
               <text fill="rgba(255,255,255,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="icon" text-anchor="middle" width="20" height="20" font-size="17.5" font-family="iconfont">
                 
@@ -55,7 +55,7 @@
               </text>
             </g>
           </g>
-          <g fill="none" class="icon" width="20" height="20" x="0" y="0">
+          <g fill="none" class="icon" width="20" height="20">
             <g>
               <text fill="rgba(255,255,255,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="icon" text-anchor="middle" width="20" height="20" font-size="17.5" font-family="iconfont">
                 
@@ -110,7 +110,7 @@
               </text>
             </g>
           </g>
-          <g fill="none" class="icon" width="20" height="20" x="0" y="0">
+          <g fill="none" class="icon" width="20" height="20">
             <g>
               <image fill="rgba(255,255,255,1)" preserveAspectRatio="none" x="-10" y="-10" href="https://gw.alipayobjects.com/zos/basement_prod/012bcf4f-423b-4922-8c24-32a89f8c41ce.svg" class="icon" width="20" height="20" font-size="17.5" font-family="iconfont"/>
             </g>
@@ -127,7 +127,7 @@
               </text>
             </g>
           </g>
-          <g fill="none" class="icon" width="20" height="20" x="0" y="0">
+          <g fill="none" class="icon" width="20" height="20">
             <g>
               <text fill="rgba(255,255,255,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="icon" text-anchor="middle" width="20" height="20" font-size="17.5" font-family="iconfont">
                 
@@ -161,7 +161,7 @@
               </text>
             </g>
           </g>
-          <g fill="none" class="icon" width="20" height="20" x="0" y="0">
+          <g fill="none" class="icon" width="20" height="20">
             <g>
               <text fill="rgba(255,255,255,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="icon" text-anchor="middle" width="20" height="20" font-size="17.5" font-family="iconfont">
                 
@@ -183,7 +183,7 @@
               </text>
             </g>
           </g>
-          <g fill="none" class="icon" width="20" height="20" x="0" y="0">
+          <g fill="none" class="icon" width="20" height="20">
             <g>
               <text fill="rgba(255,255,255,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="icon" text-anchor="middle" width="20" height="20" font-size="17.5" font-family="iconfont">
                 
@@ -202,7 +202,7 @@
               </text>
             </g>
           </g>
-          <g fill="none" class="icon" width="20" height="20" x="0" y="0">
+          <g fill="none" class="icon" width="20" height="20">
             <g>
               <text fill="rgba(255,255,255,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="icon" text-anchor="middle" width="20" height="20" font-size="17.5" font-family="iconfont">
                 
@@ -221,7 +221,7 @@
               </text>
             </g>
           </g>
-          <g fill="none" class="icon" width="20" height="20" x="0" y="0">
+          <g fill="none" class="icon" width="20" height="20">
             <g>
               <text fill="rgba(255,255,255,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="icon" text-anchor="middle" width="20" height="20" font-size="17.5" opacity="0.85" font-family="iconfont">
                 
@@ -240,7 +240,7 @@
               </text>
             </g>
           </g>
-          <g fill="none" class="icon" width="20" height="20" x="0" y="0">
+          <g fill="none" class="icon" width="20" height="20">
             <g>
               <text fill="rgba(27,50,79,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="icon" text-anchor="middle" width="20" height="20" font-size="17.5" opacity="0.25" font-family="iconfont">
                 

--- a/packages/g6/__tests__/snapshots/elements/nodes/hexagon/default.svg
+++ b/packages/g6/__tests__/snapshots/elements/nodes/hexagon/default.svg
@@ -14,7 +14,7 @@
               </text>
             </g>
           </g>
-          <g fill="none" class="icon" width="16" height="16" x="0" y="0">
+          <g fill="none" class="icon" width="16" height="16">
             <g>
               <text fill="rgba(255,255,255,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="icon" text-anchor="middle" width="16" height="16" font-size="20" font-family="iconfont">
                 
@@ -36,7 +36,7 @@
               </text>
             </g>
           </g>
-          <g fill="none" class="icon" width="16" height="16" x="0" y="0">
+          <g fill="none" class="icon" width="16" height="16">
             <g>
               <text fill="rgba(255,255,255,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="icon" text-anchor="middle" width="16" height="16" font-size="20" font-family="iconfont">
                 
@@ -55,7 +55,7 @@
               </text>
             </g>
           </g>
-          <g fill="none" class="icon" width="16" height="16" x="0" y="0">
+          <g fill="none" class="icon" width="16" height="16">
             <g>
               <text fill="rgba(255,255,255,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="icon" text-anchor="middle" width="16" height="16" font-size="20" font-family="iconfont">
                 
@@ -110,7 +110,7 @@
               </text>
             </g>
           </g>
-          <g fill="none" class="icon" width="20" height="20" x="0" y="0">
+          <g fill="none" class="icon" width="20" height="20">
             <g>
               <image fill="rgba(255,255,255,1)" preserveAspectRatio="none" x="-10" y="-10" href="https://gw.alipayobjects.com/zos/basement_prod/012bcf4f-423b-4922-8c24-32a89f8c41ce.svg" class="icon" width="20" height="20" font-family="iconfont"/>
             </g>
@@ -127,7 +127,7 @@
               </text>
             </g>
           </g>
-          <g fill="none" class="icon" width="16" height="16" x="0" y="0">
+          <g fill="none" class="icon" width="16" height="16">
             <g>
               <text fill="rgba(255,255,255,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="icon" text-anchor="middle" width="16" height="16" font-size="20" font-family="iconfont">
                 
@@ -161,7 +161,7 @@
               </text>
             </g>
           </g>
-          <g fill="none" class="icon" width="16" height="16" x="0" y="0">
+          <g fill="none" class="icon" width="16" height="16">
             <g>
               <text fill="rgba(255,255,255,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="icon" text-anchor="middle" width="16" height="16" font-size="20" font-family="iconfont">
                 
@@ -183,7 +183,7 @@
               </text>
             </g>
           </g>
-          <g fill="none" class="icon" width="16" height="16" x="0" y="0">
+          <g fill="none" class="icon" width="16" height="16">
             <g>
               <text fill="rgba(255,255,255,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="icon" text-anchor="middle" width="16" height="16" font-size="20" font-family="iconfont">
                 
@@ -202,7 +202,7 @@
               </text>
             </g>
           </g>
-          <g fill="none" class="icon" width="16" height="16" x="0" y="0">
+          <g fill="none" class="icon" width="16" height="16">
             <g>
               <text fill="rgba(255,255,255,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="icon" text-anchor="middle" width="16" height="16" font-size="20" font-family="iconfont">
                 
@@ -221,7 +221,7 @@
               </text>
             </g>
           </g>
-          <g fill="none" class="icon" width="16" height="16" x="0" y="0">
+          <g fill="none" class="icon" width="16" height="16">
             <g>
               <text fill="rgba(255,255,255,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="icon" text-anchor="middle" width="16" height="16" font-size="20" opacity="0.85" font-family="iconfont">
                 
@@ -240,7 +240,7 @@
               </text>
             </g>
           </g>
-          <g fill="none" class="icon" width="16" height="16" x="0" y="0">
+          <g fill="none" class="icon" width="16" height="16">
             <g>
               <text fill="rgba(27,50,79,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="icon" text-anchor="middle" width="16" height="16" font-size="20" opacity="0.25" font-family="iconfont">
                 

--- a/packages/g6/__tests__/snapshots/elements/nodes/image/default.svg
+++ b/packages/g6/__tests__/snapshots/elements/nodes/image/default.svg
@@ -17,7 +17,7 @@
         </g>
         <g fill="none" x="250" y="62.5" transform="matrix(1,0,0,1,250,62.500000)">
           <g>
-            <path fill="rgba(0,0,0,0)" d="M -26,-26 l 52,0 l 0,52 l-52 0 z" class="halo" stroke-width="12" stroke-opacity="0.25" width="52" height="52" x="-26" y="-26" stroke-dasharray="0,0" pointer-events="none" stroke="rgba(34,126,255,1)"/>
+            <path fill="rgba(0,0,0,0)" d="M -26,-26 l 52,0 l 0,52 l-52 0 z" class="halo" stroke-dasharray="0,0" stroke-width="12" stroke-opacity="0.25" pointer-events="none" stroke="rgba(34,126,255,1)" width="52" height="52" x="-26" y="-26"/>
           </g>
           <g>
             <image fill="rgba(23,131,255,1)" preserveAspectRatio="none" x="-20" y="-20" href="https://gw.alipayobjects.com/mdn/rms_6ae20b/afts/img/A*N4ZMS7gHsUIAAAAAAAAAAABkARQnAQ" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" width="40" height="40"/>
@@ -89,11 +89,6 @@
               </text>
             </g>
           </g>
-          <g fill="none" class="icon" width="20" height="20" x="0" y="0">
-            <g>
-              <image fill="rgba(255,255,255,1)" preserveAspectRatio="none" x="-10" y="-10" href="https://gw.alipayobjects.com/zos/basement_prod/012bcf4f-423b-4922-8c24-32a89f8c41ce.svg" class="icon" width="20" height="20"/>
-            </g>
-          </g>
         </g>
         <g fill="none" x="250" y="187.5" transform="matrix(1,0,0,1,250,187.500000)">
           <g>
@@ -121,7 +116,7 @@
         </g>
         <g fill="none" x="416.66666666666663" y="187.5" transform="matrix(1,0,0,1,416.666656,187.500000)">
           <g>
-            <path fill="rgba(0,0,0,0)" d="M -26,-26 l 52,0 l 0,52 l-52 0 z" class="halo" stroke-width="12" stroke-opacity="0.15" width="52" height="52" x="-26" y="-26" stroke-dasharray="0,0" pointer-events="none" stroke="rgba(34,126,255,1)"/>
+            <path fill="rgba(0,0,0,0)" d="M -26,-26 l 52,0 l 0,52 l-52 0 z" class="halo" stroke-dasharray="0,0" stroke-width="12" stroke-opacity="0.15" pointer-events="none" stroke="rgba(34,126,255,1)" width="52" height="52" x="-26" y="-26"/>
           </g>
           <g>
             <image fill="rgba(23,131,255,1)" preserveAspectRatio="none" x="-20" y="-20" href="https://gw.alipayobjects.com/mdn/rms_6ae20b/afts/img/A*N4ZMS7gHsUIAAAAAAAAAAABkARQnAQ" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" width="40" height="40"/>
@@ -136,7 +131,7 @@
         </g>
         <g fill="none" x="83.33333333333333" y="312.5" transform="matrix(1,0,0,1,83.333336,312.500000)">
           <g>
-            <path fill="rgba(0,0,0,0)" d="M -32,-32 l 64,0 l 0,64 l-64 0 z" class="halo" stroke-width="24" stroke-opacity="0.25" width="64" height="64" x="-32" y="-32" stroke-dasharray="0,0" pointer-events="none" stroke="rgba(34,126,255,1)"/>
+            <path fill="rgba(0,0,0,0)" d="M -32,-32 l 64,0 l 0,64 l-64 0 z" class="halo" stroke-dasharray="0,0" stroke-width="24" stroke-opacity="0.25" pointer-events="none" stroke="rgba(34,126,255,1)" width="64" height="64" x="-32" y="-32"/>
           </g>
           <g>
             <image fill="rgba(23,131,255,1)" preserveAspectRatio="none" x="-20" y="-20" href="https://gw.alipayobjects.com/mdn/rms_6ae20b/afts/img/A*N4ZMS7gHsUIAAAAAAAAAAABkARQnAQ" class="key" stroke-width="4" stroke="rgba(0,0,0,1)" width="40" height="40"/>

--- a/packages/g6/__tests__/snapshots/elements/nodes/rect/default.svg
+++ b/packages/g6/__tests__/snapshots/elements/nodes/rect/default.svg
@@ -14,7 +14,7 @@
               </text>
             </g>
           </g>
-          <g fill="none" class="icon" width="32" height="32" x="0" y="0">
+          <g fill="none" class="icon" width="32" height="32">
             <g>
               <text fill="rgba(255,255,255,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="icon" text-anchor="middle" width="32" height="32" font-size="20" font-family="iconfont">
                 
@@ -36,7 +36,7 @@
               </text>
             </g>
           </g>
-          <g fill="none" class="icon" width="32" height="32" x="0" y="0">
+          <g fill="none" class="icon" width="32" height="32">
             <g>
               <text fill="rgba(255,255,255,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="icon" text-anchor="middle" width="32" height="32" font-size="20" font-family="iconfont">
                 
@@ -55,7 +55,7 @@
               </text>
             </g>
           </g>
-          <g fill="none" class="icon" width="32" height="32" x="0" y="0">
+          <g fill="none" class="icon" width="32" height="32">
             <g>
               <text fill="rgba(255,255,255,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="icon" text-anchor="middle" width="32" height="32" font-size="20" font-family="iconfont">
                 
@@ -110,7 +110,7 @@
               </text>
             </g>
           </g>
-          <g fill="none" class="icon" width="20" height="20" x="0" y="0">
+          <g fill="none" class="icon" width="20" height="20">
             <g>
               <image fill="rgba(255,255,255,1)" preserveAspectRatio="none" x="-10" y="-10" href="https://gw.alipayobjects.com/zos/basement_prod/012bcf4f-423b-4922-8c24-32a89f8c41ce.svg" class="icon" width="20" height="20" font-family="iconfont"/>
             </g>
@@ -127,7 +127,7 @@
               </text>
             </g>
           </g>
-          <g fill="none" class="icon" width="32" height="32" x="0" y="0">
+          <g fill="none" class="icon" width="32" height="32">
             <g>
               <text fill="rgba(255,255,255,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="icon" text-anchor="middle" width="32" height="32" font-size="20" font-family="iconfont">
                 
@@ -161,7 +161,7 @@
               </text>
             </g>
           </g>
-          <g fill="none" class="icon" width="32" height="32" x="0" y="0">
+          <g fill="none" class="icon" width="32" height="32">
             <g>
               <text fill="rgba(255,255,255,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="icon" text-anchor="middle" width="32" height="32" font-size="20" font-family="iconfont">
                 
@@ -183,7 +183,7 @@
               </text>
             </g>
           </g>
-          <g fill="none" class="icon" width="32" height="32" x="0" y="0">
+          <g fill="none" class="icon" width="32" height="32">
             <g>
               <text fill="rgba(255,255,255,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="icon" text-anchor="middle" width="32" height="32" font-size="20" font-family="iconfont">
                 
@@ -202,7 +202,7 @@
               </text>
             </g>
           </g>
-          <g fill="none" class="icon" width="32" height="32" x="0" y="0">
+          <g fill="none" class="icon" width="32" height="32">
             <g>
               <text fill="rgba(255,255,255,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="icon" text-anchor="middle" width="32" height="32" font-size="20" font-family="iconfont">
                 
@@ -221,7 +221,7 @@
               </text>
             </g>
           </g>
-          <g fill="none" class="icon" width="32" height="32" x="0" y="0">
+          <g fill="none" class="icon" width="32" height="32">
             <g>
               <text fill="rgba(255,255,255,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="icon" text-anchor="middle" width="32" height="32" font-size="20" opacity="0.85" font-family="iconfont">
                 
@@ -240,7 +240,7 @@
               </text>
             </g>
           </g>
-          <g fill="none" class="icon" width="32" height="32" x="0" y="0">
+          <g fill="none" class="icon" width="32" height="32">
             <g>
               <text fill="rgba(27,50,79,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="icon" text-anchor="middle" width="32" height="32" font-size="20" opacity="0.25" font-family="iconfont">
                 

--- a/packages/g6/__tests__/snapshots/elements/nodes/star/default.svg
+++ b/packages/g6/__tests__/snapshots/elements/nodes/star/default.svg
@@ -14,7 +14,7 @@
               </text>
             </g>
           </g>
-          <g fill="none" class="icon" width="12" height="12" x="0" y="-1.9098300562505273">
+          <g fill="none" class="icon" width="12" height="12" x="0" y="-1.9098300562505273" transform="matrix(1,0,0,1,0,-1.909830)">
             <g>
               <text fill="rgba(255,255,255,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="icon" text-anchor="middle" width="12" height="12" font-size="20" font-family="iconfont">
                 
@@ -36,7 +36,7 @@
               </text>
             </g>
           </g>
-          <g fill="none" class="icon" width="12" height="12" x="0" y="-1.9098300562505273">
+          <g fill="none" class="icon" width="12" height="12" x="0" y="-1.9098300562505273" transform="matrix(1,0,0,1,0,-1.909830)">
             <g>
               <text fill="rgba(255,255,255,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="icon" text-anchor="middle" width="12" height="12" font-size="20" font-family="iconfont">
                 
@@ -55,7 +55,7 @@
               </text>
             </g>
           </g>
-          <g fill="none" class="icon" width="12" height="12" x="0" y="-1.9098300562505273">
+          <g fill="none" class="icon" width="12" height="12" x="0" y="-1.9098300562505273" transform="matrix(1,0,0,1,0,-1.909830)">
             <g>
               <text fill="rgba(255,255,255,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="icon" text-anchor="middle" width="12" height="12" font-size="20" font-family="iconfont">
                 
@@ -110,9 +110,9 @@
               </text>
             </g>
           </g>
-          <g fill="none" class="icon" width="20" height="20" x="0" y="-1.9098300562505415">
+          <g fill="none" class="icon" width="20" height="20" x="0" y="-1.9098300562505273" transform="matrix(1,0,0,1,0,-1.909830)">
             <g>
-              <image fill="rgba(255,255,255,1)" preserveAspectRatio="none" x="-10" y="-11.909830056250541" href="https://gw.alipayobjects.com/zos/basement_prod/012bcf4f-423b-4922-8c24-32a89f8c41ce.svg" class="icon" width="20" height="20" font-family="iconfont"/>
+              <image fill="rgba(255,255,255,1)" preserveAspectRatio="none" x="-10" y="-10" href="https://gw.alipayobjects.com/zos/basement_prod/012bcf4f-423b-4922-8c24-32a89f8c41ce.svg" class="icon" width="20" height="20" font-family="iconfont"/>
             </g>
           </g>
         </g>
@@ -127,7 +127,7 @@
               </text>
             </g>
           </g>
-          <g fill="none" class="icon" width="12" height="12" x="0" y="-1.9098300562505415">
+          <g fill="none" class="icon" width="12" height="12" x="0" y="-1.9098300562505273" transform="matrix(1,0,0,1,0,-1.909830)">
             <g>
               <text fill="rgba(255,255,255,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="icon" text-anchor="middle" width="12" height="12" font-size="20" font-family="iconfont">
                 
@@ -161,7 +161,7 @@
               </text>
             </g>
           </g>
-          <g fill="none" class="icon" width="12" height="12" x="0" y="-1.9098300562505415">
+          <g fill="none" class="icon" width="12" height="12" x="0" y="-1.9098300562505273" transform="matrix(1,0,0,1,0,-1.909830)">
             <g>
               <text fill="rgba(255,255,255,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="icon" text-anchor="middle" width="12" height="12" font-size="20" font-family="iconfont">
                 
@@ -183,7 +183,7 @@
               </text>
             </g>
           </g>
-          <g fill="none" class="icon" width="12" height="12" x="0" y="-1.9098300562505415">
+          <g fill="none" class="icon" width="12" height="12" x="0" y="-1.9098300562505273" transform="matrix(1,0,0,1,0,-1.909830)">
             <g>
               <text fill="rgba(255,255,255,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="icon" text-anchor="middle" width="12" height="12" font-size="20" font-family="iconfont">
                 
@@ -202,7 +202,7 @@
               </text>
             </g>
           </g>
-          <g fill="none" class="icon" width="12" height="12" x="0" y="-1.9098300562505415">
+          <g fill="none" class="icon" width="12" height="12" x="0" y="-1.9098300562505273" transform="matrix(1,0,0,1,0,-1.909830)">
             <g>
               <text fill="rgba(255,255,255,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="icon" text-anchor="middle" width="12" height="12" font-size="20" font-family="iconfont">
                 
@@ -221,7 +221,7 @@
               </text>
             </g>
           </g>
-          <g fill="none" class="icon" width="12" height="12" x="0" y="-1.9098300562505415">
+          <g fill="none" class="icon" width="12" height="12" x="0" y="-1.9098300562505273" transform="matrix(1,0,0,1,0,-1.909830)">
             <g>
               <text fill="rgba(255,255,255,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="icon" text-anchor="middle" width="12" height="12" font-size="20" opacity="0.85" font-family="iconfont">
                 
@@ -240,7 +240,7 @@
               </text>
             </g>
           </g>
-          <g fill="none" class="icon" width="12" height="12" x="0" y="-1.9098300562505415">
+          <g fill="none" class="icon" width="12" height="12" x="0" y="-1.9098300562505273" transform="matrix(1,0,0,1,0,-1.909830)">
             <g>
               <text fill="rgba(27,50,79,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="icon" text-anchor="middle" width="12" height="12" font-size="20" opacity="0.25" font-family="iconfont">
                 

--- a/packages/g6/__tests__/snapshots/elements/nodes/star/default.svg
+++ b/packages/g6/__tests__/snapshots/elements/nodes/star/default.svg
@@ -14,7 +14,7 @@
               </text>
             </g>
           </g>
-          <g fill="none" class="icon" width="12" height="12" x="0" y="-1.9098300562505273" transform="matrix(1,0,0,1,0,-1.909830)">
+          <g fill="none" class="icon" width="12" height="12">
             <g>
               <text fill="rgba(255,255,255,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="icon" text-anchor="middle" width="12" height="12" font-size="20" font-family="iconfont">
                 
@@ -36,7 +36,7 @@
               </text>
             </g>
           </g>
-          <g fill="none" class="icon" width="12" height="12" x="0" y="-1.9098300562505273" transform="matrix(1,0,0,1,0,-1.909830)">
+          <g fill="none" class="icon" width="12" height="12">
             <g>
               <text fill="rgba(255,255,255,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="icon" text-anchor="middle" width="12" height="12" font-size="20" font-family="iconfont">
                 
@@ -55,7 +55,7 @@
               </text>
             </g>
           </g>
-          <g fill="none" class="icon" width="12" height="12" x="0" y="-1.9098300562505273" transform="matrix(1,0,0,1,0,-1.909830)">
+          <g fill="none" class="icon" width="12" height="12">
             <g>
               <text fill="rgba(255,255,255,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="icon" text-anchor="middle" width="12" height="12" font-size="20" font-family="iconfont">
                 
@@ -110,7 +110,7 @@
               </text>
             </g>
           </g>
-          <g fill="none" class="icon" width="20" height="20" x="0" y="-1.9098300562505273" transform="matrix(1,0,0,1,0,-1.909830)">
+          <g fill="none" class="icon" width="20" height="20">
             <g>
               <image fill="rgba(255,255,255,1)" preserveAspectRatio="none" x="-10" y="-10" href="https://gw.alipayobjects.com/zos/basement_prod/012bcf4f-423b-4922-8c24-32a89f8c41ce.svg" class="icon" width="20" height="20" font-family="iconfont"/>
             </g>
@@ -127,7 +127,7 @@
               </text>
             </g>
           </g>
-          <g fill="none" class="icon" width="12" height="12" x="0" y="-1.9098300562505273" transform="matrix(1,0,0,1,0,-1.909830)">
+          <g fill="none" class="icon" width="12" height="12">
             <g>
               <text fill="rgba(255,255,255,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="icon" text-anchor="middle" width="12" height="12" font-size="20" font-family="iconfont">
                 
@@ -161,7 +161,7 @@
               </text>
             </g>
           </g>
-          <g fill="none" class="icon" width="12" height="12" x="0" y="-1.9098300562505273" transform="matrix(1,0,0,1,0,-1.909830)">
+          <g fill="none" class="icon" width="12" height="12">
             <g>
               <text fill="rgba(255,255,255,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="icon" text-anchor="middle" width="12" height="12" font-size="20" font-family="iconfont">
                 
@@ -183,7 +183,7 @@
               </text>
             </g>
           </g>
-          <g fill="none" class="icon" width="12" height="12" x="0" y="-1.9098300562505273" transform="matrix(1,0,0,1,0,-1.909830)">
+          <g fill="none" class="icon" width="12" height="12">
             <g>
               <text fill="rgba(255,255,255,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="icon" text-anchor="middle" width="12" height="12" font-size="20" font-family="iconfont">
                 
@@ -202,7 +202,7 @@
               </text>
             </g>
           </g>
-          <g fill="none" class="icon" width="12" height="12" x="0" y="-1.9098300562505273" transform="matrix(1,0,0,1,0,-1.909830)">
+          <g fill="none" class="icon" width="12" height="12">
             <g>
               <text fill="rgba(255,255,255,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="icon" text-anchor="middle" width="12" height="12" font-size="20" font-family="iconfont">
                 
@@ -221,7 +221,7 @@
               </text>
             </g>
           </g>
-          <g fill="none" class="icon" width="12" height="12" x="0" y="-1.9098300562505273" transform="matrix(1,0,0,1,0,-1.909830)">
+          <g fill="none" class="icon" width="12" height="12">
             <g>
               <text fill="rgba(255,255,255,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="icon" text-anchor="middle" width="12" height="12" font-size="20" opacity="0.85" font-family="iconfont">
                 
@@ -240,7 +240,7 @@
               </text>
             </g>
           </g>
-          <g fill="none" class="icon" width="12" height="12" x="0" y="-1.9098300562505273" transform="matrix(1,0,0,1,0,-1.909830)">
+          <g fill="none" class="icon" width="12" height="12">
             <g>
               <text fill="rgba(27,50,79,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="icon" text-anchor="middle" width="12" height="12" font-size="20" opacity="0.25" font-family="iconfont">
                 

--- a/packages/g6/__tests__/snapshots/elements/nodes/triangle/default.svg
+++ b/packages/g6/__tests__/snapshots/elements/nodes/triangle/default.svg
@@ -14,7 +14,7 @@
               </text>
             </g>
           </g>
-          <g fill="none" class="icon" x="0" y="6.666666666666667" width="19.777087639996633" height="19.777087639996633">
+          <g fill="none" class="icon" x="0" y="6.666666666666667" width="19.777087639996633" height="19.777087639996633" transform="matrix(1,0,0,1,0,6.666667)">
             <g>
               <text fill="rgba(255,255,255,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="icon" text-anchor="middle" width="19.777087639996633" height="19.777087639996633" font-family="iconfont">
                 
@@ -36,7 +36,7 @@
               </text>
             </g>
           </g>
-          <g fill="none" class="icon" x="0" y="6.666666666666667" width="19.777087639996633" height="19.777087639996633">
+          <g fill="none" class="icon" x="0" y="6.666666666666667" width="19.777087639996633" height="19.777087639996633" transform="matrix(1,0,0,1,0,6.666667)">
             <g>
               <text fill="rgba(255,255,255,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="icon" text-anchor="middle" width="19.777087639996633" height="19.777087639996633" font-family="iconfont">
                 
@@ -55,7 +55,7 @@
               </text>
             </g>
           </g>
-          <g fill="none" class="icon" x="0" y="6.666666666666667" width="19.777087639996633" height="19.777087639996633">
+          <g fill="none" class="icon" x="0" y="6.666666666666667" width="19.777087639996633" height="19.777087639996633" transform="matrix(1,0,0,1,0,6.666667)">
             <g>
               <text fill="rgba(255,255,255,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="icon" text-anchor="middle" width="19.777087639996633" height="19.777087639996633" font-family="iconfont">
                 
@@ -110,9 +110,9 @@
               </text>
             </g>
           </g>
-          <g fill="none" class="icon" x="0" y="6.666666666666667" width="19.777087639996633" height="19.777087639996633">
+          <g fill="none" class="icon" x="0" y="6.666666666666667" width="19.777087639996633" height="19.777087639996633" transform="matrix(1,0,0,1,0,6.666667)">
             <g>
-              <image fill="rgba(255,255,255,1)" preserveAspectRatio="none" x="-9.888543819998317" y="-3.2218771533316497" href="https://gw.alipayobjects.com/zos/basement_prod/012bcf4f-423b-4922-8c24-32a89f8c41ce.svg" class="icon" width="19.777087639996633" height="19.777087639996633" font-family="iconfont"/>
+              <image fill="rgba(255,255,255,1)" preserveAspectRatio="none" x="-9.888543819998317" y="-9.888543819998317" href="https://gw.alipayobjects.com/zos/basement_prod/012bcf4f-423b-4922-8c24-32a89f8c41ce.svg" class="icon" width="19.777087639996633" height="19.777087639996633" font-family="iconfont"/>
             </g>
           </g>
         </g>
@@ -127,7 +127,7 @@
               </text>
             </g>
           </g>
-          <g fill="none" class="icon" x="6.666666666666667" y="0" width="19.777087639996633" height="19.777087639996633">
+          <g fill="none" class="icon" x="6.666666666666667" y="0" width="19.777087639996633" height="19.777087639996633" transform="matrix(1,0,0,1,6.666667,0)">
             <g>
               <text fill="rgba(255,255,255,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="icon" text-anchor="middle" width="19.777087639996633" height="19.777087639996633" font-family="iconfont">
                 
@@ -158,7 +158,7 @@
               </text>
             </g>
           </g>
-          <g fill="none" class="icon" x="0" y="6.666666666666667" width="19.777087639996633" height="19.777087639996633">
+          <g fill="none" class="icon" x="0" y="6.666666666666667" width="19.777087639996633" height="19.777087639996633" transform="matrix(1,0,0,1,0,6.666667)">
             <g>
               <text fill="rgba(255,255,255,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="icon" text-anchor="middle" width="19.777087639996633" height="19.777087639996633" font-family="iconfont">
                 
@@ -180,7 +180,7 @@
               </text>
             </g>
           </g>
-          <g fill="none" class="icon" x="0" y="6.666666666666667" width="19.777087639996633" height="19.777087639996633">
+          <g fill="none" class="icon" x="0" y="6.666666666666667" width="19.777087639996633" height="19.777087639996633" transform="matrix(1,0,0,1,0,6.666667)">
             <g>
               <text fill="rgba(255,255,255,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="icon" text-anchor="middle" width="19.777087639996633" height="19.777087639996633" font-family="iconfont">
                 
@@ -199,7 +199,7 @@
               </text>
             </g>
           </g>
-          <g fill="none" class="icon" x="0" y="6.666666666666667" width="19.777087639996633" height="19.777087639996633">
+          <g fill="none" class="icon" x="0" y="6.666666666666667" width="19.777087639996633" height="19.777087639996633" transform="matrix(1,0,0,1,0,6.666667)">
             <g>
               <text fill="rgba(255,255,255,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="icon" text-anchor="middle" width="19.777087639996633" height="19.777087639996633" font-family="iconfont">
                 
@@ -218,7 +218,7 @@
               </text>
             </g>
           </g>
-          <g fill="none" class="icon" x="0" y="6.666666666666667" width="19.777087639996633" height="19.777087639996633">
+          <g fill="none" class="icon" x="0" y="6.666666666666667" width="19.777087639996633" height="19.777087639996633" transform="matrix(1,0,0,1,0,6.666667)">
             <g>
               <text fill="rgba(255,255,255,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="icon" text-anchor="middle" width="19.777087639996633" height="19.777087639996633" opacity="0.85" font-family="iconfont">
                 
@@ -237,7 +237,7 @@
               </text>
             </g>
           </g>
-          <g fill="none" class="icon" x="0" y="6.666666666666667" width="19.777087639996633" height="19.777087639996633">
+          <g fill="none" class="icon" x="0" y="6.666666666666667" width="19.777087639996633" height="19.777087639996633" transform="matrix(1,0,0,1,0,6.666667)">
             <g>
               <text fill="rgba(27,50,79,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="icon" text-anchor="middle" width="19.777087639996633" height="19.777087639996633" opacity="0.25" font-family="iconfont">
                 

--- a/packages/g6/__tests__/snapshots/layouts/compact-box/left-align.svg
+++ b/packages/g6/__tests__/snapshots/layouts/compact-box/left-align.svg
@@ -229,7 +229,7 @@
           <g>
             <circle fill="rgba(239,244,255,1)" class="key" stroke-width="1" stroke="rgba(95,149,255,1)" r="13"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,13,1.999970)">
+          <g fill="none" class="label" transform="matrix(1,0,0,1,13,2)">
             <g>
               <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 Classification
@@ -241,7 +241,7 @@
           <g>
             <circle fill="rgba(239,244,255,1)" class="key" stroke-width="1" stroke="rgba(95,149,255,1)" r="13"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,12.999994,2.000006)">
+          <g fill="none" class="label" transform="matrix(1,0,0,1,13,2)">
             <g>
               <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 Logistic regression
@@ -253,7 +253,7 @@
           <g>
             <circle fill="rgba(239,244,255,1)" class="key" stroke-width="1" stroke="rgba(95,149,255,1)" r="13"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,12.999996,2.000006)">
+          <g fill="none" class="label" transform="matrix(1,0,0,1,13,2)">
             <g>
               <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 Linear discriminant analysis
@@ -265,7 +265,7 @@
           <g>
             <circle fill="rgba(239,244,255,1)" class="key" stroke-width="1" stroke="rgba(95,149,255,1)" r="13"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,12.999998,2.000006)">
+          <g fill="none" class="label" transform="matrix(1,0,0,1,13,2)">
             <g>
               <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 Rules
@@ -277,7 +277,7 @@
           <g>
             <circle fill="rgba(239,244,255,1)" class="key" stroke-width="1" stroke="rgba(95,149,255,1)" r="13"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,13,1.999976)">
+          <g fill="none" class="label" transform="matrix(1,0,0,1,13,2)">
             <g>
               <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 Decision trees
@@ -289,7 +289,7 @@
           <g>
             <circle fill="rgba(239,244,255,1)" class="key" stroke-width="1" stroke="rgba(95,149,255,1)" r="13"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,13.000002,1.999976)">
+          <g fill="none" class="label" transform="matrix(1,0,0,1,13,2)">
             <g>
               <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 Naive Bayes
@@ -301,7 +301,7 @@
           <g>
             <circle fill="rgba(239,244,255,1)" class="key" stroke-width="1" stroke="rgba(95,149,255,1)" r="13"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,12.999989,1.999976)">
+          <g fill="none" class="label" transform="matrix(1,0,0,1,13,2)">
             <g>
               <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 K nearest neighbor
@@ -313,7 +313,7 @@
           <g>
             <circle fill="rgba(239,244,255,1)" class="key" stroke-width="1" stroke="rgba(95,149,255,1)" r="13"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,12.999990,1.999976)">
+          <g fill="none" class="label" transform="matrix(1,0,0,1,13,2)">
             <g>
               <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 Probabilistic neural network
@@ -325,7 +325,7 @@
           <g>
             <circle fill="rgba(239,244,255,1)" class="key" stroke-width="1" stroke="rgba(95,149,255,1)" r="13"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,12.999992,1.999991)">
+          <g fill="none" class="label" transform="matrix(1,0,0,1,13,2)">
             <g>
               <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 Support vector machine
@@ -349,7 +349,7 @@
           <g>
             <circle fill="rgba(239,244,255,1)" class="key" stroke-width="1" stroke="rgba(95,149,255,1)" r="13"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,12.999994,1.999991)">
+          <g fill="none" class="label" transform="matrix(1,0,0,1,13,2)">
             <g>
               <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 Models diversity
@@ -361,7 +361,7 @@
           <g>
             <circle fill="rgba(239,244,255,1)" class="key" stroke-width="1" stroke="rgba(95,149,255,1)" r="13"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,12.999990,1.999982)">
+          <g fill="none" class="label" transform="matrix(1,0,0,1,13,2)">
             <g>
               <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 Different initializations
@@ -373,7 +373,7 @@
           <g>
             <circle fill="rgba(239,244,255,1)" class="key" stroke-width="1" stroke="rgba(95,149,255,1)" r="13"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,12.999991,1.999982)">
+          <g fill="none" class="label" transform="matrix(1,0,0,1,13,2)">
             <g>
               <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 Different parameter choices
@@ -385,7 +385,7 @@
           <g>
             <circle fill="rgba(239,244,255,1)" class="key" stroke-width="1" stroke="rgba(95,149,255,1)" r="13"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,12.999993,1.999997)">
+          <g fill="none" class="label" transform="matrix(1,0,0,1,13,2)">
             <g>
               <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 Different architectures
@@ -397,7 +397,7 @@
           <g>
             <circle fill="rgba(239,244,255,1)" class="key" stroke-width="1" stroke="rgba(95,149,255,1)" r="13"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,12.999995,1.999997)">
+          <g fill="none" class="label" transform="matrix(1,0,0,1,13,2)">
             <g>
               <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 Different modeling methods
@@ -409,7 +409,7 @@
           <g>
             <circle fill="rgba(239,244,255,1)" class="key" stroke-width="1" stroke="rgba(95,149,255,1)" r="13"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,12.999997,1.999997)">
+          <g fill="none" class="label" transform="matrix(1,0,0,1,13,2)">
             <g>
               <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 Different training sets
@@ -421,7 +421,7 @@
           <g>
             <circle fill="rgba(239,244,255,1)" class="key" stroke-width="1" stroke="rgba(95,149,255,1)" r="13"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,12.999999,1.999997)">
+          <g fill="none" class="label" transform="matrix(1,0,0,1,13,2)">
             <g>
               <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 Different feature sets
@@ -433,7 +433,7 @@
           <g>
             <circle fill="rgba(239,244,255,1)" class="key" stroke-width="1" stroke="rgba(95,149,255,1)" r="13"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,13.000002,2.000002)">
+          <g fill="none" class="label" transform="matrix(1,0,0,1,13,2)">
             <g>
               <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 Methods
@@ -469,7 +469,7 @@
           <g>
             <circle fill="rgba(239,244,255,1)" class="key" stroke-width="1" stroke="rgba(95,149,255,1)" r="13"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,12.999991,2.000006)">
+          <g fill="none" class="label" transform="matrix(1,0,0,1,13,2)">
             <g>
               <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 Common
@@ -481,7 +481,7 @@
           <g>
             <circle fill="rgba(239,244,255,1)" class="key" stroke-width="1" stroke="rgba(95,149,255,1)" r="13"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,12.999974,2.000005)">
+          <g fill="none" class="label" transform="matrix(1,0,0,1,13,2)">
             <g>
               <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 Bagging
@@ -493,7 +493,7 @@
           <g>
             <circle fill="rgba(239,244,255,1)" class="key" stroke-width="1" stroke="rgba(95,149,255,1)" r="13"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,12.999976,2.000012)">
+          <g fill="none" class="label" transform="matrix(1,0,0,1,13,2)">
             <g>
               <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 Boosting
@@ -505,7 +505,7 @@
           <g>
             <circle fill="rgba(239,244,255,1)" class="key" stroke-width="1" stroke="rgba(95,149,255,1)" r="13"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,12.999978,2.000012)">
+          <g fill="none" class="label" transform="matrix(1,0,0,1,13,2)">
             <g>
               <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 AdaBoost
@@ -529,7 +529,7 @@
           <g>
             <circle fill="rgba(239,244,255,1)" class="key" stroke-width="1" stroke="rgba(95,149,255,1)" r="13"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,12.999993,2.000006)">
+          <g fill="none" class="label" transform="matrix(1,0,0,1,13,2)">
             <g>
               <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 Multiple linear regression
@@ -541,7 +541,7 @@
           <g>
             <circle fill="rgba(239,244,255,1)" class="key" stroke-width="1" stroke="rgba(95,149,255,1)" r="13"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,12.999995,2.000006)">
+          <g fill="none" class="label" transform="matrix(1,0,0,1,13,2)">
             <g>
               <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 Partial least squares
@@ -553,7 +553,7 @@
           <g>
             <circle fill="rgba(239,244,255,1)" class="key" stroke-width="1" stroke="rgba(95,149,255,1)" r="13"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,12.999997,2.000006)">
+          <g fill="none" class="label" transform="matrix(1,0,0,1,13,2)">
             <g>
               <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 Multi-layer feed forward neural network
@@ -565,7 +565,7 @@
           <g>
             <circle fill="rgba(239,244,255,1)" class="key" stroke-width="1" stroke="rgba(95,149,255,1)" r="13"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,12.999999,2.000006)">
+          <g fill="none" class="label" transform="matrix(1,0,0,1,13,2)">
             <g>
               <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 General regression neural network
@@ -577,7 +577,7 @@
           <g>
             <circle fill="rgba(239,244,255,1)" class="key" stroke-width="1" stroke="rgba(95,149,255,1)" r="13"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,13.000001,2.000006)">
+          <g fill="none" class="label" transform="matrix(1,0,0,1,13,2)">
             <g>
               <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 Support vector regression

--- a/packages/g6/__tests__/snapshots/layouts/dendrogram/tb.svg
+++ b/packages/g6/__tests__/snapshots/layouts/dendrogram/tb.svg
@@ -241,7 +241,7 @@
           <g>
             <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,-0.000003,18.000010)">
+          <g fill="none" class="label" transform="matrix(1,0,0,1,0,18)">
             <g>
               <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" dy="-11.5px" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 Logistic regression
@@ -253,7 +253,7 @@
           <g>
             <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,-0.000001,17.999979)">
+          <g fill="none" class="label" transform="matrix(1,0,0,1,0,18)">
             <g>
               <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" dy="-11.5px" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 Linear discriminant analysis
@@ -265,7 +265,7 @@
           <g>
             <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,-0.000015,17.999979)">
+          <g fill="none" class="label" transform="matrix(1,0,0,1,0,18)">
             <g>
               <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" dy="-11.5px" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 Rules
@@ -277,7 +277,7 @@
           <g>
             <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,-0.000014,17.999979)">
+          <g fill="none" class="label" transform="matrix(1,0,0,1,0,18)">
             <g>
               <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" dy="-11.5px" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 Decision trees
@@ -289,7 +289,7 @@
           <g>
             <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,-0.000013,17.999979)">
+          <g fill="none" class="label" transform="matrix(1,0,0,1,0,18)">
             <g>
               <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" dy="-11.5px" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 Naive Bayes
@@ -301,7 +301,7 @@
           <g>
             <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,-0.000011,17.999979)">
+          <g fill="none" class="label" transform="matrix(1,0,0,1,0,18)">
             <g>
               <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" dy="-11.5px" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 K nearest neighbor
@@ -313,7 +313,7 @@
           <g>
             <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,-0.000010,17.999979)">
+          <g fill="none" class="label" transform="matrix(1,0,0,1,0,18)">
             <g>
               <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" dy="-11.5px" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 Probabilistic neural network
@@ -325,7 +325,7 @@
           <g>
             <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,-0.000008,17.999994)">
+          <g fill="none" class="label" transform="matrix(1,0,0,1,0,18)">
             <g>
               <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" dy="-11.5px" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 Support vector machine
@@ -361,7 +361,7 @@
           <g>
             <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,-0.000007,17.999994)">
+          <g fill="none" class="label" transform="matrix(1,0,0,1,0,18)">
             <g>
               <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" dy="-11.5px" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 Different initializations
@@ -373,7 +373,7 @@
           <g>
             <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,-0.000005,17.999994)">
+          <g fill="none" class="label" transform="matrix(1,0,0,1,0,18)">
             <g>
               <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" dy="-11.5px" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 Different parameter choices
@@ -385,7 +385,7 @@
           <g>
             <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,-0.000004,17.999994)">
+          <g fill="none" class="label" transform="matrix(1,0,0,1,0,18)">
             <g>
               <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" dy="-11.5px" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 Different architectures
@@ -397,7 +397,7 @@
           <g>
             <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,-0.000003,18.000002)">
+          <g fill="none" class="label" transform="matrix(1,0,0,1,0,18)">
             <g>
               <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" dy="-11.5px" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 Different modeling methods
@@ -409,7 +409,7 @@
           <g>
             <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,-0.000001,17.999998)">
+          <g fill="none" class="label" transform="matrix(1,0,0,1,0,18)">
             <g>
               <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" dy="-11.5px" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 Different training sets
@@ -421,7 +421,7 @@
           <g>
             <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,-0.000015,18)">
+          <g fill="none" class="label" transform="matrix(1,0,0,1,0,18)">
             <g>
               <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" dy="-11.5px" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 Different feature sets
@@ -445,7 +445,7 @@
           <g>
             <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,-0.000013,18.000002)">
+          <g fill="none" class="label" transform="matrix(1,0,0,1,0,18)">
             <g>
               <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" dy="-11.5px" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 Classifier selection
@@ -457,7 +457,7 @@
           <g>
             <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,-0.000012,18.000002)">
+          <g fill="none" class="label" transform="matrix(1,0,0,1,0,18)">
             <g>
               <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" dy="-11.5px" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 Classifier fusion
@@ -481,7 +481,7 @@
           <g>
             <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,-0.000010,18.000010)">
+          <g fill="none" class="label" transform="matrix(1,0,0,1,0,18)">
             <g>
               <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" dy="-11.5px" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 Bagging
@@ -493,7 +493,7 @@
           <g>
             <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,-0.000009,18.000010)">
+          <g fill="none" class="label" transform="matrix(1,0,0,1,0,18)">
             <g>
               <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" dy="-11.5px" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 Boosting
@@ -505,7 +505,7 @@
           <g>
             <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,-0.000008,18.000010)">
+          <g fill="none" class="label" transform="matrix(1,0,0,1,0,18)">
             <g>
               <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" dy="-11.5px" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 AdaBoost
@@ -529,7 +529,7 @@
           <g>
             <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,-0.000006,18.000010)">
+          <g fill="none" class="label" transform="matrix(1,0,0,1,0,18)">
             <g>
               <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" dy="-11.5px" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 Multiple linear regression
@@ -541,7 +541,7 @@
           <g>
             <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,-0.000005,18.000010)">
+          <g fill="none" class="label" transform="matrix(1,0,0,1,0,18)">
             <g>
               <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" dy="-11.5px" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 Partial least squares
@@ -553,7 +553,7 @@
           <g>
             <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,-0.000003,18.000010)">
+          <g fill="none" class="label" transform="matrix(1,0,0,1,0,18)">
             <g>
               <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" dy="-11.5px" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 Multi-layer feed forward neural network
@@ -565,7 +565,7 @@
           <g>
             <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,-0.000002,18.000010)">
+          <g fill="none" class="label" transform="matrix(1,0,0,1,0,18)">
             <g>
               <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" dy="-11.5px" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 General regression neural network
@@ -577,7 +577,7 @@
           <g>
             <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,-0.000016,18.000010)">
+          <g fill="none" class="label" transform="matrix(1,0,0,1,0,18)">
             <g>
               <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" dy="-11.5px" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 Support vector regression

--- a/packages/g6/__tests__/unit/elements/combo.spec.ts
+++ b/packages/g6/__tests__/unit/elements/combo.spec.ts
@@ -1,4 +1,4 @@
-import { combo } from '@/__tests__/demos';
+import { elementCombo } from '@/__tests__/demos';
 import { type Graph } from '@/src';
 import { createDemoGraph } from '@@/utils';
 
@@ -6,7 +6,7 @@ describe('combo', () => {
   let graph: Graph;
 
   beforeAll(async () => {
-    graph = await createDemoGraph(combo, { animation: false });
+    graph = await createDemoGraph(elementCombo, { animation: false });
   });
 
   afterAll(() => {
@@ -19,27 +19,18 @@ describe('combo', () => {
 
   it('collapse circle combo', async () => {
     const expandCombo = async () => {
-      graph.updateComboData([
-        {
-          id: 'combo-2',
-          style: {
-            collapsed: false,
-          },
-        },
-      ]);
-      await graph.render();
+      await graph.expandElement('combo-2');
     };
     const collapseCombo = async () => {
       graph.updateComboData([
         {
           id: 'combo-2',
           style: {
-            collapsed: true,
             collapsedMarker: false,
           },
         },
       ]);
-      await graph.render();
+      await graph.collapseElement('combo-2');
     };
     await collapseCombo();
     await expect(graph).toMatchSnapshot(__filename, 'circle-collapse-center');
@@ -48,16 +39,7 @@ describe('combo', () => {
 
   it('collapse rect combo', async () => {
     const expandCombo = async () => {
-      graph.updateComboData([
-        {
-          id: 'combo-1',
-          type: 'rect',
-          style: {
-            collapsed: false,
-          },
-        },
-      ]);
-      await graph.render();
+      await graph.expandElement('combo-1');
     };
     const collapseCombo = async () => {
       graph.updateComboData([
@@ -65,12 +47,11 @@ describe('combo', () => {
           id: 'combo-1',
           type: 'rect',
           style: {
-            collapsed: true,
             collapsedMarker: false,
           },
         },
       ]);
-      await graph.render();
+      await graph.collapseElement('combo-1');
     };
 
     await collapseCombo();

--- a/packages/g6/__tests__/unit/utils/style.spec.ts
+++ b/packages/g6/__tests__/unit/utils/style.spec.ts
@@ -1,4 +1,4 @@
-import { computeElementCallbackStyle, mergeOptions } from '@/src/utils/style';
+import { computeElementCallbackStyle, getSubShapeStyle, mergeOptions } from '@/src/utils/style';
 
 describe('style', () => {
   it('computeElementCallbackStyle', () => {
@@ -46,5 +46,17 @@ describe('style', () => {
         { style: { a: 2, b: [2, 3], c: { f: 1 } }, id: '2' },
       ),
     ).toEqual({ style: { a: 2, b: [2, 3], c: { f: 1 } }, id: '2' });
+  });
+
+  it('getSubShapeStyle', () => {
+    const style = {
+      x: 100,
+      y: 100,
+      class: 'node',
+      transform: 'translate(100, 100)',
+      zIndex: 100,
+      fill: 'pink',
+    };
+    expect(getSubShapeStyle(style)).toEqual({ fill: 'pink' });
   });
 });

--- a/packages/g6/jest.config.js
+++ b/packages/g6/jest.config.js
@@ -7,7 +7,17 @@ module.exports = {
   testEnvironment: 'jsdom',
   setupFilesAfterEnv: ['./__tests__/setup.ts'],
   transform: {
-    '^.+\\.[tj]s$': ['@swc/jest'],
+    '^.+\\.[tj]s$': [
+      '@swc/jest',
+      {
+        jsc: {
+          parser: {
+            syntax: 'typescript',
+            decorators: true,
+          },
+        },
+      },
+    ],
     '^.+\\.svg$': ['<rootDir>/__tests__/utils/svg-transformer.js'],
   },
   collectCoverageFrom: ['src/**/*.ts'],

--- a/packages/g6/src/elements/combos/base-combo.ts
+++ b/packages/g6/src/elements/combos/base-combo.ts
@@ -20,6 +20,7 @@ import { subStyleProps } from '../../utils/prefix';
 import { parseSize } from '../../utils/size';
 import { mergeOptions } from '../../utils/style';
 import { add, divide } from '../../utils/vector';
+import { effect } from '../effect';
 import type { BaseNodeStyleProps } from '../nodes';
 import { BaseNode } from '../nodes';
 import { Icon, IconStyleProps } from '../shapes';
@@ -145,6 +146,7 @@ export abstract class BaseCombo<S extends BaseComboStyleProps = BaseComboStylePr
     return getExpandedBBox(childrenBBox, padding);
   }
 
+  @effect((self, attributes) => self.getCollapsedMarkerStyle(attributes))
   protected drawCollapsedMarkerShape(attributes: Required<S>, container: Group): void {
     this.upsert('collapsed-marker', Icon, this.getCollapsedMarkerStyle(attributes), container);
   }
@@ -220,9 +222,9 @@ export abstract class BaseCombo<S extends BaseComboStyleProps = BaseComboStylePr
   protected updateComboPosition(attributes: Required<S>) {
     const comboStyle = this.getComboStyle(attributes);
     Object.assign(this.style, comboStyle);
-
     // Sync combo position to model
-    attributes.context!.model.syncComboDatum({ id: this.id, style: comboStyle });
+    const { x, y } = comboStyle;
+    attributes.context!.model.syncComboDatum({ id: this.id, style: { x, y } });
   }
 
   public render(attributes: Required<S>, container: Group = this) {
@@ -236,8 +238,6 @@ export abstract class BaseCombo<S extends BaseComboStyleProps = BaseComboStylePr
     super.update(attr);
     this.updateComboPosition(this.parsedAttributes);
   }
-
-  protected hostingAnimation = false;
 
   protected onframe() {
     super.onframe();

--- a/packages/g6/src/elements/combos/base-combo.ts
+++ b/packages/g6/src/elements/combos/base-combo.ts
@@ -105,6 +105,7 @@ export abstract class BaseCombo<S extends BaseComboStyleProps = BaseComboStylePr
   };
   constructor(options: DisplayObjectConfig<BaseComboStyleProps>) {
     super(mergeOptions({ style: BaseCombo.defaultStyleProps }, options));
+    this.updateComboPosition(this.parsedAttributes);
   }
 
   /**
@@ -226,10 +227,14 @@ export abstract class BaseCombo<S extends BaseComboStyleProps = BaseComboStylePr
 
   public render(attributes: Required<S>, container: Group = this) {
     super.render(attributes, container);
-    this.updateComboPosition(attributes);
 
     // collapsed marker
     this.drawCollapsedMarkerShape(attributes, container);
+  }
+
+  public update(attr: Partial<S> = {}): void {
+    super.update(attr);
+    this.updateComboPosition(this.parsedAttributes);
   }
 
   protected hostingAnimation = false;

--- a/packages/g6/src/elements/edges/base-edge.ts
+++ b/packages/g6/src/elements/edges/base-edge.ts
@@ -218,20 +218,19 @@ export abstract class BaseEdge extends BaseElement<BaseEdgeStyleProps> implement
     super(mergeOptions({ style: BaseEdge.defaultStyleProps }, options));
   }
 
+  protected get sourceNode() {
+    const { context, sourceNode: source } = this.parsedAttributes;
+    return context.element!.getElement<Node>(source)!;
+  }
+
   protected get targetNode() {
     const { context, targetNode: target } = this.parsedAttributes;
     return context.element!.getElement<Node>(target)!;
   }
 
-  protected getNode(id: ID) {
-    return this.parsedAttributes.context.element!.getElement<Node>(id)!;
-  }
-
   protected getKeyStyle(attributes: ParsedBaseEdgeStyleProps): PathStyleProps {
-    const { sourceNode: source, targetNode: target } = attributes;
     const { loop, ...style } = this.getGraphicStyle(attributes);
-    const sourceNode = this.getNode(source);
-    const targetNode = this.getNode(target);
+    const { sourceNode, targetNode } = this;
 
     const d = loop && isSameNode(sourceNode, targetNode) ? this.getLoopPath(attributes) : this.getKeyPath(attributes);
 
@@ -244,8 +243,8 @@ export abstract class BaseEdge extends BaseElement<BaseEdgeStyleProps> implement
   protected abstract getKeyPath(attributes: ParsedBaseEdgeStyleProps): PathArray;
 
   protected getLoopPath(attributes: ParsedBaseEdgeStyleProps): PathArray {
-    const { sourceNode, sourcePort, targetPort } = attributes;
-    const node = this.getNode(sourceNode);
+    const { sourcePort, targetPort } = attributes;
+    const node = this.sourceNode;
 
     const bbox = getNodeBBox(node);
     const defaultDist = Math.max(getBBoxWidth(bbox), getBBoxHeight(bbox));
@@ -260,9 +259,8 @@ export abstract class BaseEdge extends BaseElement<BaseEdgeStyleProps> implement
   }
 
   protected getEndpoints(attributes: ParsedBaseEdgeStyleProps): [Point, Point] {
-    const { sourceNode: source, targetNode: target, sourcePort: sourcePortKey, targetPort: targetPortKey } = attributes;
-    const sourceNode = this.getNode(source);
-    const targetNode = this.getNode(target);
+    const { sourcePort: sourcePortKey, targetPort: targetPortKey } = attributes;
+    const { sourceNode, targetNode } = this;
 
     const [sourcePort, targetPort] = findPorts(sourceNode, targetNode, sourcePortKey, targetPortKey);
 

--- a/packages/g6/src/elements/edges/base-edge.ts
+++ b/packages/g6/src/elements/edges/base-edge.ts
@@ -25,6 +25,7 @@ import { mergeOptions } from '../../utils/style';
 import * as Symbol from '../../utils/symbol';
 import { getWordWrapWidthByEnds } from '../../utils/text';
 import { BaseElement } from '../base-element';
+import { effect } from '../effect';
 import type { BadgeStyleProps, LabelStyleProps } from '../shapes';
 import { Badge, Label } from '../shapes';
 
@@ -363,42 +364,60 @@ export abstract class BaseEdge extends BaseElement<BaseEdgeStyleProps> implement
     );
   }
 
+  @effect((self, attributes) => self.getLabelStyle(attributes))
   protected drawLabelShape(attributes: ParsedBaseEdgeStyleProps, container: Group) {
     this.upsert('label', Label, this.getLabelStyle(attributes), container);
   }
 
+  @effect((self, attributes) => self.getHaloStyle(attributes))
   protected drawHaloShape(attributes: ParsedBaseEdgeStyleProps, container: Group) {
     this.upsert('halo', Path, this.getHaloStyle(attributes), container);
   }
 
+  @effect((self, attributes) => self.getBadgeStyle(attributes))
   protected drawBadgeShape(attributes: ParsedBaseEdgeStyleProps, container: Group) {
     this.upsert('badge', Badge, this.getBadgeStyle(attributes), container);
   }
 
+  @effect((self, attributes) => self.getArrowStyle(attributes, 'start'))
+  protected drawSourceArrow(attributes: ParsedBaseEdgeStyleProps) {
+    this.drawArrow(attributes, 'start');
+  }
+
+  @effect((self, attributes) => self.getArrowStyle(attributes, 'end'))
+  protected drawTargetArrow(attributes: ParsedBaseEdgeStyleProps) {
+    this.drawArrow(attributes, 'end');
+  }
+
+  @effect((self, attributes) => self.getKeyStyle(attributes))
   protected drawKeyShape(attributes: ParsedBaseEdgeStyleProps, container: Group): Path | undefined {
     const key = this.upsert('key', Path, this.getKeyStyle(attributes), container);
-    this.drawArrow(attributes, 'start');
-    this.drawArrow(attributes, 'end');
     return key;
   }
 
   public render(attributes = this.parsedAttributes, container: Group = this): void {
     // 1. key shape
-    const keyShape = this.drawKeyShape(attributes, container);
-    if (!keyShape) return;
+    this.drawKeyShape(attributes, container);
+    if (!this.getShape('key')) return;
 
-    // 2. label
+    // 2. arrows
+    this.drawSourceArrow(attributes);
+    this.drawTargetArrow(attributes);
+
+    // 3. label
     this.drawLabelShape(attributes, container);
 
-    // 3. halo
+    // 4. halo
     this.drawHaloShape(attributes, container);
 
-    // 4. badge
+    // 5. badges
     this.drawBadgeShape(attributes, container);
   }
 
   protected onframe() {
     this.drawKeyShape(this.parsedAttributes, this);
+    this.drawSourceArrow(this.parsedAttributes);
+    this.drawTargetArrow(this.parsedAttributes);
     this.drawHaloShape(this.parsedAttributes, this);
     this.drawLabelShape(this.parsedAttributes, this);
     this.drawBadgeShape(this.parsedAttributes, this);

--- a/packages/g6/src/elements/edges/base-edge.ts
+++ b/packages/g6/src/elements/edges/base-edge.ts
@@ -217,19 +217,20 @@ export abstract class BaseEdge extends BaseElement<BaseEdgeStyleProps> implement
     super(mergeOptions({ style: BaseEdge.defaultStyleProps }, options));
   }
 
-  protected get sourceNode() {
-    const { context, sourceNode: source } = this.parsedAttributes;
-    return context.element!.getElement<Node>(source)!;
-  }
-
   protected get targetNode() {
     const { context, targetNode: target } = this.parsedAttributes;
     return context.element!.getElement<Node>(target)!;
   }
 
+  protected getNode(id: ID) {
+    return this.parsedAttributes.context.element!.getElement<Node>(id)!;
+  }
+
   protected getKeyStyle(attributes: ParsedBaseEdgeStyleProps): PathStyleProps {
+    const { sourceNode: source, targetNode: target } = attributes;
     const { loop, ...style } = this.getGraphicStyle(attributes);
-    const { sourceNode, targetNode } = this;
+    const sourceNode = this.getNode(source);
+    const targetNode = this.getNode(target);
 
     const d = loop && isSameNode(sourceNode, targetNode) ? this.getLoopPath(attributes) : this.getKeyPath(attributes);
 
@@ -242,8 +243,8 @@ export abstract class BaseEdge extends BaseElement<BaseEdgeStyleProps> implement
   protected abstract getKeyPath(attributes: ParsedBaseEdgeStyleProps): PathArray;
 
   protected getLoopPath(attributes: ParsedBaseEdgeStyleProps): PathArray {
-    const { sourcePort, targetPort } = attributes;
-    const node = this.sourceNode;
+    const { sourceNode, sourcePort, targetPort } = attributes;
+    const node = this.getNode(sourceNode);
 
     const bbox = getNodeBBox(node);
     const defaultDist = Math.max(getBBoxWidth(bbox), getBBoxHeight(bbox));
@@ -258,8 +259,9 @@ export abstract class BaseEdge extends BaseElement<BaseEdgeStyleProps> implement
   }
 
   protected getEndpoints(attributes: ParsedBaseEdgeStyleProps): [Point, Point] {
-    const { sourcePort: sourcePortKey, targetPort: targetPortKey } = attributes;
-    const { sourceNode, targetNode } = this;
+    const { sourceNode: source, targetNode: target, sourcePort: sourcePortKey, targetPort: targetPortKey } = attributes;
+    const sourceNode = this.getNode(source);
+    const targetNode = this.getNode(target);
 
     const [sourcePort, targetPort] = findPorts(sourceNode, targetNode, sourcePortKey, targetPortKey);
 

--- a/packages/g6/src/elements/edges/polyline.ts
+++ b/packages/g6/src/elements/edges/polyline.ts
@@ -74,9 +74,8 @@ export class Polyline extends BaseEdge {
   }
 
   protected getKeyPath(attributes: ParsedPolylineStyleProps): PathArray {
-    const { radius, sourceNode: source, targetNode: target } = attributes;
-    const sourceNode = this.getNode(source);
-    const targetNode = this.getNode(target);
+    const { radius } = attributes;
+    const { sourceNode, targetNode } = this;
     // 1. 获取连接点（若有连接桩，取连接桩中心；反之，取节点中心）和连接桩 | Get connection points (if port, take port center; otherwise, take node center) and ports
     const { sourcePoint, targetPoint, sourcePort, targetPort } = this.getEndpointsAndPorts(attributes);
 
@@ -100,9 +99,8 @@ export class Polyline extends BaseEdge {
     sourcePort: Port | undefined;
     targetPort: Port | undefined;
   } {
-    const { sourceNode: source, targetNode: target, sourcePort: sourcePortKey, targetPort: targetPortKey } = attributes;
-    const sourceNode = this.getNode(source);
-    const targetNode = this.getNode(target);
+    const { sourcePort: sourcePortKey, targetPort: targetPortKey } = attributes;
+    const { sourceNode, targetNode } = this;
 
     const [sourcePort, targetPort] = findPorts(sourceNode, targetNode, sourcePortKey, targetPortKey);
 
@@ -115,9 +113,8 @@ export class Polyline extends BaseEdge {
   }
 
   protected getControlPoints(attributes: ParsedPolylineStyleProps, sourcePoint: Point, targetPoint: Point): Point[] {
-    const { sourceNode: source, targetNode: target, controlPoints, router, routerPadding } = attributes;
-    const sourceNode = this.getNode(source);
-    const targetNode = this.getNode(target);
+    const { controlPoints, router, routerPadding } = attributes;
+    const { sourceNode, targetNode } = this;
 
     if (!router) return [...controlPoints];
 
@@ -128,8 +125,8 @@ export class Polyline extends BaseEdge {
   }
 
   protected getLoopPath(attributes: ParsedPolylineStyleProps): PathArray {
-    const { sourceNode: source, sourcePort: sourcePortKey, targetPort: targetPortKey, radius } = attributes;
-    const node = this.getNode(source);
+    const { sourcePort: sourcePortKey, targetPort: targetPortKey, radius } = attributes;
+    const node = this.sourceNode;
 
     const bbox = getNodeBBox(node);
     // 默认转折点距离为 bbox 的最大宽高的 1/4 | Default distance of the turning point is 1/4 of the maximum width and height of the bbox

--- a/packages/g6/src/elements/edges/polyline.ts
+++ b/packages/g6/src/elements/edges/polyline.ts
@@ -74,8 +74,9 @@ export class Polyline extends BaseEdge {
   }
 
   protected getKeyPath(attributes: ParsedPolylineStyleProps): PathArray {
-    const { radius } = attributes;
-    const { sourceNode, targetNode } = this;
+    const { radius, sourceNode: source, targetNode: target } = attributes;
+    const sourceNode = this.getNode(source);
+    const targetNode = this.getNode(target);
     // 1. 获取连接点（若有连接桩，取连接桩中心；反之，取节点中心）和连接桩 | Get connection points (if port, take port center; otherwise, take node center) and ports
     const { sourcePoint, targetPoint, sourcePort, targetPort } = this.getEndpointsAndPorts(attributes);
 
@@ -99,8 +100,9 @@ export class Polyline extends BaseEdge {
     sourcePort: Port | undefined;
     targetPort: Port | undefined;
   } {
-    const { sourcePort: sourcePortKey, targetPort: targetPortKey } = attributes;
-    const { sourceNode, targetNode } = this;
+    const { sourceNode: source, targetNode: target, sourcePort: sourcePortKey, targetPort: targetPortKey } = attributes;
+    const sourceNode = this.getNode(source);
+    const targetNode = this.getNode(target);
 
     const [sourcePort, targetPort] = findPorts(sourceNode, targetNode, sourcePortKey, targetPortKey);
 
@@ -113,8 +115,9 @@ export class Polyline extends BaseEdge {
   }
 
   protected getControlPoints(attributes: ParsedPolylineStyleProps, sourcePoint: Point, targetPoint: Point): Point[] {
-    const { controlPoints, router, routerPadding } = attributes;
-    const { sourceNode, targetNode } = this;
+    const { sourceNode: source, targetNode: target, controlPoints, router, routerPadding } = attributes;
+    const sourceNode = this.getNode(source);
+    const targetNode = this.getNode(target);
 
     if (!router) return [...controlPoints];
 
@@ -125,8 +128,8 @@ export class Polyline extends BaseEdge {
   }
 
   protected getLoopPath(attributes: ParsedPolylineStyleProps): PathArray {
-    const { sourcePort: sourcePortKey, targetPort: targetPortKey, radius } = attributes;
-    const node = this.sourceNode;
+    const { sourceNode: source, sourcePort: sourcePortKey, targetPort: targetPortKey, radius } = attributes;
+    const node = this.getNode(source);
 
     const bbox = getNodeBBox(node);
     // 默认转折点距离为 bbox 的最大宽高的 1/4 | Default distance of the turning point is 1/4 of the maximum width and height of the bbox

--- a/packages/g6/src/elements/effect.ts
+++ b/packages/g6/src/elements/effect.ts
@@ -1,0 +1,42 @@
+import { isEqual } from '@antv/util';
+import type { Element } from '../types';
+import { getCachedStyle, setCacheStyle } from '../utils/cache';
+
+/**
+ * <zh/> 基于样式属性是否变化控制函数是否执行
+ *
+ * <en/> Control whether the function is executed based on whether the style attribute changes
+ * @param styler - <zh/> 获取样式属性函数 | <en/> Get style attribute function
+ * @returns <zh/> 装饰器 | <en/> Decorator
+ * @description
+ * <zh/> 仅指定 getStyle 的情况下，会分别使用当前的 attributes 和 新的 attributes 调用函数，若两者相同，则不执行函数。
+ *
+ * 如果指定了 shapeKey, 则会直接获取该图形的 attributes 作为原始样式属性，通常在 getStyle 函数中获取了包围盒时使用。
+ *
+ * <en/> Only when getStyle is specified, the function will be called with the current attributes and the new attributes respectively. If they are the same, the function will not be executed.
+ *
+ * If shapeKey is specified, the attributes of the shape will be directly obtained as the original style attributes, which is usually used when the bounding box of the element is used in the getStyle function.
+ */
+export function effect(styler: (self: any, attributes: Record<string, unknown>) => Record<string, unknown>) {
+  return function (target: Element, propertyKey: string, descriptor: PropertyDescriptor) {
+    const fn = descriptor.value;
+
+    descriptor.value = function (this: Element, attr: Record<string, unknown>, ...rest: unknown[]) {
+      // 初始化后需要执行首次调用 / First call after initialization
+      const initKey = `${propertyKey}_invoke`;
+      if (!getCachedStyle(this, initKey)) {
+        setCacheStyle(this, initKey, true);
+        return fn.call(this, attr, ...rest);
+      }
+
+      const styleKey = `${propertyKey}_style`;
+      const original = getCachedStyle(this, styleKey);
+      const modified = styler(this, attr);
+      setCacheStyle(this, styleKey, modified);
+
+      if (isEqual(original, modified)) return null;
+      return fn.call(this, attr, ...rest);
+    };
+    return descriptor;
+  };
+}

--- a/packages/g6/src/elements/nodes/base-node.ts
+++ b/packages/g6/src/elements/nodes/base-node.ts
@@ -25,7 +25,6 @@ import { omitStyleProps, subObject, subStyleProps } from '../../utils/prefix';
 import { parseSize } from '../../utils/size';
 import { mergeOptions } from '../../utils/style';
 import { getWordWrapWidthByBox } from '../../utils/text';
-import { replaceTranslateInTransform } from '../../utils/transform';
 import { BaseElement } from '../base-element';
 import type { BadgeStyleProps, IconStyleProps, LabelStyleProps } from '../shapes';
 import { Badge, Icon, Label } from '../shapes';
@@ -47,13 +46,13 @@ export interface BaseNodeStyleProps
    *
    * <en/> The x-coordinate of node
    */
-  x?: number | string;
+  x?: number;
   /**
    * <zh/> y 坐标
    *
    * <en/> The y-coordinate of node
    */
-  y?: number | string;
+  y?: number;
   /**
    * <zh/> z 坐标
    *
@@ -397,12 +396,6 @@ export abstract class BaseNode<S extends BaseNodeStyleProps = BaseNodeStyleProps
   protected abstract drawKeyShape(attributes: Required<S>, container: Group): DisplayObject | undefined;
 
   public render(attributes = this.parsedAttributes, container: Group = this) {
-    // Use `transform: translate3d()` instead of `x/y/z`
-    const { x = 0, y = 0, z = 0, transform } = attributes;
-    if (x !== 0 || y !== 0 || z !== 0) {
-      this.style.transform = replaceTranslateInTransform(x as number, y as number, z as number, transform);
-    }
-
     // 1. key shape
     const keyShape = this.drawKeyShape(attributes, container);
     if (!keyShape) return;

--- a/packages/g6/src/elements/nodes/base-node.ts
+++ b/packages/g6/src/elements/nodes/base-node.ts
@@ -25,6 +25,7 @@ import { parseSize } from '../../utils/size';
 import { mergeOptions } from '../../utils/style';
 import { getWordWrapWidthByBox } from '../../utils/text';
 import { BaseElement } from '../base-element';
+import { effect } from '../effect';
 import type { BadgeStyleProps, IconStyleProps, LabelStyleProps } from '../shapes';
 import { Badge, Icon, Label } from '../shapes';
 
@@ -357,6 +358,7 @@ export abstract class BaseNode<S extends BaseNodeStyleProps = BaseNodeStyleProps
     return getRectIntersectPoint(point, keyShapeBounds);
   }
 
+  @effect((self, attributes) => self.getHaloStyle(attributes))
   protected drawHaloShape(attributes: Required<S>, container: Group): void {
     const keyShape = this.getShape('key');
     this.upsert(
@@ -367,10 +369,12 @@ export abstract class BaseNode<S extends BaseNodeStyleProps = BaseNodeStyleProps
     );
   }
 
+  @effect((self, attributes) => self.getIconStyle(attributes))
   protected drawIconShape(attributes: Required<S>, container: Group): void {
     this.upsert('icon', Icon, this.getIconStyle(attributes), container);
   }
 
+  @effect((self, attributes) => self.getBadgesStyle(attributes))
   protected drawBadgeShapes(attributes: Required<S>, container: Group): void {
     const badgesStyle = this.getBadgesStyle(attributes);
     Object.keys(badgesStyle).forEach((key) => {
@@ -378,6 +382,7 @@ export abstract class BaseNode<S extends BaseNodeStyleProps = BaseNodeStyleProps
     });
   }
 
+  @effect((self, attributes) => self.getPortsStyle(attributes))
   protected drawPortShapes(attributes: Required<S>, container: Group): void {
     const portsStyle = this.getPortsStyle(attributes);
     Object.keys(portsStyle).forEach((key) => {
@@ -385,16 +390,23 @@ export abstract class BaseNode<S extends BaseNodeStyleProps = BaseNodeStyleProps
     });
   }
 
+  @effect((self, attributes) => self.getLabelStyle(attributes))
   protected drawLabelShape(attributes: Required<S>, container: Group): void {
     this.upsert('label', Label, this.getLabelStyle(attributes), container);
   }
 
   protected abstract drawKeyShape(attributes: Required<S>, container: Group): DisplayObject | undefined;
 
+  // 用于装饰抽象方法 / Used to decorate abstract methods
+  @effect((self, attributes) => self.getKeyStyle(attributes))
+  private _drawKeyShape(attributes: Required<S>, container: Group) {
+    return this.drawKeyShape(attributes, container);
+  }
+
   public render(attributes = this.parsedAttributes, container: Group = this) {
     // 1. key shape
-    const keyShape = this.drawKeyShape(attributes, container);
-    if (!keyShape) return;
+    this._drawKeyShape(attributes, container);
+    if (!this.getShape('key')) return;
 
     // 2. halo, use shape same with keyShape
     this.drawHaloShape(attributes, container);

--- a/packages/g6/src/elements/nodes/base-node.ts
+++ b/packages/g6/src/elements/nodes/base-node.ts
@@ -20,7 +20,6 @@ import { getPortXYByPlacement, getTextStyleByPlacement, isSimplePort } from '../
 import { inferIconStyle } from '../../utils/node';
 import { getPaletteColors } from '../../utils/palette';
 import { getRectIntersectPoint } from '../../utils/point';
-import { getXYByPlacement } from '../../utils/position';
 import { omitStyleProps, subObject, subStyleProps } from '../../utils/prefix';
 import { parseSize } from '../../utils/size';
 import { mergeOptions } from '../../utils/style';
@@ -243,8 +242,7 @@ export abstract class BaseNode<S extends BaseNodeStyleProps = BaseNodeStyleProps
       this.getGraphicStyle(attributes),
       'label',
     );
-    const keyShape = this.getShape('key');
-    const keyBounds = keyShape.getLocalBounds();
+    const keyBounds = this.getShape('key').getLocalBounds();
 
     return Object.assign(
       getTextStyleByPlacement(keyBounds, placement, offsetX, offsetY),
@@ -266,10 +264,8 @@ export abstract class BaseNode<S extends BaseNodeStyleProps = BaseNodeStyleProps
     if (attributes.icon === false || (!attributes.iconText && !attributes.iconSrc)) return false;
 
     const iconStyle = subStyleProps(this.getGraphicStyle(attributes), 'icon');
-    const keyShape = this.getShape('key');
-    const [x, y] = getXYByPlacement(keyShape.getLocalBounds(), 'center');
 
-    return Object.assign({ x, y }, inferIconStyle(attributes.size!, iconStyle), iconStyle);
+    return Object.assign(inferIconStyle(attributes.size!, iconStyle), iconStyle);
   }
 
   protected getBadgesStyle(attributes: Required<S>): Record<string, NodeBadgeStyleProps | false> {

--- a/packages/g6/src/elements/nodes/circle.ts
+++ b/packages/g6/src/elements/nodes/circle.ts
@@ -40,7 +40,7 @@ export class Circle extends BaseNode {
 
   protected getIconStyle(attributes: Required<CircleStyleProps>): false | IconStyleProps {
     const style = super.getIconStyle(attributes);
-    const { r } = this.getKeyStyle(attributes);
+    const { r } = this.getShape<GCircle>('key').attributes;
     const size = (r as number) * 2 * ICON_SIZE_RATIO;
     return style ? ({ width: size, height: size, ...style } as IconStyleProps) : false;
   }

--- a/packages/g6/src/elements/nodes/diamond.ts
+++ b/packages/g6/src/elements/nodes/diamond.ts
@@ -1,7 +1,6 @@
 import type { DisplayObjectConfig } from '@antv/g';
 import type { Point } from '../../types';
 import { getDiamondPoints } from '../../utils/element';
-import { getPolygonIntersectPoint } from '../../utils/point';
 import type { PolygonStyleProps } from '../shapes';
 import { Polygon } from '../shapes/polygon';
 
@@ -25,11 +24,5 @@ export class Diamond extends Polygon {
   protected getPoints(attributes: Required<DiamondStyleProps>): Point[] {
     const [width, height] = this.getSize(attributes);
     return getDiamondPoints(width, height);
-  }
-
-  public getIntersectPoint(point: Point): Point {
-    const { points } = this.getKeyStyle(this.parsedAttributes);
-    const center = [this.attributes.x, this.attributes.y] as Point;
-    return getPolygonIntersectPoint(point, center, points).point;
   }
 }

--- a/packages/g6/src/elements/nodes/ellipse.ts
+++ b/packages/g6/src/elements/nodes/ellipse.ts
@@ -45,7 +45,7 @@ export class Ellipse extends BaseNode {
 
   protected getIconStyle(attributes: Required<EllipseStyleProps>): false | IconStyleProps {
     const style = super.getIconStyle(attributes);
-    const { rx, ry } = this.getKeyStyle(attributes);
+    const { rx, ry } = this.getShape<GEllipse>('key').attributes;
     const size = Math.min(+rx, +ry) * 2 * ICON_SIZE_RATIO;
 
     return style ? ({ width: size, height: size, ...style } as IconStyleProps) : false;

--- a/packages/g6/src/elements/nodes/image.ts
+++ b/packages/g6/src/elements/nodes/image.ts
@@ -58,12 +58,12 @@ export class Image extends BaseNode<ImageStyleProps> {
 
   protected getHaloStyle(attributes: Required<ImageStyleProps>): false | GRectStyleProps {
     if (attributes.halo === false) return false;
-    const { fill: keyStyleFill, stroke: keyStyleStroke, ...keyStyle } = this.getKeyStyle(attributes);
+    const { fill: keyStyleFill, stroke: keyStyleStroke, ...keyStyle } = this.getShape<GRect>('key').attributes;
     const haloStyle = subStyleProps(this.getGraphicStyle(attributes), 'halo');
     const haloLineWidth = Number(haloStyle.lineWidth);
     const [width, height] = add(this.getSize(attributes), [haloLineWidth, haloLineWidth]);
     const fill = 'transparent';
-    return { ...keyStyle, ...haloStyle, width, height, fill, x: -width / 2, y: -height / 2 };
+    return { ...haloStyle, width, height, fill, x: -width / 2, y: -height / 2 };
   }
 
   protected getIconStyle(attributes: Required<ImageStyleProps>): false | IconStyleProps {

--- a/packages/g6/src/elements/nodes/rect.ts
+++ b/packages/g6/src/elements/nodes/rect.ts
@@ -36,7 +36,7 @@ export class Rect extends BaseNode<RectStyleProps> {
 
   protected getIconStyle(attributes: ParsedRectStyleProps): false | IconStyleProps {
     const style = super.getIconStyle(attributes);
-    const { width, height } = this.getKeyStyle(attributes);
+    const { width, height } = this.getShape<GRect>('key').attributes;
 
     return style
       ? ({

--- a/packages/g6/src/elements/shapes/base-shape.ts
+++ b/packages/g6/src/elements/shapes/base-shape.ts
@@ -95,10 +95,8 @@ export abstract class BaseShape<StyleProps extends BaseShapeStyleProps> extends 
 
   public update(attr: Partial<StyleProps> = {}): void {
     const attributes = Object.assign({}, this.attributes, attr) as Required<StyleProps>;
-    // 先执行 render，才能检查 attributes 和 this.attributes 之间的差异
-    // Execute render first to check the difference between attributes and this.attributes
-    this.render(attributes, this);
     this.attr(attributes);
+    this.render(attributes, this);
     this.transformPosition(attributes);
     this.setVisibility();
   }
@@ -139,19 +137,11 @@ export abstract class BaseShape<StyleProps extends BaseShapeStyleProps> extends 
     ];
   }
 
-  /*
-   * <zh/> 是否自动托管动画
-   *
-   * <en/> Whether to automatically host animation
-   */
-  protected hostingAnimation = true;
-
   public animate(keyframes: Keyframe[], options?: number | KeyframeAnimationOptions): IAnimation | null {
     if (keyframes.length === 0) return null;
     const animationMap: IAnimation[] = [];
 
     const result = super.animate(keyframes, options);
-    if (!this.hostingAnimation) return result;
     if (result) animationMap.push(result);
 
     if (Array.isArray(keyframes) && keyframes.length > 0) {

--- a/packages/g6/src/elements/shapes/base-shape.ts
+++ b/packages/g6/src/elements/shapes/base-shape.ts
@@ -5,6 +5,7 @@ import type { Keyframe } from '../../types';
 import { createAnimationsProxy, preprocessKeyframes } from '../../utils/animation';
 import { updateStyle } from '../../utils/element';
 import { subObject } from '../../utils/prefix';
+import { getSubShapeStyle } from '../../utils/style';
 import { replaceTranslateInTransform } from '../../utils/transform';
 import { setVisibility } from '../../utils/visibility';
 
@@ -118,14 +119,13 @@ export abstract class BaseShape<StyleProps extends BaseShapeStyleProps> extends 
    *
    * <en/> Extracts the graphic style properties from a given attribute object.
    * Removes specific properties like position, transformation, and class name.
-   * @param attributes - <zh/> 属性对象 | <en/> attribute object
+   * @param style - <zh/> 属性对象 | <en/> attribute object
    * @returns <zh/> 仅包含样式属性的对象 | <en/> An object containing only the style properties.
    */
   public getGraphicStyle<T extends Record<string, any>>(
-    attributes: T,
+    style: T,
   ): Omit<T, 'x' | 'y' | 'z' | 'transform' | 'transformOrigin' | 'className' | 'class' | 'context' | 'zIndex'> {
-    const { x, y, z, class: cls, className, transform, transformOrigin, context, zIndex, ...style } = attributes;
-    return style;
+    return getSubShapeStyle(style);
   }
 
   /**

--- a/packages/g6/src/elements/shapes/base-shape.ts
+++ b/packages/g6/src/elements/shapes/base-shape.ts
@@ -63,7 +63,7 @@ export abstract class BaseShape<StyleProps extends BaseShapeStyleProps> extends 
     }
 
     // create
-    if (!target) {
+    if (!target || target.destroyed) {
       const instance = new Ctor({ className, style });
       container.appendChild(instance);
       this.shapeMap[className] = instance;

--- a/packages/g6/src/elements/shapes/icon.ts
+++ b/packages/g6/src/elements/shapes/icon.ts
@@ -16,13 +16,12 @@ export class Icon extends BaseShape<IconStyleProps> {
   }
 
   protected getIconStyle(attributes: IconStyleProps = this.attributes): IconStyleProps {
-    const { x = 0, y = 0 } = attributes;
+    const { width = 0, height = 0 } = attributes;
     const style = this.getGraphicStyle(attributes);
-    const { width, height } = style;
     if (this.isGImage()) {
       return {
-        x: (x as number) - (width as number) / 2,
-        y: (y as number) - (height as number) / 2,
+        x: -width / 2,
+        y: -height / 2,
         ...style,
       };
     }

--- a/packages/g6/src/elements/shapes/polygon.ts
+++ b/packages/g6/src/elements/shapes/polygon.ts
@@ -44,7 +44,7 @@ export abstract class Polygon<T extends PolygonStyleProps = PolygonStyleProps> e
   protected abstract getPoints(attributes: Required<T>): Point[];
 
   public getIntersectPoint(point: Point): Point {
-    const { points } = this.getKeyStyle(this.parsedAttributes as Required<T>);
+    const { points } = this.getShape<GPolygon>('key').attributes;
     const center: Point = [+(this.attributes?.x || 0), +(this.attributes?.y || 0)];
     return getPolygonIntersectPoint(point, center, points!).point;
   }

--- a/packages/g6/src/types/element.ts
+++ b/packages/g6/src/types/element.ts
@@ -1,4 +1,5 @@
-import type { BaseStyleProps, DisplayObject } from '@antv/g';
+import type { DisplayObject } from '@antv/g';
+import { BaseShapeStyleProps } from '../elements/shapes';
 import type { RuntimeContext } from '../runtime/types';
 import type { ComboOptions, EdgeOptions, NodeOptions } from '../spec';
 import type { Point, Port } from '../types';
@@ -65,7 +66,7 @@ export type ElementType = 'node' | 'edge' | 'combo';
 
 export type ElementOptions = NodeOptions | EdgeOptions | ComboOptions;
 
-export interface BaseElementStyleProps extends BaseStyleProps {
+export interface BaseElementStyleProps extends BaseShapeStyleProps {
   /**
    * @internal
    */

--- a/packages/g6/src/utils/style.ts
+++ b/packages/g6/src/utils/style.ts
@@ -41,3 +41,22 @@ export function mergeOptions(opt1: DisplayObjectConfig<any>, opt2: DisplayObject
     style: Object.assign({}, s1, s2),
   });
 }
+
+/**
+ * <zh/> 获取图形子图形样式
+ *
+ * <en/> Get the style of the sub-shape of the graphic
+ * @param style - <zh/> 图形样式 | <en/> graphic style
+ * @returns <zh/> 子图形样式 | <en/> sub-shape style
+ * @description
+ * <zh/> 从给定的属性对象中提取图形样式属性。删除特定的属性，如位置、变换和类名
+ *
+ * <en/> Extracts the graphic style properties from a given attribute object.
+ * Removes specific properties like position, transformation, and class name.
+ */
+export function getSubShapeStyle<T extends Record<string, any>>(
+  style: T,
+): Omit<T, 'x' | 'y' | 'z' | 'transform' | 'transformOrigin' | 'className' | 'class' | 'context' | 'zIndex'> {
+  const { x, y, z, class: cls, className, transform, transformOrigin, context, zIndex, ...rest } = style;
+  return rest;
+}


### PR DESCRIPTION
* 实现 `effect` 装饰器，用于控制依赖更新

### 效果对比：
图规模：34 个节点、60 条边

1. 入场绘制（启用动画）

**优化前：**
执行 keyShape 绘制 1W+ 次

<img width="102" alt="image" src="https://github.com/antvis/G6/assets/25787943/ec457f02-e82d-4af1-9ce9-bc274b2d794a">

**优化后：**
执行 keyShape 绘制 2k+ 次
<img width="104" alt="image" src="https://github.com/antvis/G6/assets/25787943/f8dc8228-ddeb-4002-90e9-8d5ba05c6a66">

2. 交互

**优化前：**
拖拽元素过程中执行子图形重绘

**优化后：**
跳过子图形重绘

---

* Implement the `effect` decorator to control dependency updates

### Comparison:
Graph size: 34 nodes, 60 edges

1. Entrance drawing (animation enabled)

**Before optimization:**
Perform 1W+ keyShape draws

<img width="102" alt="image" src="https://github.com/antvis/G6/assets/25787943/ec457f02-e82d-4af1-9ce9-bc274b2d794a">

**After optimization:**
Perform 2k+ keyShape draws
<img width="104" alt="image" src="https://github.com/antvis/G6/assets/25787943/f8dc8228-ddeb-4002-90e9-8d5ba05c6a66">

Interaction

**Before optimization:**
Performs a child redraw while dragging an element

**After optimization:**
Skip the child graphics redraw
 

> Discussion: https://github.com/antvis/G6/discussions/5511

