### PR TITLE
feat: Support locked combos in drag-combo behavior

### DIFF
--- a/packages/pc/src/behavior/drag-combo.ts
+++ b/packages/pc/src/behavior/drag-combo.ts
@@ -89,6 +89,10 @@ export default {
 
     if (!this.validationCombo(evt)) return;
 
+    if ((item as ICombo).hasLocked()) {
+      return;
+    }
+
     this.targets = [];
 
     // 获取所有选中的 Combo
@@ -104,7 +108,7 @@ export default {
     if (dragCombos.length === 0) {
       this.targets.push(item);
     } else {
-      this.targets = combos;
+      this.targets = combos.filter(combo => !(combo as INode | ICombo).hasLocked());
     }
 
     const beforeDragItems = [];

--- a/packages/pc/tests/unit/behavior/drag-combo-spec.ts
+++ b/packages/pc/tests/unit/behavior/drag-combo-spec.ts
@@ -323,7 +323,7 @@ describe('drag-combo', () => {
     graph.destroy();
     done();
   });
-  it.only('drag locked combo', (done) => {
+  it('drag locked combo', () => {
     const data = {
       nodes: [
         {
@@ -369,8 +369,8 @@ describe('drag-combo', () => {
         {
           id: 'B',
           label: 'group B',
-          x: 333,
-          y: 333,
+          x: 50,
+          y: 50,
         }
       ],
     };
@@ -391,20 +391,31 @@ describe('drag-combo', () => {
     graph.data(data);
     graph.render();
     graph.paint();
-    const combo = graph.findById('A') as ICombo;
-    combo.lock();
 
-    graph.on('dragend', (e) => {
-      const dragMatrix = combo.get('group').getMatrix();
-      expect(dragMatrix[6]).toEqual(50);
-      expect(dragMatrix[7]).toEqual(50);
-      done();
-    });
+    // Test locked combo
+    const comboA = graph.findById('A') as ICombo;
+    comboA.lock();
 
-    graph.emit('combo:mousedown', { x: 100, y: 100, item: combo });
-    graph.emit('drag', { x: 100, y: 100, item: combo });
-    graph.emit('drag', { x: 120, y: 120, item: combo });
-    graph.emit('dragend', { x: 120, y: 120, item: combo });
+    graph.emit('combo:mousedown', { x: 100, y: 100, item: comboA });
+    graph.emit('combo:dragstart', { x: 100, y: 100, item: comboA });
+    graph.emit('combo:drag', { x: 100, y: 100, item: comboA });
+    graph.emit('combo:drag', { x: 120, y: 120, item: comboA });
+    graph.emit('combo:dragend', { x: 120, y: 120, item: comboA });
+    const dragMatrixA = comboA.get('group').getMatrix();
+    expect(dragMatrixA[6]).toEqual(50);
+    expect(dragMatrixA[7]).toEqual(50);
+
+    // Test unlocked combo
+    const comboB = graph.findById('B') as ICombo;
+
+    graph.emit('combo:mousedown', { x: 100, y: 100, item: comboB });
+    graph.emit('combo:dragstart', { x: 100, y: 100, item: comboB });
+    graph.emit('combo:drag', { x: 100, y: 100, item: comboB });
+    graph.emit('combo:drag', { x: 120, y: 120, item: comboB });
+    graph.emit('combo:dragend', { x: 120, y: 120, item: comboB });
+    const dragMatrixB = comboB.get('group').getMatrix();
+    expect(dragMatrixB[6]).toEqual(70); // moved
+    expect(dragMatrixB[7]).toEqual(70); // moved
   });
 
   it('combo example', () => {

--- a/packages/pc/tests/unit/behavior/drag-combo-spec.ts
+++ b/packages/pc/tests/unit/behavior/drag-combo-spec.ts
@@ -1,5 +1,5 @@
 import '../../../src';
-import G6 from '../../../src';
+import G6, { ICombo } from '../../../src';
 
 const div = document.createElement('div');
 div.id = 'drag-combo-spec';
@@ -322,6 +322,89 @@ describe('drag-combo', () => {
     expect(Math.abs(comboCBBox.width - 541) < 2).toBe(true);
     graph.destroy();
     done();
+  });
+  it.only('drag locked combo', (done) => {
+    const data = {
+      nodes: [
+        {
+          id: 'node1',
+          x: 150,
+          y: 150,
+          label: 'node1',
+          comboId: 'A',
+        },
+        {
+          id: 'node2',
+          x: 200,
+          y: 250,
+          label: 'node2',
+          comboId: 'A',
+        },
+        {
+          id: 'node4',
+          x: 200,
+          y: 350,
+          label: 'node4',
+          comboId: 'B',
+        },
+      ],
+      edges: [
+        {
+          source: 'node1',
+          target: 'node4',
+        },
+        {
+          source: 'node1',
+          target: 'node2',
+        }
+      ],
+      combos: [
+        {
+          id: 'A',
+          label: 'group A',
+          type: 'circle',
+          x: 50,
+          y: 50,
+        },
+        {
+          id: 'B',
+          label: 'group B',
+          x: 333,
+          y: 333,
+        }
+      ],
+    };
+
+    const graph = new G6.Graph({
+      container: 'drag-combo-spec',
+      width: 500,
+      height: 500,
+      modes: {
+        default: [
+          {
+            type: 'drag-combo'
+          },
+        ],
+      },
+    });
+
+    graph.data(data);
+    graph.render();
+    graph.paint();
+    const combo = graph.findById('A') as ICombo;
+    combo.lock();
+
+    graph.on('dragend', (e) => {
+      const dragMatrix = combo.get('group').getMatrix();
+      expect(dragMatrix[6]).toEqual(50);
+      expect(dragMatrix[7]).toEqual(50);
+      done();
+    });
+
+    graph.emit('combo:mousedown', { x: 100, y: 100, item: combo });
+    graph.emit('drag', { x: 100, y: 100, item: combo });
+    graph.emit('drag', { x: 120, y: 120, item: combo });
+    graph.emit('dragend', { x: 120, y: 120, item: combo });
   });
 
   it('combo example', () => {


### PR DESCRIPTION
##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change
This PR ports the support for locked combos/nodes from the `drag-node` behavior.

Works exactly as for nodes