### PR TITLE
fix: update zIndex while calling setParent & deduplicate while translating.

### DIFF
--- a/packages/g6/__tests__/snapshots/behaviors/drag-element-combo/drag-combo-2-after-drop-into.svg
+++ b/packages/g6/__tests__/snapshots/behaviors/drag-element-combo/drag-combo-2-after-drop-into.svg
@@ -22,18 +22,6 @@
             <path fill="none" d="M 288.68629150101526,211.31370849898477 L 211.31370849898477,288.68629150101526" class="key" stroke-width="3" stroke="transparent"/>
           </g>
         </g>
-        <g fill="none" x="50" y="150" transform="matrix(1,0,0,1,50,150)">
-          <g>
-            <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
-          </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,0,18)">
-            <g>
-              <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" dy="11.5px" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="middle" fill-opacity="0.85" font-weight="400">
-                node-3
-              </text>
-            </g>
-          </g>
-        </g>
         <g fill="none" x="190.07999999999998" y="132.5" transform="matrix(1,0,0,1,190.080002,132.500000)">
           <g>
             <circle fill="rgba(153,173,209,1)" class="key" stroke-dasharray="0,0" stroke-width="1" fill-opacity="0.04" stroke="rgba(153,173,209,1)" r="106.74619243795068"/>
@@ -42,6 +30,18 @@
             <g>
               <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" dy="11.5px" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="middle" font-weight="400">
                 combo-2
+              </text>
+            </g>
+          </g>
+        </g>
+        <g fill="none" x="50" y="150" transform="matrix(1,0,0,1,50,150)">
+          <g>
+            <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
+          </g>
+          <g fill="none" class="label" transform="matrix(1,0,0,1,0,18)">
+            <g>
+              <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" dy="11.5px" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="middle" fill-opacity="0.85" font-weight="400">
+                node-3
               </text>
             </g>
           </g>

--- a/packages/g6/__tests__/snapshots/plugins/history/plugin-history/create-edge-redo.svg
+++ b/packages/g6/__tests__/snapshots/plugins/history/plugin-history/create-edge-redo.svg
@@ -10,6 +10,18 @@
             <path fill="none" d="M 129.553704853094,112.83459090037421 L 96.6239251139719,68.59622914543786" class="key" stroke-width="4" stroke="transparent"/>
           </g>
         </g>
+        <g fill="none" x="120" y="100" transform="matrix(1,0,0,1,120,100)">
+          <g>
+            <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16" visibility="visible"/>
+          </g>
+          <g fill="none" class="label" transform="matrix(1,0,0,1,0,18)">
+            <g>
+              <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" dy="11.5px" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="middle" fill-opacity="0.85" font-weight="400" visibility="visible">
+                node-1
+              </text>
+            </g>
+          </g>
+        </g>
         <g fill="none" x="250" y="250" transform="matrix(1,0,0,1,250,250)">
           <g>
             <path fill="rgba(153,173,209,1)" d="M -26,-26 l 52,0 l 0,52 l-52 0 z" class="key" stroke-dasharray="5,5" stroke-width="1" stroke="rgba(153,173,209,1)" width="52" height="52" x="-26" y="-26"/>
@@ -34,18 +46,6 @@
           <g>
             <path fill="none" d="M 130.47888861468547,112.09102532463709 L 227.46666666666667,224" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
             <path fill="none" d="M 130.47888861468547,112.09102532463709 L 227.46666666666667,224" class="key" stroke-width="3" stroke="transparent"/>
-          </g>
-        </g>
-        <g fill="none" x="120" y="100" transform="matrix(1,0,0,1,120,100)">
-          <g>
-            <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16" visibility="visible"/>
-          </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,0,18)">
-            <g>
-              <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" dy="11.5px" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="middle" fill-opacity="0.85" font-weight="400" visibility="visible">
-                node-1
-              </text>
-            </g>
           </g>
         </g>
         <g fill="none" x="188.11" y="191.5" transform="matrix(1,0,0,1,188.110001,191.500000)">

