### PR TITLE
fix: fix removing parent combo of node not effect

### DIFF
--- a/packages/g6/__tests__/bugs/model-remove-parent.spec.ts
+++ b/packages/g6/__tests__/bugs/model-remove-parent.spec.ts
@@ -1,0 +1,34 @@
+import { createGraph } from '@@/utils';
+
+it('model remove parent', async () => {
+  const data = {
+    nodes: [
+      { id: 'node1', combo: 'combo1', style: { x: 250, y: 150 } },
+      { id: 'node2', combo: 'combo1', style: { x: 350, y: 150 } },
+      { id: 'node3', combo: 'combo1', style: { x: 250, y: 300 } },
+    ],
+    edges: [],
+    combos: [{ id: 'combo1' }],
+  };
+
+  const graph = createGraph({
+    data,
+    node: {
+      style: {
+        labelText: (d) => d.id,
+      },
+    },
+    combo: {
+      type: 'rect',
+    },
+  });
+
+  await graph.render();
+
+  await expect(graph).toMatchSnapshot(__filename);
+
+  graph.updateNodeData([{ id: 'node3', combo: null }]);
+  await graph.draw();
+
+  await expect(graph).toMatchSnapshot(__dirname, 'remove-parent');
+});

--- a/packages/g6/__tests__/snapshots/bugs/model-remove-parent/default.svg
+++ b/packages/g6/__tests__/snapshots/bugs/model-remove-parent/default.svg
@@ -1,0 +1,50 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
+  <defs/>
+  <g >
+    <g fill="none">
+      <g fill="none" class="elements">
+        <g fill="none" transform="matrix(1,0,0,1,300.440002,237.500000)">
+          <g>
+            <path fill="rgba(153,173,209,1)" d="M -78.74000000000001,-113.5 l 157.48000000000002,0 l 0,227 l-157.48000000000002 0 z" class="key" stroke-dasharray="0,0" stroke-width="1" fill-opacity="0.04" stroke="rgba(153,173,209,1)" width="157.48000000000002" height="227" x="-78.74000000000001" y="-113.5"/>
+          </g>
+        </g>
+        <g fill="none" transform="matrix(1,0,0,1,250,150)">
+          <g>
+            <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
+          </g>
+          <g fill="none" class="label" transform="matrix(1,0,0,1,0,18)">
+            <g>
+              <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" dy="11.5px" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="middle" fill-opacity="0.85" font-weight="400">
+                node1
+              </text>
+            </g>
+          </g>
+        </g>
+        <g fill="none" transform="matrix(1,0,0,1,350,150)">
+          <g>
+            <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
+          </g>
+          <g fill="none" class="label" transform="matrix(1,0,0,1,0,18)">
+            <g>
+              <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" dy="11.5px" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="middle" fill-opacity="0.85" font-weight="400">
+                node2
+              </text>
+            </g>
+          </g>
+        </g>
+        <g fill="none" transform="matrix(1,0,0,1,250,300)">
+          <g>
+            <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
+          </g>
+          <g fill="none" class="label" transform="matrix(1,0,0,1,0,18)">
+            <g>
+              <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" dy="11.5px" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="middle" fill-opacity="0.85" font-weight="400">
+                node3
+              </text>
+            </g>
+          </g>
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/packages/g6/__tests__/snapshots/bugs/remove-parent.svg
+++ b/packages/g6/__tests__/snapshots/bugs/remove-parent.svg
@@ -1,0 +1,50 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
+  <defs/>
+  <g >
+    <g fill="none">
+      <g fill="none" class="elements">
+        <g fill="none" transform="matrix(1,0,0,1,250,300)">
+          <g>
+            <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
+          </g>
+          <g fill="none" class="label" transform="matrix(1,0,0,1,0,18)">
+            <g>
+              <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" dy="11.5px" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="middle" fill-opacity="0.85" font-weight="400">
+                node3
+              </text>
+            </g>
+          </g>
+        </g>
+        <g fill="none" transform="matrix(1,0,0,1,300.920013,162.500000)">
+          <g>
+            <path fill="rgba(153,173,209,1)" d="M -78.26,-38.5 l 156.52,0 l 0,77 l-156.52 0 z" class="key" stroke-dasharray="0,0" stroke-width="1" fill-opacity="0.04" stroke="rgba(153,173,209,1)" width="156.52" height="77" x="-78.26" y="-38.5"/>
+          </g>
+        </g>
+        <g fill="none" transform="matrix(1,0,0,1,250,150)">
+          <g>
+            <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
+          </g>
+          <g fill="none" class="label" transform="matrix(1,0,0,1,0,18)">
+            <g>
+              <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" dy="11.5px" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="middle" fill-opacity="0.85" font-weight="400">
+                node1
+              </text>
+            </g>
+          </g>
+        </g>
+        <g fill="none" transform="matrix(1,0,0,1,350,150)">
+          <g>
+            <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
+          </g>
+          <g fill="none" class="label" transform="matrix(1,0,0,1,0,18)">
+            <g>
+              <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" dy="11.5px" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="middle" fill-opacity="0.85" font-weight="400">
+                node2
+              </text>
+            </g>
+          </g>
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/packages/g6/package.json
+++ b/packages/g6/package.json
@@ -63,7 +63,7 @@
     "@antv/g": "^6.1.11",
     "@antv/g-canvas": "^2.0.29",
     "@antv/g-plugin-dragndrop": "^2.0.22",
