### PR TITLE
fix(background): avoid to cover the other plugin's dom, eg grid-line

### DIFF
--- a/packages/g6/src/plugins/background/index.ts
+++ b/packages/g6/src/plugins/background/index.ts
@@ -24,6 +24,7 @@ export class Background extends BasePlugin<BackgroundOptions> {
   static defaultOptions: Partial<BackgroundOptions> = {
     transition: 'background 0.5s',
     backgroundSize: 'cover',
+    zIndex: '-1', // aviod to cover the other plugin's dom, eg: grid-line.
   };
 
   private $element: HTMLElement = createPluginContainer('background');


### PR DESCRIPTION
### Background
There is a situation that if `grid-line` behind `background` plugin, the `background` plugin's dom will cover the `grid-line` plugin's dom and then the `grid-line` will not be seen.
![image](https://github.com/user-attachments/assets/af1fd9b8-9753-44d9-bd3a-4d7e61aa8b53)

### Fix
This PR will set `zIndex` attr of `background` plugin's dom to `-1` so we can make sure that the `background`'s dom is at the back of same level
![image](https://github.com/user-attachments/assets/dc157c04-35ef-4c1b-b207-408e3f254860)
