### PR TITLE
refactor(graph): frontElement will bring relative edges forward

### DIFF
--- a/packages/g6/__tests__/snapshots/behaviors/collapse-expand-combo/collapse-combo-2-0.svg
+++ b/packages/g6/__tests__/snapshots/behaviors/collapse-expand-combo/collapse-combo-2-0.svg
@@ -3,20 +3,6 @@
   <g >
     <g fill="none">
       <g fill="none" class="elements">
-        <g fill="none" marker-start="false" marker-end="false">
-          <g fill="none" marker-start="false" marker-end="false" stroke="transparent" stroke-width="3"/>
-          <g>
-            <path fill="none" d="M 133.9865164179446,107.77028689885812 L 286.0134835820554,192.2297131011419" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
-            <path fill="none" d="M 130.47888861468547,112.09102532463709 L 227.46666666666667,224" class="key" stroke-width="3" stroke="transparent"/>
-          </g>
-        </g>
-        <g fill="none" marker-start="false" marker-end="false">
-          <g fill="none" marker-start="false" marker-end="false" stroke="transparent" stroke-width="3"/>
-          <g>
-            <path fill="none" d="M 288.68629150101526,211.31370849898477 L 211.31370849898477,288.68629150101526" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
-            <path fill="none" d="M 288.68629150101526,211.31370849898477 L 211.31370849898477,288.68629150101526" class="key" stroke-width="3" stroke="transparent"/>
-          </g>
-        </g>
         <g fill="none" x="215.9200012207031" y="229" transform="matrix(1,0,0,1,215.919998,229)">
           <g>
             <circle fill="rgba(153,173,209,1)" class="key" stroke-dasharray="0,0" stroke-width="1" fill-opacity="0.04" stroke="rgba(153,173,209,1)" r="199.8406863177741"/>
@@ -39,6 +25,20 @@
                 combo-1
               </text>
             </g>
+          </g>
+        </g>
+        <g fill="none" marker-start="false" marker-end="false">
+          <g fill="none" marker-start="false" marker-end="false" stroke="transparent" stroke-width="3"/>
+          <g>
+            <path fill="none" d="M 133.9865164179446,107.77028689885812 L 286.0134835820554,192.2297131011419" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
+            <path fill="none" d="M 130.47888861468547,112.09102532463709 L 227.46666666666667,224" class="key" stroke-width="3" stroke="transparent"/>
+          </g>
+        </g>
+        <g fill="none" marker-start="false" marker-end="false">
+          <g fill="none" marker-start="false" marker-end="false" stroke="transparent" stroke-width="3"/>
+          <g>
+            <path fill="none" d="M 288.68629150101526,211.31370849898477 L 211.31370849898477,288.68629150101526" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
+            <path fill="none" d="M 288.68629150101526,211.31370849898477 L 211.31370849898477,288.68629150101526" class="key" stroke-width="3" stroke="transparent"/>
           </g>
         </g>
         <g fill="none" x="120" y="100" transform="matrix(1,0,0,1,120,100)">

--- a/packages/g6/__tests__/snapshots/behaviors/collapse-expand-combo/collapse-combo-2-500.svg
+++ b/packages/g6/__tests__/snapshots/behaviors/collapse-expand-combo/collapse-combo-2-500.svg
@@ -3,20 +3,6 @@
   <g >
     <g fill="none">
       <g fill="none" class="elements">
-        <g fill="none" marker-start="false" marker-end="false">
-          <g fill="none" marker-start="false" marker-end="false" stroke="transparent" stroke-width="3"/>
-          <g>
-            <path fill="none" d="M 200.83455389310305,184.90264207540883 L 214.02327996920164,192.22971266091926" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
-            <path fill="none" d="M 130.47888861468547,112.09102532463709 L 227.46666666666667,224" class="key" stroke-width="3" stroke="transparent"/>
-          </g>
-        </g>
-        <g fill="none" marker-start="false" marker-end="false">
-          <g fill="none" marker-start="false" marker-end="false" stroke="transparent" stroke-width="3"/>
-          <g>
-            <path fill="none" d="M 216.69608764359336,211.31370849898477 L 216.45585937789102,211.5539367646871" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
-            <path fill="none" d="M 288.68629150101526,211.31370849898477 L 211.31370849898477,288.68629150101526" class="key" stroke-width="3" stroke="transparent"/>
-          </g>
-        </g>
         <g fill="none" x="249.3440200805664" y="267.56617736816406" transform="matrix(1,0,0,1,249.344025,267.566162)">
           <g>
             <circle fill="rgba(153,173,209,1)" class="key" stroke-dasharray="0,0" stroke-width="1" fill-opacity="0.04" stroke="rgba(153,173,209,1)" r="148.83913610941644"/>
@@ -39,6 +25,20 @@
                 combo-1
               </text>
             </g>
+          </g>
+        </g>
+        <g fill="none" marker-start="false" marker-end="false">
+          <g fill="none" marker-start="false" marker-end="false" stroke="transparent" stroke-width="3"/>
+          <g>
+            <path fill="none" d="M 200.83455389310305,184.90264207540883 L 214.02327996920164,192.22971266091926" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
+            <path fill="none" d="M 130.47888861468547,112.09102532463709 L 227.46666666666667,224" class="key" stroke-width="3" stroke="transparent"/>
+          </g>
+        </g>
+        <g fill="none" marker-start="false" marker-end="false">
+          <g fill="none" marker-start="false" marker-end="false" stroke="transparent" stroke-width="3"/>
+          <g>
+            <path fill="none" d="M 216.69608764359336,211.31370849898477 L 216.45585937789102,211.5539367646871" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
+            <path fill="none" d="M 288.68629150101526,211.31370849898477 L 211.31370849898477,288.68629150101526" class="key" stroke-width="3" stroke="transparent"/>
           </g>
         </g>
         <g fill="none" x="186.8480420613608" y="177.13235622464705" transform="matrix(1,0,0,1,186.848038,177.132355)">

--- a/packages/g6/__tests__/snapshots/behaviors/collapse-expand/expand-combo-1.svg
+++ b/packages/g6/__tests__/snapshots/behaviors/collapse-expand/expand-combo-1.svg
@@ -3,13 +3,6 @@
   <g >
     <g fill="none">
       <g fill="none" class="elements">
-        <g fill="none" marker-start="false" marker-end="false">
-          <g fill="none" marker-start="false" marker-end="false" stroke="transparent" stroke-width="3"/>
-          <g>
-            <path fill="none" d="M 133.9865164179446,107.77028689885812 L 286.0134835820554,192.2297131011419" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
-            <path fill="none" d="M 130.47888861468547,112.09102532463709 L 227.46666666666667,224" class="key" stroke-width="3" stroke="transparent"/>
-          </g>
-        </g>
         <g fill="none" x="215.9200012207031" y="229" transform="matrix(1,0,0,1,215.919998,229)">
           <g>
             <circle fill="rgba(153,173,209,1)" class="key" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="199.8406863177741" fill-opacity="0.04"/>
@@ -34,6 +27,13 @@
             </g>
           </g>
         </g>
+        <g fill="none" marker-start="false" marker-end="false">
+          <g fill="none" marker-start="false" marker-end="false" stroke="transparent" stroke-width="3"/>
+          <g>
+            <path fill="none" d="M 133.9865164179446,107.77028689885812 L 286.0134835820554,192.2297131011419" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
+            <path fill="none" d="M 130.47888861468547,112.09102532463709 L 227.46666666666667,224" class="key" stroke-width="3" stroke="transparent"/>
+          </g>
+        </g>
         <g fill="none" x="120" y="100" transform="matrix(1,0,0,1,120,100)">
           <g>
             <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
@@ -44,13 +44,6 @@
                 node-1
               </text>
             </g>
-          </g>
-        </g>
-        <g fill="none" marker-start="false" marker-end="false">
-          <g fill="none" marker-start="false" marker-end="false" stroke="transparent" stroke-width="3"/>
-          <g>
-            <path fill="none" d="M 288.68629150101526,211.31370849898477 L 211.31370849898477,288.68629150101526" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
-            <path fill="none" d="M 288.68629150101526,211.31370849898477 L 211.31370849898477,288.68629150101526" class="key" stroke-width="3" stroke="transparent"/>
           </g>
         </g>
         <g fill="none" x="300" y="200" transform="matrix(1,0,0,1,300,200)">
@@ -75,6 +68,13 @@
                 node-3
               </text>
             </g>
+          </g>
+        </g>
+        <g fill="none" marker-start="false" marker-end="false">
+          <g fill="none" marker-start="false" marker-end="false" stroke="transparent" stroke-width="3"/>
+          <g>
+            <path fill="none" d="M 288.68629150101526,211.31370849898477 L 211.31370849898477,288.68629150101526" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
+            <path fill="none" d="M 288.68629150101526,211.31370849898477 L 211.31370849898477,288.68629150101526" class="key" stroke-width="3" stroke="transparent"/>
           </g>
         </g>
       </g>

--- a/packages/g6/__tests__/snapshots/behaviors/drag-element-combo/drag-combo-1-after-drop-move.svg
+++ b/packages/g6/__tests__/snapshots/behaviors/drag-element-combo/drag-combo-1-after-drop-move.svg
@@ -3,20 +3,6 @@
   <g >
     <g fill="none">
       <g fill="none" class="elements">
