### PR TITLE
fix: fix new node invisible after invoke graph.clear

### DIFF
--- a/packages/g6/__tests__/bugs/graph-draw-after-clear.spec.ts
+++ b/packages/g6/__tests__/bugs/graph-draw-after-clear.spec.ts
@@ -1,0 +1,17 @@
+import { elementEdgeLine } from '@@/demos';
+import { createDemoGraph, sleep } from '@@/utils';
+
+it('graph draw after clear', async () => {
+  const graph = await createDemoGraph(elementEdgeLine);
+
+  const data = graph.getData();
+
+  await graph.clear();
+
+  await sleep(200);
+
+  graph.addData(data);
+  await graph.draw();
+
+  await expect(graph).toMatchSnapshot(__filename);
+});

--- a/packages/g6/__tests__/snapshots/bugs/graph-draw-after-clear/default.svg
+++ b/packages/g6/__tests__/snapshots/bugs/graph-draw-after-clear/default.svg
@@ -1,0 +1,254 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" color-interpolation-filters="sRGB" style="background: transparent; outline: none;" tabindex="1">
+  <g>
+    <g fill="none">
+      <g fill="none" class="elements">
+        <g fill="none">
+          <g>
+            <path fill="none" stroke="rgba(153,173,209,1)" stroke-dasharray="0,0" stroke-opacity="0.15" stroke-width="12" d="M 260.876537756464,238.26539619619766 L 388.6758609251766,100.38379661386094" class="halo" pointer-events="none"/>
+            <path fill="none" stroke="transparent" stroke-dasharray="0,0" stroke-opacity="0.15" stroke-width="14" d="M 16,0 L 16,0" class="halo" pointer-events="none"/>
+          </g>
+          <g>
+            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="M 260.876537756464,238.26539619619766 L 384.5971592665026,104.78427304028682" class="key"/>
+            <path fill="none" stroke="transparent" stroke-width="3" d="M 16,0 L 16,0" class="key"/>
+            <g transform="matrix(-0.679784,0.733413,-0.733413,-0.679784,384.597168,104.784271)">
+              <path fill="rgba(153,173,209,1)" stroke="rgba(153,173,209,1)" stroke-dasharray="0,0" stroke-linejoin="round" stroke-width="1" d="M -5,0 L 5,-5 L 3,0 L 5,5 Z"/>
+            </g>
+          </g>
+          <g fill="none" class="label" transform="matrix(0.679790,-0.733407,0.733407,0.679790,327.495331,166.390976)">
+            <g>
+              <path width="61.96" height="23" x="-30.48" y="-11.5" fill="rgba(255,255,255,1)" stroke-width="0" d="M -30.48,-11.5 l 61.96,0 l 0,23 l-61.96 0 z" class="background" opacity="0.75"/>
+            </g>
+            <g>
+              <text fill="rgba(0,0,0,1)" class="text" dominant-baseline="central" dx="0.5" font-family="system-ui, sans-serif" font-size="12" font-weight="400" paint-order="stroke" text-anchor="middle">line-active</text>
+            </g>
+          </g>
+          <g fill="none" class="badge" transform="matrix(0.679790,-0.733407,0.733407,0.679790,356.712738,134.869156)">
+            <g fill="none" class="label">
+              <g>
+                <path width="12" height="12" x="-5.5" y="-6" fill="rgba(153,173,209,1)" stroke-width="0" d="M 0.5,-6 l 0,0 a 6,6,0,0,1,6,6 l 0,0 a 6,6,0,0,1,-6,6 l 0,0 a 6,6,0,0,1,-6,-6 l 0,0 a 6,6,0,0,1,6,-6 z" class="background"/>
+              </g>
+              <g>
+                <text fill="rgba(255,255,255,1)" class="text" dominant-baseline="central" dx="0.5" font-family="iconfont" font-size="8" paint-order="stroke" text-anchor="middle"></text>
+              </g>
+            </g>
+          </g>
+        </g>
+        <g fill="none">
+          <g>
+            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="3" d="M 242.20076458273422,236.02960534179272 L 153.48446200440452,77.1163666296444" class="key"/>
+            <path fill="none" stroke="transparent" stroke-width="5" d="M 16,0 L 16,0" class="key"/>
+            <g transform="matrix(0.487452,0.873150,-0.873150,0.487452,153.484467,77.116364)">
+              <path fill="rgba(153,173,209,1)" stroke="rgba(153,173,209,1)" stroke-dasharray="0,0" stroke-linejoin="round" stroke-width="1" d="M -5,0 L 5,-5 L 3,0 L 5,5 Z"/>
+            </g>
+          </g>
+          <g fill="none" class="label" transform="matrix(0.487446,0.873153,-0.873153,0.487446,194.430466,150.460922)">
+            <g>
+              <path width="77.56" height="23" x="-38.28" y="-11.5" fill="rgba(255,255,255,1)" stroke-width="0" d="M -38.28,-11.5 l 77.56,0 l 0,23 l-77.56 0 z" class="background" opacity="0.75"/>
+            </g>
+            <g>
+              <text fill="rgba(0,0,0,1)" class="text" dominant-baseline="central" dx="0.5" font-family="system-ui, sans-serif" font-size="12" font-weight="bold" paint-order="stroke" text-anchor="middle">line-highlight</text>
+            </g>
+          </g>
+          <g fill="none" class="badge" transform="matrix(0.487446,0.873153,-0.873153,0.487446,169.677948,106.122208)">
+            <g fill="none" class="label">
+              <g>
+                <path width="12" height="12" x="-5.5" y="-6" fill="rgba(153,173,209,1)" stroke-width="0" d="M 0.5,-6 l 0,0 a 6,6,0,0,1,6,6 l 0,0 a 6,6,0,0,1,-6,6 l 0,0 a 6,6,0,0,1,-6,-6 l 0,0 a 6,6,0,0,1,6,-6 z" class="background"/>
+              </g>
+              <g>
+                <text fill="rgba(255,255,255,1)" class="text" dominant-baseline="central" dx="0.5" font-family="iconfont" font-size="8" paint-order="stroke" text-anchor="middle"></text>
+              </g>
+            </g>
+          </g>
+        </g>
+        <g fill="none">
+          <g>
+            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="M 234.3033744233815,253.1009588045387 L 55.75425833069224,288.37436523750927" class="key"/>
+            <path fill="none" stroke="transparent" stroke-width="3" d="M 234.3033744233815,253.1009588045387 L 55.75425833069224,288.37436523750927" class="key"/>
+            <g transform="matrix(0.981039,-0.193810,0.193810,0.981039,55.754257,288.374359)">
+              <path fill="rgba(153,173,209,1)" stroke="rgba(153,173,209,1)" stroke-dasharray="0,0" stroke-linejoin="round" stroke-width="1" d="M -5,0 L 5,-5 L 3,0 L 5,5 Z"/>
+            </g>
+          </g>
+          <g fill="none" class="label" transform="matrix(0.981040,-0.193804,0.193804,0.981040,138.161530,272.094299)">
+            <g>
+              <path width="67.72" height="23" x="-33.36" y="-11.5" fill="rgba(255,255,255,1)" stroke-width="0" d="M -33.36,-11.5 l 67.72,0 l 0,23 l-67.72 0 z" class="background" opacity="0.75"/>
+            </g>
+            <g>
+              <text fill="rgba(0,0,0,1)" class="text" dominant-baseline="central" dx="0.5" font-family="system-ui, sans-serif" font-size="12" font-weight="400" paint-order="stroke" text-anchor="middle">line-default</text>
+            </g>
+          </g>
+          <g fill="none" class="badge" transform="matrix(0.981040,-0.193804,0.193804,0.981040,99.057266,279.819336)">
+            <g fill="none" class="label">
+              <g>
+                <path width="12" height="12" x="-5.5" y="-6" fill="rgba(153,173,209,1)" stroke-width="0" d="M 0.5,-6 l 0,0 a 6,6,0,0,1,6,6 l 0,0 a 6,6,0,0,1,-6,6 l 0,0 a 6,6,0,0,1,-6,-6 l 0,0 a 6,6,0,0,1,6,-6 z" class="background"/>
+              </g>
+              <g>
+                <text fill="rgba(255,255,255,1)" class="text" dominant-baseline="central" dx="0.5" font-family="iconfont" font-size="8" paint-order="stroke" text-anchor="middle"></text>
+              </g>
+            </g>
+          </g>
+        </g>
+        <g fill="none">
+          <g>
+            <path fill="none" stroke="rgba(153,173,209,1)" stroke-dasharray="0,0" stroke-opacity="0.15" stroke-width="12" d="M 260.876537756464,238.26539619619766 L 388.6758609251766,100.38379661386094" class="halo" pointer-events="none"/>
+            <path fill="none" stroke="transparent" stroke-dasharray="0,0" stroke-opacity="0.15" stroke-width="14" d="M 260.876537756464,238.26539619619766 L 388.6758609251766,100.38379661386094" class="halo" pointer-events="none"/>
+          </g>
+          <g>
+            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="M 260.876537756464,238.26539619619766 L 384.5971592665026,104.78427304028682" class="key"/>
+            <path fill="none" stroke="transparent" stroke-width="3" d="M 260.876537756464,238.26539619619766 L 384.5971592665026,104.78427304028682" class="key"/>
+            <g transform="matrix(-0.679784,0.733413,-0.733413,-0.679784,384.597168,104.784271)">
+              <path fill="rgba(153,173,209,1)" stroke="rgba(153,173,209,1)" stroke-dasharray="0,0" stroke-linejoin="round" stroke-width="1" d="M -5,0 L 5,-5 L 3,0 L 5,5 Z"/>
+            </g>
+          </g>
+          <g fill="none" class="label" transform="matrix(0.679790,-0.733407,0.733407,0.679790,327.495331,166.390976)">
+            <g>
+              <path width="61.96" height="23" x="-30.48" y="-11.5" fill="rgba(255,255,255,1)" stroke-width="0" d="M -30.48,-11.5 l 61.96,0 l 0,23 l-61.96 0 z" class="background" opacity="0.75"/>
+            </g>
+            <g>
+              <text fill="rgba(0,0,0,1)" class="text" dominant-baseline="central" dx="0.5" font-family="system-ui, sans-serif" font-size="12" font-weight="400" paint-order="stroke" text-anchor="middle">line-active</text>
+            </g>
+          </g>
+          <g fill="none" class="badge" transform="matrix(0.679790,-0.733407,0.733407,0.679790,352.633972,139.269592)">
+            <g fill="none" class="label">
+              <g>
+                <path width="12" height="12" x="-5.5" y="-6" fill="rgba(153,173,209,1)" stroke-width="0" d="M 0.5,-6 l 0,0 a 6,6,0,0,1,6,6 l 0,0 a 6,6,0,0,1,-6,6 l 0,0 a 6,6,0,0,1,-6,-6 l 0,0 a 6,6,0,0,1,6,-6 z" class="background"/>
+              </g>
+              <g>
+                <text fill="rgba(255,255,255,1)" class="text" dominant-baseline="central" dx="0.5" font-family="iconfont" font-size="8" paint-order="stroke" text-anchor="middle"></text>
+              </g>
+            </g>
+          </g>
+        </g>
+        <g fill="none">
+          <g>
+            <path fill="none" stroke="rgba(153,173,209,1)" stroke-dasharray="0,0" stroke-opacity="0.25" stroke-width="12" d="M 248.0986084719637,265.88662047941955 L 225.75725700655192,452.55441955964295" class="halo" pointer-events="none"/>
+            <path fill="none" stroke="transparent" stroke-dasharray="0,0" stroke-opacity="0.25" stroke-width="14" d="M 248.0986084719637,265.88662047941955 L 225.75725700655192,452.55441955964295" class="halo" pointer-events="none"/>
+          </g>
+          <g>
+            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="3" d="M 248.0986084719637,265.88662047941955 L 226.47027882956553,446.5969368798606" class="key"/>
+            <path fill="none" stroke="transparent" stroke-width="5" d="M 248.0986084719637,265.88662047941955 L 226.47027882956553,446.5969368798606" class="key"/>
+            <g transform="matrix(0.118837,-0.992914,0.992914,0.118837,226.470276,446.596924)">
+              <path fill="rgba(153,173,209,1)" stroke="rgba(153,173,209,1)" stroke-dasharray="0,0" stroke-linejoin="round" stroke-width="1" d="M -5,0 L 5,-5 L 3,0 L 5,5 Z"/>
+            </g>
+          </g>
+          <g fill="none" class="label" transform="matrix(0.118841,-0.992913,0.992913,0.118841,236.452576,363.192169)">
+            <g>
+              <path width="89.19999999999999" height="27" x="-44.099999999999994" y="-13.5" fill="rgba(255,255,255,1)" stroke-width="0" d="M -44.099999999999994,-13.5 l 89.19999999999999,0 l 0,27 l-89.19999999999999 0 z" class="background" opacity="0.75"/>
+            </g>
+            <g>
+              <text fill="rgba(0,0,0,1)" class="text" dominant-baseline="central" dx="0.5" font-family="system-ui, sans-serif" font-size="14" font-weight="bold" paint-order="stroke" text-anchor="middle">line-selected</text>
+            </g>
+          </g>
+          <g fill="none" class="badge" transform="matrix(0.118841,-0.992913,0.992913,0.118841,230.439240,413.433594)">
+            <g fill="none" class="label">
+              <g>
+                <path width="12" height="12" x="-5.5" y="-6" fill="rgba(153,173,209,1)" stroke-width="0" d="M 0.5,-6 l 0,0 a 6,6,0,0,1,6,6 l 0,0 a 6,6,0,0,1,-6,6 l 0,0 a 6,6,0,0,1,-6,-6 l 0,0 a 6,6,0,0,1,6,-6 z" class="background"/>
+              </g>
+              <g>
+                <text fill="rgba(255,255,255,1)" class="text" dominant-baseline="central" dx="0.5" font-family="iconfont" font-size="8" paint-order="stroke" text-anchor="middle"></text>
+              </g>
+            </g>
+          </g>
+        </g>
+        <g fill="none">
+          <g>
+            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="3" d="M 242.20076458273422,236.02960534179272 L 153.48446200440452,77.1163666296444" class="key"/>
+            <path fill="none" stroke="transparent" stroke-width="5" d="M 242.20076458273422,236.02960534179272 L 153.48446200440452,77.1163666296444" class="key"/>
+            <g transform="matrix(0.487452,0.873150,-0.873150,0.487452,153.484467,77.116364)">
+              <path fill="rgba(153,173,209,1)" stroke="rgba(153,173,209,1)" stroke-dasharray="0,0" stroke-linejoin="round" stroke-width="1" d="M -5,0 L 5,-5 L 3,0 L 5,5 Z"/>
+            </g>
+          </g>
+          <g fill="none" class="label" transform="matrix(0.487446,0.873153,-0.873153,0.487446,194.430466,150.460922)">
+            <g>
+              <path width="77.56" height="23" x="-38.28" y="-11.5" fill="rgba(255,255,255,1)" stroke-width="0" d="M -38.28,-11.5 l 77.56,0 l 0,23 l-77.56 0 z" class="background" opacity="0.75"/>
+            </g>
+            <g>
+              <text fill="rgba(0,0,0,1)" class="text" dominant-baseline="central" dx="0.5" font-family="system-ui, sans-serif" font-size="12" font-weight="bold" paint-order="stroke" text-anchor="middle">line-highlight</text>
+            </g>
+          </g>
+          <g fill="none" class="badge" transform="matrix(0.487446,0.873153,-0.873153,0.487446,172.602631,111.361130)">
+            <g fill="none" class="label">
+              <g>
+                <path width="12" height="12" x="-5.5" y="-6" fill="rgba(153,173,209,1)" stroke-width="0" d="M 0.5,-6 l 0,0 a 6,6,0,0,1,6,6 l 0,0 a 6,6,0,0,1,-6,6 l 0,0 a 6,6,0,0,1,-6,-6 l 0,0 a 6,6,0,0,1,6,-6 z" class="background"/>
+              </g>
+              <g>
+                <text fill="rgba(255,255,255,1)" class="text" dominant-baseline="central" dx="0.5" font-family="iconfont" font-size="8" paint-order="stroke" text-anchor="middle"></text>
+              </g>
+            </g>
+          </g>
+        </g>
+        <g fill="none">
+          <g>
+            <path fill="none" fill-opacity="0.08" stroke="rgba(27,50,79,1)" stroke-opacity="0.08" stroke-width="1" d="M 264.52153176339675,256.7175229991909 L 429.7039448507201,333.12934215540935" class="key"/>
+            <path fill="none" fill-opacity="0.08" stroke="transparent" stroke-opacity="0.08" stroke-width="3" d="M 264.52153176339675,256.7175229991909 L 429.7039448507201,333.12934215540935" class="key"/>
+            <g transform="matrix(-0.907596,-0.419845,0.419845,-0.907596,429.703949,333.129333)">
+              <path fill="rgba(27,50,79,1)" fill-opacity="0.08" stroke="rgba(27,50,79,1)" stroke-dasharray="0,0" stroke-linejoin="round" stroke-opacity="0.08" stroke-width="1" d="M -5,0 L 5,-5 L 3,0 L 5,5 Z"/>
+            </g>
+          </g>
+          <g fill="none" class="label" transform="matrix(0.907598,0.419840,-0.419840,0.907598,353.465912,297.862335)">
+            <g>
+              <path width="72.28" height="23" x="-35.64" y="-11.5" fill="rgba(255,255,255,1)" stroke-width="0" d="M -35.64,-11.5 l 72.28,0 l 0,23 l-72.28 0 z" class="background" opacity="0.1875"/>
+            </g>
+            <g>
+              <text fill="rgba(0,0,0,1)" class="text" dominant-baseline="central" dx="0.5" font-family="system-ui, sans-serif" font-size="12" font-weight="400" opacity="0.25" paint-order="stroke" text-anchor="middle">line-inactive</text>
+            </g>
+          </g>
+          <g fill="none" class="badge" transform="matrix(0.907598,0.419840,-0.419840,0.907598,391.712067,315.554413)">
+            <g fill="none" class="label">
+              <g>
+                <path width="12" height="12" x="-5.5" y="-6" fill="rgba(153,173,209,1)" stroke-width="0" d="M 0.5,-6 l 0,0 a 6,6,0,0,1,6,6 l 0,0 a 6,6,0,0,1,-6,6 l 0,0 a 6,6,0,0,1,-6,-6 l 0,0 a 6,6,0,0,1,6,-6 z" class="background" opacity="0.25"/>
+              </g>
+              <g>
+                <text fill="rgba(255,255,255,1)" class="text" dominant-baseline="central" dx="0.5" font-family="iconfont" font-size="8" paint-order="stroke" text-anchor="middle"></text>
+              </g>
+            </g>
+          </g>
+        </g>
+        <g fill="none" transform="matrix(1,0,0,1,34.171398,292.638184)">
+          <g>
+            <circle r="16" fill="rgba(23,131,255,1)" stroke="rgba(0,0,0,1)" stroke-width="0" class="key"/>
+          </g>
+        </g>
+        <g fill="none" transform="matrix(1,0,0,1,223.855865,468.441040)">
+          <g>
+            <circle r="16" fill="rgba(23,131,255,1)" stroke="rgba(0,0,0,1)" stroke-width="0" class="key"/>
+          </g>
+        </g>
+        <g fill="none" transform="matrix(1,0,0,1,449.671051,342.365936)">
+          <g>
+            <circle r="16" fill="rgba(23,131,255,1)" stroke="rgba(0,0,0,1)" stroke-width="0" class="key"/>
+          </g>
+        </g>
+        <g fill="none" transform="matrix(1,0,0,1,250,250)">
+          <g>
+            <circle r="16" fill="rgba(23,131,255,1)" stroke="rgba(0,0,0,1)" stroke-width="0" class="key"/>
+          </g>
+        </g>
+        <g fill="none" transform="matrix(1,0,0,1,34.171398,292.638184)">
+          <g>
+            <circle r="16" fill="rgba(23,131,255,1)" stroke="rgba(0,0,0,1)" stroke-width="0" class="key"/>
+          </g>
+        </g>
+        <g fill="none" transform="matrix(1,0,0,1,399.552399,88.649193)">
+          <g>
+            <circle r="16" fill="rgba(23,131,255,1)" stroke="rgba(0,0,0,1)" stroke-width="0" class="key"/>
+          </g>
+        </g>
+        <g fill="none" transform="matrix(1,0,0,1,223.855865,468.441040)">
+          <g>
+            <circle r="16" fill="rgba(23,131,255,1)" stroke="rgba(0,0,0,1)" stroke-width="0" class="key"/>
+          </g>
+        </g>
+        <g fill="none" transform="matrix(1,0,0,1,142.760513,57.907074)">
+          <g>
+            <circle r="16" fill="rgba(23,131,255,1)" stroke="rgba(0,0,0,1)" stroke-width="0" class="key"/>
+          </g>
+        </g>
+        <g fill="none" transform="matrix(1,0,0,1,449.671051,342.365936)">
+          <g>
+            <circle r="16" fill="rgba(23,131,255,1)" stroke="rgba(0,0,0,1)" stroke-width="0" class="key"/>
+          </g>
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/packages/g6/src/runtime/data.ts
+++ b/packages/g6/src/runtime/data.ts
@@ -85,12 +85,6 @@ export class DataController {
     }
   }
 
