### PR TITLE
perf: avoid unnecessary transform updates to improve performance

### DIFF
--- a/packages/g6/__tests__/bugs/element-set-position-to-origin.spec.ts
+++ b/packages/g6/__tests__/bugs/element-set-position-to-origin.spec.ts
@@ -15,16 +15,16 @@ describe('element set position to origin', () => {
     const getElementOf = (id: ID) => graph.context.element!.getElement(id)!;
 
     expect(graph.getNodeData('node-1').style).toEqual({ zIndex: 0 });
-    expect(getElementOf('node-1').style.transform).toBe('translate(0, 0)');
+    expect(getElementOf('node-1').style.transform).toEqual([['translate', 0, 0]]);
 
     graph.translateElementTo('node-1', [100, 100]);
 
     expect(graph.getNodeData('node-1').style).toEqual({ x: 100, y: 100, z: 0, zIndex: 0 });
-    expect(getElementOf('node-1').style.transform).toBe('translate(100, 100)');
+    expect(getElementOf('node-1').style.transform).toEqual([['translate', 100, 100]]);
 
     graph.translateElementTo('node-1', [0, 0]);
 
     expect(graph.getNodeData('node-1').style).toEqual({ x: 0, y: 0, z: 0, zIndex: 0 });
-    expect(getElementOf('node-1').style.transform).toBe('translate(0, 0)');
+    expect(getElementOf('node-1').style.transform).toEqual([['translate', 0, 0]]);
   });
 });

--- a/packages/g6/__tests__/demos/case-unicorns-investors.ts
+++ b/packages/g6/__tests__/demos/case-unicorns-investors.ts
@@ -18,6 +18,7 @@ export const caseUnicornsInvestors: TestCase = async (context) => {
   const graph = new Graph({
     ...context,
     data,
+    autoFit: 'view',
     node: {
       style: {
         label: true,
@@ -113,7 +114,15 @@ export const caseUnicornsInvestors: TestCase = async (context) => {
     animation: false,
   });
 
+  performance.mark('render-start');
+
   await graph.render();
+
+  performance.mark('render-end');
+
+  performance.measure('render', 'render-start', 'render-end');
+
+  console.log(performance.getEntriesByType('measure')[0].duration);
 
   return graph;
 };

--- a/packages/g6/__tests__/demos/layout-dendrogram-tb.ts
+++ b/packages/g6/__tests__/demos/layout-dendrogram-tb.ts
@@ -7,17 +7,29 @@ export const layoutDendrogramTb: TestCase = async (context) => {
     autoFit: 'view',
     data: treeToGraphData(data),
     node: {
-      style: (model) => {
-        const hasChildren = !!model.children?.length;
-        return {
-          labelMaxWidth: 200,
-          labelPlacement: hasChildren ? 'right' : 'bottom',
-          labelText: model.id,
-          labelTextAlign: 'start',
-          labelTextBaseline: hasChildren ? 'middle' : 'bottom',
-          transform: hasChildren ? [] : [['rotate', 90]],
-          ports: [{ placement: 'bottom' }, { placement: 'top' }],
+      style: (d) => {
+        const isLeafNode = !d.children?.length;
+        const style = {
+          labelText: d.id,
+          labelPlacement: 'right',
+          labelOffsetX: 2,
+          labelBackground: true,
+          ports: [{ placement: 'top' }, { placement: 'bottom' }],
         };
+        if (isLeafNode) {
+          Object.assign(style, {
+            labelTransform: [
+              ['rotate', 90],
+              ['translate', 18],
+            ],
+            labelBaseline: 'center',
+            labelTextAlign: 'left',
+          });
+        }
+        return style;
+      },
+      animation: {
+        enter: false,
       },
     },
     edge: {

--- a/packages/g6/__tests__/snapshots/layouts/compact-box/left-align.svg
+++ b/packages/g6/__tests__/snapshots/layouts/compact-box/left-align.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g transform="matrix(0.447027,0,0,0.447027,138.354950,101.783638)">
+  <g transform="matrix(0.447027,0,0,0.447027,138.354935,101.783630)">
     <g fill="none">
       <g fill="none" class="elements">
         <g fill="none">
@@ -199,7 +199,7 @@
           <g>
             <circle fill="rgba(239,244,255,1)" class="key" stroke-width="1" stroke="rgba(95,149,255,1)" r="13"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,13,2)">
+          <g fill="none" class="label" transform="matrix(1,0,0,1,12.999997,1.999998)">
             <g>
               <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 Classification
@@ -211,7 +211,7 @@
           <g>
             <circle fill="rgba(239,244,255,1)" class="key" stroke-width="1" stroke="rgba(95,149,255,1)" r="13"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,13,2)">
+          <g fill="none" class="label" transform="matrix(1,0,0,1,12.999990,1.999981)">
             <g>
               <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 Logistic regression
@@ -223,7 +223,7 @@
           <g>
             <circle fill="rgba(239,244,255,1)" class="key" stroke-width="1" stroke="rgba(95,149,255,1)" r="13"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,13,2)">
+          <g fill="none" class="label" transform="matrix(1,0,0,1,12.999992,1.999996)">
             <g>
               <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 Linear discriminant analysis
@@ -235,7 +235,7 @@
           <g>
             <circle fill="rgba(239,244,255,1)" class="key" stroke-width="1" stroke="rgba(95,149,255,1)" r="13"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,13,2)">
+          <g fill="none" class="label" transform="matrix(1,0,0,1,12.999994,1.999996)">
             <g>
               <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 Rules
@@ -247,7 +247,7 @@
           <g>
             <circle fill="rgba(239,244,255,1)" class="key" stroke-width="1" stroke="rgba(95,149,255,1)" r="13"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,13,2)">
+          <g fill="none" class="label" transform="matrix(1,0,0,1,12.999996,1.999989)">
             <g>
               <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 Decision trees
@@ -259,7 +259,7 @@
           <g>
             <circle fill="rgba(239,244,255,1)" class="key" stroke-width="1" stroke="rgba(95,149,255,1)" r="13"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,13,2)">
+          <g fill="none" class="label" transform="matrix(1,0,0,1,12.999998,1.999996)">
             <g>
               <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 Naive Bayes
@@ -295,7 +295,7 @@
           <g>
             <circle fill="rgba(239,244,255,1)" class="key" stroke-width="1" stroke="rgba(95,149,255,1)" r="13"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,13,2)">
+          <g fill="none" class="label" transform="matrix(1,0,0,1,13.000004,2.000004)">
             <g>
               <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 Support vector machine
@@ -307,7 +307,7 @@
           <g>
             <circle fill="rgba(239,244,255,1)" class="key" stroke-width="1" stroke="rgba(95,149,255,1)" r="13"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,13,2)">
