### PR TITLE
fix: support CornerPlacement for port

### DIFF
--- a/packages/g6/src/runtime/layout.ts
+++ b/packages/g6/src/runtime/layout.ts
@@ -100,8 +100,8 @@ export class LayoutController {
     const pipeline = Array.isArray(layoutOptions) ? layoutOptions : [layoutOptions];
     const { graph } = this.context;
     emit(graph, new GraphLifeCycleEvent(GraphEvent.BEFORE_LAYOUT, { type: 'post' }));
-    for (const options of pipeline) {
-      const index = pipeline.indexOf(options);
+    for (let index = 0; index < pipeline.length; index++) {
+      const options = pipeline[index];
       const data = this.getLayoutData(options);
       const opts = { ...this.presetOptions, ...options };
 
@@ -135,8 +135,8 @@ export class LayoutController {
 
     let simulation: GraphData = {};
 
-    for (const options of pipeline) {
-      const index = pipeline.indexOf(options);
+    for (let index = 0; index < pipeline.length; index++) {
+      const options = pipeline[index];
 
       const data = this.getLayoutData(options);
       const result = await this.stepLayout(data, { ...this.presetOptions, ...options, animation: false }, index);

--- a/packages/g6/src/utils/edge.ts
+++ b/packages/g6/src/utils/edge.ts
@@ -241,9 +241,10 @@ export function getCubicPath(sourcePoint: Point, targetPoint: Point, controlPoin
  * @returns <zh/> 返回绘制折线的路径 | <en/> Returns the path for drawing a polyline
  */
 export function getPolylinePath(points: Point[], radius = 0, z = false): PathArray {
+  const targetIndex = points.length - 1;
   const sourcePoint = points[0];
-  const targetPoint = points[points.length - 1];
-  const controlPoints = points.slice(1, points.length - 1);
+  const targetPoint = points[targetIndex];
+  const controlPoints = points.slice(1, targetIndex);
   const pathArray: PathArray = [['M', sourcePoint[0], sourcePoint[1]]];
   controlPoints.forEach((midPoint, i) => {
     const prevPoint = controlPoints[i - 1] || sourcePoint;
@@ -390,7 +391,7 @@ export function getCubicLoopPath(
 
   // 3. 如果定义了连接桩，调整端点以与连接桩边界相交 | If the port is defined, adjust the endpoint to intersect with the port boundary
   if (sourcePort) sourcePoint = getPortConnectionPoint(sourcePort, controlPoints[0]);
-  if (targetPort) targetPoint = getPortConnectionPoint(targetPort, controlPoints[controlPoints.length - 1]);
+  if (targetPort) targetPoint = getPortConnectionPoint(targetPort, controlPoints.at(-1) as Point);
 
   return getCubicPath(sourcePoint, targetPoint, controlPoints);
 }
@@ -463,7 +464,7 @@ export function getPolylineLoopPath(
 
   // 3. 如果定义了连接桩，调整端点以与连接桩边界相交 | If the port is defined, adjust the endpoint to intersect with the port boundary
   if (sourcePort) sourcePoint = getPortConnectionPoint(sourcePort, controlPoints[0]);
-  if (targetPort) targetPoint = getPortConnectionPoint(targetPort, controlPoints[controlPoints.length - 1]);
+  if (targetPort) targetPoint = getPortConnectionPoint(targetPort, controlPoints.at(-1) as Point);
 
   return getPolylinePath([sourcePoint, ...controlPoints, targetPoint], radius);
 }

--- a/packages/g6/src/utils/element.ts
+++ b/packages/g6/src/utils/element.ts
@@ -71,6 +71,14 @@ const PORT_MAP: Record<string, Point> = {
   right: [1, 0.5],
   bottom: [0.5, 1],
   left: [0, 0.5],
+  'left-top': [0, 0],
+  'top-left': [0, 0],
+  'left-bottom': [0, 1],
+  'bottom-left': [0, 1],
+  'right-top': [1, 0],
+  'top-right': [1, 0],
+  'right-bottom': [1, 1],
+  'bottom-right': [1, 1],
   default: [0.5, 0.5],
 };
 


### PR DESCRIPTION
Unlike badges (whose placement is handled by `getTextStyleByPlacement()`, which supports `CornerPlacement`), ports don't support `CornerPlacement` like `top-left`. This PR fixes this by adding keys in `CornerPlacement` to `PORT_MAP`.

Also, document related to ports is missing content. It don't mention its `key` and `placement` prop:
https://g6.antv.antgroup.com/api/elements/nodes/base-node#连接桩样式-ports
Readers can only guess the `placement` prop from the document about badges beside it.

**This fix don't calculate the position with node border. Thus it only works well for the corner of rect-shaped nodes.** Better note about this when adding document about ports.

---

The 2nd commits improves `packages/g6/src/utils/element.ts` with:
- rename param for `PORT_MAP` from `ports` to the more accurate `portMap`.
- `getConnectionPoint()` is calling `getNodeConnectionPoint()` with param `node: Node | Combo`,
  but `getNodeConnectionPoint()` only has param `node: Node`. Changed it to `nodeLike: Node | Combo`.
- optimized `getTextStyleByPlacement()`, saved one ternary operator with the `top` and `bottom` constants.
- for `setAttributes()`, add type `Partial<BaseShapeStyleProps>` to param `style` to match with `element: BaseShape<any>`.
- improve comments for some params.

For `packages/g6/src/utils/edge.ts`, the 3rd commit replaces `array[array.length - 1]` with `array.at(-1)`.
`array.at()`'s typing is static, it always return a type that includes `undefined`, regardless of situation.
Since `controlPoints` are `[Point, Point]`, `controlPoints.at(-1)` can only be `Point`.

For `packages/g6/src/runtime/layout.ts`, the 3rd commit replace two slow, irrational for of loop + `array.indexOf()` with faster, reasonable for loop.