-        <g fill="none" marker-start="false" marker-end="false">
-          <g fill="none" marker-start="false" marker-end="false" stroke="transparent" stroke-width="3"/>
-          <g>
-            <path fill="none" d="M 397.3696162031143,364.2176972186857 L 382.6303837968857,275.7823027813143" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
-            <path fill="none" d="M 130.47888861468547,112.09102532463709 L 227.46666666666667,224" class="key" stroke-width="3" stroke="transparent"/>
-          </g>
-        </g>
-        <g fill="none" marker-start="false" marker-end="false">
-          <g fill="none" marker-start="false" marker-end="false" stroke="transparent" stroke-width="3"/>
-          <g>
-            <path fill="none" d="M 372.0617769862907,273.89189027399135 L 307.9382230137093,386.10810972600865" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
-            <path fill="none" d="M 288.68629150101526,211.31370849898477 L 211.31370849898477,288.68629150101526" class="key" stroke-width="3" stroke="transparent"/>
-          </g>
-        </g>
         <g fill="none" x="345.02" y="359" transform="matrix(1,0,0,1,345.019989,359)">
           <g>
             <circle fill="rgba(153,173,209,1)" class="key" stroke-dasharray="0,0" stroke-width="1" fill-opacity="0.04" stroke="rgba(153,173,209,1)" r="151.8401791358269"/>
@@ -39,6 +25,20 @@
                 combo-1
               </text>
             </g>
+          </g>
+        </g>
+        <g fill="none" marker-start="false" marker-end="false">
+          <g fill="none" marker-start="false" marker-end="false" stroke="transparent" stroke-width="3"/>
+          <g>
+            <path fill="none" d="M 397.3696162031143,364.2176972186857 L 382.6303837968857,275.7823027813143" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
+            <path fill="none" d="M 130.47888861468547,112.09102532463709 L 227.46666666666667,224" class="key" stroke-width="3" stroke="transparent"/>
+          </g>
+        </g>
+        <g fill="none" marker-start="false" marker-end="false">
+          <g fill="none" marker-start="false" marker-end="false" stroke="transparent" stroke-width="3"/>
+          <g>
+            <path fill="none" d="M 372.0617769862907,273.89189027399135 L 307.9382230137093,386.10810972600865" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
+            <path fill="none" d="M 288.68629150101526,211.31370849898477 L 211.31370849898477,288.68629150101526" class="key" stroke-width="3" stroke="transparent"/>
           </g>
         </g>
         <g fill="none" x="300" y="400" transform="matrix(1,0,0,1,300,400)">

--- a/packages/g6/__tests__/snapshots/behaviors/drag-element-combo/drag-combo-1-after-drop-out.svg
+++ b/packages/g6/__tests__/snapshots/behaviors/drag-element-combo/drag-combo-1-after-drop-out.svg
@@ -3,20 +3,6 @@
   <g >
     <g fill="none">
       <g fill="none" class="elements">
-        <g fill="none" marker-start="false" marker-end="false">
-          <g fill="none" marker-start="false" marker-end="false" stroke="transparent" stroke-width="3"/>
-          <g>
-            <path fill="none" d="M 397.3696162031143,364.2176972186857 L 382.6303837968857,275.7823027813143" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
-            <path fill="none" d="M 130.47888861468547,112.09102532463709 L 227.46666666666667,224" class="key" stroke-width="3" stroke="transparent"/>
-          </g>
-        </g>
-        <g fill="none" marker-start="false" marker-end="false">
-          <g fill="none" marker-start="false" marker-end="false" stroke="transparent" stroke-width="3"/>
-          <g>
-            <path fill="none" d="M 364.82106723119176,254.9403557437306 L 65.17893276880822,155.0596442562694" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
-            <path fill="none" d="M 288.68629150101526,211.31370849898477 L 211.31370849898477,288.68629150101526" class="key" stroke-width="3" stroke="transparent"/>
-          </g>
-        </g>
         <g fill="none" x="390.08000000000004" y="332.5" transform="matrix(1,0,0,1,390.079987,332.500000)">
           <g>
             <circle fill="rgba(153,173,209,1)" class="key" stroke-dasharray="0,0" stroke-width="1" fill-opacity="0.04" stroke="rgba(153,173,209,1)" r="106.7461924379507"/>
@@ -39,6 +25,20 @@
                 combo-1
               </text>
             </g>
+          </g>
+        </g>
+        <g fill="none" marker-start="false" marker-end="false">
+          <g fill="none" marker-start="false" marker-end="false" stroke="transparent" stroke-width="3"/>
+          <g>
+            <path fill="none" d="M 397.3696162031143,364.2176972186857 L 382.6303837968857,275.7823027813143" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
+            <path fill="none" d="M 130.47888861468547,112.09102532463709 L 227.46666666666667,224" class="key" stroke-width="3" stroke="transparent"/>
+          </g>
+        </g>
+        <g fill="none" marker-start="false" marker-end="false">
+          <g fill="none" marker-start="false" marker-end="false" stroke="transparent" stroke-width="3"/>
+          <g>
+            <path fill="none" d="M 364.82106723119176,254.9403557437306 L 65.17893276880822,155.0596442562694" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
+            <path fill="none" d="M 288.68629150101526,211.31370849898477 L 211.31370849898477,288.68629150101526" class="key" stroke-width="3" stroke="transparent"/>
           </g>
         </g>
         <g fill="none" x="50" y="150" transform="matrix(1,0,0,1,50,150)">

--- a/packages/g6/__tests__/snapshots/behaviors/drag-element-combo/drag-combo-1-before-drop-move.svg
+++ b/packages/g6/__tests__/snapshots/behaviors/drag-element-combo/drag-combo-1-before-drop-move.svg
@@ -3,20 +3,6 @@
   <g >
     <g fill="none">
       <g fill="none" class="elements">
-        <g fill="none" marker-start="false" marker-end="false">
-          <g fill="none" marker-start="false" marker-end="false" stroke="transparent" stroke-width="3"/>
-          <g>
-            <path fill="none" d="M 397.3696162031143,364.2176972186857 L 382.6303837968857,275.7823027813143" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
-            <path fill="none" d="M 130.47888861468547,112.09102532463709 L 227.46666666666667,224" class="key" stroke-width="3" stroke="transparent"/>
-          </g>
-        </g>
-        <g fill="none" marker-start="false" marker-end="false">
-          <g fill="none" marker-start="false" marker-end="false" stroke="transparent" stroke-width="3"/>
-          <g>
-            <path fill="none" d="M 372.0617769862907,273.89189027399135 L 307.9382230137093,386.10810972600865" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
-            <path fill="none" d="M 288.68629150101526,211.31370849898477 L 211.31370849898477,288.68629150101526" class="key" stroke-width="3" stroke="transparent"/>
-          </g>
-        </g>
         <g fill="none" x="295.02" y="332.5" transform="matrix(1,0,0,1,295.019989,332.500000)">
           <g>
             <circle fill="rgba(153,173,209,1)" class="key" stroke-dasharray="0,0" stroke-width="1" fill-opacity="0.04" stroke="rgba(153,173,209,1)" r="168.08536521660653"/>
@@ -39,6 +25,20 @@
                 combo-1
               </text>
             </g>
+          </g>
+        </g>
+        <g fill="none" marker-start="false" marker-end="false">
+          <g fill="none" marker-start="false" marker-end="false" stroke="transparent" stroke-width="3"/>
+          <g>
+            <path fill="none" d="M 397.3696162031143,364.2176972186857 L 382.6303837968857,275.7823027813143" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
+            <path fill="none" d="M 130.47888861468547,112.09102532463709 L 227.46666666666667,224" class="key" stroke-width="3" stroke="transparent"/>
+          </g>
+        </g>
+        <g fill="none" marker-start="false" marker-end="false">
+          <g fill="none" marker-start="false" marker-end="false" stroke="transparent" stroke-width="3"/>
+          <g>
+            <path fill="none" d="M 372.0617769862907,273.89189027399135 L 307.9382230137093,386.10810972600865" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
+            <path fill="none" d="M 288.68629150101526,211.31370849898477 L 211.31370849898477,288.68629150101526" class="key" stroke-width="3" stroke="transparent"/>
           </g>
         </g>
         <g fill="none" x="300" y="400" transform="matrix(1,0,0,1,300,400)">

--- a/packages/g6/__tests__/snapshots/behaviors/drag-element-combo/drag-combo-1-before-drop-out.svg
+++ b/packages/g6/__tests__/snapshots/behaviors/drag-element-combo/drag-combo-1-before-drop-out.svg
@@ -3,20 +3,6 @@
   <g >
     <g fill="none">
       <g fill="none" class="elements">
