### PR TITLE
fix(plugins): fix error when destroy snapline plugin

### DIFF
--- a/packages/g6/src/plugins/snapline/index.ts
+++ b/packages/g6/src/plugins/snapline/index.ts
@@ -365,8 +365,8 @@ export class Snapline extends BasePlugin<SnaplineOptions> {
   }
 
   private destroyElements() {
-    this.horizontalLine.destroy();
-    this.verticalLine.destroy();
+    this.horizontalLine?.destroy();
+    this.verticalLine?.destroy();
   }
 
   public destroy() {


### PR DESCRIPTION
Sometimes, the horizontal line or vertical line may not have been created, the destroy method is undefined.
This pull request adds optional chain check.