### PR TITLE
The getNeighborIds method within the ClickSelect behavior has been changed from private to protected.

### DIFF
--- a/packages/g6/src/behaviors/click-select.ts
+++ b/packages/g6/src/behaviors/click-select.ts
@@ -152,7 +152,7 @@ export class ClickSelect extends BaseBehavior<ClickSelectOptions> {
     return multiple && this.shortcut.match(trigger);
   }
 
-  private getNeighborIds(event: IPointerEvent<Element>) {
+  protected getNeighborIds(event: IPointerEvent<Element>) {
     const { target, targetType } = event;
     const { graph } = this.context;
     const { degree } = this.options;


### PR DESCRIPTION
Fix #6871

效果：
<img width="647" height="472" alt="image" src="https://github.com/user-attachments/assets/9afe5912-d22f-4ef9-8458-973584262029" />
