### PR TITLE
feat: adds extension for solid-js

### DIFF
--- a/packages/g6-extension-solid/README.md
+++ b/packages/g6-extension-solid/README.md
@@ -1,0 +1,118 @@
+## SolidJS extension for G6
+
+<img width="500" src="https://mdn.alipayobjects.com/huamei_qa8qxu/afts/img/A*rWSiT6dnwfcAAAAAAAAAAAAADmJ7AQ/original" />
+
+This extension allows you to define G6 node by SolidJS component and JSX syntax with fine-grained reactivity.
+
+## Features
+
+- **Familiar JSX syntax**: Write components using JSX just like React, but with SolidJS's reactive primitives
+- **Fine-grained reactivity**: Unlike React's virtual DOM, SolidJS uses signals for surgical DOM updates
+- **No re-renders**: Component props are reactive signals that update only the parts of the DOM that depend on them
+
+## Usage
+
+1. Install
+
+```bash
+npm install @antv/g6-extension-solid
+```
+
+2. Import and Register
+
+```js
+import { ExtensionCategory, register } from '@antv/g6';
+import { SolidNode } from '@antv/g6-extension-solid';
+
+register(ExtensionCategory.NODE, 'solid-node', SolidNode);
+```
+
+3. Define Node
+
+SolidJS Node:
+
+```jsx
+const SolidNode = (props) => {
+  return <div>node: {props.id}</div>;
+};
+```
+
+G Node with SolidJS:
+
+```jsx
+import { Group, Rect, Text } from '@antv/g6-extension-solid';
+
+const GNode = (props) => {
+  return <Group>
+    <Rect width={100} height={100}></Rect>
+    <Text text={props.label || "node"} />
+  </Group>
+};
+```
+
+Reactive Node:
+
+```jsx
+import { createSignal } from 'solid-js';
+
+const ReactiveNode = (props) => {
+  const [count, setCount] = createSignal(0);
+  
+  return (
+    <div onClick={() => setCount(count() + 1)}>
+      Node {props.id}: {count()} clicks
+    </div>
+  );
+};
+```
+
+4. Use
+
+Use SolidNode:
+
+```jsx
+const graph = new Graph({
+  // ... other options
+  node: {
+    type: 'solid-node',
+    style: {
+      component: SolidNode,
+    },
+  },
+});
+```
+
+Use GNode:
+
+```jsx
+const graph = new Graph({
+  // ... other options
+  node: {
+    type: 'solid-node',
+    style: {
+      component: GNode,
+    },
+  },
+});
+```
+
+## Key Differences from React Extension
+
+1. **Reactivity Model**: SolidJS uses signals instead of virtual DOM, providing automatic fine-grained updates
+2. **Performance**: No re-renders - only the specific DOM nodes that depend on changed signals are updated
+3. **Props Updates**: Node attributes are automatically reactive through signals, no manual re-rendering needed
+
+## Q&A
+
+1. Difference between SolidNode and GNode
+
+SolidNode is a Solid JSX component that renders to regular DOM, while GNode supports JSX syntax but can only use G tag nodes for SVG/Canvas rendering.
+
+2. How does reactivity work?
+
+The extension automatically creates signals for node attributes. When attributes change in G6, the signals update, and SolidJS reactively updates only the parts of the DOM that depend on those signals.
+
+## Resources
+
+- [SolidJS Documentation](https://www.solidjs.com/)
+- [G6 Custom Nodes](https://g6.antv.antgroup.com/examples/element/custom-node/)

--- a/packages/g6-extension-solid/__tests__/.eslintrc
+++ b/packages/g6-extension-solid/__tests__/.eslintrc
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "no-console": "off"
+  }
+}

