### PR TITLE
fix(worker): make Web Worker available in v5

### DIFF
--- a/packages/g6/__tests__/unit/utils/object.spec.ts
+++ b/packages/g6/__tests__/unit/utils/object.spec.ts
@@ -1,0 +1,56 @@
+import { omitBy } from '@/src/utils/object';
+
+describe('object utils', () => {
+  describe('omitBy', () => {
+    it('should omit properties based on predicate', () => {
+      const obj = { a: 1, b: 2, c: 3, d: 4 };
+      const result = omitBy(obj, (value) => value % 2 === 0);
+      expect(result).toEqual({ a: 1, c: 3 });
+    });
+
+    it('should work with string values', () => {
+      const obj = { a: 'hello', b: '', c: 'world', d: null };
+      const result = omitBy(obj, (value) => !value);
+      expect(result).toEqual({ a: 'hello', c: 'world' });
+    });
+
+    it('should pass both value and key to predicate', () => {
+      const obj = { a: 1, b: 2, c: 3 };
+      const result = omitBy(obj, (value, key) => key === 'b' || value === 3);
+      expect(result).toEqual({ a: 1 });
+    });
+
+    it('should return empty object when all properties are omitted', () => {
+      const obj = { a: 1, b: 2, c: 3 };
+      const result = omitBy(obj, () => true);
+      expect(result).toEqual({});
+    });
+
+    it('should return same object when no properties are omitted', () => {
+      const obj = { a: 1, b: 2, c: 3 };
+      const result = omitBy(obj, () => false);
+      expect(result).toEqual({ a: 1, b: 2, c: 3 });
+    });
+
+    it('should handle empty object', () => {
+      const obj = {};
+      const result = omitBy(obj, () => true);
+      expect(result).toEqual({});
+    });
+
+    it('should work with undefined and null values', () => {
+      const obj = { a: undefined, b: null, c: 0, d: false, e: '' };
+      const result = omitBy(obj, (value) => value == null);
+      expect(result).toEqual({ c: 0, d: false, e: '' });
+    });
+
+    it('should only check own properties', () => {
+      const proto = { inherited: 'value' };
+      const obj = Object.create(proto);
+      obj.own = 'property';
+      const result = omitBy(obj, () => false);
+      expect(result).toEqual({ own: 'property' });
+      expect(result.inherited).toBeUndefined();
+    });
+  });
+});

--- a/packages/g6/src/runtime/layout.ts
+++ b/packages/g6/src/runtime/layout.ts
@@ -1,7 +1,7 @@
 import type { IAnimation } from '@antv/g';
 import { Graph as Graphlib } from '@antv/graphlib';
 import { Supervisor, isLayoutWithIterations } from '@antv/layout';
-import { deepMix } from '@antv/util';
+import { deepMix, isFunction } from '@antv/util';
 import { COMBO_KEY, GraphEvent, TREE_KEY } from '../constants';
 import { BaseLayout } from '../layouts';
 import type { AntVLayout } from '../layouts/types';
@@ -17,6 +17,7 @@ import { GraphLifeCycleEvent, emit } from '../utils/event';
 import { createTreeStructure } from '../utils/graphlib';
 import { idOf } from '../utils/id';
 import { isTreeLayout, layoutAdapter, layoutMapping2GraphData } from '../utils/layout';
+import { omitBy } from '../utils/object';
 import { print } from '../utils/print';
 import { dfs } from '../utils/traverse';
 import type { RuntimeContext } from './types';
@@ -164,8 +165,10 @@ export class LayoutController {
     // 使用 web worker 执行布局 / Use web worker to execute layout
     if (enableWorker) {
       const rawLayout = layout as unknown as AdaptiveLayout;
-      this.supervisor = new Supervisor(rawLayout.graphData2LayoutModel(data), rawLayout.instance, { iterations });
-      return layoutMapping2GraphData(await this.supervisor.execute());
+      layout.options = omitBy(layout.options || {}, (value) => isFunction(value));
+      this.supervisor = new Supervisor(rawLayout.graphData2LayoutModel(data), rawLayout, { iterations });
+      const positions = await this.supervisor.execute();
+      return layoutMapping2GraphData(positions);
     }
 
     if (isLayoutWithIterations(layout)) {

--- a/packages/g6/src/utils/object.ts
+++ b/packages/g6/src/utils/object.ts
@@ -1,0 +1,23 @@
+/**
+ * Creates an object composed of the properties that don't satisfy the predicate.
+ * @param obj - The source object
+ * @param predicate - The function invoked per property
+ * @returns Returns the new object
+ */
+export function omitBy<T extends Record<string, any>>(
+  obj: T,
+  predicate: (value: any, key: string) => boolean,
+): Partial<T> {
+  const result: Partial<T> = {};
+
+  for (const key in obj) {
+    if (Object.prototype.hasOwnProperty.call(obj, key)) {
+      const value = obj[key];
+      if (!predicate(value, key)) {
+        result[key] = value;
+      }
+    }
+  }
+
+  return result;
+}


### PR DESCRIPTION
@antvis/layout 修改打包方式，这里做适配 [#250](https://github.com/antvis/layout/pull/250)

支持 Web Worker 后包体积变大，暂定将相关能力迁移到 wasm 包中，不影响主包体积。

<img width="593" height="314" alt="image" src="https://github.com/user-attachments/assets/df02ce30-e21d-4756-b9b4-ccfacf0c2e10" />