-        <g fill="none" marker-start="false" marker-end="false">
-          <g fill="none" marker-start="false" marker-end="false" stroke="transparent" stroke-width="3"/>
-          <g>
-            <path fill="none" d="M 397.3696162031143,364.2176972186857 L 382.6303837968857,275.7823027813143" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
-            <path fill="none" d="M 130.47888861468547,112.09102532463709 L 227.46666666666667,224" class="key" stroke-width="3" stroke="transparent"/>
-          </g>
-        </g>
-        <g fill="none" marker-start="false" marker-end="false">
-          <g fill="none" marker-start="false" marker-end="false" stroke="transparent" stroke-width="3"/>
-          <g>
-            <path fill="none" d="M 364.82106723119176,254.9403557437306 L 65.17893276880822,155.0596442562694" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
-            <path fill="none" d="M 288.68629150101526,211.31370849898477 L 211.31370849898477,288.68629150101526" class="key" stroke-width="3" stroke="transparent"/>
-          </g>
-        </g>
         <g fill="none" x="345.02" y="359" transform="matrix(1,0,0,1,345.019989,359)">
           <g>
             <circle fill="rgba(153,173,209,1)" class="key" stroke-dasharray="0,0" stroke-width="1" fill-opacity="0.04" stroke="rgba(153,173,209,1)" r="151.8401791358269"/>
@@ -39,6 +25,20 @@
                 combo-1
               </text>
             </g>
+          </g>
+        </g>
+        <g fill="none" marker-start="false" marker-end="false">
+          <g fill="none" marker-start="false" marker-end="false" stroke="transparent" stroke-width="3"/>
+          <g>
+            <path fill="none" d="M 397.3696162031143,364.2176972186857 L 382.6303837968857,275.7823027813143" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
+            <path fill="none" d="M 130.47888861468547,112.09102532463709 L 227.46666666666667,224" class="key" stroke-width="3" stroke="transparent"/>
+          </g>
+        </g>
+        <g fill="none" marker-start="false" marker-end="false">
+          <g fill="none" marker-start="false" marker-end="false" stroke="transparent" stroke-width="3"/>
+          <g>
+            <path fill="none" d="M 364.82106723119176,254.9403557437306 L 65.17893276880822,155.0596442562694" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
+            <path fill="none" d="M 288.68629150101526,211.31370849898477 L 211.31370849898477,288.68629150101526" class="key" stroke-width="3" stroke="transparent"/>
           </g>
         </g>
         <g fill="none" x="50" y="150" transform="matrix(1,0,0,1,50,150)">

--- a/packages/g6/__tests__/snapshots/behaviors/drag-element-combo/drag-combo-2-after-drop-into.svg
+++ b/packages/g6/__tests__/snapshots/behaviors/drag-element-combo/drag-combo-2-after-drop-into.svg
@@ -3,20 +3,6 @@
   <g >
     <g fill="none">
       <g fill="none" class="elements">
-        <g fill="none" marker-start="false" marker-end="false">
-          <g fill="none" marker-start="false" marker-end="false" stroke="transparent" stroke-width="3"/>
-          <g>
-            <path fill="none" d="M 197.36961620311428,164.21769721868571 L 182.63038379688572,75.7823027813143" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
-            <path fill="none" d="M 130.47888861468547,112.09102532463709 L 227.46666666666667,224" class="key" stroke-width="3" stroke="transparent"/>
-          </g>
-        </g>
-        <g fill="none" marker-start="false" marker-end="false">
-          <g fill="none" marker-start="false" marker-end="false" stroke="transparent" stroke-width="3"/>
-          <g>
-            <path fill="none" d="M 166.84492493369953,69.10735966128493 L 63.155075066300455,140.89264033871507" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
-            <path fill="none" d="M 288.68629150101526,211.31370849898477 L 211.31370849898477,288.68629150101526" class="key" stroke-width="3" stroke="transparent"/>
-          </g>
-        </g>
         <g fill="none" x="162.8230971345027" y="144.0000002470891" transform="matrix(1,0,0,1,162.823090,144)">
           <g>
             <path fill="rgba(153,173,209,1)" d="M -144.0030971345027,-128.2461926850398 l 288.0061942690054,0 l 0,256.4923853700796 l-288.0061942690054 0 z" class="key" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" width="288.0061942690054" height="256.4923853700796" x="-144.0030971345027" y="-128.2461926850398" fill-opacity="0.04"/>
@@ -27,6 +13,13 @@
                 combo-1
               </text>
             </g>
+          </g>
+        </g>
+        <g fill="none" marker-start="false" marker-end="false">
+          <g fill="none" marker-start="false" marker-end="false" stroke="transparent" stroke-width="3"/>
+          <g>
+            <path fill="none" d="M 166.84492493369953,69.10735966128493 L 63.155075066300455,140.89264033871507" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
+            <path fill="none" d="M 288.68629150101526,211.31370849898477 L 211.31370849898477,288.68629150101526" class="key" stroke-width="3" stroke="transparent"/>
           </g>
         </g>
         <g fill="none" x="50" y="150" transform="matrix(1,0,0,1,50,150)">
@@ -51,6 +44,13 @@
                 combo-2
               </text>
             </g>
+          </g>
+        </g>
+        <g fill="none" marker-start="false" marker-end="false">
+          <g fill="none" marker-start="false" marker-end="false" stroke="transparent" stroke-width="3"/>
+          <g>
+            <path fill="none" d="M 197.36961620311428,164.21769721868571 L 182.63038379688572,75.7823027813143" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
+            <path fill="none" d="M 130.47888861468547,112.09102532463709 L 227.46666666666667,224" class="key" stroke-width="3" stroke="transparent"/>
           </g>
         </g>
         <g fill="none" x="180" y="60" transform="matrix(1,0,0,1,180,60)">

--- a/packages/g6/__tests__/snapshots/behaviors/drag-element-combo/drag-combo-2-before-drop-into.svg
+++ b/packages/g6/__tests__/snapshots/behaviors/drag-element-combo/drag-combo-2-before-drop-into.svg
@@ -3,20 +3,6 @@
   <g >
     <g fill="none">
       <g fill="none" class="elements">
-        <g fill="none" marker-start="false" marker-end="false">
-          <g fill="none" marker-start="false" marker-end="false" stroke="transparent" stroke-width="3"/>
-          <g>
-            <path fill="none" d="M 197.36961620311428,164.21769721868571 L 182.63038379688572,75.7823027813143" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
-            <path fill="none" d="M 130.47888861468547,112.09102532463709 L 227.46666666666667,224" class="key" stroke-width="3" stroke="transparent"/>
-          </g>
-        </g>
-        <g fill="none" marker-start="false" marker-end="false">
-          <g fill="none" marker-start="false" marker-end="false" stroke="transparent" stroke-width="3"/>
-          <g>
-            <path fill="none" d="M 166.84492493369953,69.10735966128493 L 63.155075066300455,140.89264033871507" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
-            <path fill="none" d="M 288.68629150101526,211.31370849898477 L 211.31370849898477,288.68629150101526" class="key" stroke-width="3" stroke="transparent"/>
-          </g>
-        </g>
         <g fill="none" x="50.5" y="162.5" transform="matrix(1,0,0,1,50.500000,162.500000)">
           <g>
             <path fill="rgba(153,173,209,1)" d="M -31.680000000000003,-38.5 l 63.36000000000001,0 l 0,77 l-63.36000000000001 0 z" class="key" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" width="63.36000000000001" height="77" x="-31.680000000000003" y="-38.5" fill-opacity="0.04"/>
@@ -27,6 +13,13 @@
                 combo-1
               </text>
             </g>
+          </g>
+        </g>
+        <g fill="none" marker-start="false" marker-end="false">
+          <g fill="none" marker-start="false" marker-end="false" stroke="transparent" stroke-width="3"/>
+          <g>
+            <path fill="none" d="M 166.84492493369953,69.10735966128493 L 63.155075066300455,140.89264033871507" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
+            <path fill="none" d="M 288.68629150101526,211.31370849898477 L 211.31370849898477,288.68629150101526" class="key" stroke-width="3" stroke="transparent"/>
           </g>
         </g>
         <g fill="none" x="50" y="150" transform="matrix(1,0,0,1,50,150)">
@@ -51,6 +44,13 @@
                 combo-2
               </text>
             </g>
+          </g>
+        </g>
+        <g fill="none" marker-start="false" marker-end="false">
+          <g fill="none" marker-start="false" marker-end="false" stroke="transparent" stroke-width="3"/>
+          <g>
+            <path fill="none" d="M 197.36961620311428,164.21769721868571 L 182.63038379688572,75.7823027813143" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
+            <path fill="none" d="M 130.47888861468547,112.09102532463709 L 227.46666666666667,224" class="key" stroke-width="3" stroke="transparent"/>
           </g>
         </g>
         <g fill="none" x="180" y="60" transform="matrix(1,0,0,1,180,60)">

--- a/packages/g6/__tests__/snapshots/behaviors/drag-element/drag-combo-shadow-after-drag.svg
+++ b/packages/g6/__tests__/snapshots/behaviors/drag-element/drag-combo-shadow-after-drag.svg
@@ -16,16 +16,6 @@
         <g fill="none" marker-start="false" marker-end="true">
           <g fill="none" marker-start="false" marker-end="true" stroke="transparent" stroke-width="3"/>
           <g>