--- a/packages/g6-extension-solid/__tests__/dataset/euro-cup.json
+++ b/packages/g6-extension-solid/__tests__/dataset/euro-cup.json
@@ -1,0 +1,114 @@
+{
+  "nodes": [
+    {
+      "id": "50251337",
+      "x": 50,
+      "y": 68,
+      "isTeamA": "1",
+      "player_id": "50251337",
+      "player_shirtnumber": "19",
+      "player_enName": "Justin Kluivert",
+      "player_name": "尤斯廷-克鲁伊维特"
+    },
+    {
+      "id": "50436685",
+      "x": 25,
+      "y": 68,
+      "isTeamA": "1",
+      "player_id": "50436685",
+      "player_shirtnumber": "24",
+      "player_enName": "Antoine Semenyo",
+      "player_name": "塞门约"
+    },
+    {
+      "id": "50204813",
+      "x": 50,
+      "y": 89,
+      "isTeamA": "1",
+      "player_id": "50204813",
+      "player_shirtnumber": "9",
+      "player_enName": "Dominic Solanke",
+      "player_name": "索兰克"
+    },
+    {
+      "id": "50250175",
+      "x": 75,
+      "y": 68,
+      "isTeamA": "1",
+      "player_id": "50250175",
+      "player_shirtnumber": "16",
+      "player_enName": "Marcus Tavernier",
+      "player_name": "塔韦尼耶"
+    },
+    {
+      "id": "50213675",
+      "x": 65,
+      "y": 48,
+      "isTeamA": "1",
+      "player_id": "50213675",
+      "player_shirtnumber": "4",
+      "player_enName": "Lewis Cook",
+      "player_name": "刘易斯-库克"
+    },
+    {
+      "id": "50186648",
+      "x": 35,
+      "y": 48,
+      "isTeamA": "1",
+      "player_id": "50186648",
+      "player_shirtnumber": "10",
+      "player_enName": "Ryan Christie",
+      "player_name": "克里斯蒂"
+    },
+    {
+      "id": "50279448",
+      "x": 38,
+      "y": 28,
+      "isTeamA": "1",
+      "player_id": "50279448",
+      "player_shirtnumber": "6",
+      "player_enName": "Chris Mepham",
+      "player_name": "迈帕姆"
+    },
+    {
+      "id": "50061646",
+      "x": 15,
+      "y": 28,
+      "isTeamA": "1",
+      "player_id": "50061646",
+      "player_shirtnumber": "15",
+      "player_enName": "Adam Smith",
+      "player_name": "亚当-史密斯"
+    },
+    {
+      "id": "50472140",
+      "x": 62,
+      "y": 28,
+      "isTeamA": "1",
+      "player_id": "50472140",
+      "player_shirtnumber": "27",
+      "player_enName": "Ilya Zabarnyi",
+      "player_name": "扎巴尔尼"
+    },
+    {
+      "id": "50544346",
+      "x": 85,
+      "y": 28,
+      "isTeamA": "1",
+      "player_id": "50544346",
+      "player_shirtnumber": "3",
+      "player_enName": "Milos Kerkez",
+      "player_name": "科尔克兹"
+    },
+    {
+      "id": "50062598",
+      "x": 50,
+      "y": 7,
+      "isTeamA": "1",
+      "player_id": "50062598",
+      "player_shirtnumber": "1",
+      "player_enName": "Neto",
+      "player_name": "内托"
+    }
+  ]
+}