--- a/packages/g6/__tests__/snapshots/plugins/history/plugin-history/create-edge-undo.svg
+++ b/packages/g6/__tests__/snapshots/plugins/history/plugin-history/create-edge-undo.svg
@@ -3,6 +3,18 @@
   <g >
     <g fill="none">
       <g fill="none" class="elements">
+        <g fill="none" x="120" y="100" transform="matrix(1,0,0,1,120,100)">
+          <g>
+            <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16" visibility="visible"/>
+          </g>
+          <g fill="none" class="label" transform="matrix(1,0,0,1,0,18)">
+            <g>
+              <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" dy="11.5px" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="middle" fill-opacity="0.85" font-weight="400" visibility="visible">
+                node-1
+              </text>
+            </g>
+          </g>
+        </g>
         <g fill="none" x="250" y="250" transform="matrix(1,0,0,1,250,250)">
           <g>
             <path fill="rgba(153,173,209,1)" d="M -26,-26 l 52,0 l 0,52 l-52 0 z" class="key" stroke-dasharray="5,5" stroke-width="1" stroke="rgba(153,173,209,1)" width="52" height="52" x="-26" y="-26"/>
@@ -27,18 +39,6 @@
           <g>
             <path fill="none" d="M 130.47888861468547,112.09102532463709 L 227.46666666666667,224" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
             <path fill="none" d="M 130.47888861468547,112.09102532463709 L 227.46666666666667,224" class="key" stroke-width="3" stroke="transparent"/>
-          </g>
-        </g>
-        <g fill="none" x="120" y="100" transform="matrix(1,0,0,1,120,100)">
-          <g>
-            <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16" visibility="visible"/>
-          </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,0,18)">
-            <g>
-              <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" dy="11.5px" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="middle" fill-opacity="0.85" font-weight="400" visibility="visible">
-                node-1
-              </text>
-            </g>
           </g>
         </g>
         <g fill="none" x="188.11" y="191.5" transform="matrix(1,0,0,1,188.110001,191.500000)">

--- a/packages/g6/__tests__/snapshots/plugins/history/plugin-history/create-edge.svg
+++ b/packages/g6/__tests__/snapshots/plugins/history/plugin-history/create-edge.svg
@@ -10,6 +10,18 @@
             <path fill="none" d="M 129.553704853094,112.83459090037421 L 96.6239251139719,68.59622914543786" class="key" stroke-width="4" stroke="transparent"/>
           </g>
         </g>
+        <g fill="none" x="120" y="100" transform="matrix(1,0,0,1,120,100)">
+          <g>
+            <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16" visibility="visible"/>
+          </g>
+          <g fill="none" class="label" transform="matrix(1,0,0,1,0,18)">
+            <g>
+              <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" dy="11.5px" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="middle" fill-opacity="0.85" font-weight="400" visibility="visible">
+                node-1
+              </text>
+            </g>
+          </g>
+        </g>
         <g fill="none" x="250" y="250" transform="matrix(1,0,0,1,250,250)">
           <g>
             <path fill="rgba(153,173,209,1)" d="M -26,-26 l 52,0 l 0,52 l-52 0 z" class="key" stroke-dasharray="5,5" stroke-width="1" stroke="rgba(153,173,209,1)" width="52" height="52" x="-26" y="-26"/>
@@ -34,18 +46,6 @@
           <g>
             <path fill="none" d="M 130.47888861468547,112.09102532463709 L 227.46666666666667,224" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
             <path fill="none" d="M 130.47888861468547,112.09102532463709 L 227.46666666666667,224" class="key" stroke-width="3" stroke="transparent"/>
-          </g>
-        </g>
-        <g fill="none" x="120" y="100" transform="matrix(1,0,0,1,120,100)">
-          <g>
-            <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16" visibility="visible"/>
-          </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,0,18)">
-            <g>
-              <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" dy="11.5px" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="middle" fill-opacity="0.85" font-weight="400" visibility="visible">
-                node-1
-              </text>
-            </g>
           </g>
         </g>
         <g fill="none" x="188.11" y="191.5" transform="matrix(1,0,0,1,188.110001,191.500000)">

