### PR TITLE
fix(behaviors): contextmenu and blur events will interrupt drag process

### DIFF
--- a/packages/g6/src/behaviors/drag-element.ts
+++ b/packages/g6/src/behaviors/drag-element.ts
@@ -183,9 +183,8 @@ export class DragElement extends BaseBehavior<DragElementOptions> {
     // @ts-expect-error internal property
     const $canvas: HTMLCanvasElement = canvas.getLayer().getContextService().$canvas;
     if ($canvas) {
-      ['contextmenu', 'blur'].forEach((type) => {
-        $canvas.addEventListener(type, this.onDragEnd);
-      });
+      $canvas.addEventListener('blur', this.onDragEnd);
+      $canvas.addEventListener('contextmenu', this.onDragEnd);
     }
 
     this.enableElements.forEach((type) => {
@@ -419,9 +418,8 @@ export class DragElement extends BaseBehavior<DragElementOptions> {
     // @ts-expect-error internal property
     const $canvas: HTMLCanvasElement = canvas.getLayer().getContextService().$canvas;
     if ($canvas) {
-      ['contextmenu', 'blur'].forEach((type) => {
-        $canvas.removeEventListener(type, this.onDragEnd);
-      });
+      $canvas.removeEventListener('blur', this.onDragEnd);
+      $canvas.removeEventListener('contextmenu', this.onDragEnd);
     }
 
     this.enableElements.forEach((type) => {

--- a/packages/g6/src/behaviors/drag-element.ts
+++ b/packages/g6/src/behaviors/drag-element.ts
@@ -155,11 +155,6 @@ export class DragElement extends BaseBehavior<DragElementOptions> {
 
   private isDragging: boolean = false;
 
-  private get animation() {
-    if (!this.options.shadow) return false;
-    return this.options.animation;
-  }
-
   constructor(context: RuntimeContext, options: DragElementOptions) {
     super(context, Object.assign({}, DragElement.defaultOptions, options));
     this.onDragStart = this.onDragStart.bind(this);
@@ -183,7 +178,16 @@ export class DragElement extends BaseBehavior<DragElementOptions> {
   }
 
   private bindEvents() {
-    const { graph } = this.context;
+    const { graph, canvas } = this.context;
+
+    // @ts-expect-error internal property
+    const $canvas: HTMLCanvasElement = canvas.getLayer().getContextService().$canvas;
+    if ($canvas) {
+      ['contextmenu', 'blur'].forEach((type) => {
+        $canvas.addEventListener(type, this.onDragEnd);
+      });
+    }
+
     this.enableElements.forEach((type) => {
       graph.on(`${type}:${CommonEvent.DRAG_START}`, this.onDragStart);
       graph.on(`${type}:${CommonEvent.DRAG}`, this.onDrag);
@@ -410,7 +414,15 @@ export class DragElement extends BaseBehavior<DragElementOptions> {
   }
 
   private unbindEvents() {
-    const { graph } = this.context;
+    const { graph, canvas } = this.context;
+
+    // @ts-expect-error internal property
+    const $canvas: HTMLCanvasElement = canvas.getLayer().getContextService().$canvas;
+    if ($canvas) {
+      ['contextmenu', 'blur'].forEach((type) => {
+        $canvas.removeEventListener(type, this.onDragEnd);
+      });
+    }
 
     this.enableElements.forEach((type) => {
       graph.off(`${type}:${CommonEvent.DRAG_START}`, this.onDragStart);


### PR DESCRIPTION
During the drag element process, once the contextmenu or blur event is triggered, the process will be interrupted. 