+          <g fill="none" class="label" transform="matrix(1,0,0,1,12.999996,2.000005)">
             <g>
               <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 Consensus
@@ -319,7 +319,7 @@
           <g>
             <circle fill="rgba(239,244,255,1)" class="key" stroke-width="1" stroke="rgba(95,149,255,1)" r="13"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,13,2)">
+          <g fill="none" class="label" transform="matrix(1,0,0,1,12.999975,2.000012)">
             <g>
               <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 Models diversity
@@ -343,7 +343,7 @@
           <g>
             <circle fill="rgba(239,244,255,1)" class="key" stroke-width="1" stroke="rgba(95,149,255,1)" r="13"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,13,2)">
+          <g fill="none" class="label" transform="matrix(1,0,0,1,13.000003,2.000002)">
             <g>
               <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 Different parameter choices
@@ -355,7 +355,7 @@
           <g>
             <circle fill="rgba(239,244,255,1)" class="key" stroke-width="1" stroke="rgba(95,149,255,1)" r="13"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,13,2)">
+          <g fill="none" class="label" transform="matrix(1,0,0,1,13.000005,2.000002)">
             <g>
               <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 Different architectures
@@ -367,7 +367,7 @@
           <g>
             <circle fill="rgba(239,244,255,1)" class="key" stroke-width="1" stroke="rgba(95,149,255,1)" r="13"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,13,2)">
+          <g fill="none" class="label" transform="matrix(1,0,0,1,13.000007,2.000002)">
             <g>
               <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 Different modeling methods
@@ -379,7 +379,7 @@
           <g>
             <circle fill="rgba(239,244,255,1)" class="key" stroke-width="1" stroke="rgba(95,149,255,1)" r="13"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,13,2)">
+          <g fill="none" class="label" transform="matrix(1,0,0,1,13.000009,2.000002)">
             <g>
               <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 Different training sets
@@ -391,7 +391,7 @@
           <g>
             <circle fill="rgba(239,244,255,1)" class="key" stroke-width="1" stroke="rgba(95,149,255,1)" r="13"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,13,2)">
+          <g fill="none" class="label" transform="matrix(1,0,0,1,13.000010,2.000018)">
             <g>
               <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 Different feature sets
@@ -403,7 +403,7 @@
           <g>
             <circle fill="rgba(239,244,255,1)" class="key" stroke-width="1" stroke="rgba(95,149,255,1)" r="13"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,13,2)">
+          <g fill="none" class="label" transform="matrix(1,0,0,1,12.999983,2.000012)">
             <g>
               <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 Methods
@@ -415,7 +415,7 @@
           <g>
             <circle fill="rgba(239,244,255,1)" class="key" stroke-width="1" stroke="rgba(95,149,255,1)" r="13"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,13,2)">
+          <g fill="none" class="label" transform="matrix(1,0,0,1,13.000012,2.000018)">
             <g>
               <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 Classifier selection
@@ -427,7 +427,7 @@
           <g>
             <circle fill="rgba(239,244,255,1)" class="key" stroke-width="1" stroke="rgba(95,149,255,1)" r="13"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,13,2)">
+          <g fill="none" class="label" transform="matrix(1,0,0,1,12.999953,2.000018)">
             <g>
               <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 Classifier fusion
@@ -439,7 +439,7 @@
           <g>
             <circle fill="rgba(239,244,255,1)" class="key" stroke-width="1" stroke="rgba(95,149,255,1)" r="13"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,13,2)">
+          <g fill="none" class="label" transform="matrix(1,0,0,1,12.999988,2.000012)">
             <g>
               <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 Common
@@ -451,7 +451,7 @@
           <g>
             <circle fill="rgba(239,244,255,1)" class="key" stroke-width="1" stroke="rgba(95,149,255,1)" r="13"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,13,2)">
+          <g fill="none" class="label" transform="matrix(1,0,0,1,12.999955,2.000018)">
             <g>
               <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 Bagging
@@ -463,7 +463,7 @@
           <g>
             <circle fill="rgba(239,244,255,1)" class="key" stroke-width="1" stroke="rgba(95,149,255,1)" r="13"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,13,2)">
+          <g fill="none" class="label" transform="matrix(1,0,0,1,12.999957,2.000018)">
             <g>
               <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 Boosting
@@ -475,7 +475,7 @@
           <g>
             <circle fill="rgba(239,244,255,1)" class="key" stroke-width="1" stroke="rgba(95,149,255,1)" r="13"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,13,2)">
+          <g fill="none" class="label" transform="matrix(1,0,0,1,12.999959,2.000018)">
             <g>
               <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 AdaBoost
@@ -487,7 +487,7 @@
           <g>
             <circle fill="rgba(239,244,255,1)" class="key" stroke-width="1" stroke="rgba(95,149,255,1)" r="13"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,13,2)">
+          <g fill="none" class="label" transform="matrix(1,0,0,1,12.999993,2.000005)">
             <g>
               <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 Regression
@@ -499,7 +499,7 @@
           <g>
             <circle fill="rgba(239,244,255,1)" class="key" stroke-width="1" stroke="rgba(95,149,255,1)" r="13"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,13,2)">
+          <g fill="none" class="label" transform="matrix(1,0,0,1,12.999990,2.000012)">
             <g>
               <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 Multiple linear regression
@@ -511,7 +511,7 @@
           <g>
             <circle fill="rgba(239,244,255,1)" class="key" stroke-width="1" stroke="rgba(95,149,255,1)" r="13"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,13,2)">
+          <g fill="none" class="label" transform="matrix(1,0,0,1,12.999991,2.000012)">
             <g>
               <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 Partial least squares
@@ -523,7 +523,7 @@
           <g>
             <circle fill="rgba(239,244,255,1)" class="key" stroke-width="1" stroke="rgba(95,149,255,1)" r="13"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,13,2)">
+          <g fill="none" class="label" transform="matrix(1,0,0,1,12.999993,2.000012)">
             <g>
               <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 Multi-layer feed forward neural network
@@ -535,7 +535,7 @@
           <g>
             <circle fill="rgba(239,244,255,1)" class="key" stroke-width="1" stroke="rgba(95,149,255,1)" r="13"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,13,2)">
+          <g fill="none" class="label" transform="matrix(1,0,0,1,12.999995,2.000012)">
             <g>
               <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 General regression neural network
@@ -547,7 +547,7 @@
           <g>
             <circle fill="rgba(239,244,255,1)" class="key" stroke-width="1" stroke="rgba(95,149,255,1)" r="13"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,13,2)">
+          <g fill="none" class="label" transform="matrix(1,0,0,1,12.999997,2.000012)">
             <g>
               <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 Support vector regression