--- a/packages/g6-extension-solid/__tests__/demos/euro-cup.tsx
+++ b/packages/g6-extension-solid/__tests__/demos/euro-cup.tsx
@@ -1,0 +1,118 @@
+/* @jsx preserve */
+/* @jsxImportSource solid-js */
+import { ExtensionCategory, register } from '@antv/g6';
+import { SolidNode } from '@antv/g6-extension-solid';
+import styled from 'styled-components';
+import data from '../dataset/euro-cup.json';
+import { Graph } from '../graph';
+
+const Player = styled.div`
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+`;
+
+const Shirt = styled.div`
+  width: 40px;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+
+  img {
+    width: 40px;
+    position: absolute;
+    left: 0;
+    top: 0;
+  }
+`;
+
+const Number = styled.div`
+  color: #fff;
+  font-family: 'DingTalk-JinBuTi';
+  font-size: 10px;
+  top: 20px;
+  left: 15px;
+  z-index: 1;
+  margin-top: 16px;
+  margin-left: -2px;
+`;
+
+const Label = styled.div`
+  max-width: 120px;
+  padding: 0 8px;
+  color: #fff;
+  font-size: 10px;
+  background-image: url('https://mdn.alipayobjects.com/huamei_92awrc/afts/img/A*s2csQ48M0AkAAAAAAAAAAAAADsvfAQ/original');
+  background-repeat: no-repeat;
+  background-size: cover;
+  display: flex;
+  justify-content: center;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
+
+const PlayerNode = ({ playerInfo }: any) => {
+  const { isTeamA, player_shirtnumber, player_name } = playerInfo;
+  return (
+    <Player>
+      <Shirt>
+        <img
+          src={
+            isTeamA
+              ? 'https://mdn.alipayobjects.com/huamei_92awrc/afts/img/A*0oAaS42vqWcAAAAAAAAAAAAADsvfAQ/original'
+              : 'https://mdn.alipayobjects.com/huamei_92awrc/afts/img/A*BYH5SauBNecAAAAAAAAAAAAADsvfAQ/original'
+          }
+        />
+        <Number>{player_shirtnumber}</Number>
+      </Shirt>
+      <Label>{player_name}</Label>
+    </Player>
+  );
+};
+
+register(ExtensionCategory.NODE, 'solid-node', SolidNode);
+
+export const EuroCup = () => {
+  return (
+    <div>
+      <Graph
+        options={{
+          data,
+          animation: false,
+          x: 10,
+          y: 50,
+          width: 480,
+          height: 720,
+          node: {
+            type: 'solid-node',
+            style: {
+              size: [100, 60],
+              ports: [{ placement: 'center' }],
+              x: (d: any) => d.x * 3.5,
+              y: (d: any) => d.y * 3.5,
+              fill: 'transparent',
+              component: (data: any) => <PlayerNode playerInfo={data} />,
+            },
+          },
+          plugins: [
+            {
+              type: 'background',
+              width: '480px',
+              height: '720px',
+              backgroundImage:
+                'url(https://mdn.alipayobjects.com/huamei_qa8qxu/afts/img/A*EmPXQLrX2xIAAAAAAAAAAAAADmJ7AQ/original)',
+              backgroundRepeat: 'no-repeat',
+              backgroundSize: 'contain',
+              opacity: 1,
+            },
+          ],
+        }}
+      />
+    </div>
+  );
+};

--- a/packages/g6-extension-solid/__tests__/demos/graph.tsx
+++ b/packages/g6-extension-solid/__tests__/demos/graph.tsx
@@ -1,0 +1,26 @@
+/* @jsx preserve */
+/* @jsxImportSource solid-js */
+import { Graph } from '../graph';
+
+export const G6Graph = () => {
+  return (
+    <Graph
+      options={{
+        data: {
+          nodes: [
+            { id: 'node-1', style: { x: 100, y: 100, labelText: 'Hello' } },
+            { id: 'node-2', style: { x: 300, y: 100, labelText: 'World' } },
+          ],
+          edges: [{ source: 'node-1', target: 'node-2' }],
+        },
+        behaviors: ['drag-element'],
+      }}
+      onRender={() => {
+        console.log('render');
+      }}
+      onDestroy={() => {
+        console.log('destroy');
+      }}
+    />
+  );
+};

--- a/packages/g6-extension-solid/__tests__/demos/index.tsx
+++ b/packages/g6-extension-solid/__tests__/demos/index.tsx
@@ -1,0 +1,4 @@
+export * from './euro-cup';
+export * from './graph';
+export * from './performance-diagnosis';
+export * from './react-node';

--- a/packages/g6-extension-solid/__tests__/demos/performance-diagnosis.tsx
+++ b/packages/g6-extension-solid/__tests__/demos/performance-diagnosis.tsx
@@ -1,0 +1,154 @@
+/* @jsx preserve */
+/* @jsxImportSource solid-js */
+import { BugOutlined } from '@ant-design/icons';
+import type { EdgeData, Element, GraphData, GraphOptions, IPointerEvent, NodeData } from '@antv/g6';
+import { ExtensionCategory, HoverActivate, idOf, register } from '@antv/g6';
+import { Flex, Typography } from 'antd';
+import { type JSX, createSignal, createEffect } from 'solid-js';
+import { Graph } from '../graph';
+
+const { Text } = Typography;
+
+const ACTIVE_COLOR = '#f6c523';
+const COLOR_MAP: Record<string, string> = {
+  'pre-inspection': '#3fc1c9',
+  problem: '#8983f3',
+  inspection: '#f48db4',
+  solution: '#ffaa64',
+};
+
+class HoverElement extends HoverActivate {
+  protected getActiveIds(event: IPointerEvent<Element>) {
+    const { model, graph } = this.context;
+    const elementId = event.target.id;
+    const { targetType: elementType } = event;
+
+    const ids = [elementId];
+    if (elementType === 'edge') {
+      const edge = model.getEdgeDatum(elementId);
+      ids.push(edge.source, edge.target);
+    } else if (elementType === 'node') {
+      ids.push(...model.getRelatedEdgesData(elementId).map(idOf));
+    }
+
+    graph.frontElement(ids);
+
+    return ids;
+  }
+}
+
+register(ExtensionCategory.BEHAVIOR, 'hover-element', HoverElement);
+
+const Node = ({ data }: { data: NodeData }) => {
+  const { text, type } = data.data as { text: string; type: string };
+
+  const isHovered = data.states?.includes('active');
+  const isSelected = data.states?.includes('selected');
+  const color = isHovered ? ACTIVE_COLOR : COLOR_MAP[type];
+
+  const containerStyle: JSX.CSSProperties = {
+    width: '100%',
+    height: '100%',
+    background: color,
+    border: `3px solid ${color}`,
+    borderRadius: '16px',
+    cursor: 'pointer',
+  };
+
+  if (isSelected) {
+    Object.assign(containerStyle, { border: `3px solid #000` });
+  }
+
+  return (
+    <Flex style={containerStyle} align="center" justify="center">
+      <Flex vertical style={{ padding: '8px 16px', textAlign: 'center' }} align="center" justify="center">
+        {type === 'problem' && <BugOutlined style={{ color: '#fff', fontSize: 24, marginBottom: 8 }} />}
+        <Text style={{ color: '#fff', fontWeight: 600, fontSize: 16 }}>{text}</Text>
+      </Flex>
+    </Flex>
+  );
+};
+
+export const PerformanceDiagnosis = () => {
+  const [data, setData] = useState<GraphData>();
+
+  createEffect(() => {
+    fetch('https://assets.antv.antgroup.com/g6/performance-diagnosis.json')
+      .then((res) => res.json())
+      .then(setData);
+  }, []);
+
+  const options: GraphOptions = {
+    data,
+    animation: false,
+    width: 800,
+    height: 600,
+    autoFit: 'view',
+    node: {
+      type: 'react',
+      style: (d: NodeData) => {
+        const style: NodeData['style'] = {
+          component: <Node data={d} />,
+          ports: [{ placement: 'top' }, { placement: 'bottom' }],
+        };
+
+        const size = {
+          'pre-inspection': [240, 120],
+          problem: [200, 120],
+          inspection: [330, 100],
+          solution: [200, 120],
+        }[d.data!.type as string] || [200, 80];
+
+        Object.assign(style, {
+          size,
+          dx: -size[0] / 2,
+          dy: -size[1] / 2,
+        });
+        return style;
+      },
+      state: {
+        active: {
+          halo: false,
+        },
+        selected: {
+          halo: false,
+        },
+      },
+    },
+    edge: {
+      type: 'polyline',
+      style: {
+        lineWidth: 3,
+        radius: 20,
+        stroke: '#8b9baf',
+        endArrow: true,
+        labelText: (d: EdgeData) => d.data!.text as string,
+        labelFill: '#8b9baf',
+        labelFontWeight: 600,
+        labelBackground: true,
+        labelBackgroundFill: '#f8f8f8',
+        labelBackgroundOpacity: 1,
+        labelBackgroundLineWidth: 3,
+        labelBackgroundStroke: '#8b9baf',
+        labelPadding: [1, 10],
+        labelBackgroundRadius: 4,
+        router: {
+          type: 'orth',
+        },
+      },
+      state: {
+        active: {
+          stroke: ACTIVE_COLOR,
+          labelBackgroundStroke: ACTIVE_COLOR,
+          halo: false,
+        },
+      },
+    },
+    layout: {
+      type: 'antv-dagre',
+    },
+    behaviors: ['zoom-canvas', 'drag-canvas', 'hover-element', 'click-select'],
+  };
+
+  return <Graph options={options} />;
+};

