### PR TITLE
fix: resolve animation conflict between hover-activate and collapse-expand

### DIFF
--- a/packages/g6/src/behaviors/hover-activate.ts
+++ b/packages/g6/src/behaviors/hover-activate.ts
@@ -155,7 +155,14 @@ export class HoverActivate extends BaseBehavior<HoverActivateOptions> {
   };
 
   private validate(event: IPointerEvent) {
-    if (this.destroyed || this.isFrozen) return false;
+    if (
+      this.destroyed ||
+      this.isFrozen ||
+      // @ts-expect-error private property
+      // 避免动画冲突，在combo折叠展开过程中不触发悬停事件 | To prevent animation conflicts, hover events are disabled during combo expand/collapse actions
+      this.context.graph.isCollapsingExpanding
+    )
+      return false;
     const { enable } = this.options;
     if (isFunction(enable)) return enable(event);
     return !!enable;


### PR DESCRIPTION
- fixed: #6063

当 hover-activate 和 collapse-expand 两种交互同时开启时，如果在展开或收起 combo 的过程中，鼠标移动导致触发悬停效果，将会引起动画冲突。解决方案：在 combo 展开或收起的过程中禁用悬停触发