### PR TITLE
fix: 修复图片节点空心光晕导致的分组边框计算问题 (#7101)

### DIFF
--- a/packages/g6/__tests__/demos/image-node-halo-test.ts
+++ b/packages/g6/__tests__/demos/image-node-halo-test.ts
@@ -1,0 +1,54 @@
+import data from '@@/dataset/dagre-combo.json';
+import { Graph } from '@antv/g6';
+
+export const imageNodeHaloTest: TestCase = async (context) => {
+  const graph = new Graph({
+    ...context,
+    autoFit: 'center',
+    data,
+    node: {
+      type: (d) => (Number(d.id) % 2 === 0 ? 'image' : 'rect'),
+      style: {
+        src: 'https://gw.alipayobjects.com/mdn/rms_6ae20b/afts/img/A*N4ZMS7gHsUIAAAAAAAAAAABkARQnAQ',
+        size: [60, 30],
+        radius: 8,
+        labelText: (d) => d.id,
+        labelBackground: true,
+        ports: [{ placement: 'top' }, { placement: 'bottom' }],
+      },
+      state: {
+        selected: {
+          haloStroke: '#111',
+          haloLineWidth: 80,
+        },
+      },
+      palette: {
+        field: (d) => d.combo,
+      },
+    },
+    edge: {
+      type: 'cubic-vertical',
+      style: {
+        endArrow: true,
+      },
+    },
+    combo: {
+      type: 'rect',
+      style: {
+        radius: 8,
+        labelText: (d) => d.id,
+      },
+    },
+    layout: {
+      type: 'antv-dagre',
+      ranksep: 50,
+      nodesep: 5,
+      sortByCombo: true,
+    },
+    behaviors: ['drag-element', 'drag-canvas', 'zoom-canvas', 'click-select'],
+  });
+
+  await graph.render();
+
+  return graph;
+};

--- a/packages/g6/__tests__/demos/index.ts
+++ b/packages/g6/__tests__/demos/index.ts
@@ -77,6 +77,7 @@ export { elementVisibility } from './element-visibility';
 export { elementVisibilityPart } from './element-visibility-part';
 export { elementZIndex } from './element-z-index';
 export { graphToDataURL } from './graph-to-data-url';
+export { imageNodeHaloTest } from './image-node-halo-test';
 export { layoutAntVDagreFlow } from './layout-antv-dagre-flow';
 export { layoutAntVDagreFlowCombo } from './layout-antv-dagre-flow-combo';
 export { layoutCircularBasic } from './layout-circular-basic';

--- a/packages/g6/src/elements/nodes/image.ts
+++ b/packages/g6/src/elements/nodes/image.ts
@@ -58,14 +58,26 @@ export class Image extends BaseNode<ImageStyleProps> {
     };
   }
 
+  public getBounds() {
+    return this.getShape('key').getBounds();
+  }
+
   protected getHaloStyle(attributes: Required<ImageStyleProps>): false | GRectStyleProps {
     if (attributes.halo === false) return false;
     const { fill: keyStyleFill, stroke: keyStyleStroke, ...keyStyle } = this.getShape<GRect>('key').attributes;
     const haloStyle = subStyleProps(this.getGraphicStyle(attributes), 'halo');
     const haloLineWidth = Number(haloStyle.lineWidth);
     const [width, height] = add(this.getSize(attributes), [haloLineWidth, haloLineWidth]);
-    const fill = 'transparent';
-    return { ...haloStyle, width, height, fill, x: -width / 2, y: -height / 2 };
+    const { lineWidth } = haloStyle;
+    const recalculate = {
+      fill: 'transparent',
+      lineWidth: lineWidth / 2,
+      width: width - lineWidth / 2,
+      height: height - lineWidth / 2,
+      x: -(width - lineWidth / 2) / 2,
+      y: -(height - lineWidth / 2) / 2,
+    };
+    return { ...haloStyle, ...recalculate };
   }
 
   protected getIconStyle(attributes: Required<ImageStyleProps>): false | IconStyleProps {


### PR DESCRIPTION
* fix: 修复图片节点空心光晕导致的分组边框计算问题 (#7101)

* fix: 修正图片节点光晕的线宽、尺寸和位置

* test: 添加图片节点光晕测试用例 imageNodeHaloTest

在相同配置参数下的节点效果
```js
      state: {
        selected: {
          haloStroke: '#111',
          haloLineWidth: 80,
        },
      },
```

### 普通节点效果图
![432ba73e364479350fbf28e7932810d](https://github.com/user-attachments/assets/6e7cd503-e80e-4ebe-ac66-418a5224b971)

### image节点修复前效果
![61c99ad51d718f87acb39dbea267070](https://github.com/user-attachments/assets/1a5d9499-2c9a-40bb-8934-673f5702061f)

### image节点修复后效果
![e01cf9c6ddcfeccf2b8d8b1525699ff](https://github.com/user-attachments/assets/f71a0f3f-fde6-42d4-a8f8-972febee7711)

## 解决方案
### 边界计算
g6\src\elements\combos\base-combo.ts 148 行，使用了getBounds来获取边界，使用的是来自 @antv/g 的底层渲染引擎
![775127067791a2d130ac54e4b56a369](https://github.com/user-attachments/assets/ff4648ab-a78b-409c-92eb-10b3ecfd398d)
此方法也会把halo计算进去，由于图片元素的halo需要中间为空心（如普通节点非空心且中心点正确则不会有影响），会导致其体积被边界计算，因此重写image节点的getBounds方法直接返回 key shape 的包围盒只考虑节点的主要图形的边界即可

### 线宽计算
为与普通节点的halo效果保持一致，重新计算了线宽、尺寸和位置