--- a/packages/g6-extension-solid/__tests__/demos/solid-node.tsx
+++ b/packages/g6-extension-solid/__tests__/demos/solid-node.tsx
@@ -1,0 +1,213 @@
+
+import type { Graph as G6Graph, GraphOptions, NodeData } from '@antv/g6';
+import { ExtensionCategory, register } from '@antv/g6';
+import { SolidNode } from '@antv/g6-extension-solid';
+import { createSignal } from 'solid-js';
+import { Graph } from '../graph';
+
+const { Content, Footer } = Layout;
+const { Text } = Typography;
+
+register(ExtensionCategory.NODE, 'solid-node', SolidNode);
+
+type Datum = {
+  name: string;
+  status: 'success' | 'error' | 'warning';
+  type: 'local' | 'remote';
+  url: string;
+};
+
+const Node = ({ data, onChange }: { data: NodeData; onChange?: (value: string) => void }) => {
+  const { status, type } = data.data as Datum;
+
+  return (
+    <Flex style={{ width: '100%', height: '100%', background: '#fff', padding: 10, borderRadius: 5 }} vertical>
+      <Flex align="center" justify="space-between">
+        <Text>
+          <DatabaseFilled />
+          Server
+          <Tag>{type}</Tag>
+        </Text>
+        <Badge status={status} />
+      </Flex>
+      <Text type="secondary">{data.id}</Text>
+      <Flex align="center">
+        <Text style={{ flexShrink: 0 }}>
+          <Text type="danger">*</Text>URL:
+        </Text>
+        <Input
+          style={{ borderRadius: 0, borderBottom: '1px solid #d9d9d9' }}
+          variant="borderless"
+          value={data.data?.url as string}
+          onChange={(event) => {
+            const url = event.target.value;
+            onChange?.(url);
+          }}
+        />
+      </Flex>
+    </Flex>
+  );
+};
+
+export const ReactNodeDemo = () => {
+  const graphRef = useRef<G6Graph | null>(null);
+
+  const [form] = Form.useForm();
+  const isValidUrl = (url: string) => {
+    return /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_+.~#?&//=]*)/.test(
+      url,
+    );
+  };
+
+  const [options, setOptions] = createSignal<GraphOptions>({
+    data: {
+      nodes: [
+        {
+          id: 'local-server-1',
+          data: { status: 'success', type: 'local', url: 'http://localhost:3000' },
+          style: { x: 50, y: 50 },
+        },
+        {
+          id: 'remote-server-1',
+          data: { status: 'warning', type: 'remote' },
+          style: { x: 350, y: 50 },
+        },
+      ],
+      edges: [{ source: 'local-server-1', target: 'remote-server-1' }],
+    },
+    node: {
+      type: 'react',
+      style: {
+        size: [240, 100],
+        component: (data: NodeData) => (
+          <Node
+            data={data}
+            onChange={(url) => {
+              setOptions((prev) => {
+                if (!graphRef.current || graphRef.current.destroyed) return prev;
+                const nodes = graphRef.current.getNodeData();
+                const index = nodes.findIndex((node) => node.id === data.id);
+                const node = nodes[index];
+                const datum = {
+                  ...node.data,
+                  url,
+                  status: url === '' ? 'warning' : isValidUrl(url) ? 'success' : 'error',
+                } as Datum;
+                nodes[index] = { ...node, data: datum };
+                return { ...prev, data: { ...prev.data, nodes } };
+              });
+            }}
+          />
+        ),
+      },
+    },
+    behaviors: ['drag-element', 'zoom-canvas', 'drag-canvas'],
+  });
+
+  return (
+    <Layout style={{ width: 800, height: 400 }}>
+      <Content style={{ minHeight: 400 }}>
+        <Graph options={options} onRender={(graph) => (graphRef.current = graph)} />
+      </Content>
+      <Footer>
+        <Form form={form} initialValues={{ serverType: 'local' }}>
+          <Form.Item label="Server Type" name="serverType">
+            <Select
+              options={[
+                { label: 'Local', value: 'local' },
+                { label: 'Remote', value: 'remote' },
+              ]}
+            />
+          </Form.Item>
+          <Form.Item>
+            <Button.Group>
+              <Button
+                style={{ width: '100%' }}
+                type="primary"
+                onClick={() => {
+                  if (!graphRef.current || graphRef.current.destroyed) return;
+                  const type = form.getFieldValue('serverType');
+                  const status = 'warning';
+                  const length = (options.data?.nodes || []).filter((node) => node?.data?.type === type).length;
+                  setOptions((options) => ({
+                    ...options,
+                    data: {
+                      ...options.data,
+                      nodes: [
+                        ...graphRef.current!.getNodeData(),
+                        {
+                          id: `${type}-server-${length + 1}`,
+                          data: { type, status },
+                          style: { x: type === 'local' ? 50 : 350, y: 50 + length * 120 },
+                        },
+                      ],
+                    },
+                  }));
+                }}
+              >
+                Add Node
+              </Button>
+              <Button
+                onClick={() => {
+                  const { data } = options;
+                  const nodes = data?.nodes || [];
+                  setOptions((options) => ({
+                    ...options,
+                    data: {
+                      ...options.data,
+                      nodes: nodes.map((node, index) => {
+                        // return node;
+                        if (index === nodes.length - 1) {
+                          return {
+                            ...node,
+                            data: {
+                              ...node.data,
+                              status: node.data!.status === 'success' ? 'warning' : 'success',
+                            },
+                          };
+                        }
+                        return node;
+                      }),
+                    },
+                  }));
+
+                  graphRef.current?.draw();
+                }}
+              >
+                Update Node
+              </Button>
+              <Button
+                danger
+                onClick={() => {
+                  const { data } = options;
+                  const nodes = data?.nodes || [];
+                  setOptions((options) => ({
+                    ...options,
+                    data: {
+                      ...options.data,
+                      nodes: nodes.filter((node, index) => index !== nodes.length - 1),
+                    },
+                  }));
+                }}
+              >
+                Remove Node
+              </Button>
+            </Button.Group>
+          </Form.Item>
+        </Form>
+
+        <Table
+          columns={[
+            { title: 'Server', key: 'server', dataIndex: 'server' },
+            { title: 'URL', key: 'url', dataIndex: 'url' },
+          ]}
+          dataSource={(options.data?.nodes || []).map((node) => ({
+            key: node.id,
+            server: node.id,
+            url: (node?.data as Datum).url || 'Not Configured',
+          }))}
+        ></Table>
+      </Footer>
+    </Layout>
+  );
+};

