### PR TITLE
fix: fix viewport transform

### DIFF
--- a/packages/g6/__tests__/bugs/fit-view.spec.ts
+++ b/packages/g6/__tests__/bugs/fit-view.spec.ts
@@ -1,0 +1,40 @@
+import { createGraph } from '@@/utils';
+
+describe('fit view', () => {
+  it('suite 1', async () => {
+    // https://github.com/antvis/G6/issues/5943
+    const graph = createGraph({
+      data: {
+        nodes: [
+          { id: 'node-1', style: { x: 250, y: 150 } },
+          { id: 'node-2', style: { x: 350, y: 150 } },
+          { id: 'node-3', style: { x: 250, y: 300 } },
+        ],
+      },
+      behaviors: ['zoom-canvas'],
+    });
+
+    await graph.draw();
+
+    await expect(graph).toMatchSnapshot(__filename);
+
+    // wheel
+    graph.emit('wheel', { deltaY: 5 });
+    graph.emit('wheel', { deltaY: 5 });
+
+    await expect(graph).toMatchSnapshot(__filename, 'after-wheel');
+
+    // fit center
+    await graph.fitCenter();
+    await graph.fitCenter();
+    await expect(graph).toMatchSnapshot(__filename, 'after-fit-center');
+
+    // fit view
+    await graph.fitView();
+    await expect(graph).toMatchSnapshot(__filename, 'after-fit-view');
+
+    // fit center again
+    await graph.fitCenter();
+    await expect(graph).toMatchSnapshot(__filename, 'after-fit-center-again');
+  });
+});

--- a/packages/g6/__tests__/bugs/focus-element.spec.ts
+++ b/packages/g6/__tests__/bugs/focus-element.spec.ts
@@ -1,0 +1,56 @@
+import { CanvasEvent, CommonEvent, NodeEvent } from '@/src';
+import { createGraph } from '@@/utils';
+
+describe('focus element', () => {
+  it('focus after drag', async () => {
+    // https://github.com/antvis/G6/issues/5955
+    const graph = createGraph({
+      data: {
+        nodes: [
+          { id: 'node-1', style: { x: 250, y: 150 } },
+          { id: 'node-2', style: { x: 350, y: 150 } },
+          { id: 'node-3', style: { x: 250, y: 300 } },
+        ],
+      },
+      behaviors: ['zoom-canvas', 'drag-canvas'],
+    });
+
+    await graph.draw();
+
+    graph.emit(CanvasEvent.DRAG, { movement: { x: 100, y: 100 }, targetType: 'canvas' });
+
+    await expect(graph).toMatchSnapshot(__filename, 'focus-before-drag');
+
+    await graph.focusElement('node-1');
+
+    await expect(graph).toMatchSnapshot(__filename, 'focus-after-drag');
+  });
+
+  it('hover after focus', async () => {
+    // https://github.com/antvis/G6/issues/5925
+    const graph = createGraph({
+      data: {
+        nodes: [
+          { id: 'node-1', style: { x: 250, y: 150 } },
+          { id: 'node-2', style: { x: 350, y: 150 } },
+          { id: 'node-3', style: { x: 250, y: 300 } },
+        ],
+      },
+      behaviors: ['zoom-canvas', 'hover-activate'],
+    });
+
+    await graph.draw();
+
+    await expect(graph).toMatchSnapshot(__filename, 'hover-before-focus');
+
+    await graph.focusElement('node-1');
+
+    graph.emit(NodeEvent.POINTER_OVER, {
+      target: { id: 'node-2' },
+      targetType: 'node',
+      type: CommonEvent.POINTER_OVER,
+    });
+
+    await expect(graph).toMatchSnapshot(__filename, 'hover-after-focus');
+  });
+});

