### PR TITLE
fix: error targetType when pointer leave (#6377)

### DIFF
--- a/packages/g6/src/runtime/behavior.ts
+++ b/packages/g6/src/runtime/behavior.ts
@@ -85,6 +85,7 @@ export class BehaviorController extends ExtensionController<BaseBehavior<CustomB
             ...stdEvent,
             type: CommonEvent.POINTER_LEAVE,
             target: this.currentTarget,
+            targetType: this.currentTargetType,
           });
         }
         if (targetElement) {


### PR DESCRIPTION
fixed [#6377](https://github.com/antvis/G6/issues/6377)