--- a/packages/g6-extension-solid/__tests__/graph.tsx
+++ b/packages/g6-extension-solid/__tests__/graph.tsx
@@ -1,0 +1,42 @@
+/* @jsx preserve */
+/* @jsxImportSource solid-js */
+import { Graph as G6Graph, GraphOptions } from '@antv/g6';
+import { createEffect, createSignal, onCleanup, onMount } from 'solid-js';
+
+export interface GraphProps {
+  options: GraphOptions;
+  onRender?: (graph: G6Graph) => void;
+  onDestroy?: () => void;
+}
+
+export const Graph = (props: GraphProps) => {
+  const [graph, setGraph] = createSignal<G6Graph>();
+  let container!: HTMLDivElement;
+
+  const setGraphOptions = async (options: GraphOptions) => {
+    const g = graph();
+    if (!g) return;
+
+    g.setOptions(options);
+
+    await g.render();
+    props.onRender?.(g);
+  };
+
+  onMount(() => {
+    const graph = new G6Graph({ container });
+    setGraph(graph);
+
+    createEffect(() => {
+      void setGraphOptions(props.options);
+    });
+
+    onCleanup(() => {
+      graph.destroy();
+      props.onDestroy?.();
+      setGraph(undefined);
+    });
+  });
+
+  return <div ref={container} style={{ width: '100%', height: '100%' }} />;
+};

