### PR TITLE
fix(transform): prevent redirected edges from being re-added in process-parallel-edges

### DIFF
--- a/packages/g6/__tests__/demos/bug-process-parallel-edges-combo-fixed.ts
+++ b/packages/g6/__tests__/demos/bug-process-parallel-edges-combo-fixed.ts
@@ -1,0 +1,94 @@
+import type { IElementDragEvent } from '@antv/g6';
+import { Graph } from '@antv/g6';
+
+/**
+ * 测试 process-parallel-edges 与 collapse-expand 配合的修复效果
+ * 确保修复后向后兼容，不影响原有功能
+ * @param context
+ */
+export const bugProcessParallelEdgesComboFixed: TestCase = async (context) => {
+  const graph = new Graph({
+    ...context,
+    data: {
+      nodes: [
+        { id: 'node1', combo: 'combo1', style: { x: 300, y: 100 } },
+        { id: 'node2', combo: 'combo1', style: { x: 300, y: 150 } },
+        { id: 'node3', combo: 'combo2', style: { x: 100, y: 100 } },
+        { id: 'node4', combo: 'combo2', style: { x: 50, y: 150 } },
+        { id: 'node5', combo: 'combo2', style: { x: 150, y: 150 } },
+      ],
+      edges: [
+        { source: 'node1', target: 'node2' },
+        { source: 'node3', target: 'node4' },
+        { source: 'node3', target: 'node5' },
+      ],
+      combos: [
+        { id: 'combo1', style: { labelText: '双击折叠', collapsed: true } },
+        { id: 'combo2', style: { labelText: '单击折叠 (无 process-parallel-edges)', collapsed: false } },
+      ],
+    },
+    node: {
+      style: {
+        labelText: (d) => d.id,
+        size: 20,
+      },
+    },
+    edge: {
+      type: 'quadratic',
+      state: {
+        highlighted: {
+          stroke: '#F5AD21',
+          labelFontWeight: 600,
+          labelFontSize: 18,
+        },
+      },
+      style: {
+        loop: false,
+        lineWidth: 2,
+        haloOpacity: 0.2,
+        endArrow: true,
+        endArrowType: 'vee',
+        stroke: '#C4CDE3',
+        labelText: 'fixed version',
+        labelFontSize: 14,
+        labelFontWeight: 500,
+        labelBackground: true,
+        labelBackgroundFill: '#FFFFFF',
+        labelBackgroundRadius: 4,
+        labelPadding: [4, 8],
+      },
+    },
+    combo: {
+      style: {
+        lineWidth: 2,
+        stroke: '#99ADD1',
+        fill: '#F3F6FF',
+        radius: 8,
+        padding: [10, 20, 30, 20],
+        labelFontSize: 12,
+        labelFill: '#666',
+      },
+    },
+    // 注意：这里没有 process-parallel-edges 变换
+    transforms: [],
+    behaviors: [
+      {
+        type: 'drag-element',
+      },
+      {
+        type: 'collapse-expand',
+        trigger: 'dblclick',
+        enable: (event: IElementDragEvent) => event.targetType === 'combo' && event.target.id === 'combo1',
+      },
+      {
+        type: 'collapse-expand',
+        trigger: 'click',
+        enable: (event: IElementDragEvent) => event.targetType === 'combo' && event.target.id === 'combo2',
+      },
+    ],
+  });
+
+  await graph.render();
+
+  return graph;
+};

--- a/packages/g6/__tests__/demos/bug-process-parallel-edges-combo-fixed.ts
+++ b/packages/g6/__tests__/demos/bug-process-parallel-edges-combo-fixed.ts
@@ -69,8 +69,13 @@ export const bugProcessParallelEdgesComboFixed: TestCase = async (context) => {
         labelFill: '#666',
       },
     },
