### PR TITLE
fix(background): add isolation style to parent element

### DIFF
--- a/packages/g6/src/runtime/canvas.ts
+++ b/packages/g6/src/runtime/canvas.ts
@@ -404,6 +404,8 @@ function configCanvasDom(layers: Record<CanvasLayer, GCanvas>) {
 
     if (domElement?.parentElement) {
       domElement.parentElement.style.display = 'grid';
+      // 给父元素设置独立的层叠上下文，避免外部元素影响内部的层叠逻辑
+      domElement.parentElement.style.isolation = 'isolate';
     }
   });
 }


### PR DESCRIPTION
- Fixed: #7197 

**Reason**  

如果 graph 容器的上层元素存在设置了定位，并且 bakground 不为透明，则会覆盖掉 `background` 插件，比如：

```
<div id="parent" style="position: relative; background: #fff;">
  <div id="graphContainer">
    <div id="g6-background" style="position: relative; background:red; z-index: -1;"></div>
  </div>
</div>
```

如上代码所示， graph 容器的 parent 设置了定位以及白色背景，`background` 插件给 `dom` 自带了 `z-index:-1` （没错，也是我提 PR 加的...）， #parent 创建了一个新的层叠上下文，且配了背景色，底下元素配了 `z-index` 都要在这个层叠上下文中比较，因此-1也就藏在了 #parent 元素下面（ graph 容器配个 `position:relative;` 也是会生成层叠上下文，但也是嵌套到 parent 的）

**Fixed**  
给graph容器加个 `isolation: isolate` 样式，创建一个独立的层叠上下文，不让更上层元素影响到