### PR TITLE
fix(plugins): fix contextmenu getContent repetitive render

### DIFF
--- a/packages/g6/src/plugins/contextmenu/index.ts
+++ b/packages/g6/src/plugins/contextmenu/index.ts
@@ -126,6 +126,7 @@ export class Contextmenu extends BasePlugin<ContextmenuOptions> {
     const content = await this.getDOMContent(event);
 
     if (content instanceof HTMLElement) {
+      this.$element.innerHTML = '';
       this.$element.appendChild(content);
     } else {
       this.$element.innerHTML = content;


### PR DESCRIPTION
* 修改 contextmenu 使用 getContent 定制内容时重复渲染的问题

---

* Fixed an issue where contextmenu used getContent to customize content with repeated rendering

issue: https://github.com/antvis/G6/issues/5965