### PR TITLE
fix(elements): fix element cannot translate to origin point

### DIFF
--- a/packages/g6/__tests__/bugs/element-set-position-to-origin.spec.ts
+++ b/packages/g6/__tests__/bugs/element-set-position-to-origin.spec.ts
@@ -1,0 +1,30 @@
+import type { ID } from '@/src';
+import { createGraph } from '@@/utils';
+
+describe('element set position to origin', () => {
+  it('suite 1', async () => {
+    const graph = createGraph({
+      data: {
+        nodes: [{ id: 'node-1' }],
+      },
+    });
+
+    await graph.draw();
+
+    // @ts-expect-error Property 'context' is protected
+    const getElementOf = (id: ID) => graph.context.element!.getElement(id)!;
+
+    expect(graph.getNodeData('node-1').style).toEqual({});
+    expect(getElementOf('node-1').style.transform).toBe('translate(0, 0)');
+
+    graph.translateElementTo('node-1', [100, 100]);
+
+    expect(graph.getNodeData('node-1').style).toEqual({ x: 100, y: 100, z: 0 });
+    expect(getElementOf('node-1').style.transform).toBe('translate(100, 100)');
+
+    graph.translateElementTo('node-1', [0, 0]);
+
+    expect(graph.getNodeData('node-1').style).toEqual({ x: 0, y: 0, z: 0 });
+    expect(getElementOf('node-1').style.transform).toBe('translate(0, 0)');
+  });
+});

--- a/packages/g6/src/elements/shapes/base-shape.ts
+++ b/packages/g6/src/elements/shapes/base-shape.ts
@@ -124,8 +124,8 @@ export abstract class BaseShape<StyleProps extends BaseShapeStyleProps> extends 
    */
   protected transformPosition(attributes: Partial<StyleProps>) {
     // Use `transform: translate3d()` instead of `x/y/z`
-    const { x = 0, y = 0, z = 0, transform } = attributes as any;
-    if (x !== 0 || y !== 0 || z !== 0) {
+    if ('x' in attributes || 'y' in attributes || 'z' in attributes) {
+      const { x = 0, y = 0, z = 0, transform } = attributes as any;
       this.style.transform = replaceTranslateInTransform(+x, +y, +z, transform);
     }
   }


### PR DESCRIPTION
Fix issue that element cannot set position to origin point`(0, 0)`