### PR TITLE
perf(animation): optimize animation object memory

### DIFF
--- a/packages/g6/src/runtime/animation.ts
+++ b/packages/g6/src/runtime/animation.ts
@@ -46,6 +46,7 @@ export class Animation {
           animation.finished.then(() => {
             cb?.afterAnimate?.(animation);
             cb?.after?.();
+            this.animations.delete(animation);
           });
         } else cb?.after?.();
 
@@ -63,6 +64,7 @@ export class Animation {
       animation.finished.then(() => {
         callbacks?.afterAnimate?.(animation);
         callbacks?.after?.();
+        this.release();
       });
     } else callbacks?.after?.();
 
@@ -145,6 +147,25 @@ export class Animation {
 
   public clear() {
     this.tasks = [];
+  }
+
+  /**
+   * <zh/> 释放存量动画对象
+   *
+   * <en/> Release stock animation objects
+   * @description see: https://github.com/antvis/G/issues/1731
+   */
+  private release() {
+    const { canvas } = this.context;
+
+    // @ts-expect-error private property
+    const animationsWithPromises = canvas.document?.timeline?.animationsWithPromises;
+    if (animationsWithPromises) {
+      // @ts-expect-error private property
+      canvas.document.timeline.animationsWithPromises = animationsWithPromises.filter(
+        (animation: IAnimation) => animation.playState !== 'finished',
+      );
+    }
   }
 
   public destroy() {


### PR DESCRIPTION
* 释放动画对象内存
> G 图形示例会存储动画对象，这在 G6 中并没有什么作用，当动画播放次数较多时，会创建大量的动画对象，导致内存持续增长，使得交互过程卡顿
> 目前在 G6 中手动对相关动画对象进行清理

---

* Release animation object memory 
> G graphics example will store animation objects, which does not have any effect in G6, when the animation is played more times, a large number of animation objects will be created, resulting in continuous memory growth, making the interaction process stuck
> The relevant animation objects are currently cleaned manually at G6

issue: https://github.com/antvis/G/issues/1731