### PR TITLE
refactor(registry): register support override

### DIFF
--- a/packages/g6/__tests__/unit/registry.spec.ts
+++ b/packages/g6/__tests__/unit/registry.spec.ts
@@ -80,4 +80,12 @@ describe('registry', () => {
       'rect-node': RectNode,
     });
   });
+
+  it('override', () => {
+    class CircleNode {}
+    class RectNode {}
+    register('node', 'circle-node', CircleNode as any);
+    register('node', 'circle-node', RectNode as any, true);
+    expect(getExtension('node', 'circle-node')).toEqual(RectNode);
+  });
 });

--- a/packages/g6/src/registry/index.ts
+++ b/packages/g6/src/registry/index.ts
@@ -38,6 +38,10 @@ const EXTENSION_REGISTRY: ExtensionRegistry = {
  * <zh/> 要注册的扩展类，在使用时创建实例
  *
  * <en/> The extension class to be registered. An instance will be created upon use
+ * @param override
+ * <zh/> 是否覆盖已注册的扩展
+ *
+ * <en/> Whether to override the registered extension
  * @remarks
  * <zh/> 内置扩展在项目导入时会自动注册。对于非内置扩展，可以通过 `register` 方法手动注册。扩展只需要注册一次，即可在项目的任何位置使用。
  *
@@ -56,9 +60,10 @@ export function register<T extends ExtensionCategory>(
   category: Loosen<T>,
   type: string,
   Ctor: ExtensionRegistry[T][string],
+  override = false,
 ) {
   const ext = EXTENSION_REGISTRY[category][type];
-  if (ext) {
+  if (!override && ext) {
     if (ext !== Ctor) print.warn(`The extension ${type} of ${category} has been registered before.`);
   } else Object.assign(EXTENSION_REGISTRY[category]!, { [type]: Ctor });
 }


### PR DESCRIPTION
* `register` 方法支持传入 `override` 参数来覆盖同名扩展

---

* the `register` method support override exists extension by pass `override`