### PR TITLE
refactor: simplify visibility logic

### DIFF
--- a/packages/g6/__tests__/unit/utils/visibility.spec.ts
+++ b/packages/g6/__tests__/unit/utils/visibility.spec.ts
@@ -27,7 +27,7 @@ describe('visibility', () => {
     setVisibility(shape, 'visible');
     expect(shape.style.visibility).toBe('visible');
     expect(vShape.style.visibility).toBe('visible');
-    expect(hShape.style.visibility).toBe('hidden');
+    expect(hShape.style.visibility).toBe('visible');
   });
 
   it('default is hidden', () => {
@@ -42,7 +42,7 @@ describe('visibility', () => {
     setVisibility(shape, 'visible');
     expect(shape.style.visibility).toBe('visible');
     expect(vShape.style.visibility).toBe('visible');
-    expect(hShape.style.visibility).toBe('hidden');
+    expect(hShape.style.visibility).toBe('visible');
   });
 
   it('setVisibility', () => {
@@ -107,16 +107,16 @@ describe('visibility', () => {
       expect(root.style.visibility).toBe('visible');
       expect(l1.style.visibility).toBe('visible');
       expect(l2.style.visibility).toBe('visible');
-      expect(l3.style.visibility).toBe('hidden');
+      expect(l3.style.visibility).toBe('visible');
       expect(l1_1.style.visibility).toBe('visible');
       expect(l1_2.style.visibility).toBe('visible');
-      expect(l1_3.style.visibility).toBe('hidden');
+      expect(l1_3.style.visibility).toBe('visible');
       expect(l2_1.style.visibility).toBe('visible');
       expect(l2_2.style.visibility).toBe('visible');
-      expect(l2_3.style.visibility).toBe('hidden');
-      expect(l3_1.style.visibility).toBe('hidden');
-      expect(l3_2.style.visibility).toBe('hidden');
-      expect(l3_3.style.visibility).toBe('hidden');
+      expect(l2_3.style.visibility).toBe('visible');
+      expect(l3_1.style.visibility).toBe('visible');
+      expect(l3_2.style.visibility).toBe('visible');
+      expect(l3_3.style.visibility).toBe('visible');
     };
 
     assertDefault();
@@ -175,8 +175,8 @@ describe('visibility', () => {
 
     setVisibility(root, 'visible');
     expect(root.style.visibility).toBe('visible');
-    expect(level1.style.visibility).toBe('hidden');
-    expect(level2.style.visibility).toBe('hidden');
+    expect(level1.style.visibility).toBe('visible');
+    expect(level2.style.visibility).toBe('visible');
 
     setVisibility(level1, 'visible');
     expect(root.style.visibility).toBe('visible');

--- a/packages/g6/src/behaviors/optimize-viewport-transform.ts
+++ b/packages/g6/src/behaviors/optimize-viewport-transform.ts
@@ -70,7 +70,7 @@ export class OptimizeViewportTransform extends BaseBehavior<OptimizeViewportTran
       } else if (visibility === 'visible' && this.hiddenShapes.includes(element)) {
         this.hiddenShapes.splice(this.hiddenShapes.indexOf(element), 1);
       } else {
-        setVisibility(element, visibility, false, filter);
+        setVisibility(element, visibility, filter);
       }
     });
   };

--- a/packages/g6/src/elements/shapes/base-shape.ts
+++ b/packages/g6/src/elements/shapes/base-shape.ts
@@ -256,7 +256,7 @@ export abstract class BaseShape<StyleProps extends BaseShapeStyleProps> extends 
 
   private setVisibility() {
     const { visibility } = this.attributes;
-    setVisibility(this, visibility, true);
+    setVisibility(this, visibility);
   }
 
   public destroy(): void {

--- a/packages/g6/src/utils/visibility.ts
+++ b/packages/g6/src/utils/visibility.ts
@@ -1,14 +1,11 @@
 import type { BaseStyleProps, DisplayObject } from '@antv/g';
 
-const ORIGINAL_MAP = new WeakMap<DisplayObject, BaseStyleProps['visibility']>();
-
 /**
  * <zh/> 设置图形实例的可见性
  *
  * <en/> Set the visibility of the shape instance
  * @param shape - <zh/> 图形实例 | <en/> shape instance
  * @param value - <zh/> 可见性 | <en/> visibility
- * @param inherited - <zh/> 是否是来自继承样式 | <en/> Whether it is from inherited styles
  * @param filter - <zh/> 筛选出需要设置可见性的图形 | <en/> Filter out the shapes that need to set visibility
  * @remarks
  * <zh/> 在设置 enableCSSParsing 为 false 的情况下，复合图形无法继承父属性，因此需要对所有子图形应用相同的可见性
@@ -18,40 +15,14 @@ const ORIGINAL_MAP = new WeakMap<DisplayObject, BaseStyleProps['visibility']>();
 export function setVisibility(
   shape: DisplayObject,
   value: BaseStyleProps['visibility'],
-  inherited = false,
   filter?: (shape: DisplayObject) => boolean,
 ) {
-  if (value === undefined) return;
-
-  const traverse = (current: DisplayObject, scope = value): void => {
-    const walk = (val = scope): void => (current.childNodes as DisplayObject[]).forEach((node) => traverse(node, val));
-
-    if (filter && !filter(current)) return walk();
-
-    if (!inherited && current === shape) {
-      shape.style.visibility = value;
-      ORIGINAL_MAP.delete(shape);
-      walk(value);
-    } else {
-      if (!ORIGINAL_MAP.has(current)) ORIGINAL_MAP.set(current, current.style.visibility);
-
-      const computedValue = scope === 'hidden' || getOriginalValue(current) === 'hidden' ? 'hidden' : 'visible';
-      current.style.visibility = computedValue;
-      walk(computedValue);
-    }
+  const callback = (node: DisplayObject) => {
+    if (filter && !filter(node)) return;
+    node.style.visibility = value;
   };
 
-  traverse(shape);
-}
-
-/**
- * <zh/> 获取图形原本的可见性
- *
- * <en/> Get the original visibility of the shape
- * @param shape - <zh/> 图形实例 | <en/> shape instance
- * @returns <zh/> 可见性 | <en/> visibility
- */
-function getOriginalValue(shape: DisplayObject) {
-  if (ORIGINAL_MAP.has(shape)) return ORIGINAL_MAP.get(shape);
-  return shape.style.visibility;
+  shape.forEach((node) => {
+    callback(node as DisplayObject);
+  });
 }


### PR DESCRIPTION
- [x] 修复某些情况下设置元素可见效不生效的问题

简化 `setVisibility` 逻辑，不再考虑元素默认可见性


---

- [x] Fixed an issue where setting element visibility did not take effect in some cases 

Simplified the 'setVisibility' logic to no longer consider the default visibility of elements

Related Issue: https://github.com/antvis/G6/issues/6559