### PR TITLE
chore: update issue template and add conversion workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,7 +1,7 @@
 name: '🐞 Bug report'
 description: Create a report to help us improve, Ask questions in Discussions / 创建一个问题报告以帮助我们改进，提问请到 Discussions
 title: '[Bug]: '
-labels: ['status: waiting for maintainer', 'bug']
+labels: ['status: waiting for maintainer']
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,7 +1,7 @@
 name: '🐞 Bug report'
 description: Create a report to help us improve, Ask questions in Discussions / 创建一个问题报告以帮助我们改进，提问请到 Discussions
 title: '[Bug]: '
-labels: ['bug']
+labels: ['status: waiting for maintainer', 'bug']
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/docs-feedback.yml
+++ b/.github/ISSUE_TEMPLATE/docs-feedback.yml
@@ -1,5 +1,5 @@
 name: 'Docs feedback'
-description: Improve documentation about AntV G6.
+description: Improve documentation about G6 / 助力 G6 打造出更易于上手操作以及便捷查阅的文档
 labels: ['status: waiting for maintainer', 'docs-feedback']
 title: '[docs] '
 body:
@@ -26,8 +26,8 @@ body:
     attributes:
       label: Issue description
       description: |
-        Let us know what went wrong when you were using this documentation and what we could do to improve it.
+        Let us know what went wrong when you were using this documentation and what we could do to improve it | 请告知您在使用此文档时遇到的问题以及我们可以改进的地方
   - type: textarea
     attributes:
       label: Context
-      description: What are you trying to accomplish? Providing context helps us come up with a solution that is more useful in the real world.
+      description: What are you trying to accomplish? Providing context helps us come up with a solution that is more useful in the real world | 您希望实现什么目标？提供上下文有助于我们提出更实用的解决方案

--- a/.github/ISSUE_TEMPLATE/docs-feedback.yml
+++ b/.github/ISSUE_TEMPLATE/docs-feedback.yml
@@ -1,0 +1,33 @@
+name: 'Docs feedback'
+description: Improve documentation about AntV G6.
+labels: ['status: waiting for maintainer', 'docs-feedback']
+title: '[docs] '
+body:
+  - type: input
+    id: page-url
+    attributes:
+      label: Related page
+      description: Which page of the documentation is this about?
+      placeholder: https://g6.antv.antgroup.com/
+    validations:
+      required: true
+  - type: dropdown
+    attributes:
+      label: Kind of issue
+      description: What kind of problem are you facing?
+      options:
+        - Unclear explanations
+        - Missing information
+        - Broken demo
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Issue description
+      description: |
+        Let us know what went wrong when you were using this documentation and what we could do to improve it.
+  - type: textarea
+    attributes:
+      label: Context
+      description: What are you trying to accomplish? Providing context helps us come up with a solution that is more useful in the real world.

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,7 +1,7 @@
 name: '💡 Feature Request'
 description: I have a suggestion (and may want to implement it) / 我有一个建议（或者想参与贡献）
 title: '[Feat]: '
-labels: ['status: waiting for maintainer', 'feature']
+labels: ['status: waiting for maintainer']
 body:
   - type: textarea
     id: description

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,9 +1,8 @@
 name: '💡 Feature Request'
 description: I have a suggestion (and may want to implement it) / 我有一个建议（或者想参与贡献）
 title: '[Feat]: '
-labels: ['feature']
+labels: ['status: waiting for maintainer', 'feature']
 body:
-
   - type: textarea
     id: description
     attributes:

--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -1,0 +1,36 @@
+name: No response
+
+# `issues`.`closed`, `issue_comment`.`created`, and `scheduled` event types are required for this Action
+# to work properly.
+on:
+  issues:
+    types: [closed]
+  issue_comment:
+    types: [created]
+  schedule:
+    # These runs in our repos are spread evenly throughout the day to avoid hitting rate limits.
+    # If you change this schedule, consider changing the remaining repositories as well.
+    # Runs at 12 am, 12 pm
+    - cron: '0 0,12 * * *'
+
+permissions: {}
+
+jobs:
+  noResponse:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: MBilalShafi/no-response-add-label@8336c12292902f27b931154c34ba4670cb9899a2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          # Number of days of inactivity before an Issue is closed for lack of response
+          daysUntilClose: 7
+          # Label requiring a response
+          responseRequiredLabel: 'status: waiting for author'
+          # Label to add back when required label is removed
+          optionalFollowupLabel: 'status: waiting for maintainer'
+          # Comment to post when closing an Issue for lack of response. Set to `false` to disable
+          closeComment: >
+            Since the issue is missing key information and has been inactive for 7 days, it has been automatically closed. If you wish to see the issue reopened, please provide the missing information.

--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -33,4 +33,5 @@ jobs:
           optionalFollowupLabel: 'status: waiting for maintainer'
           # Comment to post when closing an Issue for lack of response. Set to `false` to disable
           closeComment: >
-            Since the issue is missing key information and has been inactive for 7 days, it has been automatically closed. If you wish to see the issue reopened, please provide the missing information.
+            Since the issue is missing key information and has been inactive for 7 days, it has been automatically closed. If you wish to see the issue reopened, please provide the missing information. | 由于该 issue 缺少关键信息且已闲置 7 天，现已自动关闭。如需重新打开此问题，请提供所缺失的信息。。
+


### PR DESCRIPTION
新增 issue labels：`status: waiting for maintainer` 和 `status: waiting for author`

后续 issue 处理分为两个阶段：

- 第一阶段：了解诉求

 1. issue 被创建时会被标记为 `status: waiting for maintainer`
 2. 如果开发者希望进一步了解细节，可以进行回复并手动切换为 `status: waiting for author`
 3. 如果已经完全了解，能评估出此 issue 是 bug 还是 feature，则删除这两个标记，并进入第二阶段。
 4. 有时效性，如果挂有 `status: waiting for author` 标记七天内没有用户回复，会自动关闭此 issue

- 第二阶段：解决问题

1. 需要精细化设置标签。例如，如果 issue 描述了拖拽画布交互的 bug，则对应标签为 `behavior: drag-canvas`、`behavior`、`bug`、`v5`。方便用户检索历史 issue