### PR TITLE
更新bundle.zh.md

### DIFF
--- a/packages/site/docs/manual/further-reading/bundle.zh.md
+++ b/packages/site/docs/manual/further-reading/bundle.zh.md
@@ -55,6 +55,7 @@ npm install babel-loader@8 @babel/preset-env @open-wc/webpack-import-meta-loader
 
 <embed src="@/common/manual/feature/webpack4.md"></embed>
 :::
+> 如果你使用的是vue-cli，上述webpack配置项mode: 'production'就不需要。
 
 ## 使用 Rollup 打包项目
 

--- a/packages/site/docs/manual/further-reading/bundle.zh.md
+++ b/packages/site/docs/manual/further-reading/bundle.zh.md
@@ -55,7 +55,7 @@ npm install babel-loader@8 @babel/preset-env @open-wc/webpack-import-meta-loader
 
 <embed src="@/common/manual/feature/webpack4.md"></embed>
 :::
-> 如果你使用的是vue-cli，上述webpack配置项mode: 'production'就不需要。
+> 如果你使用的是 vue-cli，请移除 mode: 'production' 配置，否则可能会影响开发模式下的构建性能。
 
 ## 使用 Rollup 打包项目
 


### PR DESCRIPTION
vue-cli会在合并webpack配置项之前，为webpack配置项mode按开发态、生产态自动赋值。

重点是：在开发态下，开发者反复修改代码并触发构建行为时，会因为mode: 'production'这个配置状态激发的webpack在依赖缓存目录下预先缓存TerserWebpackPlugin导致运行时大小过大而重新构建耗时过长效果，影响开发体验。

所以如果不是使用原生webpack直接构建工程而是使用的vue-cli，需要这句话。