### PR TITLE
fix: correctly hide tooltip when point out

### DIFF
--- a/packages/g6/__tests__/demos/plugin-tooltip.ts
+++ b/packages/g6/__tests__/demos/plugin-tooltip.ts
@@ -1,4 +1,5 @@
 import data from '@@/dataset/combo.json';
+import type { IElementEvent } from '@antv/g6';
 import { Graph } from '@antv/g6';
 
 export const pluginTooltip: TestCase = async (context) => {
@@ -33,6 +34,7 @@ export const pluginTooltip: TestCase = async (context) => {
   pluginTooltip.form = (panel) => {
     const config = {
       trigger: 'click',
+      enable: 'all',
     };
     return [
       panel
@@ -42,6 +44,20 @@ export const pluginTooltip: TestCase = async (context) => {
           graph.setPlugins((plugins) =>
             plugins.map((plugin) => {
               if (typeof plugin === 'object' && plugin.type === 'tooltip') return { ...plugin, trigger };
+              return plugin;
+            }),
+          );
+        }),
+      panel
+        .add(config, 'enable', ['all', 'node', 'edge', 'combo'])
+        .name('Change Enable Target')
+        .onChange((enable: string) => {
+          graph.setPlugins((plugins) =>
+            plugins.map((plugin) => {
+              if (typeof plugin === 'object' && plugin.type === 'tooltip') {
+                if (enable === 'all') return { ...plugin, enable: true };
+                else return { ...plugin, enable: (event: IElementEvent) => event.targetType === enable };
+              }
               return plugin;
             }),
           );

--- a/packages/g6/src/plugins/tooltip.ts
+++ b/packages/g6/src/plugins/tooltip.ts
@@ -151,8 +151,8 @@ export class Tooltip extends BasePlugin<TooltipOptions> {
     } = event;
     // click the same item twice, tooltip will be hidden
     if (this.currentTarget === id) {
-      this.currentTarget = null;
       this.hide(event);
+      this.currentTarget = null;
     } else {
       this.currentTarget = id;
       this.show(event);
@@ -294,7 +294,9 @@ export class Tooltip extends BasePlugin<TooltipOptions> {
       this.tooltipElement?.hide();
       return;
     }
-    if (!this.tooltipElement || !this.isEnable(event)) return;
+    if (!this.tooltipElement) return;
+    // No target node: tooltip has been hidden. No need for duplicated call.
+    if (!this.currentTarget) return;
     const {
       client: { x, y },
     } = event;


### PR DESCRIPTION
Fixed when pointing out of enabled elements, tooltip will not hide.
会中文，可以用中文评论。

Reproduce: [Tooltip API](https://g6-next.antv.antgroup.com/api/plugins/tooltip) Change enable to node or edge only and then hover on those nodes or edges to see the tooltip isn't hide correctly