### PR TITLE
fix: divide by zero error when fitView with no content

### DIFF
--- a/packages/g6/__tests__/unit/runtime/viewport.spec.ts
+++ b/packages/g6/__tests__/unit/runtime/viewport.spec.ts
@@ -267,3 +267,27 @@ describe('Viewport Fit with lineWidth', () => {
     await expect(graph).toMatchSnapshot(__filename, 'with-lineWidth');
   });
 });
+
+describe('Fit View with no data in graph', () => {
+  let graph: Graph;
+
+  beforeAll(async () => {
+    graph = await createDemoGraph(async (context) => {
+      const graph = new Graph(context);
+      await graph.render();
+      return graph;
+    });
+  });
+
+  afterAll(() => {
+    graph.destroy();
+  });
+
+  it('fitView with no contents in the graph is ignored', () => {
+    // @ts-expect-error context is private.
+    const zoomBeforeFitView = graph.context.viewport?.getZoom();
+    graph.fitView();
+    // @ts-expect-error context is private.
+    expect(graph.context.viewport?.getZoom()).toBe(zoomBeforeFitView);
+  });
+});

--- a/packages/g6/src/runtime/viewport.ts
+++ b/packages/g6/src/runtime/viewport.ts
@@ -225,6 +225,9 @@ export class ViewportController {
     const scale = direction === 'x' ? scaleX : direction === 'y' ? scaleY : Math.min(scaleX, scaleY);
 
     const _animation = this.getAnimation(animation);
+    if (!Number.isFinite(scale)) {
+      return;
+    }
     await this.transform(
       {
         mode: 'relative',


### PR DESCRIPTION
If ViewportController.fitView is called when there is no content, a divide by zero error happens that causes the viewport to be scaled by -Infinity.

This can cause strange behavior, especially with the grid-line plugin.

Sandbox example showing what can happen: https://stackblitz.com/edit/g6-5049-fitview-divide-by-zero?file=src%2FApp.tsx