### PR TITLE
refactor: release 0.2.0 version of g6-extension-react

### DIFF
--- a/packages/g6-extension-react/package.json
+++ b/packages/g6-extension-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antv/g6-extension-react",
-  "version": "0.1.19",
+  "version": "0.2.0",
   "description": "Using React Component to Define Your G6 Graph Node",
   "keywords": [
     "antv",


### PR DESCRIPTION
release 0.2.0 version of g6-extension-react, remove react-g node