### PR TITLE
docs: 修正元素状态属性栏, 禁用状态名描述错误，将 disable 更正为 disabled

### DIFF
--- a/packages/site/docs/manual/element/state.en.md
+++ b/packages/site/docs/manual/element/state.en.md
@@ -27,7 +27,7 @@ G6 provides some commonly used built-in states that you can use directly:
 | `active`    | Active state    | Currently interacting element        |
 | `highlight` | Highlight state | Elements that need emphasis          |
 | `inactive`  | Inactive state  | Dimmed display of unfocused elements |
-| `disable`   | Disabled state  | Non-interactive elements             |
+| `disabled`   | Disabled state  | Non-interactive elements             |
 
 > 💡 **Tip**: These built-in states are not mandatory. You can completely define your own state names according to business requirements.
 
@@ -60,7 +60,7 @@ const graph = new Graph({
         stroke: '#FF6A00',
         lineWidth: 2,
       },
-      disable: {
+      disabled: {
         fill: '#ECECEC',
         stroke: '#BFBFBF',
         opacity: 0.5,

--- a/packages/site/docs/manual/element/state.zh.md
+++ b/packages/site/docs/manual/element/state.zh.md
@@ -27,7 +27,7 @@ G6 提供了一些常用的内置状态，您可以直接使用：
 | `active`    | 激活状态   | 当前正在交互的元素 |
 | `highlight` | 高亮状态   | 需要强调显示的元素 |
 | `inactive`  | 非活跃状态 | 淡化显示非关注元素 |
-| `disable`   | 禁用状态   | 不可交互的元素     |
+| `disabled`   | 禁用状态   | 不可交互的元素     |
 
 > 💡 **提示**：这些内置状态并非必须使用，您完全可以根据业务需求定义自己的状态名称。
 
@@ -60,7 +60,7 @@ const graph = new Graph({
         stroke: '#FF6A00',
         lineWidth: 2,
       },
-      disable: {
+      disabled: {
         fill: '#ECECEC',
         stroke: '#BFBFBF',
         opacity: 0.5,


### PR DESCRIPTION
修正的问题：

<img width="2560" height="1415" alt="image" src="https://github.com/user-attachments/assets/1bc17c07-8902-4fec-a371-e584b21e708d" />

<img width="2940" height="1666" alt="image" src="https://github.com/user-attachments/assets/4105b418-bb84-4e10-b928-24a01608f5b3" />