--- a/packages/g6-extension-solid/__tests__/index.html
+++ b/packages/g6-extension-solid/__tests__/index.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>@antv/g6-extension-react</title>
+    <style>
+      body {
+        margin: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./main.tsx"></script>
+  </body>
+</html>

--- a/packages/g6-extension-solid/__tests__/main.tsx
+++ b/packages/g6-extension-solid/__tests__/main.tsx
@@ -1,0 +1,38 @@
+/* @jsx preserve */
+/* @jsxImportSource solid-js */
+import { render } from '@antv/g6-extension-solid';
+import { RouteDefinition, Router, RouteSectionProps, useMatch, useNavigate } from '@solidjs/router';
+import * as demos from './demos';
+
+const App = (props: RouteSectionProps) => {
+  const navigate = useNavigate();
+  const match = useMatch(() => '/*');
+
+  return (
+    <Flex vertical>
+      <Select
+        value={match()?.params['*'] || Object.keys(demos)[0]}
+        options={Object.keys(demos).map((label) => ({ label, value: label }))}
+        style={{ width: 100 }}
+        onChange={(value) => navigate(value)}
+      />
+      {props.children}
+    </Flex>
+  );
+};
+
+const routes = {
+  path: '/',
+  component: App,
+  children: Object.entries(demos).map(([key, Demo]) => ({
+    path: key,
+    component: Demo,
+  })),
+} satisfies RouteDefinition;
+
+const container = document.getElementById('root')!;
+
+render(
+  () => <Router>{routes}</Router>,
+  container,
+);

--- a/packages/g6-extension-solid/__tests__/unit/attribute-changed-callback.spec.tsx
+++ b/packages/g6-extension-solid/__tests__/unit/attribute-changed-callback.spec.tsx
@@ -1,0 +1,32 @@
+import { ReactNode } from '../../src';
+
+it('attribute changed callback', () => {
+  const oldComponent = () => <div>test</div>;
+  const node = new ReactNode({
+    style: {
+      component: oldComponent,
+    },
+  });
+  Object.assign(node, {
+    isConnected: true,
+    ownerDocument: {
+      defaultView: {
+        dispatchEvent: () => {},
+      },
+    },
+  });
+
+  const spy = jest.fn();
+  node.attributeChangedCallback = spy;
+
+  const component = () => <div>test1</div>;
+
+  try {
+    node.update({ component });
+  } catch (e) {
+    // ignore
+  }
+
+  expect(spy).toHaveBeenCalled();
+  expect(spy).toHaveBeenLastCalledWith('component', oldComponent, component, undefined, undefined);
+});

--- a/packages/g6-extension-solid/__tests__/unit/default.spec.ts
+++ b/packages/g6-extension-solid/__tests__/unit/default.spec.ts
@@ -1,0 +1,5 @@
+describe('default', () => {
+  it('expect', () => {
+    expect(1).toBe(1);
+  });
+});

--- a/packages/g6-extension-solid/jest.config.js
+++ b/packages/g6-extension-solid/jest.config.js
@@ -1,0 +1,25 @@
+const esm = ['internmap', 'd3-*', 'lodash-es', 'chalk'].map((d) => `_${d}|${d}`).join('|');
+
+module.exports = {
+  transform: {
+    '^.+\\.[tj]sx?$': [
+      '@swc/jest',
+      {
+        jsc: {
+          parser: {
+            syntax: 'typescript',
+            decorators: true,
+            jsx: true,
+          },
+        },
+      },
+    ],
+  },
+  testRegex: '(/__tests__/.*\\.(test|spec))\\.(ts|tsx|js)$',
+  collectCoverageFrom: ['src/**/*.ts'],
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'json'],
+  transformIgnorePatterns: [`<rootDir>/node_modules/.pnpm/(?!(${esm}))`],
+  moduleNameMapper: {
+    '@antv/g6': '<rootDir>/../g6/src',
+  },
+};