--- a/packages/g6/__tests__/snapshots/layouts/dendrogram/tb.svg
+++ b/packages/g6/__tests__/snapshots/layouts/dendrogram/tb.svg
@@ -1,193 +1,196 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
   <defs/>
-  <g transform="matrix(0.503018,0,0,0.503018,124.748497,70.251503)">
+  <g transform="matrix(0.504032,0,0,0.504032,123.991936,64.848778)">
     <g fill="none">
       <g fill="none" class="elements">
         <g fill="none">
           <g>
             <path fill="none" d="M 280,116.00000762939453 C 280 200.00000381469727,-89.99999237060547 200.00000381469727,-89.99999237060547 284" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
-            <path fill="none" d="M 0,16 C 0 16,0 16,0 16" class="key" stroke-width="3" stroke="transparent"/>
+            <path fill="none" d="M 0,-16 C 0 -16,0 -16,0 -16" class="key" stroke-width="3" stroke="transparent"/>
           </g>
         </g>
         <g fill="none">
           <g>
             <path fill="none" d="M 280,116.00000762939453 C 280 150.00000381469727,340 150.00000381469727,340 184" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
-            <path fill="none" d="M 0,16 C 0 16,0 16,0 16" class="key" stroke-width="3" stroke="transparent"/>
+            <path fill="none" d="M 0,-16 C 0 -16,0 -16,0 -16" class="key" stroke-width="3" stroke="transparent"/>
           </g>
         </g>
         <g fill="none">
           <g>
             <path fill="none" d="M 280,116.00000762939453 C 280 200.00000381469727,650 200.00000381469727,650 284" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
-            <path fill="none" d="M 0,16 C 0 16,0 16,0 16" class="key" stroke-width="3" stroke="transparent"/>
+            <path fill="none" d="M 0,-16 C 0 -16,0 -16,0 -16" class="key" stroke-width="3" stroke="transparent"/>
           </g>
         </g>
         <g fill="none">
           <g>
             <path fill="none" d="M -89.99999237060547,316 C -89.99999237060547 350,-230 350,-230 384" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
-            <path fill="none" d="M 0,16 C 0 16,0 16,0 16" class="key" stroke-width="3" stroke="transparent"/>
+            <path fill="none" d="M 0,-16 C 0 -16,0 -16,0 -16" class="key" stroke-width="3" stroke="transparent"/>
           </g>
         </g>
         <g fill="none">
           <g>
             <path fill="none" d="M -89.99999237060547,316 C -89.99999237060547 350,-190 350,-190 384" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
-            <path fill="none" d="M 0,16 C 0 16,0 16,0 16" class="key" stroke-width="3" stroke="transparent"/>
+            <path fill="none" d="M 0,-16 C 0 -16,0 -16,0 -16" class="key" stroke-width="3" stroke="transparent"/>
           </g>
         </g>
         <g fill="none">
           <g>
             <path fill="none" d="M -89.99999237060547,316 C -89.99999237060547 350,-150 350,-150 384" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
-            <path fill="none" d="M 0,16 C 0 16,0 16,0 16" class="key" stroke-width="3" stroke="transparent"/>
+            <path fill="none" d="M 0,-16 C 0 -16,0 -16,0 -16" class="key" stroke-width="3" stroke="transparent"/>
           </g>
         </g>
         <g fill="none">
           <g>
             <path fill="none" d="M -89.99999237060547,316 C -89.99999237060547 350,-109.99999237060547 350,-109.99999237060547 384" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
-            <path fill="none" d="M 0,16 C 0 16,0 16,0 16" class="key" stroke-width="3" stroke="transparent"/>
+            <path fill="none" d="M 0,-16 C 0 -16,0 -16,0 -16" class="key" stroke-width="3" stroke="transparent"/>
           </g>
         </g>
         <g fill="none">
           <g>
             <path fill="none" d="M -89.99999237060547,316 C -89.99999237060547 350,-69.99999237060547 350,-69.99999237060547 384" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
-            <path fill="none" d="M 0,16 C 0 16,0 16,0 16" class="key" stroke-width="3" stroke="transparent"/>
+            <path fill="none" d="M 0,-16 C 0 -16,0 -16,0 -16" class="key" stroke-width="3" stroke="transparent"/>
           </g>
         </g>
         <g fill="none">
           <g>
             <path fill="none" d="M -89.99999237060547,316 C -89.99999237060547 350,-29.99999237060547 350,-29.99999237060547 384" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
-            <path fill="none" d="M 0,16 C 0 16,0 16,0 16" class="key" stroke-width="3" stroke="transparent"/>
+            <path fill="none" d="M 0,-16 C 0 -16,0 -16,0 -16" class="key" stroke-width="3" stroke="transparent"/>
           </g>
         </g>
         <g fill="none">
           <g>
             <path fill="none" d="M -89.99999237060547,316 C -89.99999237060547 350,10.000007629394531 350,10.000007629394531 384" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
-            <path fill="none" d="M 0,16 C 0 16,0 16,0 16" class="key" stroke-width="3" stroke="transparent"/>
+            <path fill="none" d="M 0,-16 C 0 -16,0 -16,0 -16" class="key" stroke-width="3" stroke="transparent"/>
           </g>
         </g>
         <g fill="none">
           <g>
             <path fill="none" d="M -89.99999237060547,316 C -89.99999237060547 350,50.00000762939453 350,50.00000762939453 384" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
-            <path fill="none" d="M 0,16 C 0 16,0 16,0 16" class="key" stroke-width="3" stroke="transparent"/>
+            <path fill="none" d="M 0,-16 C 0 -16,0 -16,0 -16" class="key" stroke-width="3" stroke="transparent"/>
           </g>
         </g>
         <g fill="none">
           <g>
             <path fill="none" d="M 340,216 C 340 250,200 250,200 284" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
-            <path fill="none" d="M 0,16 C 0 16,0 16,0 16" class="key" stroke-width="3" stroke="transparent"/>
+            <path fill="none" d="M 0,-16 C 0 -16,0 -16,0 -16" class="key" stroke-width="3" stroke="transparent"/>
           </g>
         </g>
         <g fill="none">
           <g>
             <path fill="none" d="M 340,216 C 340 250,370 250,370 284" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
-            <path fill="none" d="M 0,16 C 0 16,0 16,0 16" class="key" stroke-width="3" stroke="transparent"/>
+            <path fill="none" d="M 0,-16 C 0 -16,0 -16,0 -16" class="key" stroke-width="3" stroke="transparent"/>
           </g>
         </g>
         <g fill="none">
           <g>
             <path fill="none" d="M 340,216 C 340 250,480 250,480 284" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
