### PR TITLE
chore: pin dumi version to 2.4.17

### DIFF
--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -53,7 +53,7 @@
     "@antv/layout-wasm": "^1.4.2",
     "@antv/util": "^3.3.10",
     "antd": "^5.24.3",
-    "dumi": "^2.4.17",
+    "dumi": "2.4.17",
     "insert-css": "^2.0.0",
     "lodash": "^4.17.21",
     "react": "^19.1.0",


### PR DESCRIPTION
dumi 2.4.20 会导致 ob 代码块运行错误，先锁一下版本