### PR TITLE
refactor: getPluginInstance allow match by type secondary

### DIFF
--- a/packages/g6/__tests__/unit/runtime/graph/get-plugin-instantce.spec.ts
+++ b/packages/g6/__tests__/unit/runtime/graph/get-plugin-instantce.spec.ts
@@ -1,4 +1,4 @@
-import { BasePlugin, register } from '@/src';
+import { BasePlugin, ExtensionCategory, register } from '@/src';
 import { createGraph } from '@@/utils';
 
 describe('getPluginInstance', () => {
@@ -12,7 +12,7 @@ describe('getPluginInstance', () => {
       }
     }
 
-    register('plugin', 'custom', CustomPlugin);
+    register(ExtensionCategory.PLUGIN, 'custom', CustomPlugin);
     const graph = createGraph({
       plugins: [
         {
@@ -31,5 +31,27 @@ describe('getPluginInstance', () => {
 
     const undefinedPlugin = graph.getPluginInstance<CustomPlugin>('undefined-plugin');
     expect(undefinedPlugin).toBe(undefined);
+  });
+
+  it('getPluginInstance by type', async () => {
+    const fn = jest.fn();
+
+    class CustomPlugin extends BasePlugin<any> {
+      api() {
+        fn();
+      }
+    }
+
+    register(ExtensionCategory.PLUGIN, 'custom-2', CustomPlugin);
+    const graph = createGraph({
+      plugins: ['custom-2', 'custom-2'],
+    });
+
+    await graph.draw();
+
+    const plugin = graph.getPluginInstance<CustomPlugin>('custom-2');
+    expect(plugin instanceof CustomPlugin).toBe(true);
+    plugin.api();
+    expect(fn).toHaveBeenCalled();
   });
 });

--- a/packages/g6/src/runtime/plugin.ts
+++ b/packages/g6/src/runtime/plugin.ts
@@ -1,6 +1,7 @@
 import type { BasePlugin } from '../plugins/base-plugin';
 import { ExtensionController } from '../registry/extension';
 import type { CustomPluginOption, PluginOptions } from '../spec/plugin';
+import { print } from '../utils/print';
 import type { RuntimeContext } from './types';
 
 export class PluginController extends ExtensionController<BasePlugin<CustomPluginOption>> {
@@ -16,6 +17,12 @@ export class PluginController extends ExtensionController<BasePlugin<CustomPlugi
   }
 
   public getPluginInstance(key: string) {
-    return this.extensionMap[key];
+    const exactly = this.extensionMap[key];
+    if (exactly) return exactly;
+
+    print.warn(`Cannot find the plugin ${key}, will try to find it by type.`);
+
+    const fussily = this.extensions.find((extension) => extension.type === key);
+    if (fussily) return this.extensionMap[fussily.key];
   }
 }


### PR DESCRIPTION
In a generic situation, it should pass a exact key to `getPluginInstance`, but sometimes it may be a little bit verbose when setting the plugin in options. Now `getPluginInstance` will try to find the instance after finding by the key.

Graph options:
```ts
plugins: ['fullscreen']
```

Get instance:
```ts
graph.getPluginInstance('fullscreen');
```

> ⚠️ Note: this is just a fallback plan, and if a plugin is configured multiple times, it only returns the first instance.