--- a/packages/g6/__tests__/snapshots/plugins/history/plugin-history/hideElement-redo.svg
+++ b/packages/g6/__tests__/snapshots/plugins/history/plugin-history/hideElement-redo.svg
@@ -15,6 +15,18 @@
             </g>
           </g>
         </g>
+        <g fill="none" x="120" y="100" transform="matrix(1,0,0,1,120,100)">
+          <g>
+            <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16" visibility="hidden"/>
+          </g>
+          <g fill="none" class="label" transform="matrix(1,0,0,1,0,18)">
+            <g>
+              <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" dy="11.5px" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="middle" fill-opacity="0.85" font-weight="400" visibility="hidden">
+                node-1
+              </text>
+            </g>
+          </g>
+        </g>
         <g fill="none" x="250" y="250" transform="matrix(1,0,0,1,250,250)">
           <g>
             <path fill="rgba(153,173,209,1)" d="M -26,-26 l 52,0 l 0,52 l-52 0 z" class="key" stroke-dasharray="5,5" stroke-width="1" stroke="rgba(153,173,209,1)" width="52" height="52" x="-26" y="-26"/>
@@ -39,18 +51,6 @@
           <g>
             <path fill="none" d="M 130.47888861468547,112.09102532463709 L 227.46666666666667,224" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
             <path fill="none" d="M 130.47888861468547,112.09102532463709 L 227.46666666666667,224" class="key" stroke-width="3" stroke="transparent"/>
-          </g>
-        </g>
-        <g fill="none" x="120" y="100" transform="matrix(1,0,0,1,120,100)">
-          <g>
-            <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16" visibility="hidden"/>
-          </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,0,18)">
-            <g>
-              <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" dy="11.5px" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="middle" fill-opacity="0.85" font-weight="400" visibility="hidden">
-                node-1
-              </text>
-            </g>
           </g>
         </g>
       </g>

--- a/packages/g6/__tests__/snapshots/plugins/history/plugin-history/hideElement-undo.svg
+++ b/packages/g6/__tests__/snapshots/plugins/history/plugin-history/hideElement-undo.svg
@@ -15,6 +15,18 @@
             </g>
           </g>
         </g>
+        <g fill="none" x="120" y="100" transform="matrix(1,0,0,1,120,100)">
+          <g>
+            <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16" visibility="visible"/>
+          </g>
+          <g fill="none" class="label" transform="matrix(1,0,0,1,0,18)">
+            <g>
+              <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" dy="11.5px" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="middle" fill-opacity="0.85" font-weight="400" visibility="visible">
+                node-1
+              </text>
+            </g>
+          </g>
+        </g>
         <g fill="none" x="250" y="250" transform="matrix(1,0,0,1,250,250)">
           <g>
             <path fill="rgba(153,173,209,1)" d="M -26,-26 l 52,0 l 0,52 l-52 0 z" class="key" stroke-dasharray="5,5" stroke-width="1" stroke="rgba(153,173,209,1)" width="52" height="52" x="-26" y="-26"/>
@@ -39,18 +51,6 @@
           <g>
             <path fill="none" d="M 130.47888861468547,112.09102532463709 L 227.46666666666667,224" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
             <path fill="none" d="M 130.47888861468547,112.09102532463709 L 227.46666666666667,224" class="key" stroke-width="3" stroke="transparent"/>
-          </g>
-        </g>
-        <g fill="none" x="120" y="100" transform="matrix(1,0,0,1,120,100)">
-          <g>
-            <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16" visibility="visible"/>
-          </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,0,18)">
-            <g>
-              <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" dy="11.5px" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="middle" fill-opacity="0.85" font-weight="400" visibility="visible">
-                node-1
-              </text>
-            </g>
           </g>
         </g>
       </g>

--- a/packages/g6/__tests__/snapshots/plugins/history/plugin-history/hideElement.svg
+++ b/packages/g6/__tests__/snapshots/plugins/history/plugin-history/hideElement.svg
@@ -15,6 +15,18 @@
             </g>
           </g>
         </g>
