### PR TITLE
chore: upgrade canvas to v3 in g6-ssr

### DIFF
--- a/packages/g6-ssr/package.json
+++ b/packages/g6-ssr/package.json
@@ -31,7 +31,7 @@
     "@antv/g-canvas": "^2.0.43",
     "@antv/g6": "workspace:^",
     "cac": "^6.7.14",
-    "canvas": "^2.11.2"
+    "canvas": "^3"
   },
   "devDependencies": {
     "@antv/g-plugin-rough-canvas-renderer": "^2.0.44"


### PR DESCRIPTION
上一个 pr 漏了：https://github.com/antvis/G6/pull/7395