### PR TITLE
fix: 更新fisheye demo里的style属性，与缩略图保持一致

### DIFF
--- a/packages/site/examples/plugin/fisheye/demo/custom.js
+++ b/packages/site/examples/plugin/fisheye/demo/custom.js
@@ -40,7 +40,7 @@ fetch('https://assets.antv.antgroup.com/g6/relations.json')
           trigger: 'click',
           scaleRBy: 'wheel',
           scaleDBy: 'drag',
-          style: { fill: 'transparent', stroke: 'transparent' },
+          style: { fill: '#F08F56', stroke: '#666', lineDash: [5, 5] },
           nodeStyle: { label: true, icon: true },
         },
       ],


### PR DESCRIPTION
**问题**
https://g6.antv.antgroup.com/examples/plugin/fisheye#custom 我发现这个fisheye的demo， 放大镜的`fill`/`stroke`，都被设置成`transparent`了，这导致用户看不到放大镜，且与左侧缩略图上的效果也不一致，如图：

<img width="1681" alt="image" src="https://github.com/user-attachments/assets/bdf014f8-51c4-405b-9883-f870d54701c1" />


**解决方案**
改为与缩略图的style保持一致
<img width="1726" alt="image" src="https://github.com/user-attachments/assets/906b00d8-2701-432d-b80d-fddc34baf943" />
