### PR TITLE
fix(behaviors): fix click-select lost preset states

### DIFF
--- a/packages/g6/__tests__/bugs/element-custom-state-switch.spec.ts
+++ b/packages/g6/__tests__/bugs/element-custom-state-switch.spec.ts
@@ -1,0 +1,108 @@
+import { createGraph } from '@@/utils';
+import { CanvasEvent, CommonEvent, NodeEvent } from '@antv/g6';
+
+describe('bug: element-custom-state-switch', () => {
+  it('single select', async () => {
+    const graph = createGraph({
+      data: {
+        nodes: [{ id: 'node-1', states: ['important'], style: { x: 100, y: 100 } }],
+      },
+      node: {
+        style: {
+          fill: 'red',
+        },
+        state: {
+          important: {
+            fill: 'green',
+          },
+        },
+      },
+      behaviors: [
+        {
+          type: 'click-select',
+        },
+      ],
+    });
+
+    await graph.draw();
+
+    await expect(graph).toMatchSnapshot(__filename, 'single');
+
+    expect(graph.getElementState('node-1')).toEqual(['important']);
+
+    // click
+    graph.emit(NodeEvent.CLICK, { target: { id: 'node-1' }, targetType: 'node' });
+
+    expect(graph.getElementState('node-1')).toEqual(['important', 'selected']);
+
+    await expect(graph).toMatchSnapshot(__filename, 'single-select');
+
+    // click again
+    graph.emit(NodeEvent.CLICK, { target: { id: 'node-1' }, targetType: 'node' });
+
+    expect(graph.getElementState('node-1')).toEqual(['important']);
+
+    await expect(graph).toMatchSnapshot(__filename, 'single');
+  });
+
+  it('multiple select', async () => {
+    const graph = createGraph({
+      data: {
+        nodes: [
+          { id: 'node-1', states: ['important'], style: { x: 100, y: 100 } },
+          { id: 'node-2', style: { x: 150, y: 100 } },
+        ],
+      },
+      node: {
+        style: {
+          fill: 'red',
+        },
+        state: {
+          important: {
+            fill: 'green',
+          },
+        },
+      },
+      behaviors: [
+        {
+          type: 'click-select',
+          multiple: true,
+        },
+      ],
+    });
+
+    await graph.draw();
+
+    await expect(graph).toMatchSnapshot(__filename, 'multiple');
+
+    graph.emit(NodeEvent.CLICK, { target: { id: 'node-2' }, targetType: 'node' });
+    graph.emit(CommonEvent.KEY_DOWN, { key: 'shift' });
+    graph.emit(NodeEvent.CLICK, { target: { id: 'node-1' }, targetType: 'node' });
+    // graph.emit(CommonEvent.KEY_UP, { key: 'shift' });
+
+    expect(graph.getElementState('node-1')).toEqual(['important', 'selected']);
+    expect(graph.getElementState('node-2')).toEqual(['selected']);
+
+    await expect(graph).toMatchSnapshot(__filename, 'multiple-select');
+
+    // unselect
+    graph.emit(NodeEvent.CLICK, { target: { id: 'node-1' }, targetType: 'node' });
+    expect(graph.getElementState('node-1')).toEqual(['important']);
+    graph.emit(NodeEvent.CLICK, { target: { id: 'node-2' }, targetType: 'node' });
+    expect(graph.getElementState('node-2')).toEqual([]);
+
+    await expect(graph).toMatchSnapshot(__filename, 'multiple');
+
+    // reselect
+    graph.emit(NodeEvent.CLICK, { target: { id: 'node-1' }, targetType: 'node' });
+    graph.emit(NodeEvent.CLICK, { target: { id: 'node-2' }, targetType: 'node' });
+    graph.emit(CommonEvent.KEY_UP, { key: 'shift' });
+
+    // click canvas
+    graph.emit(CanvasEvent.CLICK);
+    expect(graph.getElementState('node-1')).toEqual(['important']);
+    expect(graph.getElementState('node-2')).toEqual([]);
+
+    await expect(graph).toMatchSnapshot(__filename, 'multiple-unselect');
+  });
+});

