### PR TITLE
fix(elements): fix incorrect ports position when rotate node

### DIFF
--- a/packages/g6/__tests__/bugs/element-port-rotate.spec.ts
+++ b/packages/g6/__tests__/bugs/element-port-rotate.spec.ts
@@ -1,0 +1,29 @@
+import { createGraph } from '@@/utils';
+
+describe('element port rotate', () => {
+  it('default', async () => {
+    const graph = createGraph({
+      data: {
+        nodes: [{ id: 'node-1', style: { x: 100, y: 100 } }],
+      },
+      node: {
+        type: 'rect',
+        style: {
+          size: [50, 150],
+          port: true,
+          portR: 3,
+          ports: [
+            { key: 'port-1', placement: [0, 0.15] },
+            { key: 'port-2', placement: 'left' },
+            { key: 'port-3', placement: [0, 0.85] },
+          ],
+          transform: 'rotate(45deg)',
+        },
+      },
+    });
+
+    await graph.draw();
+
+    await expect(graph).toMatchSnapshot(__filename);
+  });
+});

--- a/packages/g6/__tests__/snapshots/__tests__/bugs/element-port-rotate/default.svg
+++ b/packages/g6/__tests__/snapshots/__tests__/bugs/element-port-rotate/default.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
+  <defs/>
+  <g >
+    <g fill="none">
+      <g fill="none">
+        <g fill="none" x="100" y="100" transform="matrix(0.707107,0.707107,-0.707107,0.707107,100,100)">
+          <g>
+            <path fill="rgba(23,131,255,1)" d="M -25,-75 l 50,0 l 0,150 l-50 0 z" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" width="50" height="150" x="-25" y="-75"/>
+          </g>
+          <g transform="matrix(1,0,0,1,-25,-52.500000)">
+            <circle fill="rgba(23,131,255,1)" class="port-port-1" stroke-width="1" stroke="rgba(0,0,0,1)" stroke-opacity="0.65" r="3"/>
+          </g>
+          <g transform="matrix(1,0,0,1,-25,0)">
+            <circle fill="rgba(23,131,255,1)" class="port-port-2" stroke-width="1" stroke="rgba(0,0,0,1)" stroke-opacity="0.65" r="3"/>
+          </g>
+          <g transform="matrix(1,0,0,1,-25,52.500000)">
+            <circle fill="rgba(23,131,255,1)" class="port-port-3" stroke-width="1" stroke="rgba(0,0,0,1)" stroke-opacity="0.65" r="3"/>
+          </g>
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION

<img width="302" alt="image" src="https://github.com/user-attachments/assets/68fba4fe-a514-4a70-96e1-0deaa1252828">


* 修复设置节点旋转的情况下，连接桩位置不准确的问题

---
* Fixed an issue where the position of the connecting piles was not accurate when the node rotation was set

issue: https://github.com/antvis/G6/issues/5946