### PR TITLE
feat: 添加缩放中心选项(#7064)

### DIFF
--- a/packages/g6/__tests__/snapshots/behaviors/zoom-canvas/zoom-to-canvas-center.svg
+++ b/packages/g6/__tests__/snapshots/behaviors/zoom-canvas/zoom-to-canvas-center.svg
@@ -1,0 +1,538 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" color-interpolation-filters="sRGB" style="background: transparent; outline: none;" tabindex="1">
+  <g transform="matrix(.5445 0 0 .5445 113.875 113.875)">
+    <g fill="none">
+      <g fill="none" class="elements">
+        <g fill="none">
+          <g>
+            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="m332.6506 289.9426 4.0032 15.9038" class="key"/>
+            <path fill="none" stroke="transparent" stroke-width="3" d="m10 0 0 0" class="key"/>
+          </g>
+        </g>
+        <g fill="none">
+          <g>
+            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="m339.9938 282.311 21.1904 4.4746" class="key"/>
+            <path fill="none" stroke="transparent" stroke-width="3" d="m10 0 0 0" class="key"/>
+          </g>
+        </g>
+        <g fill="none">
+          <g>
+            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="m336.6996 287.853 19.7167 23.113" class="key"/>
+            <path fill="none" stroke="transparent" stroke-width="3" d="m10 0 0 0" class="key"/>
+          </g>
+        </g>
+        <g fill="none">
+          <g>
+            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="m339.758 277.274 41.527-12.9212" class="key"/>
+            <path fill="none" stroke="transparent" stroke-width="3" d="m10 0 0 0" class="key"/>
+          </g>
+        </g>
+        <g fill="none">
+          <g>
+            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="m340.1225 281.562 44.155 5.8661" class="key"/>
+            <path fill="none" stroke="transparent" stroke-width="3" d="m10 0 0 0" class="key"/>
+          </g>
+        </g>
+        <g fill="none">
+          <g>
+            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="m338.5169 274.6783 17.6542-11.8301" class="key"/>
+            <path fill="none" stroke="transparent" stroke-width="3" d="m10 0 0 0" class="key"/>
+          </g>
+        </g>
+        <g fill="none">
+          <g>
+            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="m327.442 289.8545-6.3262 21.9653" class="key"/>
+            <path fill="none" stroke="transparent" stroke-width="3" d="m10 0 0 0" class="key"/>
+          </g>
+        </g>
+        <g fill="none">
+          <g>
+            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="m321.9942 274.5435-11.4834-7.9696" class="key"/>
+            <path fill="none" stroke="transparent" stroke-width="3" d="m10 0 0 0" class="key"/>
+          </g>
+        </g>
+        <g fill="none">
+          <g>
+            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="m321.2003 275.9054-45.8074-22.0645" class="key"/>
+            <path fill="none" stroke="transparent" stroke-width="3" d="m10 0 0 0" class="key"/>
+          </g>
+        </g>
+        <g fill="none">
+          <g>
+            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="m320.2215 280.7338-55.8937 2.7347" class="key"/>
+            <path fill="none" stroke="transparent" stroke-width="3" d="m10 0 0 0" class="key"/>
+          </g>
+        </g>
+        <g fill="none">
+          <g>
+            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="m333.1342 270.6823 8.2076-26.8367" class="key"/>
+            <path fill="none" stroke="transparent" stroke-width="3" d="m10 0 0 0" class="key"/>
+          </g>
+        </g>
+        <g fill="none">
+          <g>
+            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="m321.1923 284.568-21.7089 10.4073" class="key"/>
+            <path fill="none" stroke="transparent" stroke-width="3" d="m10 0 0 0" class="key"/>
+          </g>
+        </g>
+        <g fill="none">
+          <g>
+            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="m337.6456 286.9313 10.8187 9.7277" class="key"/>
+            <path fill="none" stroke="transparent" stroke-width="3" d="m10 0 0 0" class="key"/>
+          </g>
+        </g>
+        <g fill="none">
+          <g>
+            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="m320.7204 277.0897-63.441-21.0953" class="key"/>
+            <path fill="none" stroke="transparent" stroke-width="3" d="m10 0 0 0" class="key"/>
+          </g>
+        </g>
+        <g fill="none">
+          <g>
+            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="m368.3505 298.5029-2.8263 10.4197" class="key"/>
+            <path fill="none" stroke="transparent" stroke-width="3" d="m10 0 0 0" class="key"/>
+          </g>
+        </g>
+        <g fill="none">
+          <g>
+            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="m392.051 271.3074.9217 7.5121" class="key"/>
+            <path fill="none" stroke="transparent" stroke-width="3" d="m10 0 0 0" class="key"/>
+          </g>
+        </g>
+        <g fill="none">
+          <g>
+            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="m400.5079 263.9124 21.519 5.629" class="key"/>
+            <path fill="none" stroke="transparent" stroke-width="3" d="m10 0 0 0" class="key"/>
+          </g>
+        </g>
+        <g fill="none">
+          <g>
+            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="m403.3283 284.6834 19.2352-8.5497" class="key"/>
+            <path fill="none" stroke="transparent" stroke-width="3" d="m10 0 0 0" class="key"/>
+          </g>
+        </g>
+        <g fill="none">
+          <g>
+            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="m357.877 249.77-7.0092-7.9757" class="key"/>
+            <path fill="none" stroke="transparent" stroke-width="3" d="m10 0 0 0" class="key"/>
+          </g>
+        </g>
+        <g fill="none">
+          <g>
+            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="m310.5156 315.2123-12.217-9.697" class="key"/>
+            <path fill="none" stroke="transparent" stroke-width="3" d="m10 0 0 0" class="key"/>
+          </g>
+        </g>
+        <g fill="none">
+          <g>
+            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="m292.762 257.8537-16.8449-5.3337" class="key"/>
+            <path fill="none" stroke="transparent" stroke-width="3" d="m10 0 0 0" class="key"/>
+          </g>
+        </g>
+        <g fill="none">
+          <g>
+            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="m256.4063 248.8285-64.642-4.3594" class="key"/>
+            <path fill="none" stroke="transparent" stroke-width="3" d="m10 0 0 0" class="key"/>
+          </g>
+        </g>
+        <g fill="none">
+          <g>
+            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="m270.7373 258.5038 15.375 31.792" class="key"/>
+            <path fill="none" stroke="transparent" stroke-width="3" d="m10 0 0 0" class="key"/>
+          </g>
+        </g>
+        <g fill="none">
+          <g>
+            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="m274.798 244.0977 21.6693-13.9158" class="key"/>
+            <path fill="none" stroke="transparent" stroke-width="3" d="m10 0 0 0" class="key"/>
+          </g>
+        </g>
+        <g fill="none">
+          <g>
+            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="m257.5013 254.0953-28.2968 14.6352" class="key"/>
+            <path fill="none" stroke="transparent" stroke-width="3" d="m10 0 0 0" class="key"/>
+          </g>
+        </g>
+        <g fill="none">
+          <g>
+            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="m257.5477 244.8186-19.4605-10.3133" class="key"/>
+            <path fill="none" stroke="transparent" stroke-width="3" d="m10 0 0 0" class="key"/>
+          </g>
+        </g>
+        <g fill="none">
+          <g>
+            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="m261.1607 240.9736-20.796-33.9549" class="key"/>
+            <path fill="none" stroke="transparent" stroke-width="3" d="m10 0 0 0" class="key"/>
+          </g>
+        </g>
+        <g fill="none">
+          <g>
+            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="m244.7951 280.9739-14.9283-4.666" class="key"/>
+            <path fill="none" stroke="transparent" stroke-width="3" d="m10 0 0 0" class="key"/>
+          </g>
+        </g>
+        <g fill="none">
+          <g>
+            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="m245.5907 279.1143-55.0547-30.4751" class="key"/>
+            <path fill="none" stroke="transparent" stroke-width="3" d="m10 0 0 0" class="key"/>
+          </g>
+        </g>
+        <g fill="none">
+          <g>
+            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="m263.5442 287.8659 17.7174 7.5237" class="key"/>
+            <path fill="none" stroke="transparent" stroke-width="3" d="m10 0 0 0" class="key"/>
+          </g>
+        </g>
+        <g fill="none">
+          <g>
+            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="m314.6025 227.1242 19.943 4.8127" class="key"/>
+            <path fill="none" stroke="transparent" stroke-width="3" d="m10 0 0 0" class="key"/>
+          </g>
+        </g>
+        <g fill="none">
+          <g>
+            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="m239.117 247.8619-14.4253-8.278" class="key"/>
+            <path fill="none" stroke="transparent" stroke-width="3" d="m10 0 0 0" class="key"/>
+          </g>
+        </g>
+        <g fill="none">
+          <g>
+            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="m242.2104 244.5406-21.4406-31.8865" class="key"/>
+            <path fill="none" stroke="transparent" stroke-width="3" d="m10 0 0 0" class="key"/>
+          </g>
+        </g>
+        <g fill="none">
+          <g>
+            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="m241.5174 245.0512-5.9932-7.4407" class="key"/>
+            <path fill="none" stroke="transparent" stroke-width="3" d="m10 0 0 0" class="key"/>
+          </g>
+        </g>
+        <g fill="none">
+          <g>
+            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="m237.8829 251.4817-46.1885-6.3281" class="key"/>
+            <path fill="none" stroke="transparent" stroke-width="3" d="m10 0 0 0" class="key"/>
+          </g>
+        </g>
+        <g fill="none">
+          <g>
+            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="m215.7446 224.6104-.281-10.2585" class="key"/>
+            <path fill="none" stroke="transparent" stroke-width="3" d="m10 0 0 0" class="key"/>
+          </g>
+        </g>
+        <g fill="none">
+          <g>
+            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="m220.698 225.7691 9.7643-18.4405" class="key"/>
+            <path fill="none" stroke="transparent" stroke-width="3" d="m10 0 0 0" class="key"/>
+          </g>
+        </g>
+        <g fill="none">
+          <g>
+            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="m205.5694 201.6268-21.2254-6.0206" class="key"/>
+            <path fill="none" stroke="transparent" stroke-width="3" d="m10 0 0 0" class="key"/>
+          </g>
+        </g>
+        <g fill="none">
+          <g>
+            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="m184.6806 193.8025 40.5041 3.7634" class="key"/>
+            <path fill="none" stroke="transparent" stroke-width="3" d="m10 0 0 0" class="key"/>
+          </g>
+        </g>
+        <g fill="none">
+          <g>
+            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="m166.3227 198.302-32.0478 20.6944" class="key"/>
+            <path fill="none" stroke="transparent" stroke-width="3" d="m10 0 0 0" class="key"/>
+          </g>
+        </g>
+        <g fill="none">
+          <g>
+            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="m176.0975 202.7825 4.3154 31.1086" class="key"/>
+            <path fill="none" stroke="transparent" stroke-width="3" d="m10 0 0 0" class="key"/>
+          </g>
+        </g>
+        <g fill="none">
+          <g>
+            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="m164.735 192.3974-30.3985-1.4606" class="key"/>
+            <path fill="none" stroke="transparent" stroke-width="3" d="m10 0 0 0" class="key"/>
+          </g>
+        </g>
+        <g fill="none">
+          <g>
+            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="m233.2942 208.3189-2.1952 11.6759" class="key"/>
+            <path fill="none" stroke="transparent" stroke-width="3" d="m10 0 0 0" class="key"/>
+          </g>
+        </g>
+        <g fill="none">
+          <g>
+            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="m219.6585 232.6468-28.2786 8.3252" class="key"/>
+            <path fill="none" stroke="transparent" stroke-width="3" d="m10 0 0 0" class="key"/>
+          </g>
+        </g>
+        <g fill="none">
+          <g>
+            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="m189.7246 249.8785 22.66 17.3637" class="key"/>
+            <path fill="none" stroke="transparent" stroke-width="3" d="m10 0 0 0" class="key"/>
+          </g>
+        </g>
+        <g fill="none">
+          <g>
+            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="m174.987 251.1284-11.6396 12.5505" class="key"/>
+            <path fill="none" stroke="transparent" stroke-width="3" d="m10 0 0 0" class="key"/>
+          </g>
+        </g>
+        <g fill="none">
+          <g>
+            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="m179.1077 253.4306-4.614 16.5916" class="key"/>
+            <path fill="none" stroke="transparent" stroke-width="3" d="m10 0 0 0" class="key"/>
+          </g>
+        </g>
+        <g fill="none">
+          <g>
+            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="m174.4592 236.9915-42.7835-39.73" class="key"/>
+            <path fill="none" stroke="transparent" stroke-width="3" d="m10 0 0 0" class="key"/>
+          </g>
+        </g>
+        <g fill="none">
+          <g>
+            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="m172.2886 240.6688-23.9742-7.8936" class="key"/>
+            <path fill="none" stroke="transparent" stroke-width="3" d="m10 0 0 0" class="key"/>
+          </g>
+        </g>
+        <g fill="none">
+          <g>
+            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="m173.7472 237.8496-18.4422-13.6407" class="key"/>
+            <path fill="none" stroke="transparent" stroke-width="3" d="m10 0 0 0" class="key"/>
+          </g>
+        </g>
+        <g fill="none">
+          <g>
+            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="m176.1972 235.5044-13.7431-20.3868" class="key"/>
+            <path fill="none" stroke="transparent" stroke-width="3" d="m10 0 0 0" class="key"/>
+          </g>
+        </g>
+        <g fill="none">
+          <g>
+            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="m172.27 246.8666-24.9708 8.056" class="key"/>
+            <path fill="none" stroke="transparent" stroke-width="3" d="m10 0 0 0" class="key"/>
+          </g>
+        </g>
+        <g fill="none">
+          <g>
+            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="m172.3382 240.522-37.0152-12.8267" class="key"/>
+            <path fill="none" stroke="transparent" stroke-width="3" d="m10 0 0 0" class="key"/>
+          </g>
+        </g>
+        <g fill="none">
+          <g>
+            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="m127.8112 199.838 7.5416 20.4286" class="key"/>
+            <path fill="none" stroke="transparent" stroke-width="3" d="m10 0 0 0" class="key"/>
+          </g>
+        </g>
+        <g fill="none">
+          <g>
+            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="m119.9002 181.5004-7.4511-15.0038" class="key"/>
+            <path fill="none" stroke="transparent" stroke-width="3" d="m10 0 0 0" class="key"/>
+          </g>
+        </g>
+        <g fill="none">
+          <g>
+            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="m115.402 185.9881-15.2641-7.6247" class="key"/>
+            <path fill="none" stroke="transparent" stroke-width="3" d="m10 0 0 0" class="key"/>
+          </g>
+        </g>
+        <g fill="none">
+          <g>
+            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="m130.7081 198.1736 10.197 12.372" class="key"/>
+            <path fill="none" stroke="transparent" stroke-width="3" d="m10 0 0 0" class="key"/>
+          </g>
+        </g>
+        <g fill="none">
+          <g>
+            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="m133.28 194.9533 14.6523 7.376" class="key"/>
+            <path fill="none" stroke="transparent" stroke-width="3" d="m10 0 0 0" class="key"/>
+          </g>
+        </g>
+        <g fill="none">
+          <g>
+            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="m124.7969 200.4467.6284 13.9844" class="key"/>
+            <path fill="none" stroke="transparent" stroke-width="3" d="m10 0 0 0" class="key"/>
+          </g>
+        </g>
+        <g fill="none">
+          <g>
+            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="m134.4393 248.5682-5.2222-14.7225" class="key"/>
+            <path fill="none" stroke="transparent" stroke-width="3" d="m10 0 0 0" class="key"/>
+          </g>
+        </g>
+        <g fill="none" transform="matrix(1 0 0 1 330.2096 280.245)">
+          <g>
+            <circle r="10" fill="rgba(23,131,255,1)" stroke="rgba(0,0,0,1)" stroke-width="0" class="key"/>
+          </g>
+        </g>
+        <g fill="none" transform="matrix(1 0 0 1 339.0948 315.544)">
+          <g>
+            <circle r="10" fill="rgba(23,131,255,1)" stroke="rgba(0,0,0,1)" stroke-width="0" class="key"/>
+          </g>
+        </g>
+        <g fill="none" transform="matrix(1 0 0 1 370.9684 288.8517)">
+          <g>
+            <circle r="10" fill="rgba(23,131,255,1)" stroke="rgba(0,0,0,1)" stroke-width="0" class="key"/>
+          </g>
+        </g>
+        <g fill="none" transform="matrix(1 0 0 1 362.9063 318.5738)">
+          <g>
+            <circle r="10" fill="rgba(23,131,255,1)" stroke="rgba(0,0,0,1)" stroke-width="0" class="key"/>
+          </g>
+        </g>
+        <g fill="none" transform="matrix(1 0 0 1 390.8334 261.3818)">
+          <g>
+            <circle r="10" fill="rgba(23,131,255,1)" stroke="rgba(0,0,0,1)" stroke-width="0" class="key"/>
+          </g>
+        </g>
+        <g fill="none" transform="matrix(1 0 0 1 394.1903 288.745)">
+          <g>
+            <circle r="10" fill="rgba(23,131,255,1)" stroke="rgba(0,0,0,1)" stroke-width="0" class="key"/>
+          </g>
+        </g>
+        <g fill="none" transform="matrix(1 0 0 1 431.7015 272.072)">
+          <g>
+            <circle r="10" fill="rgba(23,131,255,1)" stroke="rgba(0,0,0,1)" stroke-width="0" class="key"/>
+          </g>
+        </g>
+        <g fill="none" transform="matrix(1 0 0 1 364.4784 257.2814)">
+          <g>
+            <circle r="10" fill="rgba(23,131,255,1)" stroke="rgba(0,0,0,1)" stroke-width="0" class="key"/>
+          </g>
+        </g>
+        <g fill="none" transform="matrix(1 0 0 1 318.3482 321.4292)">
+          <g>
+            <circle r="10" fill="rgba(23,131,255,1)" stroke="rgba(0,0,0,1)" stroke-width="0" class="key"/>
+          </g>
+        </g>
+        <g fill="none" transform="matrix(1 0 0 1 302.2954 260.8724)">
+          <g>
+            <circle r="10" fill="rgba(23,131,255,1)" stroke="rgba(0,0,0,1)" stroke-width="0" class="key"/>
+          </g>
+        </g>
+        <g fill="none" transform="matrix(1 0 0 1 266.3836 249.5013)">
+          <g>
+            <circle r="10" fill="rgba(23,131,255,1)" stroke="rgba(0,0,0,1)" stroke-width="0" class="key"/>
+          </g>
+        </g>
+        <g fill="none" transform="matrix(1 0 0 1 254.3397 283.9572)">
+          <g>
+            <circle r="10" fill="rgba(23,131,255,1)" stroke="rgba(0,0,0,1)" stroke-width="0" class="key"/>
+          </g>
+        </g>
+        <g fill="none" transform="matrix(1 0 0 1 304.8816 224.7783)">
+          <g>
+            <circle r="10" fill="rgba(23,131,255,1)" stroke="rgba(0,0,0,1)" stroke-width="0" class="key"/>
+          </g>
+        </g>
+        <g fill="none" transform="matrix(1 0 0 1 344.2664 234.2828)">
+          <g>
+            <circle r="10" fill="rgba(23,131,255,1)" stroke="rgba(0,0,0,1)" stroke-width="0" class="key"/>
+          </g>
+        </g>
+        <g fill="none" transform="matrix(1 0 0 1 290.466 299.2983)">
+          <g>
+            <circle r="10" fill="rgba(23,131,255,1)" stroke="rgba(0,0,0,1)" stroke-width="0" class="key"/>
+          </g>
+        </g>
+        <g fill="none" transform="matrix(1 0 0 1 355.9004 303.3452)">
+          <g>
+            <circle r="10" fill="rgba(23,131,255,1)" stroke="rgba(0,0,0,1)" stroke-width="0" class="key"/>
+          </g>
+        </g>
+        <g fill="none" transform="matrix(1 0 0 1 247.7903 252.8391)">
+          <g>
+            <circle r="10" fill="rgba(23,131,255,1)" stroke="rgba(0,0,0,1)" stroke-width="0" class="key"/>
+          </g>
+        </g>
+        <g fill="none" transform="matrix(1 0 0 1 216.0184 234.6066)">
+          <g>
+            <circle r="10" fill="rgba(23,131,255,1)" stroke="rgba(0,0,0,1)" stroke-width="0" class="key"/>
+          </g>
+        </g>
+        <g fill="none" transform="matrix(1 0 0 1 215.1899 204.3556)">
+          <g>
+            <circle r="10" fill="rgba(23,131,255,1)" stroke="rgba(0,0,0,1)" stroke-width="0" class="key"/>
+          </g>
+        </g>
+        <g fill="none" transform="matrix(1 0 0 1 174.7235 192.8774)">
+          <g>
+            <circle r="10" fill="rgba(23,131,255,1)" stroke="rgba(0,0,0,1)" stroke-width="0" class="key"/>
+          </g>
+        </g>
+        <g fill="none" transform="matrix(1 0 0 1 235.1418 198.491)">
+          <g>
+            <circle r="10" fill="rgba(23,131,255,1)" stroke="rgba(0,0,0,1)" stroke-width="0" class="key"/>
+          </g>
+        </g>
+        <g fill="none" transform="matrix(1 0 0 1 229.2514 229.8226)">
+          <g>
+            <circle r="10" fill="rgba(23,131,255,1)" stroke="rgba(0,0,0,1)" stroke-width="0" class="key"/>
+          </g>
+        </g>
+        <g fill="none" transform="matrix(1 0 0 1 181.787 243.7962)">
+          <g>
+            <circle r="10" fill="rgba(23,131,255,1)" stroke="rgba(0,0,0,1)" stroke-width="0" class="key"/>
+          </g>
+        </g>
+        <g fill="none" transform="matrix(1 0 0 1 124.348 190.4568)">
+          <g>
+            <circle r="10" fill="rgba(23,131,255,1)" stroke="rgba(0,0,0,1)" stroke-width="0" class="key"/>
+          </g>
+        </g>
+        <g fill="none" transform="matrix(1 0 0 1 220.3222 273.3245)">
+          <g>
+            <circle r="10" fill="rgba(23,131,255,1)" stroke="rgba(0,0,0,1)" stroke-width="0" class="key"/>
+          </g>
+        </g>
+        <g fill="none" transform="matrix(1 0 0 1 156.5474 271.011)">
+          <g>
+            <circle r="10" fill="rgba(23,131,255,1)" stroke="rgba(0,0,0,1)" stroke-width="0" class="key"/>
+          </g>
+        </g>
+        <g fill="none" transform="matrix(1 0 0 1 171.8145 279.6566)">
+          <g>
+            <circle r="10" fill="rgba(23,131,255,1)" stroke="rgba(0,0,0,1)" stroke-width="0" class="key"/>
+          </g>
+        </g>
+        <g fill="none" transform="matrix(1 0 0 1 108.0012 157.5402)">
+          <g>
+            <circle r="10" fill="rgba(23,131,255,1)" stroke="rgba(0,0,0,1)" stroke-width="0" class="key"/>
+          </g>
+        </g>
+        <g fill="none" transform="matrix(1 0 0 1 138.816 229.6478)">
+          <g>
+            <circle r="10" fill="rgba(23,131,255,1)" stroke="rgba(0,0,0,1)" stroke-width="0" class="key"/>
+          </g>
+        </g>
+        <g fill="none" transform="matrix(1 0 0 1 91.1919 173.8947)">
+          <g>
+            <circle r="10" fill="rgba(23,131,255,1)" stroke="rgba(0,0,0,1)" stroke-width="0" class="key"/>
+          </g>
+        </g>
+        <g fill="none" transform="matrix(1 0 0 1 147.2652 218.2623)">
+          <g>
+            <circle r="10" fill="rgba(23,131,255,1)" stroke="rgba(0,0,0,1)" stroke-width="0" class="key"/>
+          </g>
+        </g>
+        <g fill="none" transform="matrix(1 0 0 1 156.8644 206.8258)">
+          <g>
+            <circle r="10" fill="rgba(23,131,255,1)" stroke="rgba(0,0,0,1)" stroke-width="0" class="key"/>
+          </g>
+        </g>
+        <g fill="none" transform="matrix(1 0 0 1 137.7822 257.9929)">
+          <g>
+            <circle r="10" fill="rgba(23,131,255,1)" stroke="rgba(0,0,0,1)" stroke-width="0" class="key"/>
+          </g>
+        </g>
+        <g fill="none" transform="matrix(1 0 0 1 125.8742 224.421)">
+          <g>
+            <circle r="10" fill="rgba(23,131,255,1)" stroke="rgba(0,0,0,1)" stroke-width="0" class="key"/>
+          </g>
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/packages/g6/__tests__/unit/behaviors/zoom-canvas.spec.ts
+++ b/packages/g6/__tests__/unit/behaviors/zoom-canvas.spec.ts
@@ -226,6 +226,21 @@ describe('behavior zoom canvas', () => {
     expect(graph.getZoom()).toBe(currentZoom * 1.1);
   });
 
+  it('zoom to canvas center', async () => {
+    const center = graph.getCanvasCenter();
+
+    graph.setBehaviors([{ type: 'zoom-canvas', origin: center }]);
+
+    const currentZoom = graph.getZoom();
+    const targetZoom = currentZoom * 0.5;
+
+    graph.emit(CommonEvent.WHEEL, { deltaY: 50 });
+
+    expect(graph.getZoom()).toBe(targetZoom);
+
+    await expect(graph).toMatchSnapshot(__filename, 'zoom-to-canvas-center');
+  });
+
   it('canvas event', () => {
     const canvas = graph.getCanvas();
 

--- a/packages/g6/src/behaviors/zoom-canvas.ts
+++ b/packages/g6/src/behaviors/zoom-canvas.ts
@@ -36,7 +36,7 @@ export interface ZoomCanvasOptions extends BaseBehaviorOptions {
    */
   enable?: boolean | ((event: IWheelEvent | IKeyboardEvent | IPointerEvent) => boolean);
   /**
-   * <zh/> 缩放中心(视口坐标)
+   * <zh/> 缩放中心点(视口坐标)
    * - 默认情况下为鼠标位置中心
    *
    * <en/> zoom center(viewport coordinates)

--- a/packages/g6/src/behaviors/zoom-canvas.ts
+++ b/packages/g6/src/behaviors/zoom-canvas.ts
@@ -41,8 +41,8 @@ export interface ZoomCanvasOptions extends BaseBehaviorOptions {
    *
    * <en/> zoom center(viewport coordinates)
    * - by default , the center is the mouse position center
-  */
- origin?: Point;
+   */
+  origin?: Point;
   /**
    * <zh/> 触发缩放的方式
    * - ShortcutKey：组合快捷键，**默认使用滚轮缩放**，['Control'] 表示按住 Control 键滚动鼠标滚轮时触发缩放

--- a/packages/g6/src/behaviors/zoom-canvas.ts
+++ b/packages/g6/src/behaviors/zoom-canvas.ts
@@ -36,6 +36,14 @@ export interface ZoomCanvasOptions extends BaseBehaviorOptions {
    */
   enable?: boolean | ((event: IWheelEvent | IKeyboardEvent | IPointerEvent) => boolean);
   /**
+   * <zh/> 缩放中心(视口坐标)
+   * - 默认情况下为鼠标位置中心
+   *
+   * <en/> zoom center(viewport coordinates)
+   * - by default , the center is the mouse position center
+  */
+ origin?: Point;
+  /**
    * <zh/> 触发缩放的方式
    * - ShortcutKey：组合快捷键，**默认使用滚轮缩放**，['Control'] 表示按住 Control 键滚动鼠标滚轮时触发缩放
    * - CombinationKey：缩放快捷键，例如 { zoomIn: ['Control', '+'], zoomOut: ['Control', '-'], reset: ['Control', '0'] }
@@ -160,8 +168,8 @@ export class ZoomCanvas extends BaseBehavior<ZoomCanvasOptions> {
     if (!this.validate(event)) return;
     const { graph } = this.context;
 
-    let origin: Point | undefined;
-    if ('viewport' in event) {
+    let origin: Point | undefined = this.options.origin;
+    if (!origin && 'viewport' in event) {
       origin = parsePoint(event.viewport as PointObject);
     }
 

--- a/packages/site/docs/manual/behavior/build-in/ZoomCanvas.en.md
+++ b/packages/site/docs/manual/behavior/build-in/ZoomCanvas.en.md
@@ -37,6 +37,12 @@ Whether to enable the animation of zooming
 
 Whether to enable the function of zooming the canvas
 
+### origin
+
+> [Point](/api/viewport#point)
+
+Zoom center point (viewport coordinates)
+
 ### onFinish
 
 > _() => void_

--- a/packages/site/docs/manual/behavior/build-in/ZoomCanvas.zh.md
+++ b/packages/site/docs/manual/behavior/build-in/ZoomCanvas.zh.md
@@ -56,6 +56,7 @@ const graph = new Graph({
 | type           | 交互类型名称                                             | string                                                                              | `zoom-canvas`       | ✓    |
 | animation      | 缩放动画效果设置                                         | [ViewportAnimationEffectTiming](/manual/graph/option#viewportanimationeffecttiming) | `{ duration: 200 }` |      |
 | enable         | 是否启用该交互                                           | boolean \| ((event: Event) => boolean)                                              | true                |      |
+| origin         | 缩放中心点(视口坐标)                                        | [Point](/api/viewport#point) | -                   |      |
 | onFinish       | 缩放完成时的回调函数                                     | () => void                                                                          | -                   |      |
 | preventDefault | 是否阻止浏览器默认事件                                   | boolean                                                                             | true                |      |
 | sensitivity    | 缩放灵敏度，值越大缩放速度越快                           | number                                                                              | 1                   |      |
@@ -107,6 +108,20 @@ const graph = new Graph({
   width: 800,
   height: 600,
   behaviors: ['zoom-canvas'],
+});
+```
+
+### 自定义缩放中心
+
+```javascript
+const graph = new Graph({
+  // 其他配置...
+  behaviors: [
+    {
+      type: 'zoom-canvas',
+      origin: graph.getCanvasCenter(), // 以视口中心为原点进行缩放
+    },
+  ],
 });
 ```
 


### PR DESCRIPTION
在缩放画布行为中新增 `origin` 选项，允许用户指定缩放中心点。默认情况下，缩放中心为鼠标位置#7064