### PR TITLE
Revert "feat: upgrade hull.js"

### DIFF
--- a/packages/g6-extension-3d/package.json
+++ b/packages/g6-extension-3d/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antv/g6-extension-3d",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "3D extension for G6",
   "keywords": [
     "antv",

--- a/packages/g6-extension-react/package.json
+++ b/packages/g6-extension-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antv/g6-extension-react",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "Using React Component to Define Your G6 Graph Node",
   "keywords": [
     "antv",

--- a/packages/g6-ssr/package.json
+++ b/packages/g6-ssr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antv/g6-ssr",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Support SSR for G6",
   "keywords": [
     "antv",

--- a/packages/g6/package.json
+++ b/packages/g6/package.json
@@ -68,7 +68,7 @@
     "@antv/layout": "1.2.14-beta.9",
     "@antv/util": "^3.3.10",
     "bubblesets-js": "^2.3.4",
-    "hull.js": "github:andriiheonia/hull#semver:^1.0.10"
+    "hull.js": "^1.0.6"
   },
   "devDependencies": {
     "@antv/g-svg": "^2.0.27",

--- a/packages/g6/package.json
+++ b/packages/g6/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antv/g6",
-  "version": "5.0.36",
+  "version": "5.0.37",
   "description": "A Graph Visualization Framework in JavaScript",
   "keywords": [
     "antv",

--- a/packages/g6/src/version.ts
+++ b/packages/g6/src/version.ts
@@ -1,1 +1,1 @@
-export const version = '5.0.36';
+export const version = '5.0.37';


### PR DESCRIPTION
Revert https://github.com/antvis/G6/pull/6609. 
For security reasons, installing dependencies from GitHub isn't supported
