### PR TITLE
docs: sort search results by custom priority

### DIFF
--- a/packages/site/.dumirc.ts
+++ b/packages/site/.dumirc.ts
@@ -48,6 +48,7 @@ export default defineConfig({
       // 头部搜索框配置
       apiKey: '9d1cd586972bb492b7b41b13a949ef30',
       indexName: 'antv_g6',
+      sort: ['/manual', '!/api/reference', '/api/reference'],
     },
     navs: [
       {

--- a/packages/site/.dumirc.ts
+++ b/packages/site/.dumirc.ts
@@ -48,7 +48,7 @@ export default defineConfig({
       // 头部搜索框配置
       apiKey: '9d1cd586972bb492b7b41b13a949ef30',
       indexName: 'antv_g6',
-      sort: ['/manual', '!/api/reference', '/api/reference'],
+      sort: ['!/api/reference'],
     },
     navs: [
       {

--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "@ant-design/icons": "^5.5.2",
     "@antv/algorithm": "^0.1.26",
-    "@antv/dumi-theme-antv": "^0.5.3",
+    "@antv/dumi-theme-antv": "^0.5.4",
     "@antv/g": "^6.1.14",
     "@antv/g-svg": "^2.0.27",
     "@antv/g-webgl": "^2.0.36",


### PR DESCRIPTION
- 根据自定义优先级对搜索结果排序，希望用户优先查看使用文档而不是开发者 TS 文档

|before |after |
| ----- | ---- |
| <img width="300" src="https://github.com/user-attachments/assets/4a1bb042-6392-4191-83ce-d968ab14f36e"/> | <img width="300" src="https://github.com/user-attachments/assets/ff69ec5c-ec2b-4a8a-915d-a8c254d9b1fb"/> |
| <img width="300" src="https://github.com/user-attachments/assets/f3e8ee62-9481-4c4e-90ab-419d88e77f77"/>|  <img width="300" src="https://github.com/user-attachments/assets/60ff9fb8-1cdb-44ca-bbf1-085ff2dbeaa6"/>|

- 标签页标题与文章标题联动

<img width="400" src="https://github.com/user-attachments/assets/514c7204-a52e-419b-b39c-407c76bddb0e" />
