### PR TITLE
fix: add missing await in Graph's async absolute zoom function

### DIFF
--- a/packages/g6/src/runtime/graph.ts
+++ b/packages/g6/src/runtime/graph.ts
@@ -1399,7 +1399,7 @@ export class Graph extends EventEmitter {
    * @apiCategory viewport
    */
   public async zoomTo(zoom: number, animation?: ViewportAnimationEffectTiming, origin?: Point): Promise<void> {
-    this.context.viewport!.transform({ mode: 'absolute', scale: zoom, origin }, animation);
+    await this.context.viewport!.transform({ mode: 'absolute', scale: zoom, origin }, animation);
   }
 
   /**


### PR DESCRIPTION
The function's signature claims to return a `Promise<Void` but forgets to add `await`