### PR TITLE
fix(minimap): fix collapsed combo childrenNode getShape not found

### DIFF
--- a/packages/g6/__tests__/bugs/plugin-minimap-combo-collapsed.spec.ts
+++ b/packages/g6/__tests__/bugs/plugin-minimap-combo-collapsed.spec.ts
@@ -1,0 +1,36 @@
+import { createGraph, sleep } from '@@/utils';
+
+describe('bug: plugin-minimap-combo-collapsed', () => {
+  it('should be collapsed', async () => {
+    const graph = createGraph({
+      animation: false,
+      data: {
+        nodes: [{ id: 'node1', combo: 'combo1' }, { id: 'node2' }],
+        edges: [{ source: 'node1', target: 'node2' }],
+        combos: [{ id: 'combo1' }],
+      },
+      layout: {
+        type: 'grid',
+      },
+      plugins: [
+        {
+          key: 'minimap',
+          type: 'minimap',
+          size: [240, 160],
+        },
+      ],
+    });
+
+    await graph.render();
+
+    await expect(graph).toMatchSnapshot(__filename);
+
+    await sleep(1000);
+    graph.collapseElement('combo1');
+    graph.translateElementBy('combo1', [100, 100]);
+
+    await graph.render();
+
+    await expect(graph).toMatchSnapshot(__filename, 'update collapsed combo');
+  });
+});

--- a/packages/g6/__tests__/snapshots/bugs/plugin-minimap-combo-collapsed/default.svg
+++ b/packages/g6/__tests__/snapshots/bugs/plugin-minimap-combo-collapsed/default.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
+  <defs/>
+  <g >
+    <g fill="none">
+      <g fill="none">
+        <g fill="none" x="125" y="125" transform="matrix(1,0,0,1,125,125)">
+          <g>
+            <circle fill="rgba(153,173,209,1)" class="key" stroke-dasharray="0,0" stroke-width="1" fill-opacity="0.04" stroke="rgba(153,173,209,1)" r="36.76955262170047"/>
+          </g>
+        </g>
+        <g fill="none" marker-start="false" marker-end="false">
+          <g fill="none" marker-start="false" marker-end="false" stroke="transparent" stroke-width="3"/>
+          <g>
+            <path fill="none" d="M 141,125 L 359,125" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
+            <path fill="none" d="M 16,0 L 16,0" class="key" stroke-width="3" stroke="transparent"/>
+          </g>
+        </g>
+        <g fill="none" x="125" y="125" transform="matrix(1,0,0,1,125,125)">
+          <g>
+            <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
+          </g>
+        </g>
+        <g fill="none" x="375" y="125" transform="matrix(1,0,0,1,375,125)">
+          <g>
+            <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
+          </g>
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/packages/g6/__tests__/snapshots/bugs/plugin-minimap-combo-collapsed/update collapsed combo.svg
+++ b/packages/g6/__tests__/snapshots/bugs/plugin-minimap-combo-collapsed/update collapsed combo.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
+  <defs/>
+  <g >
+    <g fill="none">
+      <g fill="none">
+        <g fill="none" x="225" y="225" transform="matrix(1,0,0,1,225,225)">
+          <g>
+            <circle fill="rgba(153,173,209,1)" class="key" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="26"/>
+          </g>
+          <g fill="none" class="collapsed-marker" x="0" y="0">
+            <g>
+              <text fill="rgba(255,255,255,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="icon" text-anchor="middle" font-size="12">
+                1
+              </text>
+            </g>
+          </g>
+        </g>
+        <g fill="none" marker-start="false" marker-end="false">
+          <g fill="none" marker-start="false" marker-end="false" stroke="transparent" stroke-width="3"/>
+          <g>
+            <path fill="none" d="M 231.30592625094465,199.77629499622137 L 246.11942999941868,140.52228000232532" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
+            <path fill="none" d="M 16,0 L 16,0" class="key" stroke-width="3" stroke="transparent"/>
+          </g>
+        </g>
+        <g fill="none" x="250" y="125" transform="matrix(1,0,0,1,250,125)">
+          <g>
+            <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
+          </g>
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/packages/g6/src/plugins/minimap/index.ts
+++ b/packages/g6/src/plugins/minimap/index.ts
@@ -187,7 +187,9 @@ export class Minimap extends BasePlugin<MinimapOptions> {
         const id = idOf(datum);
         ids.add(id);
 
-        const target = element!.getElement(id)!;
+        const target = element!.getElement(id);
+        if (!target) return;
+
         const shape = target.getShape('key');
         const cloneShape = this.shapes.get(id) || shape.cloneNode();
 


### PR DESCRIPTION
https://github.com/antvis/G6/issues/6119