### PR TITLE
fix(Minimap): fix issue 7170

### DIFF
--- a/packages/g6/src/plugins/minimap/index.ts
+++ b/packages/g6/src/plugins/minimap/index.ts
@@ -505,7 +505,7 @@ export class Minimap extends BasePlugin<MinimapOptions> {
 
   public destroy(): void {
     this.unbindEvents();
-    this.canvas.destroy();
+    this.canvas?.destroy();
     this.mask?.remove();
     super.destroy();
   }


### PR DESCRIPTION
#7170 

`Cannot read properties of undefined (reading 'destroy') at Minimap.destroy` 