### PR TITLE
fix: correct hover-activate event listeners

### DIFF
--- a/packages/g6-extension-react/__tests__/demos/performance-diagnosis.tsx
+++ b/packages/g6-extension-react/__tests__/demos/performance-diagnosis.tsx
@@ -18,15 +18,15 @@ const COLOR_MAP: Record<string, string> = {
 class HoverElement extends HoverActivate {
   protected getActiveIds(event: IPointerEvent<Element>) {
     const { model, graph } = this.context;
-    const { targetType, target } = event;
-    const targetId = target.id;
+    const elementId = event.target.id;
+    const elementType = graph.getElementType(elementId);
 
-    const ids = [targetId];
-    if (targetType === 'edge') {
-      const edge = model.getEdgeDatum(targetId);
+    const ids = [elementId];
+    if (elementType === 'edge') {
+      const edge = model.getEdgeDatum(elementId);
       ids.push(edge.source, edge.target);
-    } else if (targetType === 'node') {
-      ids.push(...model.getRelatedEdgesData(targetId).map(idOf));
+    } else if (elementType === 'node') {
+      ids.push(...model.getRelatedEdgesData(elementId).map(idOf));
     }
 
     graph.frontElement(ids);

--- a/packages/g6/__tests__/bugs/focus-element.spec.ts
+++ b/packages/g6/__tests__/bugs/focus-element.spec.ts
@@ -47,10 +47,10 @@ describe('focus element', () => {
 
     await graph.focusElement('node-1');
 
-    graph.emit(NodeEvent.POINTER_OVER, {
+    graph.emit(NodeEvent.POINTER_ENTER, {
       target: { id: 'node-2' },
       targetType: 'node',
-      type: CommonEvent.POINTER_OVER,
+      type: CommonEvent.POINTER_ENTER,
     });
 
     await expect(graph).toMatchSnapshot(__filename, 'hover-after-focus');

--- a/packages/g6/__tests__/unit/behaviors/hover-activate.spec.ts
+++ b/packages/g6/__tests__/unit/behaviors/hover-activate.spec.ts
@@ -17,11 +17,11 @@ describe('behavior hover-activate element', () => {
   it('default status', async () => {
     await expect(graph).toMatchSnapshot(__filename);
 
-    graph.emit(NodeEvent.POINTER_OVER, { target: { id: '0' }, targetType: 'node', type: CommonEvent.POINTER_OVER });
+    graph.emit(NodeEvent.POINTER_ENTER, { target: { id: '0' }, targetType: 'node', type: CommonEvent.POINTER_ENTER });
 
     await expect(graph).toMatchSnapshot(__filename, 'after-hover');
 
-    graph.emit(NodeEvent.POINTER_OUT, { target: { id: '0' }, targetType: 'node', type: CommonEvent.POINTER_OUT });
+    graph.emit(NodeEvent.POINTER_LEAVE, { target: { id: '0' }, targetType: 'node', type: CommonEvent.POINTER_LEAVE });
 
     await expect(graph).toMatchSnapshot(__filename, 'after-hover-out');
   });
@@ -29,42 +29,42 @@ describe('behavior hover-activate element', () => {
   it('state and inactiveState', async () => {
     graph.setBehaviors([{ type: 'hover-activate', state: 'active', inactiveState: 'inactive' }]);
 
-    graph.emit(NodeEvent.POINTER_OVER, { target: { id: '0' }, targetType: 'node', type: CommonEvent.POINTER_OVER });
+    graph.emit(NodeEvent.POINTER_ENTER, { target: { id: '0' }, targetType: 'node', type: CommonEvent.POINTER_ENTER });
 
     await expect(graph).toMatchSnapshot(__filename, 'state');
 
-    graph.emit(NodeEvent.POINTER_OUT, { target: { id: '0' }, targetType: 'node', type: CommonEvent.POINTER_OUT });
+    graph.emit(NodeEvent.POINTER_LEAVE, { target: { id: '0' }, targetType: 'node', type: CommonEvent.POINTER_LEAVE });
   });
 
   it('1 degree', async () => {
     graph.setBehaviors([{ type: 'hover-activate', state: 'active', inactiveState: 'inactive', degree: 1 }]);
 
-    graph.emit(NodeEvent.POINTER_OVER, { target: { id: '0' }, targetType: 'node', type: CommonEvent.POINTER_OVER });
+    graph.emit(NodeEvent.POINTER_ENTER, { target: { id: '0' }, targetType: 'node', type: CommonEvent.POINTER_ENTER });
 
     await expect(graph).toMatchSnapshot(__filename, '1-degree-node');
 
-    graph.emit(NodeEvent.POINTER_OUT, { target: { id: '0' }, targetType: 'node', type: CommonEvent.POINTER_OUT });
+    graph.emit(NodeEvent.POINTER_LEAVE, { target: { id: '0' }, targetType: 'node', type: CommonEvent.POINTER_LEAVE });
 
-    graph.emit(EdgeEvent.POINTER_OVER, { target: { id: '0-1' }, targetType: 'edge', type: CommonEvent.POINTER_OVER });
+    graph.emit(EdgeEvent.POINTER_ENTER, { target: { id: '0-1' }, targetType: 'edge', type: CommonEvent.POINTER_ENTER });
 
     await expect(graph).toMatchSnapshot(__filename, '1-degree-edge');
 
-    graph.emit(EdgeEvent.POINTER_OUT, { target: { id: '0-1' }, targetType: 'edge', type: CommonEvent.POINTER_OUT });
+    graph.emit(EdgeEvent.POINTER_LEAVE, { target: { id: '0-1' }, targetType: 'edge', type: CommonEvent.POINTER_LEAVE });
   });
 
   it('2 degree', async () => {
     graph.setBehaviors([{ type: 'hover-activate', state: 'active', inactiveState: 'inactive', degree: 2 }]);
 
-    graph.emit(NodeEvent.POINTER_OVER, { target: { id: '0' }, targetType: 'node', type: CommonEvent.POINTER_OVER });
+    graph.emit(NodeEvent.POINTER_ENTER, { target: { id: '0' }, targetType: 'node', type: CommonEvent.POINTER_ENTER });
 
     await expect(graph).toMatchSnapshot(__filename, '2-degree-node');
 
-    graph.emit(NodeEvent.POINTER_OUT, { target: { id: '0' }, targetType: 'node', type: CommonEvent.POINTER_OUT });
+    graph.emit(NodeEvent.POINTER_LEAVE, { target: { id: '0' }, targetType: 'node', type: CommonEvent.POINTER_LEAVE });
 
-    graph.emit(EdgeEvent.POINTER_OVER, { target: { id: '0-1' }, targetType: 'edge', type: CommonEvent.POINTER_OVER });
+    graph.emit(EdgeEvent.POINTER_ENTER, { target: { id: '0-1' }, targetType: 'edge', type: CommonEvent.POINTER_ENTER });
 
     await expect(graph).toMatchSnapshot(__filename, '2-degree-edge');
 
-    graph.emit(EdgeEvent.POINTER_OUT, { target: { id: '0-1' }, targetType: 'edge', type: CommonEvent.POINTER_OUT });
+    graph.emit(EdgeEvent.POINTER_LEAVE, { target: { id: '0-1' }, targetType: 'edge', type: CommonEvent.POINTER_LEAVE });
   });
 });


### PR DESCRIPTION
修正 `hover-activate` 交互绑定的监听事件 

- pointerover 👉 pointerenter
- pointerout 👉 pointerleave

- fixed: https://github.com/antvis/G6/issues/6303