### PR TITLE
feat: g6-extension-react 支持 React16~19 渲染兼容

### DIFF
--- a/packages/g6-extension-react/package.json
+++ b/packages/g6-extension-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antv/g6-extension-react",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Using React Component to Define Your G6 Graph Node",
   "keywords": [
     "antv",

--- a/packages/g6-extension-react/src/react-node/render.ts
+++ b/packages/g6-extension-react/src/react-node/render.ts
@@ -1,146 +1,59 @@
 import type * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import type { Root } from 'react-dom/client';
 
-// Let compiler not to search module usage
-const fullClone = {
-  ...ReactDOM,
-} as typeof ReactDOM & {
-  __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED?: {
-    usingClientEntryPoint?: boolean;
-  };
-  createRoot?: CreateRoot;
-};
+type ContainerType = Element | DocumentFragment;
 
-type CreateRoot = (container: ContainerType) => Root;
-
-const { version, render: reactRender, unmountComponentAtNode } = fullClone as any;
-
-let createRoot: CreateRoot | undefined;
-
-async function initCreateRoot() {
-  if (createRoot) return;
-  const mainVersion = Number((version || '').split('.')[0]);
-
-  // React 18+ 使用 createRoot
-  if (mainVersion >= 18) {
-    try {
-      /* @vite-ignore */
-      const moduleName = 'react-dom/client';
-      const client = await import(moduleName);
-      if (client.createRoot) {
-        createRoot = client.createRoot;
-      }
-    } catch (error) {
-      // 如果动态导入失败，回退到旧版本渲染
-      // Silent error
-    }
-  }
-}
+const { version } = ReactDOM;
 
 /**
- * <zh/> 切换警告
+ * <zh/> 获取 React 主版本号
  *
- * <en/> Toggle warning
- * @param skip <zh/> 是否跳过警告 | <en/> Whether to skip the warning
+ * <en/> Get React major version
+ * @returns <zh/> 主版本号 | <en/> Major version
  */
-function toggleWarning(skip: boolean) {
-  const { __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED } = fullClone;
-
-  if (
-    __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED &&
-    typeof __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED === 'object'
-  ) {
-    __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.usingClientEntryPoint = skip;
-  }
+function getReactMajorVersion(): number {
+  return Number((version || '').split('.')[0]);
 }
 
-const MARK = '__rc_react_root__';
-
-// ========================== Render ==========================
-type ContainerType = (Element | DocumentFragment) & {
-  [MARK]?: Root;
-};
-
 /**
- * <zh/> 渲染 React 节点(React >= 18)
+ * <zh/> 渲染 React 节点(兼容 React 16 ~ 19)
  *
- * <en/> Render React node(React >= 18)
+ * <en/> Render React node(Compatible with React 16 ~ 19)
  * @param node - <zh/> React 节点 | <en/> React node
- * @param container - <zh/> 容器 | <en/> Container
- */
-function modernRender(node: React.ReactNode, container: ContainerType) {
-  toggleWarning(true);
-  const root = container[MARK] || createRoot!(container);
-  toggleWarning(false);
-
-  root.render(node);
-
-  container[MARK] = root;
-}
-
-/**
- * <zh/> 使用旧的 React 渲染
- *
- * <en/> Use old React render
- * @param node - <zh/> React 节点 | <en/> React node
- * @param container - <zh/> 容器 | <en/> Container
- */
-function legacyRender(node: React.ReactElement, container: ContainerType) {
-  reactRender(node, container);
-}
-
-/**
- * <zh/> 渲染 React 节点(兼容 React 16 ~ 18)
- *
- * <en/> Render React node(Compatible with React 16 ~ 18)
- * @param node - <zh/> React 节点 | <en/> React node
- * @param container - <zh/> 容器 | <en/> Container
- */
-export async function render(node: React.ReactElement, container: ContainerType) {
-  await initCreateRoot();
-  if (createRoot) modernRender(node, container);
-  else legacyRender(node, container);
-}
-
-/**
- * <zh/> 卸载 React 节点(React >= 18)
- *
- * <en/> Unmount React node(React >= 18)
  * @param container - <zh/> 容器 | <en/> Container
  * @returns <zh/> Promise | <en/> Promise
  */
-async function modernUnmount(container: ContainerType) {
-  // Delay to unmount to avoid React 18 sync warning
-  return Promise.resolve().then(() => {
-    container[MARK]?.unmount();
-    delete container[MARK];
-  });
+export async function render(node: React.ReactElement, container: ContainerType) {
+  const majorVersion = getReactMajorVersion();
+
+  if (majorVersion >= 18) {
+    // React 18/19
+    const { render: render18 } = await import('./render18');
+    return render18(node, container);
+  } else {
+    // React 16/17
+    const { render: render16 } = await import('./render16');
+    return render16(node, container);
+  }
 }
 
 /**
- * <zh/> 卸载 React 节点(React < 18)
+ * <zh/> 卸载 React 节点(兼容 React 16 ~ 19)
  *
- * <en/> Unmount React node(React < 18)
- * @param container - <zh/> 容器 | <en/> Container
- */
-function legacyUnmount(container: ContainerType) {
-  unmountComponentAtNode(container);
-}
-
-/**
- * <zh/> 卸载 React 节点(兼容 React 16 ~ 18)
- *
- * <en/> Unmount React node(Compatible with React 16 ~ 18)
+ * <en/> Unmount React node(Compatible with React 16 ~ 19)
  * @param container - <zh/> 容器 | <en/> Container
  * @returns <zh/> Promise | <en/> Promise
  */
 export async function unmount(container: ContainerType) {
-  await initCreateRoot();
-  if (createRoot) {
-    // Delay to unmount to avoid React 18 sync warning
-    return modernUnmount(container);
-  }
+  const majorVersion = getReactMajorVersion();
 
-  legacyUnmount(container);
+  if (majorVersion >= 18) {
+    // React 18/19
+    const { unmount: unmount18 } = await import('./render18');
+    return unmount18(container);
+  } else {
+    // React 16/17
+    const { unmount: unmount16 } = await import('./render16');
+    return unmount16(container);
+  }
 }

--- a/packages/g6-extension-react/src/react-node/render.ts
+++ b/packages/g6-extension-react/src/react-node/render.ts
@@ -15,6 +15,25 @@ function getReactMajorVersion(): number {
   return Number((version || '').split('.')[0]);
 }
 
+const getRenderer = (() => {
+  let rendererPromise: Promise<{
+    render: (node: React.ReactElement, container: ContainerType) => unknown;
+    unmount: (container: ContainerType) => unknown;
+  }>;
+
+  return () => {
+    if (!rendererPromise) {
+      const majorVersion = getReactMajorVersion();
+      if (majorVersion >= 18) {
+        rendererPromise = import('./render18');
+      } else {
+        rendererPromise = import('./render16');
+      }
+    }
+    return rendererPromise;
+  };
+})();
+
 /**
  * <zh/> 渲染 React 节点(兼容 React 16 ~ 19)
  *
@@ -24,17 +43,8 @@ function getReactMajorVersion(): number {
  * @returns <zh/> Promise | <en/> Promise
  */
 export async function render(node: React.ReactElement, container: ContainerType) {
-  const majorVersion = getReactMajorVersion();
-
-  if (majorVersion >= 18) {
-    // React 18/19
-    const { render: render18 } = await import('./render18');
-    return render18(node, container);
-  } else {
-    // React 16/17
-    const { render: render16 } = await import('./render16');
-    return render16(node, container);
-  }
+  const { render } = await getRenderer();
+  return render(node, container);
 }
 
 /**
@@ -45,15 +55,6 @@ export async function render(node: React.ReactElement, container: ContainerType)
  * @returns <zh/> Promise | <en/> Promise
  */
 export async function unmount(container: ContainerType) {
-  const majorVersion = getReactMajorVersion();
-
-  if (majorVersion >= 18) {
-    // React 18/19
-    const { unmount: unmount18 } = await import('./render18');
-    return unmount18(container);
-  } else {
-    // React 16/17
-    const { unmount: unmount16 } = await import('./render16');
-    return unmount16(container);
-  }
+  const { unmount } = await getRenderer();
+  return unmount(container);
 }

--- a/packages/g6-extension-react/src/react-node/render16.ts
+++ b/packages/g6-extension-react/src/react-node/render16.ts
@@ -1,0 +1,25 @@
+import type * as React from 'react';
+import * as ReactDOM from 'react-dom';
+
+type ContainerType = Element | DocumentFragment;
+
+/**
+ * <zh/> 渲染 React 节点(React 16/17)
+ *
+ * <en/> Render React node(React 16/17)
+ * @param node - <zh/> React 节点 | <en/> React node
+ * @param container - <zh/> 容器 | <en/> Container
+ */
+export function render(node: React.ReactElement, container: ContainerType) {
+  ReactDOM.render(node, container);
+}
+
+/**
+ * <zh/> 卸载 React 节点(React 16/17)
+ *
+ * <en/> Unmount React node(React 16/17)
+ * @param container - <zh/> 容器 | <en/> Container
+ */
+export function unmount(container: ContainerType) {
+  ReactDOM.unmountComponentAtNode(container);
+}

--- a/packages/g6-extension-react/src/react-node/render16.ts
+++ b/packages/g6-extension-react/src/react-node/render16.ts
@@ -3,6 +3,8 @@ import * as ReactDOM from 'react-dom';
 
 type ContainerType = Element | DocumentFragment;
 
+const { render: reactRender, unmountComponentAtNode } = ReactDOM as any;
+
 /**
  * <zh/> 渲染 React 节点(React 16/17)
  *
@@ -11,7 +13,7 @@ type ContainerType = Element | DocumentFragment;
  * @param container - <zh/> 容器 | <en/> Container
  */
 export function render(node: React.ReactElement, container: ContainerType) {
-  ReactDOM.render(node, container);
+  reactRender(node, container);
 }
 
 /**
@@ -21,5 +23,5 @@ export function render(node: React.ReactElement, container: ContainerType) {
  * @param container - <zh/> 容器 | <en/> Container
  */
 export function unmount(container: ContainerType) {
-  ReactDOM.unmountComponentAtNode(container);
+  unmountComponentAtNode(container);
 }

--- a/packages/g6-extension-react/src/react-node/render18.ts
+++ b/packages/g6-extension-react/src/react-node/render18.ts
@@ -8,7 +8,7 @@ type ContainerType = (Element | DocumentFragment) & {
 
 const MARK = '__rc_react_root__';
 
-let ReactDOMClient: any = null;
+let ReactDOMClientPromise: Promise<typeof import('react-dom/client') | null> | null = null;
 
 /**
  * <zh/> 初始化 React 18+ 的 createRoot
@@ -16,15 +16,11 @@ let ReactDOMClient: any = null;
  * <en/> Initialize React 18+ createRoot
  * @returns ReactDOMClient
  */
-async function initReactDOMClient() {
-  if (ReactDOMClient) return ReactDOMClient;
-
-  try {
-    ReactDOMClient = await import('react-dom/client');
-    return ReactDOMClient;
-  } catch (error) {
-    return null;
+function initReactDOMClient() {
+  if (ReactDOMClientPromise === null) {
+    ReactDOMClientPromise = import('react-dom/client').catch(() => null);
   }
+  return ReactDOMClientPromise;
 }
 
 /**

--- a/packages/g6-extension-react/src/react-node/render18.ts
+++ b/packages/g6-extension-react/src/react-node/render18.ts
@@ -1,0 +1,89 @@
+import type * as React from 'react';
+import * as ReactDOM from 'react-dom';
+import type { Root } from 'react-dom/client';
+
+type ContainerType = (Element | DocumentFragment) & {
+  __rc_react_root__?: Root;
+};
+
+const MARK = '__rc_react_root__';
+
+let ReactDOMClient: any = null;
+
+/**
+ * <zh/> 初始化 React 18+ 的 createRoot
+ *
+ * <en/> Initialize React 18+ createRoot
+ * @returns ReactDOMClient
+ */
+async function initReactDOMClient() {
+  if (ReactDOMClient) return ReactDOMClient;
+
+  try {
+    ReactDOMClient = await import('react-dom/client');
+    return ReactDOMClient;
+  } catch (error) {
+    return null;
+  }
+}
+
+/**
+ * <zh/> 切换警告
+ *
+ * <en/> Toggle warning
+ * @param skip <zh/> 是否跳过警告 | <en/> Whether to skip the warning
+ */
+function toggleWarning(skip: boolean) {
+  try {
+    const { __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED } = ReactDOM as typeof ReactDOM & {
+      __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED?: {
+        usingClientEntryPoint?: boolean;
+      };
+    };
+
+    if (
+      __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED &&
+      typeof __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED === 'object'
+    ) {
+      __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.usingClientEntryPoint = skip;
+    }
+  } catch {
+    // Silent error
+  }
+}
+
+/**
+ * <zh/> 渲染 React 节点(React 18/19)
+ *
+ * <en/> Render React node(React 18/19)
+ * @param node - <zh/> React 节点 | <en/> React node
+ * @param container - <zh/> 容器 | <en/> Container
+ */
+export async function render(node: React.ReactNode, container: ContainerType) {
+  const client = await initReactDOMClient();
+  if (!client?.createRoot) {
+    throw new Error('React 18+ createRoot not available');
+  }
+
+  toggleWarning(true);
+  const root = container[MARK] || client.createRoot(container);
+  toggleWarning(false);
+
+  root.render(node);
+  container[MARK] = root;
+}
+
+/**
+ * <zh/> 卸载 React 节点(React 18/19)
+ *
+ * <en/> Unmount React node(React 18/19)
+ * @param container - <zh/> 容器 | <en/> Container
+ * @returns <zh/> Promise | <en/> Promise
+ */
+export async function unmount(container: ContainerType) {
+  // Delay to unmount to avoid React 18 sync warning
+  return Promise.resolve().then(() => {
+    container[MARK]?.unmount();
+    delete container[MARK];
+  });
+}


### PR DESCRIPTION
#7430 反馈 `g6-extension-react` 2.0.5 版本在 React19 环境有报错。

定位到问题是 #7389 PR 的调整，兼容了 React16/17/18。但对于 React 19，Vite 解析机制更严格，动态导入时不支持传入变量。

解决方案是拆分 render 文件，React16/17 使用传统渲染，React18+ 才动态 import 'react-dom/client'。

