### PR TITLE
perf: skip infer style when disable animation

### DIFF
--- a/packages/g6/src/animations/types.ts
+++ b/packages/g6/src/animations/types.ts
@@ -68,7 +68,13 @@ export interface AnimationContext {
    *
    * <en/> For example, before the element is destroyed, the final state opacity of the element needs to be set to 0
    */
-  modifiedStyle: Record<string, unknown>;
+  modifiedStyle?: Record<string, unknown>;
+  /**
+   * <zh/> 变更样式
+   *
+   * <en/> Updated style
+   */
+  updatedStyle?: Record<string, unknown>;
 }
 
 /**

--- a/packages/g6/src/runtime/animation.ts
+++ b/packages/g6/src/runtime/animation.ts
@@ -39,7 +39,7 @@ export class Animation {
         const { element, elementType, stage } = context;
         const options = getElementAnimationOptions(this.context.options, elementType, stage, localAnimation);
         cb?.before?.();
-        const animation = executor(element, this.inferStyle(context, extendOptions), options);
+        const animation = options.length ? executor(element, this.inferStyle(context, extendOptions), options) : null;
 
         if (animation) {
           cb?.beforeAnimate?.(animation);
@@ -83,7 +83,10 @@ export class Animation {
     context: AnimationContext,
     options?: ExtendOptions,
   ): [Record<string, unknown>, Record<string, unknown>] {
-    const { element, elementType, stage, originalStyle, modifiedStyle } = context;
+    const { element, elementType, stage, originalStyle, updatedStyle = {} } = context;
+
+    if (!context.modifiedStyle) context.modifiedStyle = { ...originalStyle, ...updatedStyle };
+    const { modifiedStyle } = context;
 
     const fromStyle: Record<string, unknown> = {};
     const toStyle: Record<string, unknown> = {};

--- a/packages/g6/src/runtime/element.ts
+++ b/packages/g6/src/runtime/element.ts
@@ -413,7 +413,7 @@ export class ElementController {
         elementType,
         stage,
         originalStyle: { ...element.attributes },
-        modifiedStyle: { ...element.attributes, ...style },
+        updatedStyle: style,
       },
       {
         after: () => {
@@ -486,7 +486,7 @@ export class ElementController {
         elementType,
         stage: exactStage,
         originalStyle: { ...element.attributes },
-        modifiedStyle: { ...element.attributes, ...style },
+        updatedStyle: style,
       },
       {
         before: () => {
@@ -559,7 +559,7 @@ export class ElementController {
         elementType,
         stage,
         originalStyle: { ...element.attributes },
-        modifiedStyle: { ...element.attributes },
+        updatedStyle: {},
       },
       {
         after: () => {


### PR DESCRIPTION
- [x] 没有动画时，跳过 inferStyle 过程
> 20000 节点场景下，渲染时长从 1.27s 下降至 1.13 (11%)

---
- [x] Skip the inferStyle process when there is no animation
> In the 20,000-node scene, the rendering duration decreased from 1.27s to 1.13s (11%) 