### PR TITLE
chore: publish 5.0.43 version for g6

### DIFF
--- a/packages/g6-extension-3d/package.json
+++ b/packages/g6-extension-3d/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antv/g6-extension-3d",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "description": "3D extension for G6",
   "keywords": [
     "antv",

--- a/packages/g6-extension-react/package.json
+++ b/packages/g6-extension-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antv/g6-extension-react",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "description": "Using React Component to Define Your G6 Graph Node",
   "keywords": [
     "antv",

--- a/packages/g6-ssr/package.json
+++ b/packages/g6-ssr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antv/g6-ssr",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "Support SSR for G6",
   "keywords": [
     "antv",

--- a/packages/g6/package.json
+++ b/packages/g6/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antv/g6",
-  "version": "5.0.42",
+  "version": "5.0.43",
   "description": "A Graph Visualization Framework in JavaScript",
   "keywords": [
     "antv",

--- a/packages/g6/src/version.ts
+++ b/packages/g6/src/version.ts
@@ -1,1 +1,1 @@
-export const version = '5.0.42';
+export const version = '5.0.43';


### PR DESCRIPTION
publish 5.0.43 version, includes: 
1. support config options when call layout functions
2. support behaviors of zoom-canvas and drag-canvas on mobile