### PR TITLE
chore(grid-line): add a built-in style of [background-repeat: repeat;]

### DIFF
--- a/packages/g6/src/plugins/grid-line.ts
+++ b/packages/g6/src/plugins/grid-line.ts
@@ -136,6 +136,7 @@ export class GridLine extends BasePlugin<GridLineOptions> {
       border: border ? `${borderLineWidth}px ${borderStyle} ${borderStroke}` : 'none',
       backgroundImage: `linear-gradient(${stroke} ${lineWidth}px, transparent ${lineWidth}px), linear-gradient(90deg, ${stroke} ${lineWidth}px, transparent ${lineWidth}px)`,
       backgroundSize: `${size}px ${size}px`,
+      backgroundRepeat: 'repeat',
     });
   }
 


### PR DESCRIPTION
### background
  Some component library has a global reset-style of `background-repeat: no-repeat;` and it will cause the `grid-line` plugin cannot work correct.
![image](https://github.com/user-attachments/assets/9df2f182-cf17-43ab-a9d7-ff80440c3e81)

So the `grid-line` plugin relies on the `background-repeat: repeat;`, and we should make it a built-in style in `grid-line`