### PR TITLE
fix: EdgeFilterLens在触发update时，options.r未赋值给this.r，导致配置未生效；fix: style option的ts类型应该使用CircleStyleProps

### DIFF
--- a/packages/g6/src/plugins/edge-filter-lens/index.ts
+++ b/packages/g6/src/plugins/edge-filter-lens/index.ts
@@ -1,6 +1,6 @@
 import type { BaseStyleProps } from '@antv/g';
 import { CommonEvent } from '../../constants';
-import { Circle } from '../../elements';
+import { Circle, CircleStyleProps } from '../../elements';
 import type { RuntimeContext } from '../../runtime/types';
 import type { EdgeData, GraphData, NodeData } from '../../spec';
 import type { EdgeStyle } from '../../spec/element/edge';
@@ -100,7 +100,7 @@ export interface EdgeFilterLensOptions extends BasePluginOptions {
    *
    * <en/> The style of the lens
    */
-  style?: BaseStyleProps;
+  style?: Partial<CircleStyleProps>;
   /**
    * <zh/> 在透镜中节点的样式
    *
@@ -388,6 +388,7 @@ export class EdgeFilterLens extends BasePlugin<EdgeFilterLensOptions> {
   public update(options: Partial<EdgeFilterLensOptions>) {
     this.unbindEvents();
     super.update(options);
+    this.r = options.r ?? this.r;
     this.bindEvents();
   }
 

--- a/packages/g6/src/plugins/edge-filter-lens/index.ts
+++ b/packages/g6/src/plugins/edge-filter-lens/index.ts
@@ -1,5 +1,5 @@
 import { CommonEvent } from '../../constants';
-import { Circle, CircleStyleProps } from '../../elements';
+import { Circle, type CircleStyleProps } from '../../elements';
 import type { RuntimeContext } from '../../runtime/types';
 import type { EdgeData, GraphData, NodeData } from '../../spec';
 import type { EdgeStyle } from '../../spec/element/edge';

--- a/packages/g6/src/plugins/edge-filter-lens/index.ts
+++ b/packages/g6/src/plugins/edge-filter-lens/index.ts
@@ -1,4 +1,3 @@
-import type { BaseStyleProps } from '@antv/g';
 import { CommonEvent } from '../../constants';
 import { Circle, CircleStyleProps } from '../../elements';
 import type { RuntimeContext } from '../../runtime/types';
@@ -122,7 +121,7 @@ export interface EdgeFilterLensOptions extends BasePluginOptions {
   preventDefault?: boolean;
 }
 
-const defaultLensStyle: BaseStyleProps = {
+const defaultLensStyle: Exclude<CircleStyleProps, 'r'> = {
   fill: '#fff',
   fillOpacity: 1,
   lineWidth: 1,


### PR DESCRIPTION
- fix: 当EdgeFilterLens触发update时，`options.r`未赋值给`this.r`，导致此配置未生效；
此问题与之前修复的[fisheye plugins的问题](https://github.com/antvis/G6/pull/6956)类似，我是在编写在线体验时发现：
<img width="1067" alt="image" src="https://github.com/user-attachments/assets/0ee2ee6e-ed8e-4f6f-a4ea-055601f69513" />

- fix: 更新EdgeFilterLens的`style` option的ts类型，应该使用`Partial<CircleStyleProps>`更合适；