### PR TITLE
fix: when update styles of node, it's react node does't update.

### DIFF
--- a/packages/g6-extension-react/__tests__/demos/g-node.tsx
+++ b/packages/g6-extension-react/__tests__/demos/g-node.tsx
@@ -1,4 +1,4 @@
-import type { NodeData } from '@antv/g6';
+import type { Graph as G6Graph, NodeData } from '@antv/g6';
 import { ExtensionCategory, register } from '@antv/g6';
 import { GNode, Group, Image, Rect, Text } from '../../src';
 import { Graph } from '../../src/graph';
@@ -14,8 +14,9 @@ type Datum = {
   failure: number;
 };
 
-const Node = ({ data, size }: { data: NodeData; size: [number, number] }) => {
+const Node = ({ graph, data, size }: { graph: G6Graph; data: NodeData; size: [number, number] }) => {
   const [width, height] = size;
+  const { lineWidth = 1 } = graph.getElementRenderStyle(data.id);
 
   const { name, type, status, success, time, failure } = data.data as Datum;
   const color = status === 'success' ? '#30BF78' : '#F4664A';
@@ -51,7 +52,14 @@ const Node = ({ data, size }: { data: NodeData; size: [number, number] }) => {
 
   return (
     <Group>
-      <Rect width={width} height={height} stroke={color} fill={'white'} radius={radius}>
+      <Rect
+        width={width}
+        height={height}
+        stroke={color}
+        fill={'white'}
+        radius={radius}
+        lineWidth={lineWidth ? lineWidth : 1}
+      >
         <Rect width={width} height={20} fill={color} radius={[radius, radius, 0, 0]}>
           <Image
             src={
@@ -102,10 +110,12 @@ export const GNodeDemo = () => {
           type: 'g',
           style: {
             size: [180, 60],
-            component: (data: NodeData) => <Node data={data} size={[180, 60]} />,
+            component: function (this: G6Graph, data: NodeData) {
+              return <Node graph={this} data={data} size={[180, 60]} />;
+            },
           },
         },
-        behaviors: ['drag-element', 'zoom-canvas', 'drag-canvas'],
+        behaviors: ['drag-element', 'zoom-canvas', 'drag-canvas', 'click-select'],
       }}
     />
   );

--- a/packages/g6-extension-react/src/elements/g/node.tsx
+++ b/packages/g6-extension-react/src/elements/g/node.tsx
@@ -1,5 +1,5 @@
 import type { DisplayObjectConfig } from '@antv/g';
-import { ElementEvent, Group } from '@antv/g';
+import { Group } from '@antv/g';
 import type { BaseNodeStyleProps } from '@antv/g6';
 import { Rect } from '@antv/g6';
 import { render } from '@antv/react-g';
@@ -29,15 +29,13 @@ export class GNode extends Rect {
     const { component } = attributes;
     const [width, height] = this.getSize();
 
-    const dom = this.upsert('key', Group, { width, height }, container)!;
-
-    dom.isMutationObserved = true;
-    dom.addEventListener(ElementEvent.MOUNTED, () => {
-      // component 已经被回调机制自动创建为 ReactNode
-      // component has been automatically created as ReactNode by the callback mechanism
-      render(component as unknown as ReactNode, dom);
+    return this.upsert('key', Group, { width, height }, container, {
+      afterCreate: (dom) => {
+        render(component as unknown as ReactNode, dom);
+      },
+      afterUpdate: (dom) => {
+        render(component as unknown as ReactNode, dom);
+      },
     });
-
-    return dom;
   }
 }

--- a/packages/g6/__tests__/unit/elements/shape.spec.ts
+++ b/packages/g6/__tests__/unit/elements/shape.spec.ts
@@ -1,0 +1,62 @@
+import type { BaseShapeStyleProps } from '@/src';
+import { BaseShape } from '@/src';
+import { Circle } from '@antv/g';
+
+describe('element shape', () => {
+  it('upsert hooks', () => {
+    interface ShapeStyleProps extends BaseShapeStyleProps {
+      shape: any;
+    }
+
+    const beforeCreate = jest.fn();
+    const afterCreate = jest.fn();
+    const beforeUpdate = jest.fn();
+    const afterUpdate = jest.fn();
+    const beforeDestroy = jest.fn();
+    const afterDestroy = jest.fn();
+
+    class Shape extends BaseShape<ShapeStyleProps> {
+      render() {
+        this.upsert('circle', Circle, this.attributes.shape, this, {
+          beforeCreate,
+          afterCreate,
+          beforeUpdate,
+          afterUpdate,
+          beforeDestroy,
+          afterDestroy,
+        });
+      }
+    }
+
+    const shape = new Shape({
+      style: {
+        shape: { r: 10 },
+      },
+    });
+
+    expect(beforeCreate).toHaveBeenCalledTimes(1);
+    expect(afterCreate).toHaveBeenCalledTimes(1);
+    expect(beforeUpdate).toHaveBeenCalledTimes(0);
+    expect(afterUpdate).toHaveBeenCalledTimes(0);
+    expect(beforeDestroy).toHaveBeenCalledTimes(0);
+    expect(afterDestroy).toHaveBeenCalledTimes(0);
+
+    shape.update({ shape: { r: 20 } });
+
+    expect(beforeCreate).toHaveBeenCalledTimes(1);
+    expect(afterCreate).toHaveBeenCalledTimes(1);
+    expect(beforeUpdate).toHaveBeenCalledTimes(1);
+    expect(afterUpdate).toHaveBeenCalledTimes(1);
+    expect(beforeDestroy).toHaveBeenCalledTimes(0);
+    expect(afterDestroy).toHaveBeenCalledTimes(0);
+
+    shape.update({ shape: false });
+
+    expect(beforeCreate).toHaveBeenCalledTimes(1);
+    expect(afterCreate).toHaveBeenCalledTimes(1);
+    expect(beforeUpdate).toHaveBeenCalledTimes(1);
+    expect(afterUpdate).toHaveBeenCalledTimes(1);
+    expect(beforeDestroy).toHaveBeenCalledTimes(1);
+    expect(afterDestroy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/g6/src/exports.ts
+++ b/packages/g6/src/exports.ts
@@ -159,6 +159,7 @@ export type {
   LabelStyleProps,
   PolygonStyleProps,
 } from './elements/shapes';
+export type { UpsertHooks } from './elements/shapes/base-shape';
 export type { ContourLabelStyleProps, ContourStyleProps } from './elements/shapes/contour';
 export type { BaseLayoutOptions, WebWorkerLayoutOptions } from './layouts/types';
 export type { CategoricalPalette } from './palettes/types';


### PR DESCRIPTION
* BaseShape upsert method support hook callbacks (e.t. beforeCreate, afterCreate)
* Fix issue when update styles of node, it's react node does't update.

![Aug-21-2024 20-55-54](https://github.com/user-attachments/assets/a48a3fea-a629-4450-9483-f331c3a5c579)

related issue: https://github.com/antvis/G6/issues/6192

> note: this pull request depends on https://github.com/antvis/G/pull/1757