-            <path fill="none" d="M 0,16 C 0 16,0 16,0 16" class="key" stroke-width="3" stroke="transparent"/>
+            <path fill="none" d="M 0,-16 C 0 -16,0 -16,0 -16" class="key" stroke-width="3" stroke="transparent"/>
           </g>
         </g>
         <g fill="none">
           <g>
             <path fill="none" d="M 200,316 C 200 350,100.00000762939453 350,100.00000762939453 384" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
-            <path fill="none" d="M 0,16 C 0 16,0 16,0 16" class="key" stroke-width="3" stroke="transparent"/>
+            <path fill="none" d="M 0,-16 C 0 -16,0 -16,0 -16" class="key" stroke-width="3" stroke="transparent"/>
           </g>
         </g>
         <g fill="none">
           <g>
             <path fill="none" d="M 200,316 C 200 350,140 350,140 384" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
-            <path fill="none" d="M 0,16 C 0 16,0 16,0 16" class="key" stroke-width="3" stroke="transparent"/>
+            <path fill="none" d="M 0,-16 C 0 -16,0 -16,0 -16" class="key" stroke-width="3" stroke="transparent"/>
           </g>
         </g>
         <g fill="none">
           <g>
             <path fill="none" d="M 200,316 C 200 350,180 350,180 384" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
-            <path fill="none" d="M 0,16 C 0 16,0 16,0 16" class="key" stroke-width="3" stroke="transparent"/>
+            <path fill="none" d="M 0,-16 C 0 -16,0 -16,0 -16" class="key" stroke-width="3" stroke="transparent"/>
           </g>
         </g>
         <g fill="none">
           <g>
             <path fill="none" d="M 200,316 C 200 350,220 350,220 384" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
-            <path fill="none" d="M 0,16 C 0 16,0 16,0 16" class="key" stroke-width="3" stroke="transparent"/>
+            <path fill="none" d="M 0,-16 C 0 -16,0 -16,0 -16" class="key" stroke-width="3" stroke="transparent"/>
           </g>
         </g>
         <g fill="none">
           <g>
             <path fill="none" d="M 200,316 C 200 350,260 350,260 384" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
-            <path fill="none" d="M 0,16 C 0 16,0 16,0 16" class="key" stroke-width="3" stroke="transparent"/>
+            <path fill="none" d="M 0,-16 C 0 -16,0 -16,0 -16" class="key" stroke-width="3" stroke="transparent"/>
           </g>
         </g>
         <g fill="none">
           <g>
             <path fill="none" d="M 200,316 C 200 350,300 350,300 384" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
-            <path fill="none" d="M 0,16 C 0 16,0 16,0 16" class="key" stroke-width="3" stroke="transparent"/>
+            <path fill="none" d="M 0,-16 C 0 -16,0 -16,0 -16" class="key" stroke-width="3" stroke="transparent"/>
           </g>
         </g>
         <g fill="none">
           <g>
             <path fill="none" d="M 370,316 C 370 350,350 350,350 384" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
-            <path fill="none" d="M 0,16 C 0 16,0 16,0 16" class="key" stroke-width="3" stroke="transparent"/>
+            <path fill="none" d="M 0,-16 C 0 -16,0 -16,0 -16" class="key" stroke-width="3" stroke="transparent"/>
           </g>
         </g>
         <g fill="none">
           <g>
             <path fill="none" d="M 370,316 C 370 350,390 350,390 384" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
-            <path fill="none" d="M 0,16 C 0 16,0 16,0 16" class="key" stroke-width="3" stroke="transparent"/>
+            <path fill="none" d="M 0,-16 C 0 -16,0 -16,0 -16" class="key" stroke-width="3" stroke="transparent"/>
           </g>
         </g>
         <g fill="none">
           <g>
             <path fill="none" d="M 480,316 C 480 350,440 350,440 384" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
-            <path fill="none" d="M 0,16 C 0 16,0 16,0 16" class="key" stroke-width="3" stroke="transparent"/>
+            <path fill="none" d="M 0,-16 C 0 -16,0 -16,0 -16" class="key" stroke-width="3" stroke="transparent"/>
           </g>
         </g>
         <g fill="none">
           <g>
             <path fill="none" d="M 480,316 C 480 350,480 350,480 384" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
-            <path fill="none" d="M 0,16 C 0 16,0 16,0 16" class="key" stroke-width="3" stroke="transparent"/>
+            <path fill="none" d="M 0,-16 C 0 -16,0 -16,0 -16" class="key" stroke-width="3" stroke="transparent"/>
           </g>
         </g>
         <g fill="none">
           <g>
             <path fill="none" d="M 480,316 C 480 350,520 350,520 384" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
-            <path fill="none" d="M 0,16 C 0 16,0 16,0 16" class="key" stroke-width="3" stroke="transparent"/>
+            <path fill="none" d="M 0,-16 C 0 -16,0 -16,0 -16" class="key" stroke-width="3" stroke="transparent"/>
           </g>
         </g>
         <g fill="none">
           <g>
             <path fill="none" d="M 650,316 C 650 350,570 350,570 384" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
-            <path fill="none" d="M 0,16 C 0 16,0 16,0 16" class="key" stroke-width="3" stroke="transparent"/>
+            <path fill="none" d="M 0,-16 C 0 -16,0 -16,0 -16" class="key" stroke-width="3" stroke="transparent"/>
           </g>
         </g>
         <g fill="none">
           <g>
             <path fill="none" d="M 650,316 C 650 350,610 350,610 384" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
-            <path fill="none" d="M 0,16 C 0 16,0 16,0 16" class="key" stroke-width="3" stroke="transparent"/>
+            <path fill="none" d="M 0,-16 C 0 -16,0 -16,0 -16" class="key" stroke-width="3" stroke="transparent"/>
           </g>
         </g>
         <g fill="none">
           <g>
             <path fill="none" d="M 650,316 C 650 350,650 350,650 384" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
-            <path fill="none" d="M 0,16 C 0 16,0 16,0 16" class="key" stroke-width="3" stroke="transparent"/>
+            <path fill="none" d="M 0,-16 C 0 -16,0 -16,0 -16" class="key" stroke-width="3" stroke="transparent"/>
           </g>
         </g>
         <g fill="none">
           <g>
             <path fill="none" d="M 650,316 C 650 350,690 350,690 384" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
-            <path fill="none" d="M 0,16 C 0 16,0 16,0 16" class="key" stroke-width="3" stroke="transparent"/>
+            <path fill="none" d="M 0,-16 C 0 -16,0 -16,0 -16" class="key" stroke-width="3" stroke="transparent"/>
           </g>
         </g>
         <g fill="none">
           <g>
             <path fill="none" d="M 650,316 C 650 350,730 350,730 384" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
