### PR TITLE
fix: fix error when manipulate data

### DIFF
--- a/packages/g6/__tests__/bugs/render-change-combo.spec.ts
+++ b/packages/g6/__tests__/bugs/render-change-combo.spec.ts
@@ -1,0 +1,30 @@
+import { createGraph } from '@@/utils';
+
+describe('render change combo', () => {
+  it('bug', async () => {
+    const graph = createGraph({});
+    await graph.render();
+
+    let count = 1;
+    const operation = async () => {
+      graph.setData({
+        nodes: [
+          { id: 'node1', combo: `${count}A`, style: { x: 250, y: 150 } },
+          { id: 'node2', combo: `${count}b`, style: { x: 350, y: 150 } },
+          { id: 'node3', style: { x: 250, y: 300 } },
+        ],
+        edges: [],
+        combos: [
+          { id: `${count}A`, style: { labelText: `${count}A` } },
+          { id: `${count}b`, style: { labelText: `${count}B` } },
+        ],
+      });
+      await graph.render();
+      count++;
+    };
+
+    await operation();
+
+    await operation();
+  });
+});

--- a/packages/g6/__tests__/bugs/render-deleted-data.spec.ts
+++ b/packages/g6/__tests__/bugs/render-deleted-data.spec.ts
@@ -1,0 +1,15 @@
+import { layoutCompactBoxBasic } from '@/__tests__/demos';
+import { createDemoGraph } from '@@/utils';
+
+describe('render deleted data', () => {
+  it('bug', async () => {
+    const graph = await createDemoGraph(layoutCompactBoxBasic);
+
+    const render = jest.fn(async () => {
+      graph.removeNodeData(['Classification']);
+      await graph.render();
+    });
+
+    expect(render).not.toThrow();
+  });
+});

--- a/packages/g6/src/elements/combos/base-combo.ts
+++ b/packages/g6/src/elements/combos/base-combo.ts
@@ -137,9 +137,16 @@ export abstract class BaseCombo<S extends BaseComboStyleProps = BaseComboStylePr
 
   protected getContentBBox(attributes: Required<S>): AABB {
     const { context, childrenNode = [], padding } = attributes;
-    const childrenBBox = getCombinedBBox(
-      childrenNode.map((id) => context!.element!.getElement(id)).map((child) => child!.getBounds()),
-    );
+    const children = childrenNode.map((id) => context!.element!.getElement(id)).filter(Boolean);
+    if (children.length === 0) {
+      const bbox = new AABB();
+      const { x = 0, y = 0, size } = attributes;
+      const [width, height] = parseSize(size);
+      bbox.setMinMax([x - width / 2, y - height / 2, 0], [x + width / 2, y + height / 2, 0]);
+      return bbox;
+    }
+
+    const childrenBBox = getCombinedBBox(children.map((child) => child!.getBounds()));
 
     if (!padding) return childrenBBox;
 

--- a/packages/g6/src/runtime/data.ts
+++ b/packages/g6/src/runtime/data.ts
@@ -379,7 +379,7 @@ export class DataController {
       if (children !== undefined) {
         model.attachTreeStructure(TREE_KEY);
         children.forEach((child) => {
-          this.setParent(child, id, TREE_KEY);
+          if (model.hasNode(child)) this.setParent(child, id, TREE_KEY);
         });
       }
     });

--- a/packages/g6/src/runtime/data.ts
+++ b/packages/g6/src/runtime/data.ts
@@ -378,9 +378,13 @@ export class DataController {
       const children = (datum as NodeData).children;
       if (children !== undefined) {
         model.attachTreeStructure(TREE_KEY);
-        children.forEach((child) => {
-          if (model.hasNode(child)) this.setParent(child, id, TREE_KEY);
-        });
+        const _children = children.filter((child) => model.hasNode(child));
+        _children.forEach((child) => this.setParent(child, id, TREE_KEY));
+        if (_children.length !== children.length) {
+          // 从数据中移除不存在的子节点
+          // Remove non-existent child nodes from the data
+          this.updateNodeData([{ id, children: _children }]);
+        }
       }
     });
   }


### PR DESCRIPTION
* 修复操作数据过程中可能导致异常的问题
  a. 树图中删除节点后重绘提示找不到节点
  b. 更新节点 combo 时删除原 combo 抛出异常
  c. 收起仅包含一个元素的 combo 时导致异常

---

* Faults that may occur during operation data restoration 
  a. A message indicating that a node cannot be found after being deleted from the tree 
  b. When node combo is updated, an exception is thrown when the original combo is deleted
  c. An exception occurs when a combo containing only one element is collapsed

https://github.com/antvis/G6/issues/5889 https://github.com/antvis/G6/issues/5885