### PR TITLE
docs: update custom-node.zh.md

### DIFF
--- a/packages/site/docs/manual/element/node/custom-node.zh.md
+++ b/packages/site/docs/manual/element/node/custom-node.zh.md
@@ -93,7 +93,7 @@ interface CustomCircleStyleProps extends BaseStyleProps {
   radius: number;
 }
 
-class CustomCircle extends CustomElement {
+class CustomCircle extends CustomElement<CustomCircleStyleProps> {
   constructor(options: DisplayObjectConfig<CustomCircleStyleProps>) {
     super(options);
     this.render();
@@ -104,8 +104,8 @@ class CustomCircle extends CustomElement {
     const circle = new Circle({
       style: {
         ...this.attributes,
-        x: 0,
-        y: 0,
+        cx: 0,
+        cy: 0,
         r: radius,
       },
     });


### PR DESCRIPTION
泛型类没有添加泛型；x和y属性已经变成了cx和cy