-            <path fill="none" d="M 0,16 C 0 16,0 16,0 16" class="key" stroke-width="3" stroke="transparent"/>
+            <path fill="none" d="M 0,-16 C 0 -16,0 -16,0 -16" class="key" stroke-width="3" stroke="transparent"/>
           </g>
         </g>
         <g fill="none" transform="matrix(1,0,0,1,280,100.000008)">
           <g>
             <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,16,2)">
+          <g fill="none" class="label" transform="matrix(1,0,0,1,18,2)">
+            <g>
+              <path fill="rgba(255,255,255,1)" d="M -2,-11.5 l 112.4,0 l 0,23 l-112.4 0 z" class="background" opacity="0.75" stroke-width="0" x="-2" y="-11.5" width="112.4" height="23"/>
+            </g>
             <g>
               <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 Modeling Methods
@@ -199,7 +202,10 @@
           <g>
             <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,16,2)">
+          <g fill="none" class="label" transform="matrix(1,0,0,1,18,2)">
+            <g>
+              <path fill="rgba(255,255,255,1)" d="M -2,-11.5 l 82.88,0 l 0,23 l-82.88 0 z" class="background" opacity="0.75" stroke-width="0" x="-2" y="-11.5" width="82.88" height="23"/>
+            </g>
             <g>
               <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 Classification
@@ -207,97 +213,121 @@
             </g>
           </g>
         </g>
-        <g fill="none" transform="matrix(0,1,-1,0,-230,400)">
+        <g fill="none" transform="matrix(1,0,0,1,-230,400)">
           <g>
             <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,0,18)">
+          <g fill="none" class="label" transform="matrix(0,1,-1,0,0,18)">
             <g>
-              <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" dy="-11.5px" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
+              <path fill="rgba(255,255,255,1)" d="M -2,-11.5 l 115.40000000000002,0 l 0,23 l-115.40000000000002 0 z" class="background" opacity="0.75" stroke-width="0" x="-2" y="-11.5" width="115.40000000000002" height="23"/>
+            </g>
+            <g>
+              <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 Logistic regression
               </text>
             </g>
           </g>
         </g>
-        <g fill="none" transform="matrix(0,1,-1,0,-190,400)">
+        <g fill="none" transform="matrix(1,0,0,1,-190,400)">
           <g>
             <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,0,18)">
+          <g fill="none" class="label" transform="matrix(0,1,-1,0,0,18)">
             <g>
-              <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" dy="-11.5px" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
+              <path fill="rgba(255,255,255,1)" d="M -2,-11.5 l 165.20000000000002,0 l 0,23 l-165.20000000000002 0 z" class="background" opacity="0.75" stroke-width="0" x="-2" y="-11.5" width="165.20000000000002" height="23"/>
+            </g>
+            <g>
+              <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 Linear discriminant analysis
               </text>
             </g>
           </g>
         </g>
-        <g fill="none" transform="matrix(0,1,-1,0,-150,400)">
+        <g fill="none" transform="matrix(1,0,0,1,-150,400)">
           <g>
             <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,0,18)">
+          <g fill="none" class="label" transform="matrix(0,1,-1,0,0,18)">
             <g>
-              <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" dy="-11.5px" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
+              <path fill="rgba(255,255,255,1)" d="M -2,-11.5 l 36.8,0 l 0,23 l-36.8 0 z" class="background" opacity="0.75" stroke-width="0" x="-2" y="-11.5" width="36.8" height="23"/>
+            </g>
+            <g>
+              <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 Rules
               </text>
             </g>
           </g>
         </g>
-        <g fill="none" transform="matrix(0,1,-1,0,-109.999992,400)">
+        <g fill="none" transform="matrix(1,0,0,1,-109.999992,400)">
           <g>
             <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,0,18)">
+          <g fill="none" class="label" transform="matrix(0,1,-1,0,0,18)">
             <g>
-              <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" dy="-11.5px" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
+              <path fill="rgba(255,255,255,1)" d="M -2,-11.5 l 87.92,0 l 0,23 l-87.92 0 z" class="background" opacity="0.75" stroke-width="0" x="-2" y="-11.5" width="87.92" height="23"/>
+            </g>
+            <g>
+              <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 Decision trees
               </text>
             </g>
           </g>
         </g>
-        <g fill="none" transform="matrix(0,1,-1,0,-69.999992,400)">
+        <g fill="none" transform="matrix(1,0,0,1,-69.999992,400)">
           <g>
             <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,0,18)">
+          <g fill="none" class="label" transform="matrix(0,1,-1,0,0,18)">
             <g>
-              <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" dy="-11.5px" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
+              <path fill="rgba(255,255,255,1)" d="M -2,-11.5 l 75.67999999999999,0 l 0,23 l-75.67999999999999 0 z" class="background" opacity="0.75" stroke-width="0" x="-2" y="-11.5" width="75.67999999999999" height="23"/>
+            </g>
+            <g>
+              <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 Naive Bayes
               </text>
             </g>
           </g>
         </g>
-        <g fill="none" transform="matrix(0,1,-1,0,-29.999992,400)">
+        <g fill="none" transform="matrix(1,0,0,1,-29.999992,400)">
           <g>
             <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,0,18)">
+          <g fill="none" class="label" transform="matrix(0,1,-1,0,0,18)">
             <g>
-              <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" dy="-11.5px" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
+              <path fill="rgba(255,255,255,1)" d="M -2,-11.5 l 114.91999999999999,0 l 0,23 l-114.91999999999999 0 z" class="background" opacity="0.75" stroke-width="0" x="-2" y="-11.5" width="114.91999999999999" height="23"/>
+            </g>
+            <g>
+              <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 K nearest neighbor
               </text>
             </g>
           </g>
         </g>
-        <g fill="none" transform="matrix(0,1,-1,0,10.000008,400)">
+        <g fill="none" transform="matrix(1,0,0,1,10.000008,400)">
           <g>
             <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,0,18)">
+          <g fill="none" class="label" transform="matrix(0,1,-1,0,0,18)">
             <g>
-              <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" dy="-11.5px" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
+              <path fill="rgba(255,255,255,1)" d="M -2,-11.5 l 166.4,0 l 0,23 l-166.4 0 z" class="background" opacity="0.75" stroke-width="0" x="-2" y="-11.5" width="166.4" height="23"/>
+            </g>
+            <g>
+              <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 Probabilistic neural network
               </text>
             </g>
           </g>
         </g>
-        <g fill="none" transform="matrix(0,1,-1,0,50.000008,400)">
+        <g fill="none" transform="matrix(1,0,0,1,50.000008,400)">
           <g>
             <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,0,18)">
+          <g fill="none" class="label" transform="matrix(0,1,-1,0,0,18)">
             <g>
