### PR TITLE
fix(edge-badge): add default edge badge opacity

### DIFF
--- a/packages/g6/src/themes/base.ts
+++ b/packages/g6/src/themes/base.ts
@@ -179,6 +179,7 @@ export function create(tokens: ThemeTokens): Theme {
         badgeFill: '#fff',
         badgeFontSize: 8,
         badgeOffsetX: 10,
+        badgeBackgroundOpacity: 1,
         fillOpacity: 1,
         halo: false,
         haloLineWidth: 12,


### PR DESCRIPTION
- Fixed: #7239 

![fix-7239](https://github.com/user-attachments/assets/6d3d45b7-4a15-48ca-b60a-ef8bbe059701)