-  /**
-   * <zh/> [警告] 此 API 仅供 Element Controller 调用
-   *
-   * <en/> [WARNING] This API is only for Element Controller
-   * @returns <zh/> 数据变更 | <en/> data changes
-   */
   public getChanges(): DataChange[] {
     return this.changes;
   }

--- a/packages/g6/src/runtime/element.ts
+++ b/packages/g6/src/runtime/element.ts
@@ -848,13 +848,23 @@ export class ElementController {
     )?.finished;
   }
 
-  public destroy() {
-    this.container.destroy();
+  /**
+   * <zh/> 清空所有元素
+   *
+   * <en/> clear all elements
+   */
+  public clear() {
+    this.container.children.forEach((element) => element.destroy());
     this.elementMap = {};
     this.shapeTypeMap = {};
     this.defaultStyle = {};
     this.stateStyle = {};
     this.paletteStyle = {};
+  }
+
+  public destroy() {
+    this.clear();
+    this.container.destroy();
     // @ts-expect-error force delete
     this.context = {};
   }

--- a/packages/g6/src/runtime/graph.ts
+++ b/packages/g6/src/runtime/graph.ts
@@ -1200,8 +1200,10 @@ export class Graph extends EventEmitter {
    * @apiCategory canvas
    */
   public async clear(): Promise<void> {
-    this.context.model.setData({});
-    await this.draw();
+    const { model, element } = this.context;
+    model.setData({});
+    model.clearChanges();
+    element?.clear();
   }
 
   /**


### PR DESCRIPTION
- 修复调用 `Graph.clear` 后重新添加节点时，新节点不可见的问题

---

- Fix the problem that new nodes are not visible when nodes are added again after calling Graph.clear.

Issues:

- https://github.com/antvis/G6/issues/6649