-              <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" dy="-11.5px" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
+              <path fill="rgba(255,255,255,1)" d="M -2,-11.5 l 143.72000000000003,0 l 0,23 l-143.72000000000003 0 z" class="background" opacity="0.75" stroke-width="0" x="-2" y="-11.5" width="143.72000000000003" height="23"/>
+            </g>
+            <g>
+              <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 Support vector machine
               </text>
             </g>
@@ -307,7 +337,10 @@
           <g>
             <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,16,2)">
+          <g fill="none" class="label" transform="matrix(1,0,0,1,18,2)">
+            <g>
+              <path fill="rgba(255,255,255,1)" d="M -2,-11.5 l 68.96000000000001,0 l 0,23 l-68.96000000000001 0 z" class="background" opacity="0.75" stroke-width="0" x="-2" y="-11.5" width="68.96000000000001" height="23"/>
+            </g>
             <g>
               <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 Consensus
@@ -319,7 +352,10 @@
           <g>
             <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,16,2)">
+          <g fill="none" class="label" transform="matrix(1,0,0,1,18,2)">
+            <g>
+              <path fill="rgba(255,255,255,1)" d="M -2,-11.5 l 100.16000000000001,0 l 0,23 l-100.16000000000001 0 z" class="background" opacity="0.75" stroke-width="0" x="-2" y="-11.5" width="100.16000000000001" height="23"/>
+            </g>
             <g>
               <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 Models diversity
@@ -327,73 +363,91 @@
             </g>
           </g>
         </g>
-        <g fill="none" transform="matrix(0,1,-1,0,100.000008,400)">
+        <g fill="none" transform="matrix(1,0,0,1,100.000008,400)">
           <g>
             <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,0,18)">
+          <g fill="none" class="label" transform="matrix(0,1,-1,0,0,18)">
             <g>
-              <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" dy="-11.5px" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
+              <path fill="rgba(255,255,255,1)" d="M -2,-11.5 l 135.68000000000004,0 l 0,23 l-135.68000000000004 0 z" class="background" opacity="0.75" stroke-width="0" x="-2" y="-11.5" width="135.68000000000004" height="23"/>
+            </g>
+            <g>
+              <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 Different initializations
               </text>
             </g>
           </g>
         </g>
-        <g fill="none" transform="matrix(0,1,-1,0,140,400)">
+        <g fill="none" transform="matrix(1,0,0,1,140,400)">
           <g>
             <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,0,18)">
+          <g fill="none" class="label" transform="matrix(0,1,-1,0,0,18)">
             <g>
-              <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" dy="-11.5px" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
+              <path fill="rgba(255,255,255,1)" d="M -2,-11.5 l 167.12,0 l 0,23 l-167.12 0 z" class="background" opacity="0.75" stroke-width="0" x="-2" y="-11.5" width="167.12" height="23"/>
+            </g>
+            <g>
+              <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 Different parameter choices
               </text>
             </g>
           </g>
         </g>
-        <g fill="none" transform="matrix(0,1,-1,0,180,400)">
+        <g fill="none" transform="matrix(1,0,0,1,180,400)">
           <g>
             <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,0,18)">
+          <g fill="none" class="label" transform="matrix(0,1,-1,0,0,18)">
             <g>
-              <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" dy="-11.5px" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
+              <path fill="rgba(255,255,255,1)" d="M -2,-11.5 l 136.52,0 l 0,23 l-136.52 0 z" class="background" opacity="0.75" stroke-width="0" x="-2" y="-11.5" width="136.52" height="23"/>
+            </g>
+            <g>
+              <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 Different architectures
               </text>
             </g>
           </g>
         </g>
-        <g fill="none" transform="matrix(0,1,-1,0,220,400)">
+        <g fill="none" transform="matrix(1,0,0,1,220,400)">
           <g>
             <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,0,18)">
+          <g fill="none" class="label" transform="matrix(0,1,-1,0,0,18)">
             <g>
-              <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" dy="-11.5px" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
+              <path fill="rgba(255,255,255,1)" d="M -2,-11.5 l 166.88,0 l 0,23 l-166.88 0 z" class="background" opacity="0.75" stroke-width="0" x="-2" y="-11.5" width="166.88" height="23"/>
+            </g>
+            <g>
+              <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 Different modeling methods
               </text>
             </g>
           </g>
         </g>
-        <g fill="none" transform="matrix(0,1,-1,0,260,400)">
+        <g fill="none" transform="matrix(1,0,0,1,260,400)">
           <g>
             <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,0,18)">
+          <g fill="none" class="label" transform="matrix(0,1,-1,0,0,18)">
             <g>
-              <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" dy="-11.5px" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
+              <path fill="rgba(255,255,255,1)" d="M -2,-11.5 l 131.72000000000003,0 l 0,23 l-131.72000000000003 0 z" class="background" opacity="0.75" stroke-width="0" x="-2" y="-11.5" width="131.72000000000003" height="23"/>
+            </g>
+            <g>
+              <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 Different training sets
               </text>
             </g>
           </g>
         </g>
-        <g fill="none" transform="matrix(0,1,-1,0,300,400)">
+        <g fill="none" transform="matrix(1,0,0,1,300,400)">
           <g>
             <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,0,18)">
+          <g fill="none" class="label" transform="matrix(0,1,-1,0,0,18)">
             <g>
-              <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" dy="-11.5px" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
+              <path fill="rgba(255,255,255,1)" d="M -2,-11.5 l 129.2,0 l 0,23 l-129.2 0 z" class="background" opacity="0.75" stroke-width="0" x="-2" y="-11.5" width="129.2" height="23"/>
+            </g>
+            <g>
+              <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 Different feature sets
               </text>
             </g>
@@ -403,7 +457,10 @@
           <g>
             <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,16,2)">
+          <g fill="none" class="label" transform="matrix(1,0,0,1,18,2)">
+            <g>
+              <path fill="rgba(255,255,255,1)" d="M -2,-11.5 l 55.64,0 l 0,23 l-55.64 0 z" class="background" opacity="0.75" stroke-width="0" x="-2" y="-11.5" width="55.64" height="23"/>
+            </g>
             <g>
               <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 Methods
@@ -411,25 +468,31 @@
             </g>
           </g>
         </g>
-        <g fill="none" transform="matrix(0,1,-1,0,350,400)">
+        <g fill="none" transform="matrix(1,0,0,1,350,400)">
           <g>
             <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,0,18)">
+          <g fill="none" class="label" transform="matrix(0,1,-1,0,0,18)">
             <g>
-              <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" dy="-11.5px" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
+              <path fill="rgba(255,255,255,1)" d="M -2,-11.5 l 114.8,0 l 0,23 l-114.8 0 z" class="background" opacity="0.75" stroke-width="0" x="-2" y="-11.5" width="114.8" height="23"/>
+            </g>
+            <g>
+              <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 Classifier selection
               </text>
             </g>
           </g>
         </g>