+        <g fill="none" x="120" y="100" transform="matrix(1,0,0,1,120,100)">
+          <g>
+            <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16" visibility="hidden"/>
+          </g>
+          <g fill="none" class="label" transform="matrix(1,0,0,1,0,18)">
+            <g>
+              <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" dy="11.5px" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="middle" fill-opacity="0.85" font-weight="400" visibility="hidden">
+                node-1
+              </text>
+            </g>
+          </g>
+        </g>
         <g fill="none" x="250" y="250" transform="matrix(1,0,0,1,250,250)">
           <g>
             <path fill="rgba(153,173,209,1)" d="M -26,-26 l 52,0 l 0,52 l-52 0 z" class="key" stroke-dasharray="5,5" stroke-width="1" stroke="rgba(153,173,209,1)" width="52" height="52" x="-26" y="-26"/>
@@ -39,18 +51,6 @@
           <g>
             <path fill="none" d="M 130.47888861468547,112.09102532463709 L 227.46666666666667,224" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
             <path fill="none" d="M 130.47888861468547,112.09102532463709 L 227.46666666666667,224" class="key" stroke-width="3" stroke="transparent"/>
-          </g>
-        </g>
-        <g fill="none" x="120" y="100" transform="matrix(1,0,0,1,120,100)">
-          <g>
-            <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16" visibility="hidden"/>
-          </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,0,18)">
-            <g>
-              <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" dy="11.5px" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="middle" fill-opacity="0.85" font-weight="400" visibility="hidden">
-                node-1
-              </text>
-            </g>
           </g>
         </g>
       </g>

--- a/packages/g6/__tests__/snapshots/plugins/history/plugin-history/setElementZIndex-redo.svg
+++ b/packages/g6/__tests__/snapshots/plugins/history/plugin-history/setElementZIndex-redo.svg
@@ -3,6 +3,18 @@
   <g >
     <g fill="none">
       <g fill="none" class="elements">
+        <g fill="none" x="120" y="100" transform="matrix(1,0,0,1,120,100)">
+          <g>
+            <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16" visibility="visible"/>
+          </g>
+          <g fill="none" class="label" transform="matrix(1,0,0,1,0,18)">
+            <g>
+              <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" dy="11.5px" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="middle" fill-opacity="0.85" font-weight="400" visibility="visible">
+                node-1
+              </text>
+            </g>
+          </g>
+        </g>
         <g fill="none" x="250" y="250" transform="matrix(1,0,0,1,250,250)">
           <g>
             <path fill="rgba(153,173,209,1)" d="M -26,-26 l 52,0 l 0,52 l-52 0 z" class="key" stroke-dasharray="5,5" stroke-width="1" stroke="rgba(153,173,209,1)" width="52" height="52" x="-26" y="-26"/>
@@ -27,18 +39,6 @@
           <g>
             <path fill="none" d="M 130.47888861468547,112.09102532463709 L 227.46666666666667,224" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
             <path fill="none" d="M 130.47888861468547,112.09102532463709 L 227.46666666666667,224" class="key" stroke-width="3" stroke="transparent"/>
-          </g>
-        </g>
-        <g fill="none" x="120" y="100" transform="matrix(1,0,0,1,120,100)">
-          <g>
-            <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16" visibility="visible"/>
-          </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,0,18)">
-            <g>
-              <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" dy="11.5px" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="middle" fill-opacity="0.85" font-weight="400" visibility="visible">
-                node-1
-              </text>
-            </g>
           </g>
         </g>
         <g fill="none" x="188.11" y="191.5" transform="matrix(1,0,0,1,188.110001,191.500000)">

--- a/packages/g6/__tests__/snapshots/plugins/history/plugin-history/setElementZIndex-undo.svg
+++ b/packages/g6/__tests__/snapshots/plugins/history/plugin-history/setElementZIndex-undo.svg
@@ -3,14 +3,14 @@
   <g >
     <g fill="none">
       <g fill="none" class="elements">
-        <g fill="none" x="188.11" y="191.5" transform="matrix(1,0,0,1,188.110001,191.500000)">
+        <g fill="none" x="120" y="100" transform="matrix(1,0,0,1,120,100)">
           <g>