-            <path fill="none" d="M 243.5112344158839,149.36329177569044 L 294.38202493458573,285.01873315889526" class="key" stroke-width="1" stroke="rgba(153,173,209,1)" visibility="visible"/>
-            <path fill="none" d="M 200,110 L 200,184" class="key" stroke-width="3" stroke="transparent" visibility="visible"/>
-            <g transform="matrix(-0.351123,-0.936329,0.936329,-0.351123,294.382019,285.018738)">
-              <path fill="rgba(153,173,209,1)" d="M -5,0 L 5,-5 L 3,0 L 5,5 Z" stroke="rgba(153,173,209,1)" width="10" height="10" stroke-dasharray="0,0" stroke-linejoin="round" stroke-width="1" visibility="visible"/>
-            </g>
-          </g>
-        </g>
-        <g fill="none" marker-start="false" marker-end="true">
-          <g fill="none" marker-start="false" marker-end="true" stroke="transparent" stroke-width="3"/>
-          <g>
             <path fill="none" d="M 100,110 L 100,224" class="key" stroke-width="1" stroke="rgba(153,173,209,1)" visibility="visible"/>
             <path fill="none" d="M 100,110 L 100,184" class="key" stroke-width="3" stroke="transparent" visibility="visible"/>
             <g transform="matrix(0,-1,1,0,100,224)">
@@ -56,6 +46,16 @@
         <g fill="none" x="270" y="220" transform="matrix(1,0,0,1,270,220)">
           <g>
             <circle fill="rgba(153,173,209,1)" class="key" stroke-dasharray="0,0" stroke-width="1" fill-opacity="0.04" stroke="rgba(153,173,209,1)" r="111.80339887498948"/>
+          </g>
+        </g>
+        <g fill="none" marker-start="false" marker-end="true">
+          <g fill="none" marker-start="false" marker-end="true" stroke="transparent" stroke-width="3"/>
+          <g>
+            <path fill="none" d="M 243.5112344158839,149.36329177569044 L 294.38202493458573,285.01873315889526" class="key" stroke-width="1" stroke="rgba(153,173,209,1)" visibility="visible"/>
+            <path fill="none" d="M 200,110 L 200,184" class="key" stroke-width="3" stroke="transparent" visibility="visible"/>
+            <g transform="matrix(-0.351123,-0.936329,0.936329,-0.351123,294.382019,285.018738)">
+              <path fill="rgba(153,173,209,1)" d="M -5,0 L 5,-5 L 3,0 L 5,5 Z" stroke="rgba(153,173,209,1)" width="10" height="10" stroke-dasharray="0,0" stroke-linejoin="round" stroke-width="1" visibility="visible"/>
+            </g>
           </g>
         </g>
         <g fill="none" x="240" y="140" transform="matrix(1,0,0,1,240,140)">

--- a/packages/g6/__tests__/snapshots/behaviors/drag-element/drag-combo-shadow.svg
+++ b/packages/g6/__tests__/snapshots/behaviors/drag-element/drag-combo-shadow.svg
@@ -16,16 +16,6 @@
         <g fill="none" marker-start="false" marker-end="true">
           <g fill="none" marker-start="false" marker-end="true" stroke="transparent" stroke-width="3"/>
           <g>
-            <path fill="none" d="M 223.5112344158839,129.36329177569044 L 274.38202493458573,265.01873315889526" class="key" stroke-width="1" stroke="rgba(153,173,209,1)" visibility="visible"/>
-            <path fill="none" d="M 200,110 L 200,184" class="key" stroke-width="3" stroke="transparent" visibility="visible"/>
-            <g transform="matrix(-0.351123,-0.936329,0.936329,-0.351123,274.382019,265.018738)">
-              <path fill="rgba(153,173,209,1)" d="M -5,0 L 5,-5 L 3,0 L 5,5 Z" stroke="rgba(153,173,209,1)" width="10" height="10" stroke-dasharray="0,0" stroke-linejoin="round" stroke-width="1" visibility="visible"/>
-            </g>
-          </g>
-        </g>
-        <g fill="none" marker-start="false" marker-end="true">
-          <g fill="none" marker-start="false" marker-end="true" stroke="transparent" stroke-width="3"/>
-          <g>
             <path fill="none" d="M 100,110 L 100,224" class="key" stroke-width="1" stroke="rgba(153,173,209,1)" visibility="visible"/>
             <path fill="none" d="M 100,110 L 100,184" class="key" stroke-width="3" stroke="transparent" visibility="visible"/>
             <g transform="matrix(0,-1,1,0,100,224)">
@@ -56,6 +46,16 @@
         <g fill="none" x="250" y="200" transform="matrix(1,0,0,1,250,200)">
           <g>
             <circle fill="rgba(153,173,209,1)" class="key" stroke-dasharray="0,0" stroke-width="1" fill-opacity="0.04" stroke="rgba(153,173,209,1)" r="111.80339887498948"/>
+          </g>
+        </g>
+        <g fill="none" marker-start="false" marker-end="true">
+          <g fill="none" marker-start="false" marker-end="true" stroke="transparent" stroke-width="3"/>
+          <g>
+            <path fill="none" d="M 223.5112344158839,129.36329177569044 L 274.38202493458573,265.01873315889526" class="key" stroke-width="1" stroke="rgba(153,173,209,1)" visibility="visible"/>
+            <path fill="none" d="M 200,110 L 200,184" class="key" stroke-width="3" stroke="transparent" visibility="visible"/>
+            <g transform="matrix(-0.351123,-0.936329,0.936329,-0.351123,274.382019,265.018738)">
+              <path fill="rgba(153,173,209,1)" d="M -5,0 L 5,-5 L 3,0 L 5,5 Z" stroke="rgba(153,173,209,1)" width="10" height="10" stroke-dasharray="0,0" stroke-linejoin="round" stroke-width="1" visibility="visible"/>
+            </g>
           </g>
         </g>
         <g fill="none" x="220" y="120" transform="matrix(1,0,0,1,220,120)">

--- a/packages/g6/__tests__/snapshots/behaviors/drag-element/drag-combo.svg
+++ b/packages/g6/__tests__/snapshots/behaviors/drag-element/drag-combo.svg
@@ -16,16 +16,6 @@
         <g fill="none" marker-start="false" marker-end="true">
           <g fill="none" marker-start="false" marker-end="true" stroke="transparent" stroke-width="3"/>
           <g>
-            <path fill="none" d="M 223.5112344158839,129.36329177569044 L 274.38202493458573,265.01873315889526" class="key" stroke-width="1" stroke="rgba(153,173,209,1)" visibility="visible"/>
-            <path fill="none" d="M 200,110 L 200,184" class="key" stroke-width="3" stroke="transparent" visibility="visible"/>
-            <g transform="matrix(-0.351123,-0.936329,0.936329,-0.351123,274.382019,265.018738)">
-              <path fill="rgba(153,173,209,1)" d="M -5,0 L 5,-5 L 3,0 L 5,5 Z" stroke="rgba(153,173,209,1)" width="10" height="10" stroke-dasharray="0,0" stroke-linejoin="round" stroke-width="1" visibility="visible"/>
-            </g>
-          </g>
-        </g>
-        <g fill="none" marker-start="false" marker-end="true">
-          <g fill="none" marker-start="false" marker-end="true" stroke="transparent" stroke-width="3"/>
-          <g>
             <path fill="none" d="M 100,110 L 100,224" class="key" stroke-width="1" stroke="rgba(153,173,209,1)" visibility="visible"/>
             <path fill="none" d="M 100,110 L 100,184" class="key" stroke-width="3" stroke="transparent" visibility="visible"/>
             <g transform="matrix(0,-1,1,0,100,224)">
@@ -56,6 +46,16 @@
         <g fill="none" x="250" y="200" transform="matrix(1,0,0,1,250,200)">
           <g>
             <circle fill="rgba(153,173,209,1)" class="key" stroke-dasharray="0,0" stroke-width="1" fill-opacity="0.04" stroke="rgba(153,173,209,1)" r="111.80339887498948"/>
+          </g>
+        </g>
+        <g fill="none" marker-start="false" marker-end="true">
+          <g fill="none" marker-start="false" marker-end="true" stroke="transparent" stroke-width="3"/>
+          <g>
+            <path fill="none" d="M 223.5112344158839,129.36329177569044 L 274.38202493458573,265.01873315889526" class="key" stroke-width="1" stroke="rgba(153,173,209,1)" visibility="visible"/>
+            <path fill="none" d="M 200,110 L 200,184" class="key" stroke-width="3" stroke="transparent" visibility="visible"/>
+            <g transform="matrix(-0.351123,-0.936329,0.936329,-0.351123,274.382019,265.018738)">
+              <path fill="rgba(153,173,209,1)" d="M -5,0 L 5,-5 L 3,0 L 5,5 Z" stroke="rgba(153,173,209,1)" width="10" height="10" stroke-dasharray="0,0" stroke-linejoin="round" stroke-width="1" visibility="visible"/>
+            </g>
           </g>
         </g>
         <g fill="none" x="220" y="120" transform="matrix(1,0,0,1,220,120)">