-        <g fill="none" transform="matrix(0,1,-1,0,390,400)">
+        <g fill="none" transform="matrix(1,0,0,1,390,400)">
           <g>
             <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,0,18)">
+          <g fill="none" class="label" transform="matrix(0,1,-1,0,0,18)">
             <g>
-              <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" dy="-11.5px" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
+              <path fill="rgba(255,255,255,1)" d="M -2,-11.5 l 98,0 l 0,23 l-98 0 z" class="background" opacity="0.75" stroke-width="0" x="-2" y="-11.5" width="98" height="23"/>
+            </g>
+            <g>
+              <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 Classifier fusion
               </text>
             </g>
@@ -439,7 +502,10 @@
           <g>
             <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,16,2)">
+          <g fill="none" class="label" transform="matrix(1,0,0,1,18,2)">
+            <g>
+              <path fill="rgba(255,255,255,1)" d="M -2,-11.5 l 56.48000000000001,0 l 0,23 l-56.48000000000001 0 z" class="background" opacity="0.75" stroke-width="0" x="-2" y="-11.5" width="56.48000000000001" height="23"/>
+            </g>
             <g>
               <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 Common
@@ -447,37 +513,46 @@
             </g>
           </g>
         </g>
-        <g fill="none" transform="matrix(0,1,-1,0,440,400)">
+        <g fill="none" transform="matrix(1,0,0,1,440,400)">
           <g>
             <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,0,18)">
+          <g fill="none" class="label" transform="matrix(0,1,-1,0,0,18)">
             <g>
-              <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" dy="-11.5px" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
+              <path fill="rgba(255,255,255,1)" d="M -2,-11.5 l 52.4,0 l 0,23 l-52.4 0 z" class="background" opacity="0.75" stroke-width="0" x="-2" y="-11.5" width="52.4" height="23"/>
+            </g>
+            <g>
+              <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 Bagging
               </text>
             </g>
           </g>
         </g>
-        <g fill="none" transform="matrix(0,1,-1,0,480,400)">
+        <g fill="none" transform="matrix(1,0,0,1,480,400)">
           <g>
             <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,0,18)">
+          <g fill="none" class="label" transform="matrix(0,1,-1,0,0,18)">
             <g>
-              <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" dy="-11.5px" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
+              <path fill="rgba(255,255,255,1)" d="M -2,-11.5 l 56.239999999999995,0 l 0,23 l-56.239999999999995 0 z" class="background" opacity="0.75" stroke-width="0" x="-2" y="-11.5" width="56.239999999999995" height="23"/>
+            </g>
+            <g>
+              <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 Boosting
               </text>
             </g>
           </g>
         </g>
-        <g fill="none" transform="matrix(0,1,-1,0,520,400)">
+        <g fill="none" transform="matrix(1,0,0,1,520,400)">
           <g>
             <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,0,18)">
+          <g fill="none" class="label" transform="matrix(0,1,-1,0,0,18)">
             <g>
-              <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" dy="-11.5px" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
+              <path fill="rgba(255,255,255,1)" d="M -2,-11.5 l 61.040000000000006,0 l 0,23 l-61.040000000000006 0 z" class="background" opacity="0.75" stroke-width="0" x="-2" y="-11.5" width="61.040000000000006" height="23"/>
+            </g>
+            <g>
+              <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 AdaBoost
               </text>
             </g>
@@ -487,7 +562,10 @@
           <g>
             <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,16,2)">
+          <g fill="none" class="label" transform="matrix(1,0,0,1,18,2)">
+            <g>
+              <path fill="rgba(255,255,255,1)" d="M -2,-11.5 l 69.56,0 l 0,23 l-69.56 0 z" class="background" opacity="0.75" stroke-width="0" x="-2" y="-11.5" width="69.56" height="23"/>
+            </g>
             <g>
               <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 Regression
@@ -495,61 +573,76 @@
             </g>
           </g>
         </g>
-        <g fill="none" transform="matrix(0,1,-1,0,570,400)">
+        <g fill="none" transform="matrix(1,0,0,1,570,400)">
           <g>
             <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,0,18)">
+          <g fill="none" class="label" transform="matrix(0,1,-1,0,0,18)">
             <g>
-              <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" dy="-11.5px" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
+              <path fill="rgba(255,255,255,1)" d="M -2,-11.5 l 151.15999999999994,0 l 0,23 l-151.15999999999994 0 z" class="background" opacity="0.75" stroke-width="0" x="-2" y="-11.5" width="151.15999999999994" height="23"/>
+            </g>
+            <g>
+              <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 Multiple linear regression
               </text>
             </g>
           </g>
         </g>
-        <g fill="none" transform="matrix(0,1,-1,0,610,400)">
+        <g fill="none" transform="matrix(1,0,0,1,610,400)">
           <g>
             <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,0,18)">
+          <g fill="none" class="label" transform="matrix(0,1,-1,0,0,18)">
             <g>
-              <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" dy="-11.5px" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
+              <path fill="rgba(255,255,255,1)" d="M -2,-11.5 l 122.47999999999999,0 l 0,23 l-122.47999999999999 0 z" class="background" opacity="0.75" stroke-width="0" x="-2" y="-11.5" width="122.47999999999999" height="23"/>
+            </g>
+            <g>
+              <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 Partial least squares
               </text>
             </g>
           </g>
         </g>
-        <g fill="none" transform="matrix(0,1,-1,0,650,400)">
+        <g fill="none" transform="matrix(1,0,0,1,650,400)">
           <g>
             <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,0,18)">
+          <g fill="none" class="label" transform="matrix(0,1,-1,0,0,18)">
             <g>
-              <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" dy="-11.5px" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
+              <path fill="rgba(255,255,255,1)" d="M -2,-11.5 l 234.67999999999995,0 l 0,23 l-234.67999999999995 0 z" class="background" opacity="0.75" stroke-width="0" x="-2" y="-11.5" width="234.67999999999995" height="23"/>
+            </g>
+            <g>
+              <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 Multi-layer feed forward neural network
               </text>
             </g>
           </g>
         </g>
-        <g fill="none" transform="matrix(0,1,-1,0,690,400)">
+        <g fill="none" transform="matrix(1,0,0,1,690,400)">
           <g>
             <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,0,18)">
+          <g fill="none" class="label" transform="matrix(0,1,-1,0,0,18)">
             <g>
-              <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" dy="-11.5px" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
+              <path fill="rgba(255,255,255,1)" d="M -2,-11.5 l 203.95999999999998,0 l 0,23 l-203.95999999999998 0 z" class="background" opacity="0.75" stroke-width="0" x="-2" y="-11.5" width="203.95999999999998" height="23"/>
+            </g>
+            <g>
+              <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 General regression neural network
               </text>
             </g>
           </g>
         </g>