--- a/packages/g6/__tests__/snapshots/bugs/element-custom-state-switch/multiple-select.svg
+++ b/packages/g6/__tests__/snapshots/bugs/element-custom-state-switch/multiple-select.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
+  <defs/>
+  <g >
+    <g fill="none">
+      <g fill="none">
+        <g fill="none" x="100" y="100" transform="matrix(1,0,0,1,100,100)">
+          <g>
+            <circle fill="none" class="halo" stroke-width="24" stroke="rgba(0,128,0,1)" stroke-opacity="0.25" r="16" stroke-dasharray="0,0" pointer-events="none"/>
+          </g>
+          <g>
+            <circle fill="rgba(0,128,0,1)" class="key" stroke-width="4" stroke="rgba(0,0,0,1)" r="16"/>
+          </g>
+        </g>
+        <g fill="none" x="150" y="100" transform="matrix(1,0,0,1,150,100)">
+          <g>
+            <circle fill="none" class="halo" stroke-width="24" stroke="rgba(255,0,0,1)" stroke-opacity="0.25" r="16" stroke-dasharray="0,0" pointer-events="none"/>
+          </g>
+          <g>
+            <circle fill="rgba(255,0,0,1)" class="key" stroke-width="4" stroke="rgba(0,0,0,1)" r="16"/>
+          </g>
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/packages/g6/__tests__/snapshots/bugs/element-custom-state-switch/multiple-unselect.svg
+++ b/packages/g6/__tests__/snapshots/bugs/element-custom-state-switch/multiple-unselect.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
+  <defs/>
+  <g >
+    <g fill="none">
+      <g fill="none">
+        <g fill="none" x="100" y="100" transform="matrix(1,0,0,1,100,100)">
+          <g>
+            <circle fill="rgba(0,128,0,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
+          </g>
+        </g>
+        <g fill="none" x="150" y="100" transform="matrix(1,0,0,1,150,100)">
+          <g>
+            <circle fill="rgba(255,0,0,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
+          </g>
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/packages/g6/__tests__/snapshots/bugs/element-custom-state-switch/multiple.svg
+++ b/packages/g6/__tests__/snapshots/bugs/element-custom-state-switch/multiple.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
+  <defs/>
+  <g >
+    <g fill="none">
+      <g fill="none">
+        <g fill="none" x="100" y="100" transform="matrix(1,0,0,1,100,100)">
+          <g>
+            <circle fill="rgba(0,128,0,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
+          </g>
+        </g>
+        <g fill="none" x="150" y="100" transform="matrix(1,0,0,1,150,100)">
+          <g>
+            <circle fill="rgba(255,0,0,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
+          </g>
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/packages/g6/__tests__/snapshots/bugs/element-custom-state-switch/single-select.svg
+++ b/packages/g6/__tests__/snapshots/bugs/element-custom-state-switch/single-select.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
+  <defs/>
+  <g >
+    <g fill="none">
+      <g fill="none">
+        <g fill="none" x="100" y="100" transform="matrix(1,0,0,1,100,100)">
+          <g>
+            <circle fill="none" class="halo" stroke-width="24" stroke="rgba(0,128,0,1)" stroke-opacity="0.25" r="16" stroke-dasharray="0,0" pointer-events="none"/>
+          </g>
+          <g>
+            <circle fill="rgba(0,128,0,1)" class="key" stroke-width="4" stroke="rgba(0,0,0,1)" r="16"/>
+          </g>
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/packages/g6/__tests__/snapshots/bugs/element-custom-state-switch/single.svg
+++ b/packages/g6/__tests__/snapshots/bugs/element-custom-state-switch/single.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
+  <defs/>
+  <g >
+    <g fill="none">
+      <g fill="none">
+        <g fill="none" x="100" y="100" transform="matrix(1,0,0,1,100,100)">
+          <g>
+            <circle fill="rgba(0,128,0,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
+          </g>
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/packages/g6/src/behaviors/click-select.ts
+++ b/packages/g6/src/behaviors/click-select.ts
@@ -188,7 +188,7 @@ export class ClickSelect extends BaseBehavior<ClickSelectOptions> {
         Object.assign(states, this.getClearStates(!!unselectedState));
         const addState = (list: ID[], state: State) => {
           list.forEach((id) => {
-            if (!states[id]) states[id] = [];
+            if (!states[id]) states[id] = graph.getElementState(id);
             states[id].push(state);
           });
         };
@@ -206,8 +206,7 @@ export class ClickSelect extends BaseBehavior<ClickSelectOptions> {
       if (type === 'select') {
         const addState = (list: ID[], state: State) => {
           list.forEach((id) => {
-            const datum = graph.getElementData(id);
-            const dataStatesSet = new Set(statesOf(datum));
+            const dataStatesSet = new Set(graph.getElementState(id));
             dataStatesSet.add(state);
             dataStatesSet.delete(unselectedState);
             states[id] = Array.from(dataStatesSet);


### PR DESCRIPTION
Fix the issue that when setting states in data, once the states are set by the click select behavior, the preset states are lost.

issue: https://github.com/antvis/G6/issues/6154