--- a/packages/g6/__tests__/snapshots/elements/combo/combo-zIndex.svg
+++ b/packages/g6/__tests__/snapshots/elements/combo/combo-zIndex.svg
@@ -1,0 +1,48 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; position: absolute; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
+  <defs/>
+  <g >
+    <g fill="none">
+      <g fill="none" class="elements">
+        <g fill="none" x="215" y="205" transform="matrix(1,0,0,1,215,205)">
+          <g>
+            <circle fill="rgba(153,173,209,1)" class="key" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(0,0,0,1)" r="178.33115263464205"/>
+          </g>
+        </g>
+        <g fill="none" x="250" y="250" transform="matrix(1,0,0,1,250,250)">
+          <g>
+            <path fill="rgba(153,173,209,1)" d="M -76,-76 l 152,0 l 0,152 l-152 0 z" class="key" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(0,0,0,1)" width="152" height="152" x="-76" y="-76"/>
+          </g>
+        </g>
+        <g fill="none" marker-start="false" marker-end="false">
+          <g fill="none" marker-start="false" marker-end="false" stroke="transparent" stroke-width="3"/>
+          <g>
+            <path fill="none" d="M 133.9865164179446,107.77028689885812 L 286.0134835820554,192.2297131011419" class="key" stroke-width="1" stroke="rgba(255,0,0,1)"/>
+            <path fill="none" d="M 133.9865164179446,107.77028689885812 L 286.0134835820554,192.2297131011419" class="key" stroke-width="3" stroke="transparent"/>
+          </g>
+        </g>
+        <g fill="none" marker-start="false" marker-end="false">
+          <g fill="none" marker-start="false" marker-end="false" stroke="transparent" stroke-width="3"/>
+          <g>
+            <path fill="none" d="M 288.68629150101526,211.31370849898477 L 211.31370849898477,288.68629150101526" class="key" stroke-width="1" stroke="rgba(255,0,0,1)"/>
+            <path fill="none" d="M 288.68629150101526,211.31370849898477 L 211.31370849898477,288.68629150101526" class="key" stroke-width="3" stroke="transparent"/>
+          </g>
+        </g>
+        <g fill="none" x="120" y="100" transform="matrix(1,0,0,1,120,100)">
+          <g>
+            <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
+          </g>
+        </g>
+        <g fill="none" x="300" y="200" transform="matrix(1,0,0,1,300,200)">
+          <g>
+            <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
+          </g>
+        </g>
+        <g fill="none" x="200" y="300" transform="matrix(1,0,0,1,200,300)">
+          <g>
+            <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
+          </g>
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/packages/g6/__tests__/snapshots/elements/combo/rect-collapse-center.svg
+++ b/packages/g6/__tests__/snapshots/elements/combo/rect-collapse-center.svg
@@ -3,13 +3,6 @@
   <g >
     <g fill="none">
       <g fill="none" class="elements">
-        <g fill="none" marker-start="false" marker-end="false">
-          <g fill="none" marker-start="false" marker-end="false" stroke="transparent" stroke-width="3"/>
-          <g>
-            <path fill="none" d="M 130.47888861468547,112.09102532463709 L 227.46666666666667,224" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
-            <path fill="none" d="M 133.9865164179446,107.77028689885812 L 286.0134835820554,192.2297131011419" class="key" stroke-width="3" stroke="transparent"/>
-          </g>
-        </g>
         <g fill="none" x="188.11" y="191.5" transform="matrix(1,0,0,1,188.110001,191.500000)">
           <g>
             <circle fill="rgba(153,173,209,1)" class="key" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="153.21566140574532" fill-opacity="0.04"/>
@@ -32,6 +25,13 @@
                 combo-1
               </text>
             </g>
+          </g>
+        </g>
+        <g fill="none" marker-start="false" marker-end="false">
+          <g fill="none" marker-start="false" marker-end="false" stroke="transparent" stroke-width="3"/>
+          <g>
+            <path fill="none" d="M 130.47888861468547,112.09102532463709 L 227.46666666666667,224" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
+            <path fill="none" d="M 133.9865164179446,107.77028689885812 L 286.0134835820554,192.2297131011419" class="key" stroke-width="3" stroke="transparent"/>
           </g>
         </g>
         <g fill="none" x="120" y="100" transform="matrix(1,0,0,1,120,100)">

--- a/packages/g6/__tests__/snapshots/plugins/history/plugin-history/collapse-undo.svg
+++ b/packages/g6/__tests__/snapshots/plugins/history/plugin-history/collapse-undo.svg
@@ -3,13 +3,6 @@
   <g >
     <g fill="none">
       <g fill="none" class="elements">
-        <g fill="none" marker-start="false" marker-end="false">
-          <g fill="none" marker-start="false" marker-end="false" stroke="transparent" stroke-width="3"/>
-          <g>
-            <path fill="none" d="M 130.47888861468547,112.09102532463709 L 227.46666666666667,224" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
-            <path fill="none" d="M 130.47888861468547,112.09102532463709 L 227.46666666666667,224" class="key" stroke-width="3" stroke="transparent"/>
-          </g>
-        </g>
         <g fill="none" x="188.11" y="191.5" transform="matrix(1,0,0,1,188.110001,191.500000)">
           <g>
             <circle fill="rgba(153,173,209,1)" class="key" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="153.21566140574532" fill-opacity="0.04"/>
@@ -39,6 +32,13 @@
                 2
               </text>
             </g>
+          </g>
+        </g>
+        <g fill="none" marker-start="false" marker-end="false">
+          <g fill="none" marker-start="false" marker-end="false" stroke="transparent" stroke-width="3"/>
+          <g>
+            <path fill="none" d="M 130.47888861468547,112.09102532463709 L 227.46666666666667,224" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
+            <path fill="none" d="M 130.47888861468547,112.09102532463709 L 227.46666666666667,224" class="key" stroke-width="3" stroke="transparent"/>
           </g>
         </g>
         <g fill="none" x="120" y="100" transform="matrix(1,0,0,1,120,100)">

--- a/packages/g6/__tests__/snapshots/plugins/history/plugin-history/create-edge-redo.svg
+++ b/packages/g6/__tests__/snapshots/plugins/history/plugin-history/create-edge-redo.svg
@@ -4,13 +4,6 @@
     <g fill="none">
       <g fill="none" class="elements">
         <g fill="none" marker-start="false" marker-end="false">
-          <g fill="none" marker-start="false" marker-end="false" stroke="transparent" stroke-width="3"/>
-          <g>
-            <path fill="none" d="M 130.47888861468547,112.09102532463709 L 227.46666666666667,224" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
-            <path fill="none" d="M 130.47888861468547,112.09102532463709 L 227.46666666666667,224" class="key" stroke-width="3" stroke="transparent"/>
-          </g>
-        </g>
-        <g fill="none" marker-start="false" marker-end="false">
           <g fill="none" marker-start="false" marker-end="false" stroke="transparent" stroke-width="4"/>
           <g>
             <path fill="none" d="M 129.553704853094,112.83459090037421 L 96.6239251139719,68.59622914543786" class="key" stroke-width="2" stroke="rgba(255,0,0,1)"/>
@@ -34,6 +27,13 @@
                 2
               </text>
             </g>
+          </g>
+        </g>
+        <g fill="none" marker-start="false" marker-end="false">
+          <g fill="none" marker-start="false" marker-end="false" stroke="transparent" stroke-width="3"/>
+          <g>
+            <path fill="none" d="M 130.47888861468547,112.09102532463709 L 227.46666666666667,224" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
+            <path fill="none" d="M 130.47888861468547,112.09102532463709 L 227.46666666666667,224" class="key" stroke-width="3" stroke="transparent"/>
           </g>
         </g>
         <g fill="none" x="120" y="100" transform="matrix(1,0,0,1,120,100)">

--- a/packages/g6/__tests__/snapshots/plugins/history/plugin-history/create-edge-undo.svg
+++ b/packages/g6/__tests__/snapshots/plugins/history/plugin-history/create-edge-undo.svg
@@ -3,13 +3,6 @@
   <g >
     <g fill="none">
       <g fill="none" class="elements">
-        <g fill="none" marker-start="false" marker-end="false">
-          <g fill="none" marker-start="false" marker-end="false" stroke="transparent" stroke-width="3"/>
-          <g>
-            <path fill="none" d="M 130.47888861468547,112.09102532463709 L 227.46666666666667,224" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
-            <path fill="none" d="M 130.47888861468547,112.09102532463709 L 227.46666666666667,224" class="key" stroke-width="3" stroke="transparent"/>
-          </g>
-        </g>
         <g fill="none" x="250" y="250" transform="matrix(1,0,0,1,250,250)">
           <g>
             <path fill="rgba(153,173,209,1)" d="M -26,-26 l 52,0 l 0,52 l-52 0 z" class="key" stroke-dasharray="5,5" stroke-width="1" stroke="rgba(153,173,209,1)" width="52" height="52" x="-26" y="-26"/>
@@ -27,6 +20,13 @@
                 2
               </text>
             </g>
+          </g>
+        </g>
+        <g fill="none" marker-start="false" marker-end="false">
+          <g fill="none" marker-start="false" marker-end="false" stroke="transparent" stroke-width="3"/>
+          <g>
+            <path fill="none" d="M 130.47888861468547,112.09102532463709 L 227.46666666666667,224" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
+            <path fill="none" d="M 130.47888861468547,112.09102532463709 L 227.46666666666667,224" class="key" stroke-width="3" stroke="transparent"/>
           </g>
         </g>
         <g fill="none" x="120" y="100" transform="matrix(1,0,0,1,120,100)">

