### PR TITLE
fix: fix node not find for removed combo

### DIFF
--- a/packages/g6/__tests__/bugs/element-remove-combo.spec.ts
+++ b/packages/g6/__tests__/bugs/element-remove-combo.spec.ts
@@ -1,0 +1,33 @@
+import { createGraph } from '@@/utils';
+
+describe('element remove combo', () => {
+  it('remove combo', async () => {
+    const graph = createGraph({
+      animation: true,
+      data: {
+        nodes: [
+          { id: 'node-1', data: {}, combo: 'combo-1' },
+          { id: 'node-2', data: {}, combo: 'combo-1' },
+          { id: 'node-3', data: {}, combo: 'combo-1' },
+        ],
+        combos: [
+          { id: 'combo-1', data: {}, combo: 'combo-2' },
+          { id: 'combo-2', data: {}, style: {} },
+        ],
+      },
+      layout: {
+        type: 'force',
+      },
+    });
+
+    await graph.draw();
+
+    graph.removeComboData(['combo-1']);
+
+    const draw = jest.fn(async () => {
+      await graph.draw();
+    });
+
+    expect(draw).not.toThrow();
+  });
+});

--- a/packages/g6/src/runtime/data.ts
+++ b/packages/g6/src/runtime/data.ts
@@ -570,6 +570,7 @@ export class DataController {
     const { model } = this;
 
     const id = idOf(datum);
+    if (!model.hasNode(id)) return;
     const original = toG6Data(model.getNode(id));
     const value = mergeElementsData(original, datum);
     model.mergeNodeData(id, value);


### PR DESCRIPTION
* 修复删除 combo 后重新绘制提示找不到对应 id 节点的问题

> 问题原因：删除动画帧中同步了 combo 位置，此时 combo 已从 data model 中移除

---

* Fixed an issue where a prompt indicating that the corresponding id node cannot be found was displayed when combo is redrawn after being deleted

> The combo position was synchronized in the deleted animation frame, and combo was removed from the data model

ISSUE: https://github.com/antvis/G6/issues/5942