### PR TITLE
Fix: ensure only one vedge connects a combo to a node

### DIFF
--- a/packages/core/src/graph/graph.ts
+++ b/packages/core/src/graph/graph.ts
@@ -2781,6 +2781,12 @@ export default abstract class AbstractGraph extends EventEmitter implements IAbs
         if (addedVEdgeMap[key]) {
           addedVEdgeMap[key].size += size;
           return;
+        } else {
+          const inverseKey = `${vEdgeInfo.target}-${vEdgeInfo.source}`;
+          if (addedVEdgeMap[inverseKey]) {
+            addedVEdgeMap[inverseKey].size += size;
+            return;
+          }
         }
         addedVEdgeMap[key] = vEdgeInfo;
       }

--- a/packages/core/src/util/validation.ts
+++ b/packages/core/src/util/validation.ts
@@ -45,7 +45,7 @@ export const dataValidation = (data?: GraphData | TreeGraphData): boolean => {
   // 3. 边的 source 和 target 必须存在于节点 或 Combo中
   const ids = new Set<string>();
   ((nodes as NodeConfig[]) || []).forEach(node => ids.add(node.id));
-  ((nodes as ComboConfig[]) || []).forEach(combo => ids.add(combo.id));
+  ((combos as ComboConfig[]) || []).forEach(combo => ids.add(combo.id));
   const nonEdges = ((edges as EdgeConfig[]) || []).find(function (edge) {
     return !ids.has(edge.source) || !ids.has(edge.target);
   });

--- a/packages/core/tests/unit/graph/graph-combo-spec.ts
+++ b/packages/core/tests/unit/graph/graph-combo-spec.ts
@@ -114,14 +114,14 @@ const data = {
 describe('graph with combo', () => {
   let graph: Graph;
 
-  function makeGraph(config = {}) {
+  function makeGraph(config = {}, forceData = undefined) {
     graph = new Graph({
       container: div,
       width: 500,
       height: 600,
       ...config
     });
-    graph.read(clone(data));
+    graph.read(clone(forceData || data));
   }
 
   it('createCombo', () => {
@@ -327,6 +327,29 @@ describe('graph with combo', () => {
     });
 
     graph.destroy();
+  });
+
+  it('collapse combo should create only one edge', () => {
+    // this data reproduces the issue where one combo was connected to a node with 2 vedges
+    const data = {
+      nodes: [
+        { id: "node1", x: 250, y: 150, comboId: "combo" },
+        { id: "node2", x: 350, y: 150, comboId: "combo" },
+        { id: "node3", x: 250, y: 300 },
+      ],
+      combos: [{ id: "combo", label: "Combo" }],
+      edges: [
+        { id: "edge1", source: "node1", target: "node3" },
+        { id: "edge2", target: "node2", source: "node3" },
+      ],
+    };
+
+    makeGraph({}, data);
+
+    graph.collapseCombo('combo');
+
+    const edges = graph.get('vedges');
+    expect(edges).toHaveLength(1);
   });
 
   it('combo mapper', () => {


### PR DESCRIPTION
Closes https://github.com/antvis/G6/issues/6484

The solution I proposed in the ticket was wrong. With the new fix, we also check the inverse key and exit if we find it.

Additionally, I fixed a regression I introduced a while ago in the validation function. (which fixes the validation tests)