### PR TITLE
refactor: drag canvas can be triggered on elements

### DIFF
--- a/packages/g6/__tests__/bugs/focus-element.spec.ts
+++ b/packages/g6/__tests__/bugs/focus-element.spec.ts
@@ -1,5 +1,5 @@
-import { CanvasEvent, CommonEvent, NodeEvent } from '@/src';
-import { createGraph } from '@@/utils';
+import { CommonEvent, NodeEvent } from '@/src';
+import { createGraph, dispatchCanvasEvent } from '@@/utils';
 
 describe('focus element', () => {
   it('focus after drag', async () => {
@@ -17,9 +17,9 @@ describe('focus element', () => {
 
     await graph.draw();
 
-    graph.emit(CanvasEvent.DRAG_START, { targetType: 'canvas' });
-    graph.emit(CanvasEvent.DRAG, { movement: { x: 100, y: 100 }, targetType: 'canvas' });
-    graph.emit(CanvasEvent.DRAG_END);
+    dispatchCanvasEvent(graph, CommonEvent.DRAG_START, { targetType: 'canvas' });
+    dispatchCanvasEvent(graph, CommonEvent.DRAG, { movement: { x: 100, y: 100 }, targetType: 'canvas' });
+    dispatchCanvasEvent(graph, CommonEvent.DRAG_END);
 
     await expect(graph).toMatchSnapshot(__filename, 'focus-before-drag');
 

--- a/packages/g6/__tests__/snapshots/behaviors/drag-canvas/drag-on-element-default.svg
+++ b/packages/g6/__tests__/snapshots/behaviors/drag-canvas/drag-on-element-default.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
+  <defs/>
+  <g >
+    <g fill="none">
+      <g fill="none">
+        <g fill="none" x="100" y="100" transform="matrix(1,0,0,1,100,100)">
+          <g>
+            <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="10"/>
+          </g>
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/packages/g6/__tests__/snapshots/behaviors/drag-canvas/drag-on-element.svg
+++ b/packages/g6/__tests__/snapshots/behaviors/drag-canvas/drag-on-element.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
+  <defs/>
+  <g transform="matrix(1,0,0,1,-50,-50)">
+    <g fill="none">
+      <g fill="none">
+        <g fill="none" x="100" y="100" transform="matrix(1,0,0,1,100,100)">
+          <g>
+            <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="10"/>
+          </g>
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/packages/g6/__tests__/unit/behaviors/drag-canvas.spec.ts
+++ b/packages/g6/__tests__/unit/behaviors/drag-canvas.spec.ts
@@ -1,7 +1,7 @@
 import { behaviorDragCanvas } from '@/__tests__/demos';
 import type { Graph } from '@/src';
-import { CanvasEvent, CommonEvent } from '@/src';
-import { createDemoGraph, sleep } from '@@/utils';
+import { CommonEvent } from '@/src';
+import { createDemoGraph, dispatchCanvasEvent, sleep } from '@@/utils';
 
 describe('behavior drag canvas', () => {
   let graph: Graph;
@@ -61,9 +61,11 @@ describe('behavior drag canvas', () => {
 
   it('drag', () => {
     const [x, y] = graph.getPosition();
-    graph.emit(CanvasEvent.DRAG_START, { targetType: 'canvas' });
-    graph.emit(CanvasEvent.DRAG, { movement: { x: 10, y: 10 }, targetType: 'canvas' });
-    graph.emit(CanvasEvent.DRAG_END);
+
+    dispatchCanvasEvent(graph, CommonEvent.DRAG_START, { targetType: 'canvas' });
+    dispatchCanvasEvent(graph, CommonEvent.DRAG, { movement: { x: 10, y: 10 }, targetType: 'canvas' });
+    dispatchCanvasEvent(graph, CommonEvent.DRAG_END);
+
     expect(graph.getPosition()).toBeCloseTo([x + 10, y + 10]);
   });
 
@@ -105,9 +107,10 @@ describe('behavior drag canvas', () => {
     const onFinish = jest.fn();
     graph.updateBehavior({ key: 'drag-canvas', trigger: 'drag', onFinish });
 
-    graph.emit(CanvasEvent.DRAG_START, { targetType: 'canvas' });
-    graph.emit(CanvasEvent.DRAG, { movement: { x: 10, y: 10 }, targetType: 'canvas' });
-    graph.emit(CanvasEvent.DRAG_END);
+    dispatchCanvasEvent(graph, CommonEvent.DRAG_START, { targetType: 'canvas' });
+    dispatchCanvasEvent(graph, CommonEvent.DRAG, { movement: { x: 10, y: 10 }, targetType: 'canvas' });
+    dispatchCanvasEvent(graph, CommonEvent.DRAG_END);
+
     expect(onFinish).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/g6/__tests__/unit/behaviors/drag-canvas.spec.ts
+++ b/packages/g6/__tests__/unit/behaviors/drag-canvas.spec.ts
@@ -1,7 +1,7 @@
 import { behaviorDragCanvas } from '@/__tests__/demos';
 import type { Graph } from '@/src';
 import { CommonEvent } from '@/src';
-import { createDemoGraph, dispatchCanvasEvent, sleep } from '@@/utils';
+import { createDemoGraph, createGraph, dispatchCanvasEvent, sleep } from '@@/utils';
 
 describe('behavior drag canvas', () => {
   let graph: Graph;
@@ -112,5 +112,29 @@ describe('behavior drag canvas', () => {
     dispatchCanvasEvent(graph, CommonEvent.DRAG_END);
 
     expect(onFinish).toHaveBeenCalledTimes(1);
+  });
+
+  it('trigger on element', async () => {
+    const graph = createGraph({
+      data: {
+        nodes: [{ id: 'node-1', style: { x: 100, y: 100 } }],
+      },
+      node: {
+        style: {
+          size: 20,
+        },
+      },
+      behaviors: [{ type: 'drag-canvas', enable: true }],
+    });
+
+    await graph.draw();
+
+    await expect(graph).toMatchSnapshot(__filename, 'drag-on-element-default');
+
+    dispatchCanvasEvent(graph, CommonEvent.DRAG_START, { targetType: 'node' });
+    dispatchCanvasEvent(graph, CommonEvent.DRAG, { movement: { x: -50, y: -50 }, targetType: 'node' });
+    dispatchCanvasEvent(graph, CommonEvent.DRAG_END);
+
+    await expect(graph).toMatchSnapshot(__filename, 'drag-on-element');
   });
 });

--- a/packages/g6/__tests__/utils/canvas.ts
+++ b/packages/g6/__tests__/utils/canvas.ts
@@ -1,0 +1,8 @@
+import type { Graph } from '@/src';
+import { CustomEvent } from '@antv/g';
+
+export function dispatchCanvasEvent(graph: Graph, type: string, data?: any) {
+  // @ts-expect-error private method
+  const canvas = graph.context.canvas.document;
+  canvas.dispatchEvent(new CustomEvent(type, data));
+}

--- a/packages/g6/__tests__/utils/index.ts
+++ b/packages/g6/__tests__/utils/index.ts
@@ -1,3 +1,4 @@
+export { dispatchCanvasEvent } from './canvas';
 export { createDemoGraph, createEdgeNode, createGraph, createGraphCanvas } from './create';
 export { createDeterministicRandom } from './random';
 export { sleep } from './sleep';


### PR DESCRIPTION
* Drag Canvas 交互能够在元素上触发
> 过去，DragCanvas 只能在指针位于画布空白处时才能触发，无法在位于元素上方时触发
> 现在只需要将 `enable` 置为 `true`，即可在任意位置激活拖动画布交互

```typescript
{
  type: 'drag-canvas',
  enable: true
}
```

> ⚠️ 警告：该配置项下默认情况下会和 `DragElement` 交互有冲突，建议通过更多事件参数进行条件区分

---
* Drag Canvas can be triggered on elements
> In the past, DragCanvas could only be triggered when the pointer was in a blank area of the canvas, not when it was above an element 
> Now just need to set `enable` to `true` to activate drag-canvas behavior anywhere

> ⚠️ Warning: This options item conflicts with `DragElement` behavior by default. It is recommended to use more event parameters to distinguish conditions