-    "@antv/graphlib": "^2.0.3",
+    "@antv/graphlib": "^2.0.4",
     "@antv/hierarchy": "^0.6.14",
     "@antv/layout": "1.2.14-beta.9",
     "@antv/util": "^3.3.10",

--- a/packages/g6/src/runtime/data.ts
+++ b/packages/g6/src/runtime/data.ts
@@ -1,5 +1,5 @@
 import { Graph as GraphLib } from '@antv/graphlib';
-import { isNumber, isUndefined, uniq } from '@antv/util';
+import { isNil, isNumber, uniq } from '@antv/util';
 import { COMBO_KEY, ChangeType, TREE_KEY } from '../constants';
 import type { ComboData, EdgeData, GraphData, NodeData } from '../spec';
 import type {
@@ -518,8 +518,15 @@ export class DataController {
       const id = idOf(datum);
       const parent = parentIdOf(datum);
 
-      if (parent) {
+      if (parent !== undefined) {
         if (!model.hasTreeStructure(COMBO_KEY)) model.attachTreeStructure(COMBO_KEY);
+
+        // 解除原父节点的子节点关系，更新原父节点及其祖先的数据
+        // Remove the child relationship of the original parent node, update the data of the original parent node and its ancestors
+        if (parent === null) {
+          this.refreshComboData(id);
+        }
+
         this.setParent(id, parentIdOf(datum), COMBO_KEY);
       }
 
@@ -665,7 +672,7 @@ export class DataController {
    * @param hierarchyKey - <zh/> 层次结构类型 | <en/> hierarchy type
    * @param update - <zh/> 添加新/旧父节点数据更新记录 | <en/> add new/old parent node data update record
    */
-  public setParent(id: ID, parent: ID | undefined, hierarchyKey: HierarchyKey, update: boolean = true) {
+  public setParent(id: ID, parent: ID | undefined | null, hierarchyKey: HierarchyKey, update: boolean = true) {
     if (id === parent) return;
     const elementData = this.getNodeLikeDatum(id);
     const originalParentId = parentIdOf(elementData);
@@ -891,7 +898,7 @@ export class DataController {
         this.model.mergeNodeData(idOf(childData), value);
       });
 
-      if (!isUndefined(grandParent)) this.refreshComboData(grandParent);
+      if (!isNil(grandParent)) this.refreshComboData(grandParent);
     }
   }
 

--- a/packages/g6/src/spec/data.ts
+++ b/packages/g6/src/spec/data.ts
@@ -92,7 +92,7 @@ export interface NodeData {
    *
    * <en/> ID of the combo to which the node belongs
    */
-  combo?: ID;
+  combo?: ID | null;
   /**
    * <zh/> 子节点 ID
    *
@@ -161,7 +161,7 @@ export interface ComboData {
    *
    * <en/> ID of the combo to which the combo belongs
    */
-  combo?: ID;
+  combo?: ID | null;
   [key: string]: unknown;
 }
 

--- a/packages/site/docs/manual/faq.en.md
+++ b/packages/site/docs/manual/faq.en.md
@@ -268,3 +268,11 @@ graph.on(NodeEvent.CLICK, (event: IPointerEvent) => {
   // handler
 });
 ```
+
+### Remove the parent combo of the node
+
+Update the node data, set the `combo` value to `null`.
+
+```typescript
+graph.updateNodeData([{ id: 'node-id', combo: null }]);
+```

--- a/packages/site/docs/manual/faq.zh.md
+++ b/packages/site/docs/manual/faq.zh.md
@@ -268,3 +268,11 @@ graph.on(NodeEvent.CLICK, (event: IPointerEvent) => {
   // handler
 });
 ```
+
+### 解除节点所在组合
+
+更新节点数据，`combo` 值设置为 `null`。
+
+```typescript
+graph.updateNodeData([{ id: 'node-id', combo: null }]);
+```


### PR DESCRIPTION
- [x] 修复移除节点所在 combo 不生效的问题

---

- [x] fix: fix removing parent combo of node not effect

Related Issue: https://github.com/antvis/G6/issues/6539

```typescript
graph.updateNodeData([{ id: "node-id", combo: null }]);
```