### PR TITLE
fix: drag canvas and minimap conflict in chrome (#7038)

### DIFF
--- a/packages/g6/src/plugins/minimap/index.ts
+++ b/packages/g6/src/plugins/minimap/index.ts
@@ -392,6 +392,8 @@ export class Minimap extends BasePlugin<MinimapOptions> {
     if (!this.mask) {
       this.mask = document.createElement('div');
       this.mask.addEventListener('pointerdown', this.onMaskDragStart);
+      this.mask.draggable = true;
+      this.mask.addEventListener('dragstart', (event) => event.preventDefault && event.preventDefault());
     }
 
     this.container.appendChild(this.mask);


### PR DESCRIPTION
fixed #7038 

测试了下在火狐浏览器没有这个bug，在谷歌浏览器中有这个bug。怀疑谷歌浏览器的默认拖拽行为有点问题。

暂时想到的办法

- 启用遮罩mask的draggable属性
- 阻止浏览器的默认拖拽行为