### PR TITLE
fix: fix click connot trigger context menu

### DIFF
--- a/packages/g6/src/plugins/contextmenu/index.ts
+++ b/packages/g6/src/plugins/contextmenu/index.ts
@@ -213,13 +213,15 @@ export class Contextmenu extends BasePlugin<ContextmenuOptions> {
   };
 
   private onMenuItemClick = (event: MouseEvent) => {
-    const { onClick } = this.options;
+    const { onClick, trigger } = this.options;
     if (event.target instanceof HTMLElement) {
       if (event.target.className.includes('g6-contextmenu-li')) {
         const value = event.target.getAttribute('value') as string;
         onClick?.(value, event.target);
+        this.hide();
       }
     }
-    this.hide();
+
+    if (trigger !== 'click') this.hide();
   };
 }


### PR DESCRIPTION
* 修复 trigger 为 click 时 contextmenu 无法唤起的问题

> graph node:click 和 document click 事件同时触发，导致打开菜单栏后立即被关闭

---

* Fix to contextmenu not evoking when trigger is click

> graph node:click and document click events fire at the same time, causing the menu bar to be closed immediately after opening

ISSUE: https://github.com/antvis/G6/issues/6005