-    // 注意：这里没有 process-parallel-edges 变换
-    transforms: [],
+    // 注意：这里添加了 process-parallel-edges 变换来测试修复效果
+    transforms: [
+      {
+        type: 'process-parallel-edges',
+        distance: 60,
+      },
+    ],
     behaviors: [
       {
         type: 'drag-element',

--- a/packages/g6/__tests__/demos/index.ts
+++ b/packages/g6/__tests__/demos/index.ts
@@ -21,6 +21,7 @@ export { behaviorOptimizeViewportTransform } from './behavior-optimize-viewport-
 export { behaviorScrollCanvas } from './behavior-scroll-canvas';
 export { behaviorZoomCanvas } from './behavior-zoom-canvas';
 export { bugDragRotatedCanvas } from './bug-drag-rotated-canvas';
+export { bugProcessParallelEdgesComboFixed } from './bug-process-parallel-edges-combo-fixed';
 export { bugTooltipResize } from './bug-tooltip-resize';
 export { canvasCursor } from './canvas-cursor';
 export { caseFishbone } from './case-fishbone';

--- a/packages/g6/src/transforms/process-parallel-edges.ts
+++ b/packages/g6/src/transforms/process-parallel-edges.ts
@@ -121,9 +121,23 @@ export class ProcessParallelEdges extends BaseTransform<ProcessParallelEdgesOpti
     combosToUpdate.forEach(addRelatedEdges);
 
     const pushParallelEdges = (edge: EdgeData) => {
-      const edgeData = model.getEdgeData().map((edge) => getEdgeEndsContext(model, edge));
-      const parallelEdges = getParallelEdges(edge, edgeData, true);
-      parallelEdges.forEach((e) => !edges.has(idOf(e)) && edges.set(idOf(e), e));
+      // 获取已被标记删除的边ID集合
+      // Get the set of edge IDs that have been marked for removal
+      const removedEdgeIds = new Set(input.remove.edges.keys());
+
+      // 过滤掉已删除的边，避免重定向后重新添加（修复combo收起时内部边变成loop边的问题）
+      // Filter out removed edges to prevent them from being re-added after redirection (fixes the issue where internal edges become loop edges when combo collapses)
+      const validEdgeData = model
+        .getEdgeData()
+        .filter((edge) => !removedEdgeIds.has(idOf(edge)))
+        .map((edge) => getEdgeEndsContext(model, edge));
+
+      // 查找平行边并添加到处理列表，确保只处理有效的边
+      // Find parallel edges and add them to the processing list, ensuring only valid edges are processed
+      getParallelEdges(edge, validEdgeData, true).forEach((e) => {
+        const id = idOf(e);
+        if (!edges.has(id)) edges.set(id, e);
+      });
     };
 
     if (edgesToRemove.size) edgesToRemove.forEach(pushParallelEdges);


### PR DESCRIPTION
## 📋 Description / 描述

### 🐛 Problem / 问题描述
修复了当combo收起时，内部边被错误地重定向为外部loop边的问题。这是由于 `process-parallel-edges` transform 没有正确处理被其他transform（如 `collapse-expand-combo`）标记删除的边导致的。

Fixed an issue where internal edges were incorrectly redirected as external loop edges when combos collapse. This was caused by the `process-parallel-edges` transform not properly handling edges marked for removal by other transforms (such as `collapse-expand-combo`).

### 🔧 Solution / 解决方案
在 `process-parallel-edges` transform 的 `getAffectedParallelEdges` 方法中添加了过滤逻辑，确保不处理已被其他transform标记删除的边。

Added filtering logic in the `getAffectedParallelEdges` method of `process-parallel-edges` transform to ensure edges marked for removal by other transforms are not processed.

**关键修改 / Key Changes:**
- ✅ 过滤掉 `input.remove.edges` 中的边，避免重新处理
- ✅ 改进了Transform间的协调机制，遵循"后续Transform不应处理前面已标记删除的数据"原则
- ✅ 添加了详细的中英文注释，解释修复原因和实现逻辑
- ✅ 优化了代码结构，使用更优雅的链式调用

### 🧪 Testing / 测试
- ✅ 添加了测试用例 `bug-process-parallel-edges-combo-fixed.ts` 验证修复效果
- ✅ 确保修复后combo收起时内部边正确消失，不会变成外部loop边
- ✅ 验证了向后兼容性，不影响原有的平行边处理功能


## 🔗 Related Issues / 相关Issues
- Fixes #7168

## ✅ Checklist / 检查清单
- [x] 代码符合项目规范
- [x] 添加了测试用例
- [x] 确保向后兼容
- [x] 添加了详细注释
- [x] 验证了修复效果

## 📚 Additional Notes / 补充说明
这个修复不仅解决了combo收起的问题，还改进了Transform协调机制，让Transform之间的协作更加可靠。修改完全向后兼容，不会影响任何现有功能。

This fix not only resolves the combo collapse issue but also improves the Transform coordination mechanism, making collaboration between Transforms more reliable. The changes are fully backward compatible and do not affect any existing functionality.