-            <circle fill="rgba(153,173,209,1)" class="key" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="153.21566140574532" fill-opacity="0.04"/>
+            <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16" visibility="visible"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,0,153.215668)">
+          <g fill="none" class="label" transform="matrix(1,0,0,1,0,18)">
             <g>
-              <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" dy="11.5px" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="middle" font-weight="400">
-                combo-2
+              <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" dy="11.5px" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="middle" fill-opacity="0.85" font-weight="400" visibility="visible">
+                node-1
               </text>
             </g>
           </g>
@@ -41,14 +41,14 @@
             <path fill="none" d="M 130.47888861468547,112.09102532463709 L 227.46666666666667,224" class="key" stroke-width="3" stroke="transparent"/>
           </g>
         </g>
-        <g fill="none" x="120" y="100" transform="matrix(1,0,0,1,120,100)">
+        <g fill="none" x="188.11" y="191.5" transform="matrix(1,0,0,1,188.110001,191.500000)">
           <g>
-            <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16" visibility="visible"/>
+            <circle fill="rgba(153,173,209,1)" class="key" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="153.21566140574532" fill-opacity="0.04"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,0,18)">
+          <g fill="none" class="label" transform="matrix(1,0,0,1,0,153.215668)">
             <g>
-              <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" dy="11.5px" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="middle" fill-opacity="0.85" font-weight="400" visibility="visible">
-                node-1
+              <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" dy="11.5px" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="middle" font-weight="400">
+                combo-2
               </text>
             </g>
           </g>

--- a/packages/g6/__tests__/snapshots/plugins/history/plugin-history/setElementZIndex.svg
+++ b/packages/g6/__tests__/snapshots/plugins/history/plugin-history/setElementZIndex.svg
@@ -29,18 +29,6 @@
             <path fill="none" d="M 130.47888861468547,112.09102532463709 L 227.46666666666667,224" class="key" stroke-width="3" stroke="transparent"/>
           </g>
         </g>
-        <g fill="none" x="120" y="100" transform="matrix(1,0,0,1,120,100)">
-          <g>
-            <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16" visibility="visible"/>
-          </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,0,18)">
-            <g>
-              <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" dy="11.5px" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="middle" fill-opacity="0.85" font-weight="400" visibility="visible">
-                node-1
-              </text>
-            </g>
-          </g>
-        </g>
         <g fill="none" x="188.11" y="191.5" transform="matrix(1,0,0,1,188.110001,191.500000)">
           <g>
             <circle fill="rgba(153,173,209,1)" class="key" stroke-dasharray="0,0" stroke-width="1" stroke="rgba(153,173,209,1)" r="153.21566140574532" fill-opacity="0.04"/>
@@ -49,6 +37,18 @@
             <g>
               <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" dy="11.5px" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="middle" font-weight="400">
                 combo-2
+              </text>
+            </g>
+          </g>
+        </g>
+        <g fill="none" x="120" y="100" transform="matrix(1,0,0,1,120,100)">
+          <g>
+            <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16" visibility="visible"/>
+          </g>
+          <g fill="none" class="label" transform="matrix(1,0,0,1,0,18)">
+            <g>
+              <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" dy="11.5px" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="middle" fill-opacity="0.85" font-weight="400" visibility="visible">
+                node-1
               </text>
             </g>
           </g>