--- a/packages/g6/__tests__/snapshots/plugins/history/plugin-history/create-edge.svg
+++ b/packages/g6/__tests__/snapshots/plugins/history/plugin-history/create-edge.svg
@@ -4,13 +4,6 @@
     <g fill="none">
       <g fill="none" class="elements">
         <g fill="none" marker-start="false" marker-end="false">
-          <g fill="none" marker-start="false" marker-end="false" stroke="transparent" stroke-width="3"/>
-          <g>
-            <path fill="none" d="M 130.47888861468547,112.09102532463709 L 227.46666666666667,224" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
-            <path fill="none" d="M 130.47888861468547,112.09102532463709 L 227.46666666666667,224" class="key" stroke-width="3" stroke="transparent"/>
-          </g>
-        </g>
-        <g fill="none" marker-start="false" marker-end="false">
           <g fill="none" marker-start="false" marker-end="false" stroke="transparent" stroke-width="4"/>
           <g>
             <path fill="none" d="M 129.553704853094,112.83459090037421 L 96.6239251139719,68.59622914543786" class="key" stroke-width="2" stroke="rgba(255,0,0,1)"/>
@@ -34,6 +27,13 @@
                 2
               </text>
             </g>
+          </g>
+        </g>
+        <g fill="none" marker-start="false" marker-end="false">
+          <g fill="none" marker-start="false" marker-end="false" stroke="transparent" stroke-width="3"/>
+          <g>
+            <path fill="none" d="M 130.47888861468547,112.09102532463709 L 227.46666666666667,224" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
+            <path fill="none" d="M 130.47888861468547,112.09102532463709 L 227.46666666666667,224" class="key" stroke-width="3" stroke="transparent"/>
           </g>
         </g>
         <g fill="none" x="120" y="100" transform="matrix(1,0,0,1,120,100)">

--- a/packages/g6/__tests__/snapshots/plugins/history/plugin-history/expand-redo.svg
+++ b/packages/g6/__tests__/snapshots/plugins/history/plugin-history/expand-redo.svg
@@ -3,20 +3,6 @@
   <g >
     <g fill="none">
       <g fill="none" class="elements">
-        <g fill="none" marker-start="false" marker-end="false">
-          <g fill="none" marker-start="false" marker-end="false" stroke="transparent" stroke-width="3"/>
-          <g>
-            <path fill="none" d="M 133.9865164179446,107.77028689885812 L 286.0134835820554,192.2297131011419" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
-            <path fill="none" d="M 130.47888861468547,112.09102532463709 L 227.46666666666667,224" class="key" stroke-width="3" stroke="transparent"/>
-          </g>
-        </g>
-        <g fill="none" marker-start="false" marker-end="false">
-          <g fill="none" marker-start="false" marker-end="false" stroke="transparent" stroke-width="3"/>
-          <g>
-            <path fill="none" d="M 288.68629150101526,211.31370849898477 L 211.31370849898477,288.68629150101526" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
-            <path fill="none" d="M 288.68629150101526,211.31370849898477 L 211.31370849898477,288.68629150101526" class="key" stroke-width="3" stroke="transparent"/>
-          </g>
-        </g>
         <g fill="none" x="215.9200012207031" y="229" transform="matrix(1,0,0,1,215.919998,229)">
           <g>
             <circle fill="rgba(153,173,209,1)" class="key" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="199.8406863177741" fill-opacity="0.04"/>
@@ -53,6 +39,13 @@
             </g>
           </g>
         </g>
+        <g fill="none" marker-start="false" marker-end="false">
+          <g fill="none" marker-start="false" marker-end="false" stroke="transparent" stroke-width="3"/>
+          <g>
+            <path fill="none" d="M 288.68629150101526,211.31370849898477 L 211.31370849898477,288.68629150101526" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
+            <path fill="none" d="M 288.68629150101526,211.31370849898477 L 211.31370849898477,288.68629150101526" class="key" stroke-width="3" stroke="transparent"/>
+          </g>
+        </g>
         <g fill="none" x="250.44" y="262.5" transform="matrix(1,0,0,1,250.440002,262.500000)">
           <g>
             <path fill="rgba(153,173,209,1)" d="M -81.62,-88.5 l 163.24,0 l 0,177 l-163.24 0 z" class="key" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" width="163.24" height="177" x="-81.62" y="-88.5" fill-opacity="0.04"/>
@@ -63,6 +56,13 @@
                 combo-1
               </text>
             </g>
+          </g>
+        </g>
+        <g fill="none" marker-start="false" marker-end="false">
+          <g fill="none" marker-start="false" marker-end="false" stroke="transparent" stroke-width="3"/>
+          <g>
+            <path fill="none" d="M 133.9865164179446,107.77028689885812 L 286.0134835820554,192.2297131011419" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
+            <path fill="none" d="M 130.47888861468547,112.09102532463709 L 227.46666666666667,224" class="key" stroke-width="3" stroke="transparent"/>
           </g>
         </g>
         <g fill="none" x="120" y="100" transform="matrix(1,0,0,1,120,100)">

--- a/packages/g6/__tests__/snapshots/plugins/history/plugin-history/expand-undo.svg
+++ b/packages/g6/__tests__/snapshots/plugins/history/plugin-history/expand-undo.svg
@@ -3,13 +3,6 @@
   <g >
     <g fill="none">
       <g fill="none" class="elements">
-        <g fill="none" marker-start="false" marker-end="false">
-          <g fill="none" marker-start="false" marker-end="false" stroke="transparent" stroke-width="3"/>
-          <g>
-            <path fill="none" d="M 130.47888861468547,112.09102532463709 L 227.46666666666667,224" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
-            <path fill="none" d="M 130.47888861468547,112.09102532463709 L 227.46666666666667,224" class="key" stroke-width="3" stroke="transparent"/>
-          </g>
-        </g>
         <g fill="none" x="188.11" y="191.5" transform="matrix(1,0,0,1,188.110001,191.500000)">
           <g>
             <circle fill="rgba(153,173,209,1)" class="key" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="153.21566140574532" fill-opacity="0.04"/>
@@ -39,6 +32,13 @@
                 2
               </text>
             </g>
+          </g>
+        </g>
+        <g fill="none" marker-start="false" marker-end="false">
+          <g fill="none" marker-start="false" marker-end="false" stroke="transparent" stroke-width="3"/>
+          <g>
+            <path fill="none" d="M 130.47888861468547,112.09102532463709 L 227.46666666666667,224" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
+            <path fill="none" d="M 130.47888861468547,112.09102532463709 L 227.46666666666667,224" class="key" stroke-width="3" stroke="transparent"/>
           </g>
         </g>
         <g fill="none" x="120" y="100" transform="matrix(1,0,0,1,120,100)">

--- a/packages/g6/__tests__/snapshots/plugins/history/plugin-history/expand.svg
+++ b/packages/g6/__tests__/snapshots/plugins/history/plugin-history/expand.svg
@@ -3,13 +3,6 @@
   <g >
     <g fill="none">
       <g fill="none" class="elements">
-        <g fill="none" marker-start="false" marker-end="false">
-          <g fill="none" marker-start="false" marker-end="false" stroke="transparent" stroke-width="3"/>
-          <g>
-            <path fill="none" d="M 133.9865164179446,107.77028689885812 L 286.0134835820554,192.2297131011419" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
-            <path fill="none" d="M 130.47888861468547,112.09102532463709 L 227.46666666666667,224" class="key" stroke-width="3" stroke="transparent"/>
-          </g>
-        </g>
         <g fill="none" x="215.9200012207031" y="229" transform="matrix(1,0,0,1,215.919998,229)">
           <g>
             <circle fill="rgba(153,173,209,1)" class="key" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="199.8406863177741" fill-opacity="0.04"/>
@@ -34,6 +27,13 @@
             </g>
           </g>
         </g>
+        <g fill="none" marker-start="false" marker-end="false">
+          <g fill="none" marker-start="false" marker-end="false" stroke="transparent" stroke-width="3"/>
+          <g>
+            <path fill="none" d="M 133.9865164179446,107.77028689885812 L 286.0134835820554,192.2297131011419" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
+            <path fill="none" d="M 130.47888861468547,112.09102532463709 L 227.46666666666667,224" class="key" stroke-width="3" stroke="transparent"/>
+          </g>
+        </g>
         <g fill="none" x="120" y="100" transform="matrix(1,0,0,1,120,100)">
           <g>
             <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
@@ -44,13 +44,6 @@
                 node-1
               </text>
             </g>
-          </g>
-        </g>
-        <g fill="none" marker-start="false" marker-end="false">
-          <g fill="none" marker-start="false" marker-end="false" stroke="transparent" stroke-width="3"/>
-          <g>
-            <path fill="none" d="M 288.68629150101526,211.31370849898477 L 211.31370849898477,288.68629150101526" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
-            <path fill="none" d="M 288.68629150101526,211.31370849898477 L 211.31370849898477,288.68629150101526" class="key" stroke-width="3" stroke="transparent"/>
           </g>
         </g>
         <g fill="none" x="300" y="200" transform="matrix(1,0,0,1,300,200)">
@@ -75,6 +68,13 @@
                 node-3
               </text>
             </g>