--- a/packages/g6/__tests__/demos/viewport-fit.ts
+++ b/packages/g6/__tests__/demos/viewport-fit.ts
@@ -33,9 +33,9 @@ export const viewportFit: TestCase = async (context) => {
       focusElement: () => graph.focusElement('1'),
     };
     return [
-      panel.add(config, 'x', -100, 100, 1).onChange((x: number) => graph.translateTo([x, config.y])),
-      panel.add(config, 'y', -100, 100, 1).onChange((y: number) => graph.translateTo([config.x, y])),
-      panel.add(config, 'zoom', 0.01, 10, 0.1).onChange((zoom: number) => graph.zoomTo(zoom)),
+      panel.add(config, 'x', -100, 100, 1).onChange((x: number) => graph.translateTo([x, config.y], false)),
+      panel.add(config, 'y', -100, 100, 1).onChange((y: number) => graph.translateTo([config.x, y], false)),
+      panel.add(config, 'zoom', 0.01, 10, 0.1).onChange((zoom: number) => graph.zoomTo(zoom, false)),
       panel.add(config, 'fitView'),
       panel.add(config, 'fitCenter'),
       panel.add(config, 'focusElement'),

--- a/packages/g6/__tests__/snapshots/__tests__/bugs/behaviors-drag-element-combo/drag-combo-A-over-C.svg
+++ b/packages/g6/__tests__/snapshots/__tests__/bugs/behaviors-drag-element-combo/drag-combo-A-over-C.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g transform="matrix(0.819672,0,0,0.819672,-6.147559,-25.819664)">
+  <g transform="matrix(0.819672,0,0,0.819672,-6.147559,-25.819689)">
     <g fill="none">
       <g fill="none">
         <g fill="none" x="540" y="480" transform="matrix(1,0,0,1,540,480)">

--- a/packages/g6/__tests__/snapshots/__tests__/bugs/behaviors-drag-element-combo/drag-combo-C-over-A.svg
+++ b/packages/g6/__tests__/snapshots/__tests__/bugs/behaviors-drag-element-combo/drag-combo-C-over-A.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g transform="matrix(0.819672,0,0,0.819672,-6.147559,-25.819664)">
+  <g transform="matrix(0.819672,0,0,0.819672,-6.147559,-25.819689)">
     <g fill="none">
       <g fill="none">
         <g fill="none" x="540" y="480" transform="matrix(1,0,0,1,540,480)">

--- a/packages/g6/__tests__/snapshots/__tests__/bugs/fit-view/after-fit-center-again.svg
+++ b/packages/g6/__tests__/snapshots/__tests__/bugs/fit-view/after-fit-center-again.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
+  <defs/>
+  <g transform="matrix(2.747253,0,0,2.747253,-574.175781,-368.131866)">
+    <g fill="none">
+      <g fill="none">
+        <g fill="none" x="250" y="150" transform="matrix(1,0,0,1,250,150)">
+          <g>
+            <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
+          </g>
+        </g>
+        <g fill="none" x="350" y="150" transform="matrix(1,0,0,1,350,150)">
+          <g>
+            <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
+          </g>
+        </g>
+        <g fill="none" x="250" y="300" transform="matrix(1,0,0,1,250,300)">
+          <g>
+            <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
+          </g>
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/packages/g6/__tests__/snapshots/__tests__/bugs/fit-view/after-fit-center.svg
+++ b/packages/g6/__tests__/snapshots/__tests__/bugs/fit-view/after-fit-center.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
+  <defs/>
+  <g transform="matrix(0.902500,0,0,0.902500,-20.750019,46.937508)">
+    <g fill="none">
+      <g fill="none">
+        <g fill="none" x="250" y="150" transform="matrix(1,0,0,1,250,150)">
+          <g>
+            <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
+          </g>
+        </g>
+        <g fill="none" x="350" y="150" transform="matrix(1,0,0,1,350,150)">
+          <g>
+            <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
+          </g>
+        </g>
+        <g fill="none" x="250" y="300" transform="matrix(1,0,0,1,250,300)">
+          <g>
+            <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
+          </g>
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/packages/g6/__tests__/snapshots/__tests__/bugs/fit-view/after-fit-view.svg
+++ b/packages/g6/__tests__/snapshots/__tests__/bugs/fit-view/after-fit-view.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
+  <defs/>
+  <g transform="matrix(2.747253,0,0,2.747253,-574.175781,-368.131866)">
+    <g fill="none">
+      <g fill="none">
+        <g fill="none" x="250" y="150" transform="matrix(1,0,0,1,250,150)">
+          <g>
+            <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
+          </g>
+        </g>
+        <g fill="none" x="350" y="150" transform="matrix(1,0,0,1,350,150)">
+          <g>
+            <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
+          </g>
+        </g>
+        <g fill="none" x="250" y="300" transform="matrix(1,0,0,1,250,300)">
+          <g>
+            <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
+          </g>
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/packages/g6/__tests__/snapshots/__tests__/bugs/fit-view/after-wheel.svg
+++ b/packages/g6/__tests__/snapshots/__tests__/bugs/fit-view/after-wheel.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
+  <defs/>
+  <g transform="matrix(0.902500,0,0,0.902500,24.375006,24.375006)">
+    <g fill="none">
+      <g fill="none">
+        <g fill="none" x="250" y="150" transform="matrix(1,0,0,1,250,150)">
+          <g>
+            <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
+          </g>
+        </g>
+        <g fill="none" x="350" y="150" transform="matrix(1,0,0,1,350,150)">
+          <g>
+            <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
+          </g>
+        </g>
+        <g fill="none" x="250" y="300" transform="matrix(1,0,0,1,250,300)">
+          <g>
+            <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
+          </g>
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/packages/g6/__tests__/snapshots/__tests__/bugs/fit-view/default.svg
+++ b/packages/g6/__tests__/snapshots/__tests__/bugs/fit-view/default.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
+  <defs/>
+  <g >
+    <g fill="none">
+      <g fill="none">
+        <g fill="none" x="250" y="150" transform="matrix(1,0,0,1,250,150)">
+          <g>
+            <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
+          </g>
+        </g>
+        <g fill="none" x="350" y="150" transform="matrix(1,0,0,1,350,150)">
+          <g>
+            <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
+          </g>
+        </g>
+        <g fill="none" x="250" y="300" transform="matrix(1,0,0,1,250,300)">
+          <g>
+            <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
+          </g>
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/packages/g6/__tests__/snapshots/__tests__/bugs/focus-element/focus-after-drag.svg
+++ b/packages/g6/__tests__/snapshots/__tests__/bugs/focus-element/focus-after-drag.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
+  <defs/>
+  <g transform="matrix(1,0,0,1,0,100)">
+    <g fill="none">
+      <g fill="none">
+        <g fill="none" x="250" y="150" transform="matrix(1,0,0,1,250,150)">
+          <g>
+            <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
+          </g>
+        </g>
+        <g fill="none" x="350" y="150" transform="matrix(1,0,0,1,350,150)">
+          <g>
+            <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
+          </g>
+        </g>
+        <g fill="none" x="250" y="300" transform="matrix(1,0,0,1,250,300)">
+          <g>
+            <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
+          </g>
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/packages/g6/__tests__/snapshots/__tests__/bugs/focus-element/focus-before-drag.svg
+++ b/packages/g6/__tests__/snapshots/__tests__/bugs/focus-element/focus-before-drag.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
+  <defs/>
+  <g transform="matrix(1,0,0,1,100,100)">
+    <g fill="none">
+      <g fill="none">
+        <g fill="none" x="250" y="150" transform="matrix(1,0,0,1,250,150)">
+          <g>
+            <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
+          </g>
+        </g>
+        <g fill="none" x="350" y="150" transform="matrix(1,0,0,1,350,150)">
+          <g>
+            <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
+          </g>
+        </g>
+        <g fill="none" x="250" y="300" transform="matrix(1,0,0,1,250,300)">
+          <g>
+            <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
+          </g>
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/packages/g6/__tests__/snapshots/__tests__/bugs/focus-element/hover-after-focus.svg
+++ b/packages/g6/__tests__/snapshots/__tests__/bugs/focus-element/hover-after-focus.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
+  <defs/>
+  <g transform="matrix(1,0,0,1,-0.000015,100)">
+    <g fill="none">
+      <g fill="none">
+        <g fill="none" x="250" y="150" transform="matrix(1,0,0,1,250,150)">
+          <g>
+            <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
+          </g>
+        </g>
+        <g fill="none" x="350" y="150" transform="matrix(1,0,0,1,350,150)">
+          <g>
+            <circle fill="none" class="halo" stroke-width="12" stroke="rgba(23,131,255,1)" stroke-opacity="0.15" r="16" stroke-dasharray="0,0" pointer-events="none"/>
+          </g>
+          <g>
+            <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
+          </g>
+        </g>
+        <g fill="none" x="250" y="300" transform="matrix(1,0,0,1,250,300)">
+          <g>
+            <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
+          </g>
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/packages/g6/__tests__/snapshots/__tests__/bugs/focus-element/hover-before-focus.svg
+++ b/packages/g6/__tests__/snapshots/__tests__/bugs/focus-element/hover-before-focus.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
+  <defs/>
+  <g >
+    <g fill="none">
+      <g fill="none">
+        <g fill="none" x="250" y="150" transform="matrix(1,0,0,1,250,150)">
+          <g>
+            <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
+          </g>
+        </g>
+        <g fill="none" x="350" y="150" transform="matrix(1,0,0,1,350,150)">
+          <g>
+            <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
+          </g>
+        </g>
+        <g fill="none" x="250" y="300" transform="matrix(1,0,0,1,250,300)">
+          <g>
+            <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
+          </g>
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/packages/g6/__tests__/snapshots/behaviors/focus-element/focus-node-2.svg
+++ b/packages/g6/__tests__/snapshots/behaviors/focus-element/focus-node-2.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g transform="matrix(1,0,0,1,50,150)">
+  <g transform="matrix(1,0,0,1,49.999985,150)">
     <g fill="none">
       <g fill="none">
         <g fill="none" x="200" y="150" transform="matrix(1,0,0,1,200,150)">

--- a/packages/g6/__tests__/snapshots/behaviors/focus-element/focus-node-3.svg
+++ b/packages/g6/__tests__/snapshots/behaviors/focus-element/focus-node-3.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g transform="matrix(1,0,0,1,150,50)">
+  <g transform="matrix(1,0,0,1,150,49.999985)">
     <g fill="none">
       <g fill="none">
         <g fill="none" x="200" y="150" transform="matrix(1,0,0,1,200,150)">

--- a/packages/g6/__tests__/snapshots/behaviors/focus-element/focus-node-4.svg
+++ b/packages/g6/__tests__/snapshots/behaviors/focus-element/focus-node-4.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g transform="matrix(1,0,0,1,50,50)">
+  <g transform="matrix(1,0,0,1,49.999985,50)">
     <g fill="none">
       <g fill="none">
         <g fill="none" x="200" y="150" transform="matrix(1,0,0,1,200,150)">

--- a/packages/g6/__tests__/snapshots/layouts/combo-layout/combined.svg
+++ b/packages/g6/__tests__/snapshots/layouts/combo-layout/combined.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g transform="matrix(0.561690,0,0,0.561690,237.206848,225.343063)">
+  <g transform="matrix(0.561690,0,0,0.561690,237.206833,225.343048)">
     <g fill="none">
       <g fill="none">
         <g fill="none" x="53.98262405395508" y="310.34185791015625" transform="matrix(1,0,0,1,53.982624,310.341858)">

--- a/packages/g6/__tests__/snapshots/layouts/compact-box/basic.svg
+++ b/packages/g6/__tests__/snapshots/layouts/compact-box/basic.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g transform="matrix(0.478011,0,0,0.478011,147.915894,285.850861)">
+  <g transform="matrix(0.478011,0,0,0.478011,147.915878,285.850861)">
     <g fill="none">
       <g fill="none">
         <g fill="none" marker-start="false" marker-end="false">

--- a/packages/g6/__tests__/snapshots/layouts/custom-layout-horizontal/default.svg
+++ b/packages/g6/__tests__/snapshots/layouts/custom-layout-horizontal/default.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g transform="matrix(1,0,0,1,44.999985,149.999985)">
+  <g transform="matrix(1,0,0,1,44.999985,150)">
     <g fill="none">
       <g fill="none">
         <g fill="none" x="16" y="100" transform="matrix(1,0,0,1,16,100)">

--- a/packages/g6/__tests__/snapshots/layouts/d3-force/default.svg
+++ b/packages/g6/__tests__/snapshots/layouts/d3-force/default.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g transform="matrix(1.646065,0,0,1.646065,-161.314682,-189.647263)">
+  <g transform="matrix(1.646065,0,0,1.646065,-161.314651,-189.647263)">
     <g fill="none">
       <g fill="none">
         <g fill="none" marker-start="false" marker-end="false">

--- a/packages/g6/__tests__/snapshots/layouts/dagre/antv-flow-combo.svg
+++ b/packages/g6/__tests__/snapshots/layouts/dagre/antv-flow-combo.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g transform="matrix(0.819672,0,0,0.819672,-6.147559,-25.819664)">
+  <g transform="matrix(0.819672,0,0,0.819672,-6.147559,-25.819689)">
     <g fill="none">
       <g fill="none">
         <g fill="none" x="122.5" y="400" transform="matrix(1,0,0,1,122.500000,400)">

--- a/packages/g6/__tests__/snapshots/layouts/dagre/antv-flow.svg
+++ b/packages/g6/__tests__/snapshots/layouts/dagre/antv-flow.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g transform="matrix(0.485437,0,0,0.485437,-36.407745,-41.262115)">
+  <g transform="matrix(0.485437,0,0,0.485437,-36.407745,-41.262142)">
     <g fill="none">
       <g fill="none">
         <g fill="none" marker-start="false" marker-end="true">

--- a/packages/g6/__tests__/snapshots/layouts/dendrogram/basic.svg
+++ b/packages/g6/__tests__/snapshots/layouts/dendrogram/basic.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g transform="matrix(0.446397,0,0,0.446397,63.120502,286.158112)">
+  <g transform="matrix(0.446397,0,0,0.446397,63.120487,286.158142)">
     <g fill="none">
       <g fill="none">
         <g fill="none" marker-start="false" marker-end="false">

--- a/packages/g6/__tests__/snapshots/layouts/dendrogram/tb.svg
+++ b/packages/g6/__tests__/snapshots/layouts/dendrogram/tb.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g transform="matrix(0.503018,0,0,0.503018,274.647888,147.716309)">
+  <g transform="matrix(0.503018,0,0,0.503018,274.647888,147.716293)">
     <g fill="none">
       <g fill="none">
         <g fill="none" marker-start="false" marker-end="false">

--- a/packages/g6/__tests__/snapshots/layouts/indented/default.svg
+++ b/packages/g6/__tests__/snapshots/layouts/indented/default.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g transform="matrix(0.500000,0,0,0.500000,125.000008,25.000015)">
+  <g transform="matrix(0.500000,0,0,0.500000,125,25)">
     <g fill="none">
       <g fill="none">
         <g fill="none" marker-start="false" marker-end="false">

--- a/packages/g6/__tests__/snapshots/plugins/bubble-sets/default.svg
+++ b/packages/g6/__tests__/snapshots/plugins/bubble-sets/default.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g transform="matrix(0.738356,0,0,0.738356,82.873100,59.688751)">
+  <g transform="matrix(0.738356,0,0,0.738356,82.873100,59.688728)">
     <g fill="none">
       <g fill="none">
         <g fill="none" marker-start="false" marker-end="false">

--- a/packages/g6/__tests__/snapshots/plugins/bubble-sets/element-position-update.svg
+++ b/packages/g6/__tests__/snapshots/plugins/bubble-sets/element-position-update.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g transform="matrix(0.738356,0,0,0.738356,82.873093,64.611076)">
+  <g transform="matrix(0.738356,0,0,0.738356,82.873100,64.611092)">
     <g fill="none">
       <g fill="none">
         <g fill="none" marker-start="false" marker-end="false">

--- a/packages/g6/__tests__/snapshots/plugins/bubble-sets/member-add.svg
+++ b/packages/g6/__tests__/snapshots/plugins/bubble-sets/member-add.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g transform="matrix(0.738356,0,0,0.738356,82.873100,59.688751)">
+  <g transform="matrix(0.738356,0,0,0.738356,82.873100,59.688728)">
     <g fill="none">
       <g fill="none">
         <g fill="none" marker-start="false" marker-end="false">

--- a/packages/g6/__tests__/snapshots/plugins/bubble-sets/member-remove.svg
+++ b/packages/g6/__tests__/snapshots/plugins/bubble-sets/member-remove.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g transform="matrix(0.738356,0,0,0.738356,82.873100,59.688751)">
+  <g transform="matrix(0.738356,0,0,0.738356,82.873100,59.688728)">
     <g fill="none">
       <g fill="none">
         <g fill="none" marker-start="false" marker-end="false">

--- a/packages/g6/__tests__/snapshots/plugins/bubble-sets/member-update.svg
+++ b/packages/g6/__tests__/snapshots/plugins/bubble-sets/member-update.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g transform="matrix(0.738356,0,0,0.738356,82.873100,59.688751)">
+  <g transform="matrix(0.738356,0,0,0.738356,82.873100,59.688728)">
     <g fill="none">
       <g fill="none">
         <g fill="none" marker-start="false" marker-end="false">

--- a/packages/g6/__tests__/snapshots/plugins/bubble-sets/non-member-add.svg
+++ b/packages/g6/__tests__/snapshots/plugins/bubble-sets/non-member-add.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g transform="matrix(0.738356,0,0,0.738356,82.873100,59.688751)">
+  <g transform="matrix(0.738356,0,0,0.738356,82.873100,59.688728)">
     <g fill="none">
       <g fill="none">
         <g fill="none" marker-start="false" marker-end="false">

--- a/packages/g6/__tests__/snapshots/plugins/bubble-sets/non-member-remove.svg
+++ b/packages/g6/__tests__/snapshots/plugins/bubble-sets/non-member-remove.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g transform="matrix(0.738356,0,0,0.738356,82.873100,59.688751)">
+  <g transform="matrix(0.738356,0,0,0.738356,82.873100,59.688728)">
     <g fill="none">
       <g fill="none">
         <g fill="none" marker-start="false" marker-end="false">

--- a/packages/g6/__tests__/snapshots/plugins/bubble-sets/non-member-update.svg
+++ b/packages/g6/__tests__/snapshots/plugins/bubble-sets/non-member-update.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g transform="matrix(0.738356,0,0,0.738356,82.873100,59.688751)">
+  <g transform="matrix(0.738356,0,0,0.738356,82.873100,59.688728)">
     <g fill="none">
       <g fill="none">
         <g fill="none" marker-start="false" marker-end="false">

--- a/packages/g6/__tests__/snapshots/plugins/bubble-sets/options-update.svg
+++ b/packages/g6/__tests__/snapshots/plugins/bubble-sets/options-update.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g transform="matrix(0.738356,0,0,0.738356,82.873093,64.611076)">
+  <g transform="matrix(0.738356,0,0,0.738356,82.873100,64.611092)">
     <g fill="none">
       <g fill="none">
         <g fill="none" marker-start="false" marker-end="false">

--- a/packages/g6/__tests__/snapshots/plugins/hull/plugin-hull/addMember__node3.svg
+++ b/packages/g6/__tests__/snapshots/plugins/hull/plugin-hull/addMember__node3.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g transform="matrix(0.738356,0,0,0.738356,82.873116,59.688713)">
+  <g transform="matrix(0.738356,0,0,0.738356,82.873100,59.688713)">
     <g fill="none">
       <g fill="none">
         <g fill="none" marker-start="false" marker-end="false">

--- a/packages/g6/__tests__/snapshots/plugins/hull/plugin-hull/corner__rounded.svg
+++ b/packages/g6/__tests__/snapshots/plugins/hull/plugin-hull/corner__rounded.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g transform="matrix(0.738356,0,0,0.738356,82.873093,59.688713)">
+  <g transform="matrix(0.738356,0,0,0.738356,82.873100,59.688713)">
     <g fill="none">
       <g fill="none">
         <g fill="none" marker-start="false" marker-end="false">

--- a/packages/g6/__tests__/snapshots/plugins/hull/plugin-hull/corner__sharp.svg
+++ b/packages/g6/__tests__/snapshots/plugins/hull/plugin-hull/corner__sharp.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g transform="matrix(0.738356,0,0,0.738356,82.873093,59.688713)">
+  <g transform="matrix(0.738356,0,0,0.738356,82.873100,59.688713)">
     <g fill="none">
       <g fill="none">
         <g fill="none" marker-start="false" marker-end="false">

--- a/packages/g6/__tests__/snapshots/plugins/hull/plugin-hull/default.svg
+++ b/packages/g6/__tests__/snapshots/plugins/hull/plugin-hull/default.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g transform="matrix(0.738356,0,0,0.738356,82.873100,59.688751)">
+  <g transform="matrix(0.738356,0,0,0.738356,82.873100,59.688728)">
     <g fill="none">
       <g fill="none">
         <g fill="none" marker-start="false" marker-end="false">

--- a/packages/g6/__tests__/snapshots/plugins/hull/plugin-hull/emptyMembers.svg
+++ b/packages/g6/__tests__/snapshots/plugins/hull/plugin-hull/emptyMembers.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g transform="matrix(0.738356,0,0,0.738356,82.873116,59.688713)">
+  <g transform="matrix(0.738356,0,0,0.738356,82.873100,59.688713)">
     <g fill="none">
       <g fill="none">
         <g fill="none" marker-start="false" marker-end="false">
@@ -307,7 +307,7 @@
             </g>
           </g>
         </g>
-        <g fill="none" x="302.71799912589677" y="472.28200087410323" transform="matrix(1,0,0,1,302.717987,472.282013)">
+        <g fill="none" x="302.7179991258976" y="472.2820008741024" transform="matrix(1,0,0,1,302.717987,472.282013)">
           <g>
             <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="15"/>
           </g>

--- a/packages/g6/__tests__/snapshots/plugins/hull/plugin-hull/labelAutoRotate__false.svg
+++ b/packages/g6/__tests__/snapshots/plugins/hull/plugin-hull/labelAutoRotate__false.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g transform="matrix(0.738356,0,0,0.738356,82.873116,59.688713)">
+  <g transform="matrix(0.738356,0,0,0.738356,82.873100,59.688713)">
     <g fill="none">
       <g fill="none">
         <g fill="none" marker-start="false" marker-end="false">

--- a/packages/g6/__tests__/snapshots/plugins/hull/plugin-hull/labelAutoRotate__true.svg
+++ b/packages/g6/__tests__/snapshots/plugins/hull/plugin-hull/labelAutoRotate__true.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g transform="matrix(0.738356,0,0,0.738356,82.873116,59.688713)">
+  <g transform="matrix(0.738356,0,0,0.738356,82.873100,59.688713)">
     <g fill="none">
       <g fill="none">
         <g fill="none" marker-start="false" marker-end="false">

--- a/packages/g6/__tests__/snapshots/plugins/hull/plugin-hull/labelCloseToHull__false.svg
+++ b/packages/g6/__tests__/snapshots/plugins/hull/plugin-hull/labelCloseToHull__false.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g transform="matrix(0.738356,0,0,0.738356,82.873093,59.688713)">
+  <g transform="matrix(0.738356,0,0,0.738356,82.873100,59.688713)">
     <g fill="none">
       <g fill="none">
         <g fill="none" marker-start="false" marker-end="false">

--- a/packages/g6/__tests__/snapshots/plugins/hull/plugin-hull/labelCloseToHull__true.svg
+++ b/packages/g6/__tests__/snapshots/plugins/hull/plugin-hull/labelCloseToHull__true.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g transform="matrix(0.738356,0,0,0.738356,82.873093,59.688713)">
+  <g transform="matrix(0.738356,0,0,0.738356,82.873100,59.688713)">
     <g fill="none">
       <g fill="none">
         <g fill="none" marker-start="false" marker-end="false">

--- a/packages/g6/__tests__/snapshots/plugins/hull/plugin-hull/labelPlacement__bottom.svg
+++ b/packages/g6/__tests__/snapshots/plugins/hull/plugin-hull/labelPlacement__bottom.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g transform="matrix(0.738356,0,0,0.738356,82.873116,59.688713)">
+  <g transform="matrix(0.738356,0,0,0.738356,82.873100,59.688713)">
     <g fill="none">
       <g fill="none">
         <g fill="none" marker-start="false" marker-end="false">

--- a/packages/g6/__tests__/snapshots/plugins/hull/plugin-hull/labelPlacement__left.svg
+++ b/packages/g6/__tests__/snapshots/plugins/hull/plugin-hull/labelPlacement__left.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g transform="matrix(0.738356,0,0,0.738356,82.873093,59.688713)">
+  <g transform="matrix(0.738356,0,0,0.738356,82.873100,59.688713)">
     <g fill="none">
       <g fill="none">
         <g fill="none" marker-start="false" marker-end="false">

--- a/packages/g6/__tests__/snapshots/plugins/hull/plugin-hull/labelPlacement__right.svg
+++ b/packages/g6/__tests__/snapshots/plugins/hull/plugin-hull/labelPlacement__right.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g transform="matrix(0.738356,0,0,0.738356,82.873116,59.688713)">
+  <g transform="matrix(0.738356,0,0,0.738356,82.873100,59.688713)">
     <g fill="none">
       <g fill="none">
         <g fill="none" marker-start="false" marker-end="false">

--- a/packages/g6/__tests__/snapshots/plugins/hull/plugin-hull/labelPlacement__top.svg
+++ b/packages/g6/__tests__/snapshots/plugins/hull/plugin-hull/labelPlacement__top.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g transform="matrix(0.738356,0,0,0.738356,82.873093,59.688713)">
+  <g transform="matrix(0.738356,0,0,0.738356,82.873100,59.688713)">
     <g fill="none">
       <g fill="none">
         <g fill="none" marker-start="false" marker-end="false">

--- a/packages/g6/__tests__/snapshots/plugins/hull/plugin-hull/padding__0.svg
+++ b/packages/g6/__tests__/snapshots/plugins/hull/plugin-hull/padding__0.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g transform="matrix(0.738356,0,0,0.738356,82.873116,59.688713)">
+  <g transform="matrix(0.738356,0,0,0.738356,82.873100,59.688713)">
     <g fill="none">
       <g fill="none">
         <g fill="none" marker-start="false" marker-end="false">

--- a/packages/g6/__tests__/snapshots/plugins/hull/plugin-hull/padding__20.svg
+++ b/packages/g6/__tests__/snapshots/plugins/hull/plugin-hull/padding__20.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g transform="matrix(0.738356,0,0,0.738356,82.873116,59.688713)">
+  <g transform="matrix(0.738356,0,0,0.738356,82.873100,59.688713)">
     <g fill="none">
       <g fill="none">
         <g fill="none" marker-start="false" marker-end="false">

--- a/packages/g6/__tests__/snapshots/plugins/hull/plugin-hull/removeMember__node1.svg
+++ b/packages/g6/__tests__/snapshots/plugins/hull/plugin-hull/removeMember__node1.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g transform="matrix(0.738356,0,0,0.738356,82.873116,59.688713)">
+  <g transform="matrix(0.738356,0,0,0.738356,82.873100,59.688713)">
     <g fill="none">
       <g fill="none">
         <g fill="none" marker-start="false" marker-end="false">

--- a/packages/g6/__tests__/snapshots/plugins/hull/plugin-hull/updateMember.svg
+++ b/packages/g6/__tests__/snapshots/plugins/hull/plugin-hull/updateMember.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g transform="matrix(0.738356,0,0,0.738356,82.873116,59.688713)">
+  <g transform="matrix(0.738356,0,0,0.738356,82.873100,59.688713)">
     <g fill="none">
       <g fill="none">
         <g fill="none" marker-start="false" marker-end="false">

--- a/packages/g6/__tests__/snapshots/plugins/hull/plugin-hull/updateMember__position.svg
+++ b/packages/g6/__tests__/snapshots/plugins/hull/plugin-hull/updateMember__position.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g transform="matrix(0.738356,0,0,0.738356,82.873116,59.688713)">
+  <g transform="matrix(0.738356,0,0,0.738356,82.873100,59.688713)">
     <g fill="none">
       <g fill="none">
         <g fill="none" marker-start="false" marker-end="false">
@@ -307,7 +307,7 @@
             </g>
           </g>
         </g>
-        <g fill="none" x="302.71799912589677" y="472.28200087410323" transform="matrix(1,0,0,1,302.717987,472.282013)">
+        <g fill="none" x="302.7179991258976" y="472.2820008741024" transform="matrix(1,0,0,1,302.717987,472.282013)">
           <g>
             <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="15"/>
           </g>
@@ -322,7 +322,7 @@
       </g>
       <g fill="none">
         <g>
-          <path fill="rgba(173,216,230,1)" d="M 288.6319609879662,495.9005006058128 L 413.9139618620694,570.6184997317096 A 27.5 27.5 0 0 0 442.0860381379306 523.3815002682904 L 316.80403726382735,448.66350114239367 A 27.5 27.5 0 0 0 288.6319609879662 495.9005006058128" class="key" fill-opacity="0.2" stroke="rgba(0,0,255,1)" stroke-opacity="0.2" stroke-width="5"/>
+          <path fill="rgba(173,216,230,1)" d="M 288.63196098796686,495.9005006058118 L 413.91396186206924,570.6184997317094 A 27.5 27.5 0 0 0 442.08603813793076 523.3815002682906 L 316.8040372638284,448.66350114239293 A 27.5 27.5 0 0 0 288.63196098796686 495.9005006058118" class="key" fill-opacity="0.2" stroke="rgba(0,0,255,1)" stroke-opacity="0.2" stroke-width="5"/>
         </g>
         <g fill="none" class="label" transform="matrix(0.858855,0.512220,-0.512220,0.858855,382.916595,552.131714)">
           <g>

--- a/packages/g6/__tests__/snapshots/plugins/timebar/backward-1-time-modify.svg
+++ b/packages/g6/__tests__/snapshots/plugins/timebar/backward-1-time-modify.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g transform="matrix(0.823772,0,0,0.823772,43.398037,-6.240090)">
+  <g transform="matrix(0.823772,0,0,0.823772,43.398037,-6.240065)">
     <g fill="none">
       <g fill="none">
         <g fill="none" marker-start="false" marker-end="false">

--- a/packages/g6/__tests__/snapshots/plugins/timebar/backward-1-time-visibility.svg
+++ b/packages/g6/__tests__/snapshots/plugins/timebar/backward-1-time-visibility.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g transform="matrix(0.823772,0,0,0.823772,43.398037,-6.240090)">
+  <g transform="matrix(0.823772,0,0,0.823772,43.398037,-6.240065)">
     <g fill="none">
       <g fill="none">
         <g fill="none" marker-start="false" marker-end="false">

--- a/packages/g6/__tests__/snapshots/plugins/timebar/default.svg
+++ b/packages/g6/__tests__/snapshots/plugins/timebar/default.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g transform="matrix(0.823772,0,0,0.823772,43.398037,-6.240090)">
+  <g transform="matrix(0.823772,0,0,0.823772,43.398037,-6.240065)">
     <g fill="none">
       <g fill="none">
         <g fill="none" marker-start="false" marker-end="false">

--- a/packages/g6/__tests__/snapshots/plugins/timebar/forward-1-time-modify.svg
+++ b/packages/g6/__tests__/snapshots/plugins/timebar/forward-1-time-modify.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g transform="matrix(0.823772,0,0,0.823772,43.398037,-6.240090)">
+  <g transform="matrix(0.823772,0,0,0.823772,43.398037,-6.240065)">
     <g fill="none">
       <g fill="none">
         <g fill="none" marker-start="false" marker-end="false">

--- a/packages/g6/__tests__/snapshots/plugins/timebar/forward-1-time-visibility.svg
+++ b/packages/g6/__tests__/snapshots/plugins/timebar/forward-1-time-visibility.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g transform="matrix(0.823772,0,0,0.823772,43.398037,-6.240090)">
+  <g transform="matrix(0.823772,0,0,0.823772,43.398037,-6.240065)">
     <g fill="none">
       <g fill="none">
         <g fill="none" marker-start="false" marker-end="false">

--- a/packages/g6/__tests__/snapshots/plugins/timebar/forward-2-time-modify.svg
+++ b/packages/g6/__tests__/snapshots/plugins/timebar/forward-2-time-modify.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g transform="matrix(0.823772,0,0,0.823772,43.398037,-6.240090)">
+  <g transform="matrix(0.823772,0,0,0.823772,43.398037,-6.240065)">
     <g fill="none">
       <g fill="none">
         <g fill="none" marker-start="false" marker-end="false">

--- a/packages/g6/__tests__/snapshots/plugins/timebar/play-1-time-modify.svg
+++ b/packages/g6/__tests__/snapshots/plugins/timebar/play-1-time-modify.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g transform="matrix(0.823772,0,0,0.823772,43.398037,-6.240090)">
+  <g transform="matrix(0.823772,0,0,0.823772,43.398037,-6.240065)">
     <g fill="none">
       <g fill="none">
         <g fill="none" marker-start="false" marker-end="false">

--- a/packages/g6/__tests__/snapshots/plugins/timebar/play-2-time-modify.svg
+++ b/packages/g6/__tests__/snapshots/plugins/timebar/play-2-time-modify.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g transform="matrix(0.823772,0,0,0.823772,43.398037,-6.240090)">
+  <g transform="matrix(0.823772,0,0,0.823772,43.398037,-6.240065)">
     <g fill="none">
       <g fill="none">
         <g fill="none" marker-start="false" marker-end="false">

--- a/packages/g6/__tests__/snapshots/plugins/timebar/reset-modify.svg
+++ b/packages/g6/__tests__/snapshots/plugins/timebar/reset-modify.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g transform="matrix(0.823772,0,0,0.823772,43.398037,-6.240090)">
+  <g transform="matrix(0.823772,0,0,0.823772,43.398037,-6.240065)">
     <g fill="none">
       <g fill="none">
         <g fill="none" marker-start="false" marker-end="false">

--- a/packages/g6/__tests__/snapshots/plugins/timebar/reset-visibility.svg
+++ b/packages/g6/__tests__/snapshots/plugins/timebar/reset-visibility.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g transform="matrix(0.823772,0,0,0.823772,43.398037,-6.240090)">
+  <g transform="matrix(0.823772,0,0,0.823772,43.398037,-6.240065)">
     <g fill="none">
       <g fill="none">
         <g fill="none" marker-start="false" marker-end="false">

--- a/packages/g6/__tests__/snapshots/plugins/tooltip/edge.svg
+++ b/packages/g6/__tests__/snapshots/plugins/tooltip/edge.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g transform="matrix(0.564549,0,0,0.564549,239.850281,236.068527)">
+  <g transform="matrix(0.564549,0,0,0.564549,239.850266,236.068527)">
     <g fill="none">
       <g fill="none">
         <g fill="none" x="62.707279920578" y="303.5454406738281" transform="matrix(1,0,0,1,62.707279,303.545441)">

--- a/packages/g6/__tests__/snapshots/plugins/tooltip/hover.svg
+++ b/packages/g6/__tests__/snapshots/plugins/tooltip/hover.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g transform="matrix(0.564549,0,0,0.564549,239.850281,236.068527)">
+  <g transform="matrix(0.564549,0,0,0.564549,239.850266,236.068527)">
     <g fill="none">
       <g fill="none">
         <g fill="none" x="62.707279920578" y="303.5454406738281" transform="matrix(1,0,0,1,62.707279,303.545441)">

--- a/packages/g6/__tests__/snapshots/plugins/tooltip/node.svg
+++ b/packages/g6/__tests__/snapshots/plugins/tooltip/node.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g transform="matrix(0.564549,0,0,0.564549,239.850281,236.068527)">
+  <g transform="matrix(0.564549,0,0,0.564549,239.850266,236.068527)">
     <g fill="none">
       <g fill="none">
         <g fill="none" x="62.707279920578" y="303.5454406738281" transform="matrix(1,0,0,1,62.707279,303.545441)">

--- a/packages/g6/__tests__/snapshots/plugins/tooltip/show-tooltip-by-id.svg
+++ b/packages/g6/__tests__/snapshots/plugins/tooltip/show-tooltip-by-id.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g transform="matrix(0.564549,0,0,0.564549,239.850281,236.068527)">
+  <g transform="matrix(0.564549,0,0,0.564549,239.850266,236.068527)">
     <g fill="none">
       <g fill="none">
         <g fill="none" x="62.707279920578" y="303.5454406738281" transform="matrix(1,0,0,1,62.707279,303.545441)">

--- a/packages/g6/__tests__/snapshots/runtime/graph/add-children-data/add-children-data.svg
+++ b/packages/g6/__tests__/snapshots/runtime/graph/add-children-data/add-children-data.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g transform="matrix(0.478011,0,0,0.478011,147.915878,285.850830)">
+  <g transform="matrix(0.478011,0,0,0.478011,147.915863,285.850861)">
     <g fill="none">
       <g fill="none">
         <g fill="none" marker-start="false" marker-end="false">

--- a/packages/g6/__tests__/snapshots/runtime/graph/add-children-data/default.svg
+++ b/packages/g6/__tests__/snapshots/runtime/graph/add-children-data/default.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g transform="matrix(0.478011,0,0,0.478011,147.915894,285.850861)">
+  <g transform="matrix(0.478011,0,0,0.478011,147.915878,285.850861)">
     <g fill="none">
       <g fill="none">
         <g fill="none" marker-start="false" marker-end="false">

--- a/packages/g6/__tests__/snapshots/runtime/graph/graph/after-rotate-90.svg
+++ b/packages/g6/__tests__/snapshots/runtime/graph/graph/after-rotate-90.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g transform="matrix(0,-1,1,0,-0.000031,499.999969)">
+  <g transform="matrix(0,-1,1,0,0,499.999969)">
     <g fill="none">
       <g fill="none">
         <g fill="none" marker-start="false" marker-end="false">

--- a/packages/g6/__tests__/snapshots/runtime/graph/graph/after-translate-node-1.svg
+++ b/packages/g6/__tests__/snapshots/runtime/graph/graph/after-translate-node-1.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g transform="matrix(1,0,0,1,-0.000046,-0.000046)">
+  <g >
     <g fill="none">
       <g fill="none">
         <g fill="none" marker-start="false" marker-end="false">

--- a/packages/g6/__tests__/snapshots/runtime/graph/graph/after-zoom-2.svg
+++ b/packages/g6/__tests__/snapshots/runtime/graph/graph/after-zoom-2.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g transform="matrix(2,0,0,2,-250.000031,-250.000031)">
+  <g transform="matrix(2,0,0,2,-250,-250)">
     <g fill="none">
       <g fill="none">
         <g fill="none" marker-start="false" marker-end="false">

--- a/packages/g6/__tests__/snapshots/runtime/viewport/auto-fit-with-padding.svg
+++ b/packages/g6/__tests__/snapshots/runtime/viewport/auto-fit-with-padding.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g transform="matrix(2.666667,0,0,2.666667,-366.666626,-366.666626)">
+  <g transform="matrix(2.666667,0,0,2.666667,-366.666656,-366.666656)">
     <g fill="none">
       <g fill="none">
         <g fill="none" x="200" y="250" transform="matrix(1,0,0,1,200,250)">

--- a/packages/g6/__tests__/snapshots/runtime/viewport/fitCenter-animation.svg
+++ b/packages/g6/__tests__/snapshots/runtime/viewport/fitCenter-animation.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g >
+  <g transform="matrix(1,0,0,1,-0.000015,0)">
     <g fill="none">
       <g fill="none">
         <g fill="none" x="200" y="250" transform="matrix(1,0,0,1,200,250)">

--- a/packages/g6/__tests__/snapshots/runtime/viewport/fitView-animation.svg
+++ b/packages/g6/__tests__/snapshots/runtime/viewport/fitView-animation.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g transform="matrix(3.333333,0,0,3.333333,-583.333252,-583.333252)">
+  <g transform="matrix(3.333333,0,0,3.333333,-583.333313,-583.333374)">
     <g fill="none">
       <g fill="none">
         <g fill="none" x="200" y="250" transform="matrix(1,0,0,1,200,250)">

--- a/packages/g6/__tests__/snapshots/runtime/viewport/fitView.svg
+++ b/packages/g6/__tests__/snapshots/runtime/viewport/fitView.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g transform="matrix(3.333333,0,0,3.333333,-583.333252,-583.333435)">
+  <g transform="matrix(3.333333,0,0,3.333333,-583.333313,-583.333374)">
     <g fill="none">
       <g fill="none">
         <g fill="none" x="200" y="250" transform="matrix(1,0,0,1,200,250)">

--- a/packages/g6/__tests__/snapshots/runtime/viewport/re-fitCenter-animation.svg
+++ b/packages/g6/__tests__/snapshots/runtime/viewport/re-fitCenter-animation.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g transform="matrix(3.333333,0,0,3.333333,-583.333252,-583.333252)">
+  <g transform="matrix(3.333333,0,0,3.333333,-583.333313,-583.333313)">
     <g fill="none">
       <g fill="none">
         <g fill="none" x="200" y="250" transform="matrix(1,0,0,1,200,250)">

--- a/packages/g6/__tests__/snapshots/runtime/viewport/re-focusElement-animation.svg
+++ b/packages/g6/__tests__/snapshots/runtime/viewport/re-focusElement-animation.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g transform="matrix(3.333333,0,0,3.333333,-416.666595,-583.333252)">
+  <g transform="matrix(3.333333,0,0,3.333333,-416.666656,-583.333252)">
     <g fill="none">
       <g fill="none">
         <g fill="none" x="200" y="250" transform="matrix(1,0,0,1,200,250)">

--- a/packages/g6/__tests__/snapshots/runtime/viewport/re-focusElement.svg
+++ b/packages/g6/__tests__/snapshots/runtime/viewport/re-focusElement.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g transform="matrix(3.333333,0,0,3.333333,-416.666656,-583.333313)">
+  <g transform="matrix(3.333333,0,0,3.333333,-416.666656,-583.333252)">
     <g fill="none">
       <g fill="none">
         <g fill="none" x="200" y="250" transform="matrix(1,0,0,1,200,250)">

--- a/packages/g6/__tests__/snapshots/runtime/viewport/rotate-135.svg
+++ b/packages/g6/__tests__/snapshots/runtime/viewport/rotate-135.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g transform="matrix(-0.707107,-0.707107,0.707107,-0.707107,249.999954,603.553284)">
+  <g transform="matrix(-0.707107,-0.707107,0.707107,-0.707107,249.999985,603.553345)">
     <g fill="none">
       <g fill="none">
         <g fill="none" marker-start="false" marker-end="false">

--- a/packages/g6/__tests__/snapshots/runtime/viewport/rotate-90.svg
+++ b/packages/g6/__tests__/snapshots/runtime/viewport/rotate-90.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g transform="matrix(0,-1,1,0,-0.000015,499.999939)">
+  <g transform="matrix(0,-1,1,0,0,499.999969)">
     <g fill="none">
       <g fill="none">
         <g fill="none" marker-start="false" marker-end="false">

--- a/packages/g6/__tests__/snapshots/runtime/viewport/with-lineWidth.svg
+++ b/packages/g6/__tests__/snapshots/runtime/viewport/with-lineWidth.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g transform="matrix(3.200000,0,0,3.200000,-550.000061,-550.000061)">
+  <g transform="matrix(3.200000,0,0,3.200000,-550,-550)">
     <g fill="none">
       <g fill="none">
         <g fill="none" x="200" y="250" transform="matrix(1,0,0,1,200,250)">

--- a/packages/g6/__tests__/snapshots/runtime/viewport/zoom-0.5.svg
+++ b/packages/g6/__tests__/snapshots/runtime/viewport/zoom-0.5.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g transform="matrix(0.500000,0,0,0.500000,125.000008,125.000008)">
+  <g transform="matrix(0.500000,0,0,0.500000,125,125)">
     <g fill="none">
       <g fill="none">
         <g fill="none" marker-start="false" marker-end="false">

--- a/packages/g6/__tests__/unit/runtime/graph/graph.spec.ts
+++ b/packages/g6/__tests__/unit/runtime/graph/graph.spec.ts
@@ -261,17 +261,17 @@ describe('Graph', () => {
 
   it('translateBy/translateTo', async () => {
     const [px, py] = graph.getPosition();
-    graph.translateBy([100, 100]);
+    await graph.translateBy([100, 100]);
     expect(graph.getPosition()).toBeCloseTo([px + 100, py + 100]);
     await expect(graph).toMatchSnapshot(__filename, 'after-translate');
-    graph.translateTo([0, 0]);
+    await graph.translateTo([0, 0]);
     expect(graph.getPosition()).toBeCloseTo([px, py]);
   });
 
   it('zoomTo/zoomBy', async () => {
     const zoom = graph.getZoom();
     expect(zoom).toBeCloseTo(1);
-    graph.zoomTo(2);
+    await graph.zoomTo(2);
     expect(graph.getZoom()).toBeCloseTo(2);
     await expect(graph).toMatchSnapshot(__filename, 'after-zoom-2');
     graph.zoomBy(0.5);


### PR DESCRIPTION
* 修复视口变换导致的 fitView/fitCenter/focusElement 问题
> 问题原因，之前由于历史原因，具有动画的视口变换采用 `camera.gotoLandmark` 实现，无动画的视口变换通过 `rotate`/`pan`/`setZoomByViewportPoint` 实现。两者混合调用时会出现异常，主要是 pan 通过旋转相机实现平移，不会改变视点位置

---
* fix the viewport fitView/fitCenter/focusElement problem caused by transformation
> Previously, due to historical reasons, the viewport transformation with animation was implemented by `camera.gotoLandmark`, while the viewport transformation without animation was implemented by `rotate` / `pan` / `setZoomByViewportPoint`. Exceptions occur when the two are called together, mainly because pan implements translation by rotating the camera, without changing the viewpoint position

Relative Fix: https://github.com/antvis/G/pull/1721

ISSUE: 
- https://github.com/antvis/G6/issues/5943
- https://github.com/antvis/G6/issues/5925
- https://github.com/antvis/G6/issues/5955