### PR TITLE
docs(site): 修复 v5 文档交互示例，将 'drag-node' 更正为 'drag-element'

### DIFF
--- a/packages/site/docs/manual/graph/extensions.en.md
+++ b/packages/site/docs/manual/graph/extensions.en.md
@@ -59,7 +59,7 @@ In `GraphOptions.behaviors`, for example:
 ```ts
 const graph = new Graph({
   // ... other options
-  behaviors: ['drag-canvas', 'zoom-canvas', 'drag-node'],
+  behaviors: ['drag-canvas', 'zoom-canvas', 'drag-element'],
 });
 ```
 

--- a/packages/site/docs/manual/graph/extensions.zh.md
+++ b/packages/site/docs/manual/graph/extensions.zh.md
@@ -59,7 +59,7 @@ const graph = new Graph({
 ```ts
 const graph = new Graph({
   // ... 其他配置
-  behaviors: ['drag-canvas', 'zoom-canvas', 'drag-node'],
+  behaviors: ['drag-canvas', 'zoom-canvas', 'drag-element'],
 });
 ```
 

--- a/packages/site/docs/manual/graph/graph.zh.md
+++ b/packages/site/docs/manual/graph/graph.zh.md
@@ -137,7 +137,7 @@ const graph = new Graph({
   },
 
   // 交互行为
-  behaviors: ['drag-canvas', 'zoom-canvas', 'drag-node'],
+  behaviors: ['drag-canvas', 'zoom-canvas', 'drag-element'],
 
   // 初始数据
   data: {
@@ -198,7 +198,7 @@ const graph = new Graph({
   },
 
   // 交互行为
-  behaviors: ['drag-canvas', 'zoom-canvas', 'drag-node'],
+  behaviors: ['drag-canvas', 'zoom-canvas', 'drag-element'],
 
   // 初始数据
   data: {


### PR DESCRIPTION
## 变更说明
- 修复 v5 文档交互示例错误：将 drag-node 更正为 drag-element 。
- 同步修正中英文文档，保持示例一致性与正确性。
- 仅文档改动，不涉及运行逻辑或 API 变更。
## 背景
- G6 v5 的交互配置应使用 drag-element 。
- 原文档在部分示例中沿用了 v4 的 drag-node ，与 v5 行为命名不一致，可能误导用户。
## 影响与兼容性
- 文档更正，不影响代码或构建。
- 无破坏性变更，无需 changeset。