### PR TITLE
fix: fix issue that history beforeAddCommand returns false

### DIFF
--- a/packages/g6/__tests__/unit/plugins/history/plugin-history.spec.ts
+++ b/packages/g6/__tests__/unit/plugins/history/plugin-history.spec.ts
@@ -119,4 +119,13 @@ describe('history plugin', () => {
     await graph.draw();
     expect(history.undoStack.length).toEqual(undoStackLen + 1);
   });
+
+  it('canUndo/canRedo/clear', async () => {
+    expect(history.canUndo()).toBeTruthy();
+    expect(history.canRedo()).toBeTruthy();
+    history.clear();
+    expect(history.undoStack.length).toEqual(0);
+    expect(history.canUndo()).toBeFalsy();
+    expect(history.canRedo()).toBeFalsy();
+  });
 });

--- a/packages/g6/__tests__/unit/plugins/history/plugin-history.spec.ts
+++ b/packages/g6/__tests__/unit/plugins/history/plugin-history.spec.ts
@@ -105,4 +105,18 @@ describe('history plugin', () => {
     await expect(graph).toMatchSnapshot(__filename, 'setElementZIndex-redo');
     history.undo();
   });
+
+  it('beforeAddCommand', async () => {
+    const undoStackLen = history.undoStack.length;
+
+    graph.updatePlugin({ key: 'history', beforeAddCommand: () => false });
+    graph.setElementVisibility('node-1', 'hidden');
+    await graph.draw();
+    expect(history.undoStack.length).toEqual(undoStackLen);
+
+    graph.updatePlugin({ key: 'history', beforeAddCommand: () => true });
+    graph.setElementVisibility('node-1', 'visible');
+    await graph.draw();
+    expect(history.undoStack.length).toEqual(undoStackLen + 1);
+  });
 });


### PR DESCRIPTION
- fixed #5935
- fixed #5924

确保当 beforeAddCommand 返回 false 时，命令不会被加入历史记录。 
移除 isFirstDraw 逻辑，以确保每次数据更新都会被记录到历史堆栈中。