### PR TITLE
refactor(behaviors): optimize drag-element behavior

### DIFF
--- a/packages/g6/__tests__/bugs/behaviors-click-select-drag-node.spec.ts
+++ b/packages/g6/__tests__/bugs/behaviors-click-select-drag-node.spec.ts
@@ -1,0 +1,64 @@
+import { CommonEvent, NodeEvent } from '@/src';
+import { createGraph } from '@@/utils';
+
+describe('behavior drag-node with click select', () => {
+  const createDemoGraph = async () => {
+    const graph = createGraph({
+      data: {
+        nodes: [
+          { id: 'node-1', style: { x: 100, y: 100 } },
+          { id: 'node-2', combo: 'combo-1', style: { x: 200, y: 100 } },
+          { id: 'node-3', style: { x: 100, y: 200 } },
+          { id: 'node-4', combo: 'combo-1', style: { x: 200, y: 200 } },
+        ],
+        edges: [
+          { source: 'node-1', target: 'node-2' },
+          { source: 'node-2', target: 'node-4' },
+          { source: 'node-1', target: 'node-3' },
+          { source: 'node-3', target: 'node-4' },
+        ],
+        combos: [{ id: 'combo-1' }],
+      },
+      node: { style: { size: 20 } },
+      edge: {
+        style: { endArrow: true },
+      },
+      behaviors: [{ type: 'drag-element' }, { type: 'click-select', multiple: true }],
+    });
+    await graph.render();
+    return graph;
+  };
+
+  it('drag unselected node', async () => {
+    const graph = await createDemoGraph();
+
+    graph.emit(NodeEvent.CLICK, { target: { id: 'node-1' }, targetType: 'node' });
+
+    await expect(graph).toMatchSnapshot(__filename, 'click-node-1');
+
+    // drag node-2
+    graph.emit(NodeEvent.DRAG_START, { target: { id: 'node-2' }, targetType: 'node' });
+    graph.emit(NodeEvent.DRAG, { dx: 20, dy: 20 });
+    graph.emit(NodeEvent.DRAG_END);
+
+    await expect(graph).toMatchSnapshot(__filename, 'drag-node-2');
+  });
+
+  it('drag selected node', async () => {
+    const graph = await createDemoGraph();
+
+    graph.emit(CommonEvent.KEY_DOWN, { key: 'shift' });
+    graph.emit(NodeEvent.CLICK, { target: { id: 'node-1' }, targetType: 'node' });
+    graph.emit(NodeEvent.CLICK, { target: { id: 'node-2' }, targetType: 'node' });
+    graph.emit(CommonEvent.KEY_UP, { key: 'shift' });
+
+    await expect(graph).toMatchSnapshot(__filename, 'click-node-1-node-2');
+
+    // drag node-2
+    graph.emit(NodeEvent.DRAG_START, { target: { id: 'node-2' }, targetType: 'node' });
+    graph.emit(NodeEvent.DRAG, { dx: 20, dy: 20 });
+    graph.emit(NodeEvent.DRAG_END);
+
+    await expect(graph).toMatchSnapshot(__filename, 'drag-node-1-node-2');
+  });
+});

--- a/packages/g6/__tests__/main.ts
+++ b/packages/g6/__tests__/main.ts
@@ -1,8 +1,12 @@
 import type { Controller } from 'lil-gui';
 import GUI from 'lil-gui';
+import { ComboEvent, CommonEvent, EdgeEvent, NodeEvent } from '../src';
 import '../src/preset';
 import * as demos from './demos';
 import { createGraphCanvas } from './utils';
