### PR TITLE
Avoid call onDragEnd() multiple times

### DIFF
--- a/packages/g6/src/behaviors/drag-element.ts
+++ b/packages/g6/src/behaviors/drag-element.ts
@@ -281,6 +281,7 @@ export class DragElement extends BaseBehavior<DragElementOptions> {
    * @internal
    */
   protected onDragEnd() {
+    if (!this.enable) return; // It can be called multiple times
     this.enable = false;
     if (this.options.shadow) {
       if (!this.shadow) return;


### PR DESCRIPTION
onDragEnd() can be call from DRAG_END event handler but too from 'blur' and 'contextmenu' event handler, protect it to avoid call endBatch() multiple times.