### PR TITLE
refactor: pass context in layout

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           name: snapshots
           path: |
-            packages/g6/__tests__/integration/snapshots/**/*-actual.svg
+            packages/g6/__tests__/snapshots/**/*-actual.svg
           retention-days: 1
 
       - name: Coveralls GitHub Action

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -36,6 +36,7 @@
     "bubblesets",
     "cancelviewportanimate",
     "convexhull",
+    "Dagre",
     "dendrogram",
     "elementstatechange",
     "elementtranslate",

--- a/packages/g6/__tests__/demos/index.ts
+++ b/packages/g6/__tests__/demos/index.ts
@@ -67,6 +67,7 @@ export { layoutCompactBoxBasic } from './layout-compact-box-basic';
 export { layoutCompactBoxTopToBottom } from './layout-compact-box-left-align';
 export { layoutCompactBoxLeftAlign } from './layout-compact-box-top-to-bottom';
 export { layoutConcentric } from './layout-concentric';
+export { layoutCustomDagre } from './layout-custom-dagre';
 export { layoutCustomHorizontal } from './layout-custom-horizontal';
 export { layoutCustomIterative } from './layout-custom-iterative';
 export { layoutD3Force } from './layout-d3-force';

--- a/packages/g6/__tests__/demos/layout-custom-dagre.ts
+++ b/packages/g6/__tests__/demos/layout-custom-dagre.ts
@@ -12,7 +12,6 @@ class CustomLayout extends BaseLayout<CustomLayoutOptions> {
   id = 'custom-layout';
 
   async execute(data: GraphData): Promise<GraphData> {
-    // @ts-ignore
     const AdaptiveDagreLayout = layoutAdapter(DagreLayout, this.context);
     const layout = new AdaptiveDagreLayout(this.context, this.options);
     const model = await layout.execute(data);

--- a/packages/g6/__tests__/demos/layout-custom-dagre.ts
+++ b/packages/g6/__tests__/demos/layout-custom-dagre.ts
@@ -12,6 +12,7 @@ class CustomLayout extends BaseLayout<CustomLayoutOptions> {
   id = 'custom-layout';
 
   async execute(data: GraphData): Promise<GraphData> {
+    // @ts-ignore
     const AdaptiveDagreLayout = layoutAdapter(DagreLayout, this.context);
     const layout = new AdaptiveDagreLayout(this.context, this.options);
     const model = await layout.execute(data);

--- a/packages/g6/__tests__/demos/layout-custom-dagre.ts
+++ b/packages/g6/__tests__/demos/layout-custom-dagre.ts
@@ -1,0 +1,63 @@
+import type { BaseLayoutOptions, GraphData, NodeData } from '@/src';
+import { BaseLayout, DagreLayout, ExtensionCategory, Graph, register } from '@/src';
+import { layoutAdapter } from '@/src/utils/layout';
+
+interface CustomLayoutOptions extends BaseLayoutOptions {
+  gap?: number;
+  nodeSize: (node: NodeData) => number;
+  center: [number, number];
+}
+
+class CustomLayout extends BaseLayout<CustomLayoutOptions> {
+  id = 'custom-layout';
+
+  async execute(data: GraphData): Promise<GraphData> {
+    const AdaptiveDagreLayout = layoutAdapter(DagreLayout, this.context);
+    const layout = new AdaptiveDagreLayout(this.context, this.options);
+    const model = await layout.execute(data);
+    return model;
+  }
+}
+
+export const layoutCustomDagre: TestCase = async (context) => {
+  register(ExtensionCategory.LAYOUT, 'custom-layout', CustomLayout);
+
+  const data = {
+    nodes: [
+      { id: 'kspacey', data: { label: 'Kevin Spacey', width: 144, height: 100 } },
+      { id: 'swilliams', data: { label: 'Saul Williams', width: 160, height: 100 } },
+      { id: 'bpitt', data: { label: 'Brad Pitt', width: 108, height: 100 } },
+      { id: 'hford', data: { label: 'Harrison Ford', width: 168, height: 100 } },
+      { id: 'lwilson', data: { label: 'Luke Wilson', width: 144, height: 100 } },
+      { id: 'kbacon', data: { label: 'Kevin Bacon', width: 121, height: 100 } },
+    ],
+    edges: [
+      { id: 'kspacey->swilliams', source: 'kspacey', target: 'swilliams' },
+      { id: 'swilliams->kbacon', source: 'swilliams', target: 'kbacon' },
+      { id: 'bpitt->kbacon', source: 'bpitt', target: 'kbacon' },
+      { id: 'hford->lwilson', source: 'hford', target: 'lwilson' },
+      { id: 'lwilson->kbacon', source: 'lwilson', target: 'kbacon' },
+    ],
+  };
+
+  const graph = new Graph({
+    ...context,
+    autoFit: 'center',
+    data,
+    layout: {
+      type: 'custom-layout',
+    },
+    zoom: 0.8,
+    node: {
+      type: 'rect',
+      style: {
+        labelText: (d) => d.data!.label as string,
+        size: (d) => [d.data!.width, d.data!.height] as [number, number],
+      },
+    },
+  });
+
+  await graph.render();
+
+  return graph;
+};

--- a/packages/g6/__tests__/snapshots/layouts/custom-dagre/default.svg
+++ b/packages/g6/__tests__/snapshots/layouts/custom-dagre/default.svg
@@ -2,7 +2,6 @@
   <defs/>
   <g transform="matrix(0.800000,0,0,0.800000,40.399998,10.999996)">
     <g fill="none">
-      <g fill="none"/>
       <g fill="none">
         <g fill="none" marker-start="false" marker-end="false">
           <g fill="none" marker-start="false" marker-end="false" stroke="transparent" stroke-width="3"/>
@@ -39,15 +38,13 @@
             <path fill="none" d="M 0,0 L 0,0" class="key" stroke-width="3" stroke="transparent"/>
           </g>
         </g>
-      </g>
-      <g fill="none">
         <g fill="none" x="80" y="84" transform="matrix(1,0,0,1,80,84)">
           <g>
             <path fill="rgba(23,131,255,1)" d="M -72,-50 l 144,0 l 0,100 l-144 0 z" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" width="144" height="100" x="-72" y="-50"/>
           </g>
           <g fill="none" class="label" transform="matrix(1,0,0,1,0,52)">
             <g>
-              <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" dy="11.5px" class="text" font-size="12" text-anchor="middle" fill-opacity="0.85" font-weight="400">
+              <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" dy="11.5px" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="middle" fill-opacity="0.85" font-weight="400">
                 Kevin Spacey
               </text>
             </g>
@@ -59,7 +56,7 @@
           </g>
           <g fill="none" class="label" transform="matrix(1,0,0,1,0,52)">
             <g>
-              <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" dy="11.5px" class="text" font-size="12" text-anchor="middle" fill-opacity="0.85" font-weight="400">
+              <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" dy="11.5px" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="middle" fill-opacity="0.85" font-weight="400">
                 Saul Williams
               </text>
             </g>
@@ -71,7 +68,7 @@
           </g>
           <g fill="none" class="label" transform="matrix(1,0,0,1,0,52)">
             <g>
-              <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" dy="11.5px" class="text" font-size="12" text-anchor="middle" fill-opacity="0.85" font-weight="400">
+              <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" dy="11.5px" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="middle" fill-opacity="0.85" font-weight="400">
                 Brad Pitt
               </text>
             </g>
@@ -83,7 +80,7 @@
           </g>
           <g fill="none" class="label" transform="matrix(1,0,0,1,0,52)">
             <g>
-              <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" dy="11.5px" class="text" font-size="12" text-anchor="middle" fill-opacity="0.85" font-weight="400">
+              <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" dy="11.5px" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="middle" fill-opacity="0.85" font-weight="400">
                 Harrison Ford
               </text>
             </g>
@@ -95,7 +92,7 @@
           </g>
           <g fill="none" class="label" transform="matrix(1,0,0,1,0,52)">
             <g>
-              <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" dy="11.5px" class="text" font-size="12" text-anchor="middle" fill-opacity="0.85" font-weight="400">
+              <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" dy="11.5px" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="middle" fill-opacity="0.85" font-weight="400">
                 Luke Wilson
               </text>
             </g>
@@ -107,7 +104,7 @@
           </g>
           <g fill="none" class="label" transform="matrix(1,0,0,1,0,52)">
             <g>
-              <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" dy="11.5px" class="text" font-size="12" text-anchor="middle" fill-opacity="0.85" font-weight="400">
+              <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" dy="11.5px" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="middle" fill-opacity="0.85" font-weight="400">
                 Kevin Bacon
               </text>
             </g>

--- a/packages/g6/__tests__/snapshots/layouts/custom-dagre/default.svg
+++ b/packages/g6/__tests__/snapshots/layouts/custom-dagre/default.svg
@@ -1,0 +1,119 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
+  <defs/>
+  <g transform="matrix(0.800000,0,0,0.800000,40.399998,10.999996)">
+    <g fill="none">
+      <g fill="none"/>
+      <g fill="none">
+        <g fill="none" marker-start="false" marker-end="false">
+          <g fill="none" marker-start="false" marker-end="false" stroke="transparent" stroke-width="3"/>
+          <g>
+            <path fill="none" d="M 80,134 L 80,248" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
+            <path fill="none" d="M 0,0 L 0,0" class="key" stroke-width="3" stroke="transparent"/>
+          </g>
+        </g>
+        <g fill="none" marker-start="false" marker-end="false">
+          <g fill="none" marker-start="false" marker-end="false" stroke="transparent" stroke-width="3"/>
+          <g>
+            <path fill="none" d="M 128.29396325459317,348 L 215.70603674540683,438.5" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
+            <path fill="none" d="M 0,0 L 0,0" class="key" stroke-width="3" stroke="transparent"/>
+          </g>
+        </g>
+        <g fill="none" marker-start="false" marker-end="false">
+          <g fill="none" marker-start="false" marker-end="false" stroke="transparent" stroke-width="3"/>
+          <g>
+            <path fill="none" d="M 264,348 L 264,438.5" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
+            <path fill="none" d="M 0,0 L 0,0" class="key" stroke-width="3" stroke="transparent"/>
+          </g>
+        </g>
+        <g fill="none" marker-start="false" marker-end="false">
+          <g fill="none" marker-start="false" marker-end="false" stroke="transparent" stroke-width="3"/>
+          <g>
+            <path fill="none" d="M 440,134 L 440,248" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
+            <path fill="none" d="M 0,0 L 0,0" class="key" stroke-width="3" stroke="transparent"/>
+          </g>
+        </g>
+        <g fill="none" marker-start="false" marker-end="false">
+          <g fill="none" marker-start="false" marker-end="false" stroke="transparent" stroke-width="3"/>
+          <g>
+            <path fill="none" d="M 393.8057742782152,348 L 310.1942257217848,438.5" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
+            <path fill="none" d="M 0,0 L 0,0" class="key" stroke-width="3" stroke="transparent"/>
+          </g>
+        </g>
+      </g>
+      <g fill="none">
+        <g fill="none" x="80" y="84" transform="matrix(1,0,0,1,80,84)">
+          <g>
+            <path fill="rgba(23,131,255,1)" d="M -72,-50 l 144,0 l 0,100 l-144 0 z" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" width="144" height="100" x="-72" y="-50"/>
+          </g>
+          <g fill="none" class="label" transform="matrix(1,0,0,1,0,52)">
+            <g>
+              <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" dy="11.5px" class="text" font-size="12" text-anchor="middle" fill-opacity="0.85" font-weight="400">
+                Kevin Spacey
+              </text>
+            </g>
+          </g>
+        </g>
+        <g fill="none" x="80" y="298" transform="matrix(1,0,0,1,80,298)">
+          <g>
+            <path fill="rgba(23,131,255,1)" d="M -80,-50 l 160,0 l 0,100 l-160 0 z" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" width="160" height="100" x="-80" y="-50"/>
+          </g>
+          <g fill="none" class="label" transform="matrix(1,0,0,1,0,52)">
+            <g>
+              <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" dy="11.5px" class="text" font-size="12" text-anchor="middle" fill-opacity="0.85" font-weight="400">
+                Saul Williams
+              </text>
+            </g>
+          </g>
+        </g>
+        <g fill="none" x="264" y="298" transform="matrix(1,0,0,1,264,298)">
+          <g>
+            <path fill="rgba(23,131,255,1)" d="M -54,-50 l 108,0 l 0,100 l-108 0 z" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" width="108" height="100" x="-54" y="-50"/>
+          </g>
+          <g fill="none" class="label" transform="matrix(1,0,0,1,0,52)">
+            <g>
+              <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" dy="11.5px" class="text" font-size="12" text-anchor="middle" fill-opacity="0.85" font-weight="400">
+                Brad Pitt
+              </text>
+            </g>
+          </g>
+        </g>
+        <g fill="none" x="440" y="84" transform="matrix(1,0,0,1,440,84)">
+          <g>
+            <path fill="rgba(23,131,255,1)" d="M -84,-50 l 168,0 l 0,100 l-168 0 z" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" width="168" height="100" x="-84" y="-50"/>
+          </g>
+          <g fill="none" class="label" transform="matrix(1,0,0,1,0,52)">
+            <g>
+              <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" dy="11.5px" class="text" font-size="12" text-anchor="middle" fill-opacity="0.85" font-weight="400">
+                Harrison Ford
+              </text>
+            </g>
+          </g>
+        </g>
+        <g fill="none" x="440" y="298" transform="matrix(1,0,0,1,440,298)">
+          <g>
+            <path fill="rgba(23,131,255,1)" d="M -72,-50 l 144,0 l 0,100 l-144 0 z" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" width="144" height="100" x="-72" y="-50"/>
+          </g>
+          <g fill="none" class="label" transform="matrix(1,0,0,1,0,52)">
+            <g>
+              <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" dy="11.5px" class="text" font-size="12" text-anchor="middle" fill-opacity="0.85" font-weight="400">
+                Luke Wilson
+              </text>
+            </g>
+          </g>
+        </g>
+        <g fill="none" x="264" y="488.5" transform="matrix(1,0,0,1,264,488.500000)">
+          <g>
+            <path fill="rgba(23,131,255,1)" d="M -60.5,-50 l 121,0 l 0,100 l-121 0 z" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" width="121" height="100" x="-60.5" y="-50"/>
+          </g>
+          <g fill="none" class="label" transform="matrix(1,0,0,1,0,52)">
+            <g>
+              <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" dy="11.5px" class="text" font-size="12" text-anchor="middle" fill-opacity="0.85" font-weight="400">
+                Kevin Bacon
+              </text>
+            </g>
+          </g>
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/packages/g6/__tests__/unit/layouts/custom-dagre.spec.ts
+++ b/packages/g6/__tests__/unit/layouts/custom-dagre.spec.ts
@@ -1,0 +1,11 @@
+import { layoutCustomDagre } from '@/__tests__/demos';
+import { createDemoGraph } from '@@/utils';
+
+describe('custom dagre', () => {
+  it('render', async () => {
+    const graph = await createDemoGraph(layoutCustomDagre);
+    await expect(graph).toMatchSnapshot(__filename);
+
+    graph.destroy();
+  });
+});

--- a/packages/g6/__tests__/unit/utils/layout.spec.ts
+++ b/packages/g6/__tests__/unit/utils/layout.spec.ts
@@ -88,9 +88,10 @@ describe('layout', () => {
         },
       },
     } as any;
+    // @ts-ignore
     const AdaptiveDagreLayout = layoutAdapter(DagreLayout, context);
 
-    const layout = new AdaptiveDagreLayout();
+    const layout = new AdaptiveDagreLayout(context);
 
     const result = await layout.execute(dagreData);
     expect(result).toEqual({
@@ -167,7 +168,7 @@ describe('layout', () => {
 
     const onTick = jest.fn();
 
-    const layout = new AdaptiveDagreLayout({
+    const layout = new AdaptiveDagreLayout(context, {
       onTick,
     });
 
@@ -186,9 +187,10 @@ describe('layout', () => {
         },
       },
     } as any;
+    // @ts-ignore
     const AdaptiveDagreLayout = layoutAdapter(DagreLayout, context);
 
-    const layout = new AdaptiveDagreLayout();
+    const layout = new AdaptiveDagreLayout(context);
 
     expect(invokeLayoutMethod(layout, 'execute', dagreData)).toBeTruthy();
     expect(invokeLayoutMethod(layout, 'null')).toBe(null);

--- a/packages/g6/__tests__/unit/utils/layout.spec.ts
+++ b/packages/g6/__tests__/unit/utils/layout.spec.ts
@@ -88,7 +88,6 @@ describe('layout', () => {
         },
       },
     } as any;
-    // @ts-ignore
     const AdaptiveDagreLayout = layoutAdapter(DagreLayout, context);
 
     const layout = new AdaptiveDagreLayout(context);
@@ -187,7 +186,6 @@ describe('layout', () => {
         },
       },
     } as any;
-    // @ts-ignore
     const AdaptiveDagreLayout = layoutAdapter(DagreLayout, context);
 
     const layout = new AdaptiveDagreLayout(context);

--- a/packages/g6/package.json
+++ b/packages/g6/package.json
@@ -61,7 +61,7 @@
     "@antv/g-plugin-dragndrop": "^2.0.5",
     "@antv/graphlib": "^2.0.2",
     "@antv/hierarchy": "^0.6.12",
-    "@antv/layout": "1.2.14-beta.4",
+    "@antv/layout": "^1.2.14-beta.4",
     "@antv/util": "^3.3.7",
     "bubblesets-js": "^2.3.3",
     "hull.js": "^1.0.6"

--- a/packages/g6/package.json
+++ b/packages/g6/package.json
@@ -56,24 +56,24 @@
   "dependencies": {
     "@antv/component": "^2.0.1",
     "@antv/event-emitter": "^0.1.3",
-    "@antv/g": "^6.0.5",
-    "@antv/g-canvas": "^2.0.4",
-    "@antv/g-plugin-dragndrop": "^2.0.4",
+    "@antv/g": "^6.0.6",
+    "@antv/g-canvas": "^2.0.7",
+    "@antv/g-plugin-dragndrop": "^2.0.5",
     "@antv/graphlib": "^2.0.2",
     "@antv/hierarchy": "^0.6.12",
-    "@antv/layout": "^1.2.14-beta.3",
+    "@antv/layout": "1.2.14-beta.4",
     "@antv/util": "^3.3.7",
-    "bubblesets-js": "^2.3.2",
-    "hull.js": "^1.0.5"
+    "bubblesets-js": "^2.3.3",
+    "hull.js": "^1.0.6"
   },
   "devDependencies": {
-    "@antv/g-svg": "^2.0.5",
+    "@antv/g-svg": "^2.0.7",
     "@antv/layout-gpu": "^1.1.5",
     "@antv/layout-wasm": "^1.4.0",
     "@types/hull.js": "^1.0.4",
     "@types/xmlserializer": "^0.6.6",
     "cross-env": "^7.0.3",
-    "jest-canvas-mock": "^2.5.1",
+    "jest-canvas-mock": "^2.5.2",
     "jest-random-mock": "^1.0.0",
     "xmlserializer": "^0.6.1"
   },

--- a/packages/g6/src/layouts/base-layout.ts
+++ b/packages/g6/src/layouts/base-layout.ts
@@ -1,3 +1,4 @@
+import type { RuntimeContext } from '../runtime/types';
 import type { GraphData } from '../spec';
 import type { BaseLayoutOptions } from './types';
 
@@ -6,7 +7,10 @@ export abstract class BaseLayout<O extends BaseLayoutOptions = any> {
 
   public options: O;
 
-  constructor(options?: O) {
+  protected context: RuntimeContext;
+
+  constructor(context: RuntimeContext, options?: O) {
+    this.context = context;
     this.options = options || ({} as O);
   }
 

--- a/packages/g6/src/runtime/layout.ts
+++ b/packages/g6/src/runtime/layout.ts
@@ -258,9 +258,9 @@ export class LayoutController {
     const STDCtor =
       Object.getPrototypeOf(Ctor.prototype) === BaseLayout.prototype
         ? Ctor
-        : layoutAdapter(Ctor as new (...args: any[]) => AntVLayout, this.context);
+        : layoutAdapter(Ctor as new (options?: Record<string, unknown>) => AntVLayout, this.context);
 
-    const layout = new STDCtor();
+    const layout = new STDCtor(this.context);
     const config = { nodeSize, width, height, center };
 
     switch (layout.id) {

--- a/packages/g6/src/utils/layout.ts
+++ b/packages/g6/src/utils/layout.ts
@@ -103,7 +103,7 @@ export function layoutMapping2GraphData(layoutMapping: LayoutMapping): GraphData
  * @returns <zh/> G6 布局类 | <en/> G6 layout class
  */
 export function layoutAdapter(
-  Ctor: new (options?: Record<string, unknown>) => AntVLayout,
+  Ctor: new (options: Record<string, unknown>) => AntVLayout,
   context: RuntimeContext,
 ): new (context: RuntimeContext, options?: Record<string, unknown>) => BaseLayout {
   class AdaptLayout extends BaseLayout implements AdaptiveLayout {
@@ -113,7 +113,7 @@ export function layoutAdapter(
 
     constructor(context: RuntimeContext, options?: Record<string, unknown>) {
       super(context, options);
-      this.instance = new Ctor();
+      this.instance = new Ctor({});
       this.id = this.instance.id;
 
       if ('stop' in this.instance && 'tick' in this.instance) {

--- a/packages/g6/src/utils/layout.ts
+++ b/packages/g6/src/utils/layout.ts
@@ -103,16 +103,16 @@ export function layoutMapping2GraphData(layoutMapping: LayoutMapping): GraphData
  * @returns <zh/> G6 布局类 | <en/> G6 layout class
  */
 export function layoutAdapter(
-  Ctor: new (options?: any) => AntVLayout,
+  Ctor: new (options?: Record<string, unknown>) => AntVLayout,
   context: RuntimeContext,
-): new (options?: any) => BaseLayout {
+): new (context: RuntimeContext, options?: Record<string, unknown>) => BaseLayout {
   class AdaptLayout extends BaseLayout implements AdaptiveLayout {
     public instance: AntVLayout;
 
     public id: string;
 
-    constructor(options?: Record<string, unknown>) {
-      super(options);
+    constructor(context: RuntimeContext, options?: Record<string, unknown>) {
+      super(context, options);
       this.instance = new Ctor();
       this.id = this.instance.id;
 

--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -49,7 +49,7 @@
     "@antv/g6-extension-3d": "workspace:*",
     "@antv/g6-extension-react": "workspace:*",
     "@antv/graphlib": "^2.0.2",
-    "@antv/layout": "1.2.14-beta.4",
+    "@antv/layout": "^1.2.14-beta.4",
     "@antv/layout-gpu": "^1.1.5",
     "@antv/layout-wasm": "^1.4.0",
     "@antv/util": "^3.3.7",


### PR DESCRIPTION
- 将 context 透传到 layout 类。从而满足自定义布局中使用 @antv/layout 中的布局计算元素位置