### PR TITLE
fix: packages/g6-extension-react/README.md Usage description

### DIFF
--- a/packages/g6-extension-react/README.md
+++ b/packages/g6-extension-react/README.md
@@ -55,7 +55,7 @@ const graph = new Graph({
   node: {
     type: 'react',
     style: {
-      component: () => <GNode />,
+      component: () => <ReactNode />,
     },
   },
 });
@@ -69,7 +69,7 @@ const graph = new Graph({
   node: {
     type: 'g',
     style: {
-      component: () => <ReactNode />,
+      component: () => <GNode />,
     },
   },
 });


### PR DESCRIPTION

Simple fix for `packages/g6-extension-react/README.md`:

![image](https://github.com/user-attachments/assets/f6b1b9e5-3528-475c-b804-242196bad70c)
