### PR TITLE
refactor: collapse-expand support align option

### DIFF
--- a/packages/g6/__tests__/demos/behavior-expand-collapse-node.ts
+++ b/packages/g6/__tests__/demos/behavior-expand-collapse-node.ts
@@ -27,7 +27,7 @@ export const behaviorExpandCollapseNode: TestCase = async (context) => {
       nodeSep: 30,
       rankSep: 100,
     },
-    behaviors: [{ type: 'collapse-expand', trigger: 'click' }, 'drag-element'],
+    behaviors: [{ type: 'collapse-expand', trigger: 'click', align: false }, 'drag-element'],
   });
 
   await graph.render();

--- a/packages/g6/src/behaviors/collapse-expand.ts
+++ b/packages/g6/src/behaviors/collapse-expand.ts
@@ -46,6 +46,12 @@ export interface CollapseExpandOptions extends BaseBehaviorOptions {
    * <en/> Callback when expand is completed
    */
   onExpand?: (id: ID) => void;
+  /**
+   * <zh/> 是否对准目标元素，避免视图偏移
+   *
+   * <en/> Whether to focus on the target element to avoid view offset
+   */
+  align?: boolean;
 }
 
 /**
@@ -62,6 +68,7 @@ export class CollapseExpand extends BaseBehavior<CollapseExpandOptions> {
     enable: true,
     animation: true,
     trigger: CommonEvent.DBLCLICK,
+    align: true,
   };
 
   constructor(context: RuntimeContext, options: CollapseExpandOptions) {
@@ -100,12 +107,12 @@ export class CollapseExpand extends BaseBehavior<CollapseExpandOptions> {
     const data = model.getElementDataById(id) as NodeLikeData;
     if (!data) return false;
 
-    const { onCollapse, onExpand, animation } = this.options;
+    const { onCollapse, onExpand, animation, align } = this.options;
     if (isCollapsed(data)) {
-      await graph.expandElement(id, animation);
+      await graph.expandElement(id, { animation, align });
       onExpand?.(id);
     } else {
-      await graph.collapseElement(id, animation);
+      await graph.collapseElement(id, { animation, align });
       onCollapse?.(id);
     }
   };

--- a/packages/g6/src/exports.ts
+++ b/packages/g6/src/exports.ts
@@ -206,6 +206,7 @@ export type {
   WatermarkOptions,
 } from './plugins';
 export type { CanvasConfig, DataURLOptions } from './runtime/canvas';
+export type { CollapseExpandNodeOptions } from './runtime/element';
 export type { RuntimeContext } from './runtime/types';
 export type {
   BehaviorOptions,

--- a/packages/g6/src/runtime/graph.ts
+++ b/packages/g6/src/runtime/graph.ts
@@ -53,6 +53,7 @@ import { BehaviorController } from './behavior';
 import type { DataURLOptions } from './canvas';
 import { Canvas } from './canvas';
 import { DataController } from './data';
+import type { CollapseExpandNodeOptions } from './element';
 import { ElementController } from './element';
 import { LayoutController } from './layout';
 import { PluginController } from './plugin';
@@ -1286,7 +1287,7 @@ export class Graph extends EventEmitter {
    * @apiCategory viewport
    */
   public async fitCenter(animation?: ViewportAnimationEffectTiming): Promise<void> {
-    await this.context.viewport?.fitCenter(animation);
+    await this.context.viewport?.fitCenter({ animation });
   }
 
   private async autoFit(): Promise<void> {
@@ -1316,7 +1317,7 @@ export class Graph extends EventEmitter {
    * @apiCategory viewport
    */
   public async focusElement(id: ID | ID[], animation?: ViewportAnimationEffectTiming): Promise<void> {
-    await this.context.viewport?.focusElements(Array.isArray(id) ? id : [id], animation);
+    await this.context.viewport?.focusElements(Array.isArray(id) ? id : [id], { animation });
   }
 
   /**
@@ -1782,50 +1783,53 @@ export class Graph extends EventEmitter {
   private isCollapsingExpanding = false;
 
   /**
-   * <zh/> 收起组合
+   * <zh/> 收起元素
    *
-   * <en/> Collapse Combo
+   * <en/> Collapse element
    * @param id - <zh/> 元素 ID | <en/> element ID
-   * @param animation - <zh/> 是否启用动画 | <en/> whether to enable animation
+   * @param options - <zh/> 是否启用动画或者配置收起节点的配置项 | <en/> whether to enable animation or the options of collapsing node
    * @apiCategory element
    */
-  public async collapseElement(id: ID, animation: boolean = true): Promise<void> {
+  public async collapseElement(id: ID, options: boolean | CollapseExpandNodeOptions = true): Promise<void> {
     const { model, element } = this.context;
     if (isCollapsed(model.getNodeLikeData([id])[0])) return;
-
     if (this.isCollapsingExpanding) return;
+
+    if (typeof options === 'boolean') options = { animation: options, align: true };
 
     const elementType = model.getElementType(id);
 
     await this.frontElement(id);
     this.isCollapsingExpanding = true;
     this.setElementCollapsibility(id, true);
-    if (elementType === 'node') await element!.collapseNode(id, animation);
-    else if (elementType === 'combo') await element!.collapseCombo(id, animation);
+    if (elementType === 'node') await element!.collapseNode(id, options);
+    else if (elementType === 'combo') await element!.collapseCombo(id, !!options.animation);
 
     this.isCollapsingExpanding = false;
   }
 
   /**
-   * <zh/> 展开组合
+   * <zh/> 展开元素
    *
-   * <en/> Expand Combo
+   * <en/> Expand Element
    * @param id - <zh/> 元素 ID | <en/> element ID
-   * @param animation - <zh/> 是否启用动画 | <en/> whether to enable animation
+   * @param animation - <zh/> 是否启用动画或者配置收起节点的配置项 | <en/> whether to enable animation or the options of collapsing node
+   * @param options
    * @apiCategory element
    */
-  public async expandElement(id: ID, animation: boolean = true): Promise<void> {
+  public async expandElement(id: ID, options: boolean | CollapseExpandNodeOptions = true): Promise<void> {
     const { model, element } = this.context;
     if (!isCollapsed(model.getNodeLikeData([id])[0])) return;
-
     if (this.isCollapsingExpanding) return;
+
+    if (typeof options === 'boolean') options = { animation: options, align: true };
 
     const elementType = model.getElementType(id);
 
     this.isCollapsingExpanding = true;
     this.setElementCollapsibility(id, false);
-    if (elementType === 'node') await element!.expandNode(id, animation);
-    else if (elementType === 'combo') await element!.expandCombo(id, animation);
+    if (elementType === 'node') await element!.expandNode(id, options);
+    else if (elementType === 'combo') await element!.expandCombo(id, !!options.animation);
 
     this.isCollapsingExpanding = false;
   }


### PR DESCRIPTION
- [x] 树图中节点展开收起支持配置 `align` 选项(默认为 true)

开启该选项时，展开收起操作始终保持目标元素位置不变（避免丢失目标）

---

- [x] Node expansion and collapse in tree graph supports configuring 'align' option (default is true) (Avoid losing the target)

When this option is on, the Expand and Collapse action always keeps the target element position unchanged

Relative Issue: https://github.com/antvis/G6/issues/6494

开启效果：
![Nov-25-2024 17-45-30](https://github.com/user-attachments/assets/86fde959-595e-4638-940a-30640f4f0cff)

关闭效果：
![Nov-25-2024 17-45-27](https://github.com/user-attachments/assets/d412e0ba-3350-4753-aaf6-62d33443c3fb)