+
+// inject
+Object.assign(window, { NodeEvent, EdgeEvent, ComboEvent, CommonEvent });
 
 type Options = {
   Search: string;

--- a/packages/g6/__tests__/snapshots/bugs/behaviors-click-select-drag-node/click-node-1-node-2.svg
+++ b/packages/g6/__tests__/snapshots/bugs/behaviors-click-select-drag-node/click-node-1-node-2.svg
@@ -1,0 +1,76 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
+  <defs/>
+  <g >
+    <g fill="none">
+      <g fill="none" class="elements">
+        <g fill="none">
+          <g>
+            <path fill="none" d="M 100,110 L 100,184" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
+            <path fill="none" d="M 100,110 L 100,184" class="key" stroke-width="3" stroke="transparent"/>
+            <g transform="matrix(0,-1,1,0,100,184)">
+              <path fill="rgba(153,173,209,1)" d="M -5,0 L 5,-5 L 3,0 L 5,5 Z" stroke="rgba(153,173,209,1)" stroke-dasharray="0,0" stroke-linejoin="round" stroke-width="1"/>
+            </g>
+          </g>
+        </g>
+        <g fill="none" transform="matrix(1,0,0,1,100,100)">
+          <g>
+            <circle fill="none" class="halo" stroke-width="24" stroke="rgba(23,131,255,1)" stroke-opacity="0.25" r="10" stroke-dasharray="0,0" pointer-events="none"/>
+          </g>
+          <g>
+            <circle fill="rgba(23,131,255,1)" class="key" stroke-width="4" stroke="rgba(0,0,0,1)" r="10"/>
+          </g>
+        </g>
+        <g fill="none" transform="matrix(1,0,0,1,100,200)">
+          <g>
+            <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="10"/>
+          </g>
+        </g>
+        <g fill="none" transform="matrix(1,0,0,1,200,150)">
+          <g>
+            <circle fill="rgba(153,173,209,1)" class="key" stroke-dasharray="0,0" stroke-width="1" fill-opacity="0.04" stroke="rgba(153,173,209,1)" r="72.80109889280519"/>
+          </g>
+        </g>
+        <g fill="none">
+          <g>
+            <path fill="none" d="M 110,100 L 184,100" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
+            <path fill="none" d="M 110,100 L 184,100" class="key" stroke-width="3" stroke="transparent"/>
+            <g transform="matrix(-1,0,-0,-1,184,100)">
+              <path fill="rgba(153,173,209,1)" d="M -5,0 L 5,-5 L 3,0 L 5,5 Z" stroke="rgba(153,173,209,1)" stroke-dasharray="0,0" stroke-linejoin="round" stroke-width="1"/>
+            </g>
+          </g>
+        </g>
+        <g fill="none">
+          <g>
+            <path fill="none" d="M 200,110 L 200,184" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
+            <path fill="none" d="M 200,110 L 200,184" class="key" stroke-width="3" stroke="transparent"/>
+            <g transform="matrix(0,-1,1,0,200,184)">
+              <path fill="rgba(153,173,209,1)" d="M -5,0 L 5,-5 L 3,0 L 5,5 Z" stroke="rgba(153,173,209,1)" stroke-dasharray="0,0" stroke-linejoin="round" stroke-width="1"/>
+            </g>
+          </g>
+        </g>
+        <g fill="none">
+          <g>
+            <path fill="none" d="M 110,200 L 184,200" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
+            <path fill="none" d="M 110,200 L 184,200" class="key" stroke-width="3" stroke="transparent"/>
+            <g transform="matrix(-1,0,-0,-1,184,200)">
+              <path fill="rgba(153,173,209,1)" d="M -5,0 L 5,-5 L 3,0 L 5,5 Z" stroke="rgba(153,173,209,1)" stroke-dasharray="0,0" stroke-linejoin="round" stroke-width="1"/>
+            </g>
+          </g>
+        </g>
+        <g fill="none" transform="matrix(1,0,0,1,200,100)">
+          <g>
+            <circle fill="none" class="halo" stroke-width="24" stroke="rgba(23,131,255,1)" stroke-opacity="0.25" r="10" stroke-dasharray="0,0" pointer-events="none"/>
+          </g>
+          <g>
+            <circle fill="rgba(23,131,255,1)" class="key" stroke-width="4" stroke="rgba(0,0,0,1)" r="10"/>
+          </g>
+        </g>
+        <g fill="none" transform="matrix(1,0,0,1,200,200)">
+          <g>
+            <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="10"/>
+          </g>
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/packages/g6/__tests__/snapshots/bugs/behaviors-click-select-drag-node/click-node-1.svg
+++ b/packages/g6/__tests__/snapshots/bugs/behaviors-click-select-drag-node/click-node-1.svg
@@ -1,0 +1,73 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
+  <defs/>
+  <g >
+    <g fill="none">
+      <g fill="none" class="elements">
+        <g fill="none">
+          <g>
+            <path fill="none" d="M 100,110 L 100,184" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
+            <path fill="none" d="M 100,110 L 100,184" class="key" stroke-width="3" stroke="transparent"/>
+            <g transform="matrix(0,-1,1,0,100,184)">
+              <path fill="rgba(153,173,209,1)" d="M -5,0 L 5,-5 L 3,0 L 5,5 Z" stroke="rgba(153,173,209,1)" stroke-dasharray="0,0" stroke-linejoin="round" stroke-width="1"/>
+            </g>
+          </g>
+        </g>
+        <g fill="none" transform="matrix(1,0,0,1,100,100)">
+          <g>
+            <circle fill="none" class="halo" stroke-width="24" stroke="rgba(23,131,255,1)" stroke-opacity="0.25" r="10" stroke-dasharray="0,0" pointer-events="none"/>
+          </g>
+          <g>
+            <circle fill="rgba(23,131,255,1)" class="key" stroke-width="4" stroke="rgba(0,0,0,1)" r="10"/>
+          </g>
+        </g>
+        <g fill="none" transform="matrix(1,0,0,1,100,200)">
+          <g>
+            <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="10"/>
+          </g>
+        </g>
+        <g fill="none" transform="matrix(1,0,0,1,200,150)">
+          <g>
+            <circle fill="rgba(153,173,209,1)" class="key" stroke-dasharray="0,0" stroke-width="1" fill-opacity="0.04" stroke="rgba(153,173,209,1)" r="72.80109889280519"/>
+          </g>
+        </g>
+        <g fill="none">
+          <g>
+            <path fill="none" d="M 110,100 L 184,100" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
+            <path fill="none" d="M 110,100 L 184,100" class="key" stroke-width="3" stroke="transparent"/>
+            <g transform="matrix(-1,0,-0,-1,184,100)">
+              <path fill="rgba(153,173,209,1)" d="M -5,0 L 5,-5 L 3,0 L 5,5 Z" stroke="rgba(153,173,209,1)" stroke-dasharray="0,0" stroke-linejoin="round" stroke-width="1"/>
+            </g>
+          </g>
+        </g>
+        <g fill="none">
+          <g>
+            <path fill="none" d="M 200,110 L 200,184" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
+            <path fill="none" d="M 200,110 L 200,184" class="key" stroke-width="3" stroke="transparent"/>
+            <g transform="matrix(0,-1,1,0,200,184)">
+              <path fill="rgba(153,173,209,1)" d="M -5,0 L 5,-5 L 3,0 L 5,5 Z" stroke="rgba(153,173,209,1)" stroke-dasharray="0,0" stroke-linejoin="round" stroke-width="1"/>
+            </g>
+          </g>
+        </g>
+        <g fill="none">
+          <g>
+            <path fill="none" d="M 110,200 L 184,200" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
+            <path fill="none" d="M 110,200 L 184,200" class="key" stroke-width="3" stroke="transparent"/>
+            <g transform="matrix(-1,0,-0,-1,184,200)">
+              <path fill="rgba(153,173,209,1)" d="M -5,0 L 5,-5 L 3,0 L 5,5 Z" stroke="rgba(153,173,209,1)" stroke-dasharray="0,0" stroke-linejoin="round" stroke-width="1"/>
+            </g>
+          </g>
+        </g>
+        <g fill="none" transform="matrix(1,0,0,1,200,100)">
+          <g>
+            <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="10"/>
+          </g>
+        </g>
+        <g fill="none" transform="matrix(1,0,0,1,200,200)">
+          <g>
+            <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="10"/>
+          </g>
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/packages/g6/__tests__/snapshots/bugs/behaviors-click-select-drag-node/drag-node-1-node-2.svg
+++ b/packages/g6/__tests__/snapshots/bugs/behaviors-click-select-drag-node/drag-node-1-node-2.svg
@@ -1,0 +1,76 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
+  <defs/>
+  <g >
+    <g fill="none">
+      <g fill="none" class="elements">
+        <g fill="none">
+          <g>
+            <path fill="none" d="M 117.57464374963666,129.70142500145332 L 103.88057000058133,184.47771999767468" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
+            <path fill="none" d="M 100,110 L 100,184" class="key" stroke-width="3" stroke="transparent"/>
+            <g transform="matrix(0.242536,-0.970142,0.970142,0.242536,103.880569,184.477722)">
+              <path fill="rgba(153,173,209,1)" d="M -5,0 L 5,-5 L 3,0 L 5,5 Z" stroke="rgba(153,173,209,1)" stroke-dasharray="0,0" stroke-linejoin="round" stroke-width="1"/>
+            </g>
+          </g>
+        </g>
+        <g fill="none" transform="matrix(1,0,0,1,100,200)">
+          <g>
+            <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="10"/>
+          </g>
+        </g>
+        <g fill="none" transform="matrix(1,0,0,1,210,160)">
+          <g>
+            <circle fill="rgba(153,173,209,1)" class="key" stroke-dasharray="0,0" stroke-width="1" fill-opacity="0.04" stroke="rgba(153,173,209,1)" r="67.08203932499369"/>
+          </g>
+        </g>
+        <g fill="none">
+          <g>
+            <path fill="none" d="M 130,120 L 204,120" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
+            <path fill="none" d="M 110,100 L 184,100" class="key" stroke-width="3" stroke="transparent"/>
+            <g transform="matrix(-1,0,-0,-1,204,120)">
+              <path fill="rgba(153,173,209,1)" d="M -5,0 L 5,-5 L 3,0 L 5,5 Z" stroke="rgba(153,173,209,1)" stroke-dasharray="0,0" stroke-linejoin="round" stroke-width="1"/>
+            </g>
+          </g>
+        </g>
+        <g fill="none">
+          <g>
+            <path fill="none" d="M 217.57464374963666,129.70142500145332 L 203.88057000058134,184.47771999767468" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
+            <path fill="none" d="M 200,110 L 200,184" class="key" stroke-width="3" stroke="transparent"/>
+            <g transform="matrix(0.242536,-0.970142,0.970142,0.242536,203.880569,184.477722)">
+              <path fill="rgba(153,173,209,1)" d="M -5,0 L 5,-5 L 3,0 L 5,5 Z" stroke="rgba(153,173,209,1)" stroke-dasharray="0,0" stroke-linejoin="round" stroke-width="1"/>
+            </g>
+          </g>
+        </g>
+        <g fill="none">
+          <g>
+            <path fill="none" d="M 110,200 L 184,200" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
+            <path fill="none" d="M 110,200 L 184,200" class="key" stroke-width="3" stroke="transparent"/>
+            <g transform="matrix(-1,0,-0,-1,184,200)">
+              <path fill="rgba(153,173,209,1)" d="M -5,0 L 5,-5 L 3,0 L 5,5 Z" stroke="rgba(153,173,209,1)" stroke-dasharray="0,0" stroke-linejoin="round" stroke-width="1"/>
+            </g>
+          </g>
+        </g>
+        <g fill="none" transform="matrix(1,0,0,1,200,200)">
+          <g>
+            <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="10"/>
+          </g>
+        </g>
+        <g fill="none" transform="matrix(1,0,0,1,120,120)">
+          <g>
+            <circle fill="none" class="halo" stroke-width="24" stroke="rgba(23,131,255,1)" stroke-opacity="0.25" r="10" stroke-dasharray="0,0" pointer-events="none"/>
+          </g>
+          <g>
+            <circle fill="rgba(23,131,255,1)" class="key" stroke-width="4" stroke="rgba(0,0,0,1)" r="10"/>
+          </g>
+        </g>
+        <g fill="none" transform="matrix(1,0,0,1,220,120)">
+          <g>
+            <circle fill="none" class="halo" stroke-width="24" stroke="rgba(23,131,255,1)" stroke-opacity="0.25" r="10" stroke-dasharray="0,0" pointer-events="none"/>
+          </g>
+          <g>
+            <circle fill="rgba(23,131,255,1)" class="key" stroke-width="4" stroke="rgba(0,0,0,1)" r="10"/>
+          </g>
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/packages/g6/__tests__/snapshots/bugs/behaviors-click-select-drag-node/drag-node-2.svg
+++ b/packages/g6/__tests__/snapshots/bugs/behaviors-click-select-drag-node/drag-node-2.svg
@@ -1,0 +1,73 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="background: transparent; outline: none;" color-interpolation-filters="sRGB" tabindex="1">
+  <defs/>
+  <g >
+    <g fill="none">
+      <g fill="none" class="elements">
+        <g fill="none">
+          <g>
+            <path fill="none" d="M 100,110 L 100,184" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
+            <path fill="none" d="M 100,110 L 100,184" class="key" stroke-width="3" stroke="transparent"/>
+            <g transform="matrix(0,-1,1,0,100,184)">
+              <path fill="rgba(153,173,209,1)" d="M -5,0 L 5,-5 L 3,0 L 5,5 Z" stroke="rgba(153,173,209,1)" stroke-dasharray="0,0" stroke-linejoin="round" stroke-width="1"/>
+            </g>
+          </g>
+        </g>
+        <g fill="none" transform="matrix(1,0,0,1,100,100)">
+          <g>
+            <circle fill="none" class="halo" stroke-width="24" stroke="rgba(23,131,255,1)" stroke-opacity="0.25" r="10" stroke-dasharray="0,0" pointer-events="none"/>
+          </g>
+          <g>
+            <circle fill="rgba(23,131,255,1)" class="key" stroke-width="4" stroke="rgba(0,0,0,1)" r="10"/>
+          </g>
+        </g>
+        <g fill="none" transform="matrix(1,0,0,1,100,200)">
+          <g>
+            <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="10"/>
+          </g>
+        </g>
+        <g fill="none" transform="matrix(1,0,0,1,210,160)">
+          <g>
+            <circle fill="rgba(153,173,209,1)" class="key" stroke-dasharray="0,0" stroke-width="1" fill-opacity="0.04" stroke="rgba(153,173,209,1)" r="67.08203932499369"/>
+          </g>
+        </g>
+        <g fill="none">
+          <g>
+            <path fill="none" d="M 109.86393923832144,101.64398987305357 L 204.2176972186857,117.36961620311429" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
+            <path fill="none" d="M 110,100 L 184,100" class="key" stroke-width="3" stroke="transparent"/>
+            <g transform="matrix(-0.986394,-0.164399,0.164399,-0.986394,204.217697,117.369614)">
+              <path fill="rgba(153,173,209,1)" d="M -5,0 L 5,-5 L 3,0 L 5,5 Z" stroke="rgba(153,173,209,1)" stroke-dasharray="0,0" stroke-linejoin="round" stroke-width="1"/>
+            </g>
+          </g>
+        </g>
+        <g fill="none">
+          <g>
+            <path fill="none" d="M 217.57464374963666,129.70142500145332 L 203.88057000058134,184.47771999767468" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
+            <path fill="none" d="M 200,110 L 200,184" class="key" stroke-width="3" stroke="transparent"/>
+            <g transform="matrix(0.242536,-0.970142,0.970142,0.242536,203.880569,184.477722)">
+              <path fill="rgba(153,173,209,1)" d="M -5,0 L 5,-5 L 3,0 L 5,5 Z" stroke="rgba(153,173,209,1)" stroke-dasharray="0,0" stroke-linejoin="round" stroke-width="1"/>
+            </g>
+          </g>
+        </g>
+        <g fill="none">
+          <g>
+            <path fill="none" d="M 110,200 L 184,200" class="key" stroke-width="1" stroke="rgba(153,173,209,1)"/>
+            <path fill="none" d="M 110,200 L 184,200" class="key" stroke-width="3" stroke="transparent"/>
+            <g transform="matrix(-1,0,-0,-1,184,200)">
+              <path fill="rgba(153,173,209,1)" d="M -5,0 L 5,-5 L 3,0 L 5,5 Z" stroke="rgba(153,173,209,1)" stroke-dasharray="0,0" stroke-linejoin="round" stroke-width="1"/>
+            </g>
+          </g>
+        </g>
+        <g fill="none" transform="matrix(1,0,0,1,200,200)">
+          <g>
+            <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="10"/>
+          </g>
+        </g>
+        <g fill="none" transform="matrix(1,0,0,1,220,120)">
+          <g>
+            <circle fill="rgba(23,131,255,1)" class="key" stroke-width="0" stroke="rgba(0,0,0,1)" r="10"/>
+          </g>
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/packages/g6/src/behaviors/drag-element.ts
+++ b/packages/g6/src/behaviors/drag-element.ts
@@ -242,11 +242,18 @@ export class DragElement extends BaseBehavior<DragElementOptions> {
     this.enable = this.validate(event);
     if (!this.enable) return;
 
-    const { batch, canvas } = this.context;
+    const { batch, canvas, graph } = this.context;
     canvas.setCursor(this.options!.cursor?.grabbing || 'grabbing');
     this.isDragging = true;
     batch!.startBatch();
-    this.target = this.getSelectedNodeIDs([event.target.id]);
+
+    // 如果当前节点是选中状态，则查询出画布中所有选中的节点，否则只拖拽当前节点
+    // If the current node is selected, query all selected nodes in the canvas, otherwise only drag the current node
+    const id = event.target.id;
+    const states = graph.getElementState(id);
+    if (states.includes(this.options.state)) this.target = this.getSelectedNodeIDs([id]);
+    else this.target = [id];
+
     this.hideEdge();
     this.context.graph.frontElement(this.target);
     if (this.options.shadow) this.createShadow(this.target);


### PR DESCRIPTION
- [x] 优化 `DragElement` 交互

当启用 `ClickSelect` 时，如果当前拖拽的节点未被选中，则不会同时拖拽其他选中节点。

![Dec-12-2024 17-32-43](https://github.com/user-attachments/assets/216c0235-83fa-4d51-96db-de93d0bd2c4e)

---

- [x] Optimize the `DragElement` interaction

When `ClickSelect` is enabled, if the currently dragged node is not selected, other selected nodes will not be dragged simultaneously. 