### PR TITLE
fix: register can not override

### DIFF
--- a/packages/g6/__tests__/demos/element-visibility-part.ts
+++ b/packages/g6/__tests__/demos/element-visibility-part.ts
@@ -20,7 +20,7 @@ class CustomCircle extends Circle {
 }
 
 export const elementVisibilityPart: TestCase = async (context) => {
-  register(ExtensionCategory.NODE, 'custom-circle', CustomCircle, true);
+  register(ExtensionCategory.NODE, 'custom-circle', CustomCircle);
 
   const graph = new Graph({
     ...context,

--- a/packages/g6/__tests__/unit/registry.spec.ts
+++ b/packages/g6/__tests__/unit/registry.spec.ts
@@ -89,7 +89,7 @@ describe('registry', () => {
     class CircleNode {}
     class RectNode {}
     register(ExtensionCategory.NODE, 'circle-node', CircleNode as any);
-    register(ExtensionCategory.NODE, 'circle-node', RectNode as any, true);
+    register(ExtensionCategory.NODE, 'circle-node', RectNode as any);
     expect(getExtension(ExtensionCategory.NODE, 'circle-node')).toEqual(RectNode);
   });
 

--- a/packages/g6/src/registry/register.ts
+++ b/packages/g6/src/registry/register.ts
@@ -19,10 +19,6 @@ import type { ExtensionRegistry } from './types';
  * @param Ctor
  * <zh/> 要注册的扩展类，在使用时创建实例
  *
- * <en/> The extension class to be registered. An instance will be created upon use
- * @param override
- * <zh/> 是否覆盖已注册的扩展
- *
  * <en/> Whether to override the registered extension
  * @remarks
  * <zh/> 内置扩展在项目导入时会自动注册。对于非内置扩展，可以通过 `register` 方法手动注册。扩展只需要注册一次，即可在项目的任何位置使用。
@@ -42,10 +38,11 @@ export function register<T extends ExtensionCategory>(
   category: Loosen<T>,
   type: string,
   Ctor: ExtensionRegistry[T][string],
-  override = false,
 ) {
   const ext = EXTENSION_REGISTRY[category][type];
-  if (!override && ext) {
-    if (ext !== Ctor) print.warn(`The extension ${type} of ${category} has been registered before.`);
-  } else Object.assign(EXTENSION_REGISTRY[category]!, { [type]: Ctor });
+  if (ext && ext) {
+    print.warn(`The extension ${type} of ${category} has been registered before, and will be overridden.`);
+  }
+
+  Object.assign(EXTENSION_REGISTRY[category]!, { [type]: Ctor });
 }


### PR DESCRIPTION
虽然 `register` 有第三参数 `override` 配置，但是从设计上来说有几个考虑点：

1. 是否需要让用户决定是否 override
2. 是否可以 override

> 我觉得应该是需要可以 override，但是用户不需要设置 override = `true` | `false`，因为这没有意义。G6 需要通过 warn 提醒用户的时候，plugin 被重写，可能带来运行问题。

有两种选择：

1. 内置的 plugin 不让覆盖，避免内置插件出现运行故障，开发者又发觉不了
2. 所有插件允许覆盖，但是需要做好提醒

本 pr 采用方案 2，方案 1 需要额外的枚举值记录内置插件。

- fixed https://github.com/antvis/G6/issues/7023