+          </g>
+        </g>
+        <g fill="none" marker-start="false" marker-end="false">
+          <g fill="none" marker-start="false" marker-end="false" stroke="transparent" stroke-width="3"/>
+          <g>
+            <path fill="none" d="M 288.68629150101526,211.31370849898477 L 211.31370849898477,288.68629150101526" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
+            <path fill="none" d="M 288.68629150101526,211.31370849898477 L 211.31370849898477,288.68629150101526" class="key" stroke-width="3" stroke="transparent"/>
           </g>
         </g>
       </g>

--- a/packages/g6/__tests__/snapshots/plugins/history/plugin-history/hideElement-redo.svg
+++ b/packages/g6/__tests__/snapshots/plugins/history/plugin-history/hideElement-redo.svg
@@ -3,13 +3,6 @@
   <g >
     <g fill="none">
       <g fill="none" class="elements">
-        <g fill="none" marker-start="false" marker-end="false">
-          <g fill="none" marker-start="false" marker-end="false" stroke="transparent" stroke-width="3"/>
-          <g>
-            <path fill="none" d="M 130.47888861468547,112.09102532463709 L 227.46666666666667,224" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
-            <path fill="none" d="M 130.47888861468547,112.09102532463709 L 227.46666666666667,224" class="key" stroke-width="3" stroke="transparent"/>
-          </g>
-        </g>
         <g fill="none" x="188.11" y="191.5" transform="matrix(1,0,0,1,188.110001,191.500000)">
           <g>
             <circle fill="rgba(153,173,209,1)" class="key" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="153.21566140574532" fill-opacity="0.04"/>
@@ -39,6 +32,13 @@
                 2
               </text>
             </g>
+          </g>
+        </g>
+        <g fill="none" marker-start="false" marker-end="false">
+          <g fill="none" marker-start="false" marker-end="false" stroke="transparent" stroke-width="3"/>
+          <g>
+            <path fill="none" d="M 130.47888861468547,112.09102532463709 L 227.46666666666667,224" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
+            <path fill="none" d="M 130.47888861468547,112.09102532463709 L 227.46666666666667,224" class="key" stroke-width="3" stroke="transparent"/>
           </g>
         </g>
         <g fill="none" x="120" y="100" transform="matrix(1,0,0,1,120,100)">

--- a/packages/g6/__tests__/snapshots/plugins/history/plugin-history/hideElement-undo.svg
+++ b/packages/g6/__tests__/snapshots/plugins/history/plugin-history/hideElement-undo.svg
@@ -3,13 +3,6 @@
   <g >
     <g fill="none">
       <g fill="none" class="elements">
-        <g fill="none" marker-start="false" marker-end="false">
-          <g fill="none" marker-start="false" marker-end="false" stroke="transparent" stroke-width="3"/>
-          <g>
-            <path fill="none" d="M 130.47888861468547,112.09102532463709 L 227.46666666666667,224" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
-            <path fill="none" d="M 130.47888861468547,112.09102532463709 L 227.46666666666667,224" class="key" stroke-width="3" stroke="transparent"/>
-          </g>
-        </g>
         <g fill="none" x="188.11" y="191.5" transform="matrix(1,0,0,1,188.110001,191.500000)">
           <g>
             <circle fill="rgba(153,173,209,1)" class="key" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="153.21566140574532" fill-opacity="0.04"/>
@@ -39,6 +32,13 @@
                 2
               </text>
             </g>
+          </g>
+        </g>
+        <g fill="none" marker-start="false" marker-end="false">
+          <g fill="none" marker-start="false" marker-end="false" stroke="transparent" stroke-width="3"/>
+          <g>
+            <path fill="none" d="M 130.47888861468547,112.09102532463709 L 227.46666666666667,224" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
+            <path fill="none" d="M 130.47888861468547,112.09102532463709 L 227.46666666666667,224" class="key" stroke-width="3" stroke="transparent"/>
           </g>
         </g>
         <g fill="none" x="120" y="100" transform="matrix(1,0,0,1,120,100)">

--- a/packages/g6/__tests__/snapshots/plugins/history/plugin-history/hideElement.svg
+++ b/packages/g6/__tests__/snapshots/plugins/history/plugin-history/hideElement.svg
@@ -3,13 +3,6 @@
   <g >
     <g fill="none">
       <g fill="none" class="elements">
-        <g fill="none" marker-start="false" marker-end="false">
-          <g fill="none" marker-start="false" marker-end="false" stroke="transparent" stroke-width="3"/>
-          <g>
-            <path fill="none" d="M 130.47888861468547,112.09102532463709 L 227.46666666666667,224" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
-            <path fill="none" d="M 130.47888861468547,112.09102532463709 L 227.46666666666667,224" class="key" stroke-width="3" stroke="transparent"/>
-          </g>
-        </g>
         <g fill="none" x="188.11" y="191.5" transform="matrix(1,0,0,1,188.110001,191.500000)">
           <g>
             <circle fill="rgba(153,173,209,1)" class="key" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="153.21566140574532" fill-opacity="0.04"/>
@@ -39,6 +32,13 @@
                 2
               </text>
             </g>
+          </g>
+        </g>
+        <g fill="none" marker-start="false" marker-end="false">
+          <g fill="none" marker-start="false" marker-end="false" stroke="transparent" stroke-width="3"/>
+          <g>
+            <path fill="none" d="M 130.47888861468547,112.09102532463709 L 227.46666666666667,224" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
+            <path fill="none" d="M 130.47888861468547,112.09102532463709 L 227.46666666666667,224" class="key" stroke-width="3" stroke="transparent"/>
           </g>
         </g>
         <g fill="none" x="120" y="100" transform="matrix(1,0,0,1,120,100)">

--- a/packages/g6/__tests__/snapshots/plugins/history/plugin-history/setElementZIndex-redo.svg
+++ b/packages/g6/__tests__/snapshots/plugins/history/plugin-history/setElementZIndex-redo.svg
@@ -3,13 +3,6 @@
   <g >
     <g fill="none">
       <g fill="none" class="elements">
-        <g fill="none" marker-start="false" marker-end="false">
-          <g fill="none" marker-start="false" marker-end="false" stroke="transparent" stroke-width="3"/>
-          <g>
-            <path fill="none" d="M 130.47888861468547,112.09102532463709 L 227.46666666666667,224" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
-            <path fill="none" d="M 130.47888861468547,112.09102532463709 L 227.46666666666667,224" class="key" stroke-width="3" stroke="transparent"/>
-          </g>
-        </g>
         <g fill="none" x="250" y="250" transform="matrix(1,0,0,1,250,250)">
           <g>
             <path fill="rgba(153,173,209,1)" d="M -26,-26 l 52,0 l 0,52 l-52 0 z" class="key" stroke-dasharray="5,5" stroke-width="1" stroke="rgba(153,173,209,1)" width="52" height="52" x="-26" y="-26"/>
@@ -27,6 +20,13 @@
                 2
               </text>
             </g>
+          </g>
+        </g>
+        <g fill="none" marker-start="false" marker-end="false">
+          <g fill="none" marker-start="false" marker-end="false" stroke="transparent" stroke-width="3"/>
+          <g>
+            <path fill="none" d="M 130.47888861468547,112.09102532463709 L 227.46666666666667,224" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
+            <path fill="none" d="M 130.47888861468547,112.09102532463709 L 227.46666666666667,224" class="key" stroke-width="3" stroke="transparent"/>
           </g>
         </g>
         <g fill="none" x="120" y="100" transform="matrix(1,0,0,1,120,100)">

--- a/packages/g6/__tests__/snapshots/plugins/history/plugin-history/setElementZIndex-undo.svg
+++ b/packages/g6/__tests__/snapshots/plugins/history/plugin-history/setElementZIndex-undo.svg
@@ -3,13 +3,6 @@
   <g >
     <g fill="none">
       <g fill="none" class="elements">
-        <g fill="none" marker-start="false" marker-end="false">
-          <g fill="none" marker-start="false" marker-end="false" stroke="transparent" stroke-width="3"/>
-          <g>
-            <path fill="none" d="M 130.47888861468547,112.09102532463709 L 227.46666666666667,224" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
-            <path fill="none" d="M 130.47888861468547,112.09102532463709 L 227.46666666666667,224" class="key" stroke-width="3" stroke="transparent"/>
-          </g>
-        </g>
         <g fill="none" x="188.11" y="191.5" transform="matrix(1,0,0,1,188.110001,191.500000)">
           <g>
             <circle fill="rgba(153,173,209,1)" class="key" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="153.21566140574532" fill-opacity="0.04"/>
@@ -39,6 +32,13 @@
                 2
               </text>
             </g>
+          </g>
+        </g>
+        <g fill="none" marker-start="false" marker-end="false">
+          <g fill="none" marker-start="false" marker-end="false" stroke="transparent" stroke-width="3"/>
+          <g>
+            <path fill="none" d="M 130.47888861468547,112.09102532463709 L 227.46666666666667,224" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
+            <path fill="none" d="M 130.47888861468547,112.09102532463709 L 227.46666666666667,224" class="key" stroke-width="3" stroke="transparent"/>
           </g>
         </g>
         <g fill="none" x="120" y="100" transform="matrix(1,0,0,1,120,100)">

