### PR TITLE
docs: fix the button link URLs on the English homepage(#7136)

### DIFF
--- a/packages/site/.dumirc.ts
+++ b/packages/site/.dumirc.ts
@@ -420,14 +420,20 @@ export default defineConfig({
             zh: '开始使用',
             en: 'Getting Started',
           },
-          link: `/manual/introduction`,
+          link: {
+            zh: '/manual/introduction',
+            en: '/en/manual/introduction',
+          },
         },
         {
           text: {
             zh: '图表示例',
             en: 'Playground',
           },
-          link: `/examples`,
+          link: {
+            zh: '/examples',
+            en: '/en/examples',
+          },
           type: 'primary',
         },
       ],


### PR DESCRIPTION
改进文档问题：https://github.com/antvis/G6/issues/7136
文档地址：https://g6.antv.antgroup.com/en

![CleanShot 2025-05-15 at 17 23 57@2x](https://github.com/user-attachments/assets/71496094-e3e3-400a-bcc9-6c15330d0763)