--- a/packages/g6/__tests__/unit/plugins/history/plugin-history.spec.ts
+++ b/packages/g6/__tests__/unit/plugins/history/plugin-history.spec.ts
@@ -98,6 +98,7 @@ describe('history plugin', () => {
 
   it('setElementZIndex', async () => {
     graph.setElementZIndex('combo-2', 100);
+    graph.setElementZIndex('node-1', 101);
     await expect(graph).toMatchSnapshot(__filename, 'setElementZIndex');
     history.undo();
     await expect(graph).toMatchSnapshot(__filename, 'setElementZIndex-undo');

--- a/packages/g6/__tests__/utils/dir.ts
+++ b/packages/g6/__tests__/utils/dir.ts
@@ -10,11 +10,16 @@ import path from 'path';
  */
 export function getSnapshotDir(dir: string, detail: string = 'default'): [string, string] {
   const root = process.cwd();
-  const subDir = dir
-    .replace(root, '')
-    .replace('__tests__/unit/', '')
-    .replace('__tests__/bugs/', 'bugs/')
-    .replace('.spec.ts', '');
-  const outputDir = path.join(root, '__tests__', 'snapshots', subDir);
+
+  const relativeDir = dir.replace(root, '');
+
+  const relativeDirSlices = relativeDir.split(path.sep);
+
+  const testsPartIdx = relativeDirSlices.findIndex((slice) => slice === '__tests__');
+  if (testsPartIdx !== -1) relativeDirSlices[testsPartIdx] = '';
+  const unitPartIdx = relativeDirSlices.findIndex((slice) => slice === 'unit');
+  if (unitPartIdx !== -1) relativeDirSlices[unitPartIdx] = '';
+
+  const outputDir = path.join(root, '__tests__', 'snapshots', ...relativeDirSlices).replace('.spec.ts', '');
   return [outputDir, detail];
 }

--- a/packages/g6/src/runtime/data.ts
+++ b/packages/g6/src/runtime/data.ts
@@ -1,5 +1,5 @@
 import { Graph as GraphLib } from '@antv/graphlib';
-import { isUndefined, uniq } from '@antv/util';
+import { get, isUndefined, set, uniq } from '@antv/util';
 import { COMBO_KEY, ChangeType, TREE_KEY } from '../constants';
 import type { ComboData, EdgeData, GraphData, NodeData } from '../spec';
 import type {
@@ -529,9 +529,18 @@ export class DataController {
    */
   public setParent(id: ID, parent: ID | undefined, hierarchyKey: HierarchyKey, update: boolean = true) {
     if (id === parent) return;
-    const originalParentId = parentIdOf(this.getNodeLikeDatum(id));
+    const elementData = this.getNodeLikeDatum(id);
+    const originalParentId = parentIdOf(elementData);
 
+    if (parent) {
+      const parentData = this.getNodeLikeDatum(parent);
+      if (parentData.style?.zIndex !== undefined) {
+        const zIndex = get(parentData, ['style', 'zIndex'], 0) + (this.isCombo(parent) ? 1 : 0);
+        set(elementData, ['style', 'zIndex'], zIndex);
+      }
+    }
     // Sync data
+
     if (originalParentId !== parent && hierarchyKey === COMBO_KEY) {
       const modifiedDatum = { id, combo: parent };
       if (this.isCombo(id)) this.syncComboDatum(modifiedDatum);
@@ -617,10 +626,13 @@ export class DataController {
     if ([dx, dy, dz].some(isNaN) || [dx, dy, dz].every((o) => o === 0)) return;
     const combo = this.getComboData([id])[0];
     if (!combo) return;
+    const seenNodeLikeIds = new Set<ID>();
     dfs<NodeLikeData>(
       combo,
       (succeed) => {
         const succeedID = idOf(succeed);
+        if (seenNodeLikeIds.has(succeedID)) return;
+        seenNodeLikeIds.add(succeedID);
         const [x, y, z] = positionOf(succeed);
         const value = mergeElementsData(succeed, {
           style: { x: x + dx, y: y + dy, z: z + dz },

--- a/packages/g6/src/utils/visibility.ts
+++ b/packages/g6/src/utils/visibility.ts
@@ -23,8 +23,8 @@ export function setVisibility(
 ) {
   if (value === undefined) return;
 
-  const traverse = (current: DisplayObject, scope = value) => {
-    const walk = (val = scope) => (current.childNodes as DisplayObject[]).forEach((node) => traverse(node, val));
+  const traverse = (current: DisplayObject, scope = value): void => {
+    const walk = (val = scope): void => (current.childNodes as DisplayObject[]).forEach((node) => traverse(node, val));
 
     if (filter && !filter(current)) return walk();
 


### PR DESCRIPTION
* fix(DataController): after calling graph.addChildrenData(nodeInCombo,  [nodeNotInCombo]), can not listen click event of added node. 
* fix(DataController): translateComboBy will make twice tranlations to the same child node of a combo