--- a/packages/g6-extension-solid/package.json
+++ b/packages/g6-extension-solid/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "@antv/g6-extension-solid",
+  "version": "0.2.3",
+  "description": "Using SolidJS Component to Define Your G6 Graph Node",
+  "keywords": [
+    "antv",
+    "g6",
+    "extension",
+    "solid",
+    "solidjs",
+    "node"
+  ],
+  "repository": "https://github.com/antvis/G6.git",
+  "license": "MIT",
+  "author": "Aarebecca",
+  "main": "lib/index.js",
+  "module": "esm/index.js",
+  "types": "lib/index.d.ts",
+  "files": [
+    "src",
+    "esm",
+    "lib",
+    "dist",
+    "README"
+  ],
+  "scripts": {
+    "build": "run-p build:*",
+    "build:cjs": "rimraf ./lib && tsc --module commonjs --outDir lib -p tsconfig.build.json",
+    "build:esm": "rimraf ./esm && tsc --module ESNext --outDir esm -p tsconfig.build.json",
+    "build:umd": "rimraf ./dist && rollup -c",
+    "ci": "run-s lint type-check test build",
+    "dev": "vite",
+    "lint": "eslint ./src __tests__ --quiet && prettier ./src __tests__ --check",
+    "prepublishOnly": "npm run ci",
+    "test": "jest",
+    "type-check": "tsc --noEmit -p tsconfig.test.json"
+  },
+  "dependencies": {
+    "@antv/g": "^6.1.24",
+    "@antv/g-svg": "^2.0.38"
+  },
+  "devDependencies": {
+    "@antv/g6": "workspace:*",
+    "@solidjs/router": "^0.15.3",
+    "solid-js": "^1.8.0"
+  },
+  "peerDependencies": {
+    "@antv/g6": "workspace:^",
+    "solid-js": ">=1.8.0"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  }
+}

--- a/packages/g6-extension-solid/rollup.config.mjs
+++ b/packages/g6-extension-solid/rollup.config.mjs
@@ -1,0 +1,31 @@
+import commonjs from '@rollup/plugin-commonjs';
+import resolve from '@rollup/plugin-node-resolve';
+import terser from '@rollup/plugin-terser';
+import typescript from '@rollup/plugin-typescript';
+import nodePolyfills from 'rollup-plugin-polyfill-node';
+import { visualizer } from 'rollup-plugin-visualizer';
+
+const isBundleVis = !!process.env.BUNDLE_VIS;
+
+export default [
+  {
+    input: 'src/index.ts',
+    output: {
+      file: 'dist/g6-extension-react.min.js',
+      name: 'G6ExtensionReact',
+      format: 'umd',
+      sourcemap: false,
+      inlineDynamicImports: true,
+    },
+    plugins: [
+      nodePolyfills(),
+      resolve(),
+      commonjs(),
+      typescript({
+        tsconfig: 'tsconfig.build.json',
+      }),
+      terser(),
+      ...(isBundleVis ? [visualizer()] : []),
+    ],
+  },
+];

--- a/packages/g6-extension-solid/src/index.ts
+++ b/packages/g6-extension-solid/src/index.ts
@@ -1,0 +1,3 @@
+export { SolidNode, render, unmount } from './solid-node';
+
+export type { SolidNodeStyleProps } from './solid-node';

--- a/packages/g6-extension-solid/src/solid-node/index.ts
+++ b/packages/g6-extension-solid/src/solid-node/index.ts
@@ -1,0 +1,4 @@
+export { SolidNode } from './node';
+export { render, unmount } from './render';
+
+export type { SolidNodeStyleProps } from './node';

