### PR TITLE
fix(runtime): fix camera position lost after canvas resize

### DIFF
--- a/packages/g6/src/runtime/canvas.ts
+++ b/packages/g6/src/runtime/canvas.ts
@@ -147,7 +147,16 @@ export class Canvas {
 
   public resize(width: number, height: number) {
     Object.assign(this.extends.config, { width, height });
-    Object.values(this.getLayers()).forEach((canvas) => canvas.resize(width, height));
+    Object.values(this.getLayers()).forEach((canvas) => {
+      const camera = canvas.getCamera();
+      const position = camera.getPosition();
+      const focalPoint = camera.getFocalPoint();
+
+      canvas.resize(width, height);
+
+      camera.setPosition(position);
+      camera.setFocalPoint(focalPoint);
+    });
   }
 
   public getBounds() {


### PR DESCRIPTION
* 修复 resize 后画布位置异常的问题

> 问题原因： g canvas resize 后会重置相机位置
---

* Fixed abnormal canvas position after resize 

> Cause of problem: g canvas resize will reset the camera position

issue: https://github.com/antvis/G6/issues/5854
