### PR TITLE
Fix wrong layout names in layouts/types.ts

### DIFF
--- a/packages/g6/src/layouts/types.ts
+++ b/packages/g6/src/layouts/types.ts
@@ -99,7 +99,7 @@ interface RadialLayout extends BaseLayoutOptions, RadialLayoutOptions {
 }
 
 interface FruchtermanLayout extends BaseLayoutOptions, FruchtermanLayoutOptions {
-  type: 'fruchterman' | 'fruchtermanGPU';
+  type: 'fruchterman' | 'fruchterman-gpu';
 }
 
 interface D3ForceLayout extends BaseLayoutOptions, D3ForceLayoutOptions {
@@ -115,7 +115,7 @@ interface ForceLayout extends BaseLayoutOptions, ForceLayoutOptions {
 }
 
 interface ForceAtlas2 extends BaseLayoutOptions, ForceAtlas2LayoutOptions {
-  type: 'forceAtlas2';
+  type: 'force-atlas2';
 }
 
 interface AntVDagreLayout extends BaseLayoutOptions, AntVDagreLayoutOptions {


### PR DESCRIPTION
Ref:
- https://g6.antv.antgroup.com/manual/getting-started/extensions#布局
- `packages/g6/sr/registry/build-in.ts`