### PR TITLE
chore: remove petercat

### DIFF
--- a/packages/site/.dumirc.ts
+++ b/packages/site/.dumirc.ts
@@ -41,10 +41,6 @@ export default defineConfig({
     showAPIDoc: false, // 是否在 demo 页展示API文档
     feedback: true, // 是否显示反馈组件
     links: true, // 是否显示links答疑小蜜
-    petercat: {
-      show: true,
-      token: '4bd33b46-9b3c-4df1-be17-9206ea7c7e34',
-    },
     prefersColor: {
       default: 'light',
       switch: false,


### PR DESCRIPTION
- fixed #7468 

小预告：由 AntV 出品的 AI 答疑助手即将在 11.22 各大官网上线，三方 Petercat 没 key了😭先做下线处理。