### PR TITLE
fix: improve polyline orth routing for rendering with dagre layout

### DIFF
--- a/packages/g6/__tests__/unit/utils/bbox.spec.ts
+++ b/packages/g6/__tests__/unit/utils/bbox.spec.ts
@@ -11,6 +11,7 @@ import {
   getPointBBox,
   getTriangleCenter,
   isPointInBBox,
+  isPointOnBBoxBoundary,
   isPointOutsideBBox,
 } from '@/src/utils/bbox';
 import { AABB } from '@antv/g';
@@ -71,6 +72,12 @@ describe('bbox', () => {
   it('isPointOutsideBBox', () => {
     expect(isPointOutsideBBox([2, 2, 2], bbox)).toBe(true);
     expect(isPointOutsideBBox([0.5, 0.5, 0], bbox)).toBe(false);
+  });
+
+  it('isPointOnBBoxBoundary', () => {
+    expect(isPointOnBBoxBoundary([0, 0.5, 0], bbox)).toEqual(true);
+    expect(isPointOnBBoxBoundary([0, 2, 0], bbox)).toEqual(false);
+    expect(isPointOnBBoxBoundary([0, 2, 0], bbox, true)).toEqual(true);
   });
 
   it('getNearestSideToPoint', () => {

--- a/packages/g6/src/utils/bbox.ts
+++ b/packages/g6/src/utils/bbox.ts
@@ -118,6 +118,27 @@ export function isPointInBBox(point: Point, bbox: AABB) {
 }
 
 /**
+ * <zh/> 判断点是否在给定的包围盒的边界或边界的延长线上
+ *
+ * <en/> Whether the point is on the boundary or extension line of the given box
+ * @param point - <zh/> 点 | <en/> Point
+ * @param bbox - <zh/> 包围盒 | <en/> Bounding box
+ * @param extended - <zh/> 是否判断边界的延长线 | <en/> Whether to judge the extension line of the boundary
+ * @returns <zh/> 如果点在包围盒的边界或边界的延长线上返回 true，否则返回 false | <en/> Returns true if the point is on the boundary or extension line of the bounding box, false otherwise
+ */
+export function isPointOnBBoxBoundary(point: Point, bbox: AABB, extended = false): boolean {
+  const {
+    min: [minX, minY],
+    max: [maxX, maxY],
+  } = bbox;
+
+  const onTopOrBottomLine = (point[1] === minY || point[1] === maxY) && (extended || isBetween(point[0], minX, maxX));
+  const onLeftOrRightLine = (point[0] === minX || point[0] === maxX) && (extended || isBetween(point[1], minY, maxY));
+
+  return onTopOrBottomLine || onLeftOrRightLine;
+}
+
+/**
  * <zh/> 判断点是否在给定的包围盒外
  *
  * <en/> Whether the point is outside the given box

--- a/packages/g6/src/utils/router/orth.ts
+++ b/packages/g6/src/utils/router/orth.ts
@@ -8,6 +8,7 @@ import {
   getNearestPointToPoint,
   getNodeBBox,
   isPointInBBox,
+  isPointOnBBoxBoundary,
   isPointOutsideBBox,
 } from '../bbox';
 import { isOrthogonal, moveTo, round } from '../point';
@@ -199,7 +200,8 @@ export function pointToNode(from: Point, to: Point, toBBox: AABB, direction: Dir
     [to[0], from[1]],
     [from[0], to[1]],
   ];
-  const freePoints = points.filter((p) => isPointOutsideBBox(p, toBBox));
+  const freePoints = points.filter((p) => isPointOutsideBBox(p, toBBox) && !isPointOnBBoxBoundary(p, toBBox, true));
+
   const freeDirectionPoints = freePoints.filter((p) => getDirection(p, from) !== direction);
 
   if (freeDirectionPoints.length > 0) {


### PR DESCRIPTION
- fixed #5952

调整 polyline 正交路由算法，以便在结合 dagre 布局时优化路径绘制效果