### PR TITLE
refactor(plugins): adjust minimap to avoid flash in some scene

### DIFF
--- a/packages/g6/__tests__/demos/plugin-minimap.ts
+++ b/packages/g6/__tests__/demos/plugin-minimap.ts
@@ -5,7 +5,7 @@ export const pluginMinimap: TestCase = async (context) => {
   const graph = new Graph({
     ...context,
     data: { nodes: Array.from({ length: 20 }).map((_, i) => ({ id: `node${i}` })) },
-    behaviors: ['drag-canvas', 'zoom-canvas', 'drag-element'],
+    behaviors: ['drag-canvas', 'zoom-canvas', 'drag-element', 'hover-activate'],
     plugins: [
       {
         key: 'minimap',


### PR DESCRIPTION
In some situation, drag canvas or hover element may cause minimap blink, 
This pull request fixed above problem by replacing throttle with debounce and add wait time to reduce update times.
