### PR TITLE
fix: removing immediate parameter from debounce

### DIFF
--- a/packages/g6/src/plugins/minimap/index.ts
+++ b/packages/g6/src/plugins/minimap/index.ts
@@ -139,14 +139,10 @@ export class Minimap extends BasePlugin<MinimapOptions> {
   }
 
   private setOnRender() {
-    this.onRender = debounce(
-      () => {
-        this.renderMinimap();
-        this.renderMask();
-      },
-      this.options.delay,
-      true,
-    );
+    this.onRender = debounce(() => {
+      this.renderMinimap();
+      this.renderMask();
+    }, this.options.delay);
   }
 
   private bindEvents() {


### PR DESCRIPTION
This pr addresses an issue in the Minimap plugin where the render process is delayed due to the use of the immediate parameter in the debounce function.
### Problem Statement
The use of the immediate parameter in the debounce function was causing the render function to execute immediately on the first call, rather than waiting for subsequent debounce triggers. This led to render delays, especially in scenarios where frequent changes are detected.
### How to Reproduce
To observe the issue, visit the following link: [Minimap Example](https://g6.antv.antgroup.com/examples/plugin/minimap#basic).

- Quickly drag one of the nodes or "balls" in the main graph area.

- You will notice that the Minimap's updates seem to lag behind the main graph visualization, reflecting changes slower than expected.

<img width="1686" alt="image" src="https://github.com/user-attachments/assets/3156710a-d250-4644-adbb-c141241926b8" />