-        <g fill="none" transform="matrix(0,1,-1,0,730,400)">
+        <g fill="none" transform="matrix(1,0,0,1,730,400)">
           <g>
             <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="16"/>
           </g>
-          <g fill="none" class="label" transform="matrix(1,0,0,1,0,18)">
+          <g fill="none" class="label" transform="matrix(0,1,-1,0,0,18)">
             <g>
-              <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" dy="-11.5px" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
+              <path fill="rgba(255,255,255,1)" d="M -2,-11.5 l 156.31999999999996,0 l 0,23 l-156.31999999999996 0 z" class="background" opacity="0.75" stroke-width="0" x="-2" y="-11.5" width="156.31999999999996" height="23"/>
+            </g>
+            <g>
+              <text fill="rgba(0,0,0,1)" dominant-baseline="central" paint-order="stroke" dx="0.5" class="text" font-size="12" font-family="system-ui, sans-serif" text-anchor="left" fill-opacity="0.85" font-weight="400">
                 Support vector regression
               </text>
             </g>

--- a/packages/g6/src/animations/executor.ts
+++ b/packages/g6/src/animations/executor.ts
@@ -64,13 +64,13 @@ export const executor: AnimationExecutor = (element, keyframes, options) => {
 
       // x/y -> translate
       if (keyframes.some((keyframe) => Object.keys(keyframe).some((attr) => ['x', 'y', 'z'].includes(attr)))) {
-        const { x = 0, y = 0, z = 0, transform = '' } = shape.attributes || {};
+        const { x = 0, y = 0, z, transform = '' } = shape.attributes || {};
         keyframes.forEach((keyframe) => {
           // @ts-expect-error ignore type error
           keyframe.transform = replaceTranslateInTransform(
-            (keyframe.x as number) || (x as number),
-            (keyframe.y as number) || (y as number),
-            (keyframe.z as number) || (z as number),
+            (keyframe.x as number) ?? (x as number),
+            (keyframe.y as number) ?? (y as number),
+            (keyframe.z as number) ?? (z as number),
             transform,
           );
         });

--- a/packages/g6/src/utils/element.ts
+++ b/packages/g6/src/utils/element.ts
@@ -1,5 +1,5 @@
-import type { AABB, DisplayObject, TextStyleProps } from '@antv/g';
-import { get, isString, set } from '@antv/util';
+import type { AABB, BaseStyleProps, DisplayObject, TextStyleProps } from '@antv/g';
+import { get, isNumber, isString, set } from '@antv/util';
 import { BaseCombo, BaseEdge, BaseNode } from '../elements';
 import type { Combo, Edge, Element, Node, NodePortStyleProps, Placement, Point, TriangleDirection } from '../types';
 import type { NodeLabelStyleProps, Port } from '../types/node';
@@ -465,6 +465,25 @@ export function getDiamondPoints(width: number, height: number): Point[] {
  */
 export function isVisible(element: DisplayObject) {
   return get(element, ['style', 'visibility']) !== 'hidden';
+}
+
+/**
+ * <zh/> 设置元素属性（优化性能）
+ *
+ * <en/> Set element attributes (optimize performance)
+ * @param element - <zh/> 元素 | <en/> element
+ * @param style - <zh/> 样式 | <en/> style
+ */
+export function setAttributes(element: DisplayObject, style: BaseStyleProps) {
+  const { zIndex, transform, transformOrigin, visibility, cursor, clipPath, ...rest } = style;
+  Object.assign(element.attributes, rest);
+
+  if (transform) element.setAttribute('transform', transform);
+  if (isNumber(zIndex)) element.setAttribute('zIndex', zIndex);
+  if (transformOrigin) element.setAttribute('transformOrigin', transformOrigin);
+  if (visibility) element.setAttribute('visibility', visibility);
+  if (cursor) element.setAttribute('cursor', cursor);
+  if (clipPath) element.setAttribute('clipPath', clipPath);
 }
 
 /**

--- a/packages/g6/src/utils/transform.ts
+++ b/packages/g6/src/utils/transform.ts
@@ -1,4 +1,5 @@
 import type { TransformArray } from '@antv/g';
+import { isNumber } from '@antv/util';
 
 /**
  * <zh/> 从 transform 字符串中替换 translate 部分
@@ -8,36 +9,39 @@ import type { TransformArray } from '@antv/g';
  * @param y - <zh/> y | <en/> y
  * @param z - <zh/> z | <en/> z
  * @param transform - <zh/> transform 字符串 | <en/> transform string
- * @returns <zh/> 替换后的 transform 字符串 | <en/> replaced transform string
+ * @returns <zh/> 替换后的 transform 字符串，返回 null 表示无需替换 | <en/> the replaced transform string, return null means no need to replace
  */
 export function replaceTranslateInTransform(
   x: number,
   y: number,
-  z: number,
-  transform: string | TransformArray,
+  z?: number,
+  transform: string | TransformArray = [],
 ): string | TransformArray | null {
+  if (!transform && x === 0 && y === 0 && z === 0) return null;
+
   if (Array.isArray(transform)) {
-    let hasTranslate = false;
+    let translateIndex = -1;
     const newTransform: TransformArray = [];
 
     for (let i = 0; i < transform.length; i++) {
       const t = transform[i];
       if (t[0] === 'translate') {
         if (t[1] === x && t[2] === y) return null;
-        hasTranslate = true;
+        translateIndex = i;
         newTransform.push(['translate', x, y]);
       } else if (t[0] === 'translate3d') {
         if (t[1] === x && t[2] === y && t[3] === z) return null;
-        hasTranslate = true;
-        newTransform.push(['translate3d', x, y, z]);
+        translateIndex = i;
+        newTransform.push(['translate3d', x, y, z ?? 0]);
       } else {
         newTransform.push(t);
       }
     }
 
-    if (!hasTranslate) {
-      newTransform.splice(0, 0, z === 0 ? ['translate', x, y] : ['translate3d', x, y, z]);
+    if (translateIndex === -1) {
+      newTransform.splice(0, 0, isNumber(z) ? ['translate3d', x, y, z ?? 0] : ['translate', x, y]);
     }
+    if (newTransform.length === 0) return null;
     return newTransform;
   }
 


### PR DESCRIPTION
- [x] 减少多余的 `transform` 更新以提升性能
- [x] 避免使用 G 样式设置 API 以优化性能

> 对于大部分 G6 样式，直接拷贝至内置 attributes 对象性能会比 setAttribute API 更好

优化结果：（以 perf20000Elements 用例为基准）
首屏渲染时长
优化前：930 ms
优化后：900 ms
提升约：3.2%