--- a/packages/g6-extension-solid/src/solid-node/node.tsx
+++ b/packages/g6-extension-solid/src/solid-node/node.tsx
@@ -1,0 +1,53 @@
+import type { DisplayObjectConfig, HTMLStyleProps as GHTMLStyleProps } from '@antv/g';
+import type { BaseNodeStyleProps, HTMLStyleProps } from '@antv/g6';
+import { HTML } from '@antv/g6';
+import type { Component, JSX } from 'solid-js';
+import { render, unmount } from './render';
+
+export interface SolidNodeStyleProps extends BaseNodeStyleProps {
+  /**
+   * <zh/> SolidJS 组件
+   *
+   * <en/> SolidJS component
+   */
+  component: Component;
+}
+
+export class SolidNode extends HTML {
+  
+
+  protected getKeyStyle(attributes: Required<HTMLStyleProps>): GHTMLStyleProps {
+    return { ...super.getKeyStyle(attributes) };
+  }
+
+  constructor(options: DisplayObjectConfig<SolidNodeStyleProps>) {
+    super(options as any);
+  }
+
+  public update(attr?: Partial<SolidNodeStyleProps> | undefined): void {
+    super.update(attr);
+  }
+
+  public connectedCallback() {
+    super.connectedCallback();
+    const { component } = this.attributes as unknown as SolidNodeStyleProps;
+    // component 已经被回调机制自动创建为 SolidNode
+    // component has been automatically created as SolidNode by the callback mechanism
+    render(component, this.getDomElement());
+  }
+
+  public attributeChangedCallback(name: any, oldValue: any, newValue: any) {
+    super.attributeChangedCallback(name, oldValue, newValue);
+    if (name === 'component' && oldValue !== newValue) {
+      render(
+        (this.attributes as unknown as SolidNodeStyleProps).component,
+        this.getDomElement(),
+      );
+    }
+  }
+
+  public destroy(): void {
+    unmount(this.getDomElement());
+    super.destroy();
+  }
+}

--- a/packages/g6-extension-solid/src/solid-node/render.ts
+++ b/packages/g6-extension-solid/src/solid-node/render.ts
@@ -1,0 +1,41 @@
+import type { Component } from 'solid-js';
+import { render as solidRender } from 'solid-js/web';
+
+// Track disposal functions for cleanup
+const MARK = '__solid_dispose__';
+
+type ContainerType = (Element | DocumentFragment) & {
+  [MARK]?: () => void;
+};
+
+/**
+ * <zh/> 渲染 SolidJS 组件
+ *
+ * <en/> Render SolidJS component
+ * @param component - <zh/> SolidJS 组件 | <en/> SolidJS component
+ * @param container - <zh/> 容器 | <en/> Container
+ */
+export function render(component: Component, container: ContainerType) {
+  // Clean up any existing component first
+  if (container[MARK]) {
+    container[MARK]();
+    delete container[MARK];
+  }
+
+  // Render the new component and store the disposal function
+  const dispose = solidRender(component, container);
+  container[MARK] = dispose;
+}
+
+/**
+ * <zh/> 卸载 SolidJS 组件
+ *
+ * <en/> Unmount SolidJS component
+ * @param container - <zh/> 容器 | <en/> Container
+ */
+export function unmount(container: ContainerType) {
+  if (container[MARK]) {
+    container[MARK]();
+    delete container[MARK];
+  }
+}

--- a/packages/g6-extension-solid/tsconfig.build.json
+++ b/packages/g6-extension-solid/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "paths": {}
+  },
+  "include": ["src/**/*"],
+  "extends": "./tsconfig.json"
+}

--- a/packages/g6-extension-solid/tsconfig.json
+++ b/packages/g6-extension-solid/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "jsx": "react-jsx",
+    "outDir": "lib",
+    "paths": {
+      "@antv/g6": ["../g6/src/index.ts"],
+      "@antv/g6-extension-react": ["./src/index.ts"]
+    }
+  },
+  "extends": "../../tsconfig.json",
+  "include": ["src/**/*", "__tests__/**/*"]
+}

--- a/packages/g6-extension-solid/tsconfig.test.json
+++ b/packages/g6-extension-solid/tsconfig.test.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "paths": {
+      "@antv/g6": ["../g6/src/index.ts"],
+      "@antv/g6-extension-react": ["./src/index.ts"]
+    },
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*", "__tests__/**/*", "../g6/src/layouts/hierarchy.d.ts"],
+  "extends": "./tsconfig.json"
+}

--- a/packages/g6-extension-solid/vite.config.js
+++ b/packages/g6-extension-solid/vite.config.js
@@ -1,0 +1,17 @@
+import path from 'path';
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  root: './__tests__',
+  server: {
+    port: 8082,
+    open: '/',
+  },
+  plugins: [{ name: 'isolation' }],
+  resolve: {
+    alias: {
+      '@antv/g6': path.resolve(__dirname, '../g6/src'),
+      '@antv/g6-extension-react': path.resolve(__dirname, './src'),
+    },
+  },
+});


### PR DESCRIPTION
Seeing as `g6-extension-react` exists, I decided to spend some time to add `g6-extension-solid`. 

SolidJS is a JSX library that allows you to create incredibly performant UIs.

It has the following points:

- Does not use a virtual DOM (VDOM)
- Renders only once (no re-renders like React)
- Uses fine-grained reactivity to track changes and apply highly performant updates

I believe Solid is a superior library to React and much easier to maintain (as you can see from the core implementation).

There is still more to do to finish this but I wanted to push up the draft PR to get a sense if this would be okay to add as part of G6? 

If not, happy to publish it under my own scope separately.