### PR TITLE
fix(brush-select and lasso-select): adapt html node

### DIFF
--- a/packages/g6/src/behaviors/brush-select.ts
+++ b/packages/g6/src/behaviors/brush-select.ts
@@ -397,8 +397,8 @@ export class BrushSelect extends BaseBehavior<BrushSelectOptions> {
 }
 
 export const getCursorPoint = (event: IPointerEvent, graph: Graph): Point => {
-  // Fixed #7182: 判断html类型节点，并把html节点的浏览器坐标转换为canvas坐标
-  // （没有直接判断的方式，nativeEvent.target非canvas则表示html节点触发的）
+  // Fixed #7182: 判断 html 类型节点，并把 html 节点的浏览器坐标转换为 canvas 坐标。
+  // 没有直接判断的方式，nativeEvent.target 非 canvas 则表示 html 节点触发的。
   // Fixed #7182: Handles brush selection on HTML nodes by converting client coordinates to canvas coordinates.
   // An HTML node is identified if the event's targetType is 'node' but the nativeEvent.target is not the canvas element.
   if (

--- a/packages/g6/src/behaviors/brush-select.ts
+++ b/packages/g6/src/behaviors/brush-select.ts
@@ -168,7 +168,7 @@ export class BrushSelect extends BaseBehavior<BrushSelectOptions> {
     if (!this.startPoint) return;
     const { immediately, mode } = this.options;
 
-    this.endPoint = getCursorPoint(event);
+    this.endPoint = getCursorPoint(event, this.context.graph);
 
     this.rectShape?.attr({
       x: Math.min(this.endPoint[0], this.startPoint[0]),
@@ -192,7 +192,7 @@ export class BrushSelect extends BaseBehavior<BrushSelectOptions> {
       return;
     }
 
-    this.endPoint = getCursorPoint(event);
+    this.endPoint = getCursorPoint(event, this.context.graph);
     this.updateElementsStates(getBoundingPoints(this.startPoint, this.endPoint));
 
     this.clearBrush();
@@ -396,6 +396,17 @@ export class BrushSelect extends BaseBehavior<BrushSelectOptions> {
   }
 }
 
-export const getCursorPoint = (event: IPointerEvent): Point => {
+export const getCursorPoint = (event: IPointerEvent, graph: Graph): Point => {
+  // Fixed #7182: 判断html类型节点，并把html节点的浏览器坐标转换为canvas坐标
+  // （没有直接判断的方式，nativeEvent.target非canvas则表示html节点触发的）
+  // Fixed #7182: Handles brush selection on HTML nodes by converting client coordinates to canvas coordinates.
+  // An HTML node is identified if the event's targetType is 'node' but the nativeEvent.target is not the canvas element.
+  if (
+    (event.targetType === 'node' || event.targetType === 'combo') &&
+    !(event.nativeEvent.target instanceof HTMLCanvasElement)
+  ) {
+    const [x, y] = graph.getCanvasByClient([event.client.x, event.client.y]);
+    return [x, y];
+  }
   return [event.canvas.x, event.canvas.y];
 };

--- a/packages/g6/src/behaviors/lasso-select.ts
+++ b/packages/g6/src/behaviors/lasso-select.ts
@@ -31,7 +31,7 @@ export class LassoSelect extends BrushSelect {
    */
   protected onPointerDown(event: IPointerEvent) {
     if (!super.validate(event) || !super.isKeydown() || this.points) return;
-    const { canvas } = this.context;
+    const { canvas, graph } = this.context;
 
     this.pathShape = new Path({
       id: 'g6-lasso-select',
@@ -40,7 +40,7 @@ export class LassoSelect extends BrushSelect {
 
     canvas.appendChild(this.pathShape);
 
-    this.points = [getCursorPoint(event)];
+    this.points = [getCursorPoint(event, graph)];
   }
 
   /**
@@ -52,7 +52,7 @@ export class LassoSelect extends BrushSelect {
     if (!this.points) return;
     const { immediately, mode } = this.options;
 
-    this.points.push(getCursorPoint(event));
+    this.points.push(getCursorPoint(event, this.context.graph));
 
     this.pathShape?.setAttribute('d', pointsToPath(this.points));
 


### PR DESCRIPTION
- Fixed: #7182 

### 原因
动作进行时鼠标进过html节点获取到的是浏览器的坐标系  
`brush-select` 和 `lasso-select` 都有这个问题，原因是相同的

### 改动
判断是html节点，转换坐标系后返回  

### 验证
brush-select  
![7182](https://github.com/user-attachments/assets/746cbdf4-15cf-4300-a0a1-04e97970945e)  

lasso-select  
![7182-2](https://github.com/user-attachments/assets/cae764ea-a7e0-4019-ac5c-3bbdbb9952e0)