--- a/packages/g6/__tests__/snapshots/plugins/history/plugin-history/setElementZIndex.svg
+++ b/packages/g6/__tests__/snapshots/plugins/history/plugin-history/setElementZIndex.svg
@@ -3,13 +3,6 @@
   <g >
     <g fill="none">
       <g fill="none" class="elements">
-        <g fill="none" marker-start="false" marker-end="false">
-          <g fill="none" marker-start="false" marker-end="false" stroke="transparent" stroke-width="3"/>
-          <g>
-            <path fill="none" d="M 130.47888861468547,112.09102532463709 L 227.46666666666667,224" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
-            <path fill="none" d="M 130.47888861468547,112.09102532463709 L 227.46666666666667,224" class="key" stroke-width="3" stroke="transparent"/>
-          </g>
-        </g>
         <g fill="none" x="250" y="250" transform="matrix(1,0,0,1,250,250)">
           <g>
             <path fill="rgba(153,173,209,1)" d="M -26,-26 l 52,0 l 0,52 l-52 0 z" class="key" stroke-dasharray="5,5" stroke-width="1" stroke="rgba(153,173,209,1)" width="52" height="52" x="-26" y="-26"/>
@@ -27,6 +20,13 @@
                 2
               </text>
             </g>
+          </g>
+        </g>
+        <g fill="none" marker-start="false" marker-end="false">
+          <g fill="none" marker-start="false" marker-end="false" stroke="transparent" stroke-width="3"/>
+          <g>
+            <path fill="none" d="M 130.47888861468547,112.09102532463709 L 227.46666666666667,224" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
+            <path fill="none" d="M 130.47888861468547,112.09102532463709 L 227.46666666666667,224" class="key" stroke-width="3" stroke="transparent"/>
           </g>
         </g>
         <g fill="none" x="120" y="100" transform="matrix(1,0,0,1,120,100)">

--- a/packages/g6/__tests__/snapshots/plugins/history/plugin-history/setElementsState-redo.svg
+++ b/packages/g6/__tests__/snapshots/plugins/history/plugin-history/setElementsState-redo.svg
@@ -3,13 +3,6 @@
   <g >
     <g fill="none">
       <g fill="none" class="elements">
-        <g fill="none" marker-start="false" marker-end="false">
-          <g fill="none" marker-start="false" marker-end="false" stroke="transparent" stroke-width="3"/>
-          <g>
-            <path fill="none" d="M 130.47888861468547,112.09102532463709 L 227.46666666666667,224" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
-            <path fill="none" d="M 130.47888861468547,112.09102532463709 L 227.46666666666667,224" class="key" stroke-width="3" stroke="transparent"/>
-          </g>
-        </g>
         <g fill="none" x="188.11" y="191.5" transform="matrix(1,0,0,1,188.110001,191.500000)">
           <g>
             <circle fill="rgba(153,173,209,1)" class="key" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="153.21566140574532" fill-opacity="0.04"/>
@@ -39,6 +32,13 @@
                 2
               </text>
             </g>
+          </g>
+        </g>
+        <g fill="none" marker-start="false" marker-end="false">
+          <g fill="none" marker-start="false" marker-end="false" stroke="transparent" stroke-width="3"/>
+          <g>
+            <path fill="none" d="M 130.47888861468547,112.09102532463709 L 227.46666666666667,224" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
+            <path fill="none" d="M 130.47888861468547,112.09102532463709 L 227.46666666666667,224" class="key" stroke-width="3" stroke="transparent"/>
           </g>
         </g>
         <g fill="none" x="120" y="100" transform="matrix(1,0,0,1,120,100)">

--- a/packages/g6/__tests__/snapshots/plugins/history/plugin-history/setElementsState-undo.svg
+++ b/packages/g6/__tests__/snapshots/plugins/history/plugin-history/setElementsState-undo.svg
@@ -3,13 +3,6 @@
   <g >
     <g fill="none">
       <g fill="none" class="elements">
-        <g fill="none" marker-start="false" marker-end="false">
-          <g fill="none" marker-start="false" marker-end="false" stroke="transparent" stroke-width="3"/>
-          <g>
-            <path fill="none" d="M 130.47888861468547,112.09102532463709 L 227.46666666666667,224" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
-            <path fill="none" d="M 130.47888861468547,112.09102532463709 L 227.46666666666667,224" class="key" stroke-width="3" stroke="transparent"/>
-          </g>
-        </g>
         <g fill="none" x="188.11" y="191.5" transform="matrix(1,0,0,1,188.110001,191.500000)">
           <g>
             <circle fill="rgba(153,173,209,1)" class="key" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="153.21566140574532" fill-opacity="0.04"/>
@@ -39,6 +32,13 @@
                 2
               </text>
             </g>
+          </g>
+        </g>
+        <g fill="none" marker-start="false" marker-end="false">
+          <g fill="none" marker-start="false" marker-end="false" stroke="transparent" stroke-width="3"/>
+          <g>
+            <path fill="none" d="M 130.47888861468547,112.09102532463709 L 227.46666666666667,224" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
+            <path fill="none" d="M 130.47888861468547,112.09102532463709 L 227.46666666666667,224" class="key" stroke-width="3" stroke="transparent"/>
           </g>
         </g>
         <g fill="none" x="120" y="100" transform="matrix(1,0,0,1,120,100)">

--- a/packages/g6/__tests__/snapshots/plugins/history/plugin-history/setElementsState.svg
+++ b/packages/g6/__tests__/snapshots/plugins/history/plugin-history/setElementsState.svg
@@ -3,13 +3,6 @@
   <g >
     <g fill="none">
       <g fill="none" class="elements">
-        <g fill="none" marker-start="false" marker-end="false">
-          <g fill="none" marker-start="false" marker-end="false" stroke="transparent" stroke-width="3"/>
-          <g>
-            <path fill="none" d="M 130.47888861468547,112.09102532463709 L 227.46666666666667,224" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
-            <path fill="none" d="M 130.47888861468547,112.09102532463709 L 227.46666666666667,224" class="key" stroke-width="3" stroke="transparent"/>
-          </g>
-        </g>
         <g fill="none" x="188.11" y="191.5" transform="matrix(1,0,0,1,188.110001,191.500000)">
           <g>
             <circle fill="rgba(153,173,209,1)" class="key" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="153.21566140574532" fill-opacity="0.04"/>
@@ -39,6 +32,13 @@
                 2
               </text>
             </g>
+          </g>
+        </g>
+        <g fill="none" marker-start="false" marker-end="false">
+          <g fill="none" marker-start="false" marker-end="false" stroke="transparent" stroke-width="3"/>
+          <g>
+            <path fill="none" d="M 130.47888861468547,112.09102532463709 L 227.46666666666667,224" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
+            <path fill="none" d="M 130.47888861468547,112.09102532463709 L 227.46666666666667,224" class="key" stroke-width="3" stroke="transparent"/>
           </g>
         </g>
         <g fill="none" x="120" y="100" transform="matrix(1,0,0,1,120,100)">

--- a/packages/g6/__tests__/unit/elements/combo.spec.ts
+++ b/packages/g6/__tests__/unit/elements/combo.spec.ts
@@ -1,6 +1,6 @@
-import { type Graph } from '@/src';
+import type { Graph } from '@/src';
 import { elementCombo } from '@@/demos';
-import { createDemoGraph } from '@@/utils';
+import { createDemoGraph, createGraph } from '@@/utils';
 
 describe('combo', () => {
   let graph: Graph;
@@ -95,5 +95,57 @@ describe('combo', () => {
     await expandCombo();
     await collapseCombo((children: any) => children.length.toString() + 'nodes');
     await expect(graph).toMatchSnapshot(__filename, 'circle-marker-custom');
+  });
+});
+
+describe('combo drag zIndex', () => {
+  it('drag combo will bring related edges forward', async () => {
+    const graph = createGraph({
+      data: {
+        nodes: [
+          { id: 'node-1', combo: 'combo-2', style: { x: 120, y: 100 } },
+          { id: 'node-2', combo: 'combo-1', style: { x: 300, y: 200 } },
+          { id: 'node-3', combo: 'combo-1', style: { x: 200, y: 300 } },
+        ],
+        edges: [
+          { id: 'edge-1', source: 'node-1', target: 'node-2' },
+          { id: 'edge-2', source: 'node-2', target: 'node-3' },
+        ],
+        combos: [
+          {
+            id: 'combo-1',
+            type: 'rect',
+            combo: 'combo-2',
+          },
+          {
+            id: 'combo-2',
+          },
+        ],
+      },
+      edge: {
+        style: {
+          stroke: 'red',
+        },
+      },
+      combo: {
+        style: {
+          lineWidth: 1,
+          fillOpacity: 1,
+          stroke: 'black',
+        },
+      },
+    });
+
+    await graph.render();
+
+    await expect(graph).toMatchSnapshot(__filename, 'combo-zIndex');
+
+    await graph.frontElement('combo-1');
+
+    await expect(graph).toMatchSnapshot(__filename, 'combo-zIndex');
+
+    await graph.frontElement('combo-2');
+
+    await expect(graph).toMatchSnapshot(__filename, 'combo-zIndex');
   });
 });


### PR DESCRIPTION
`graph.frontElement` method invocation will bring relative edges forward to avoid edges being covered.