### PR TITLE
docs: zoom-canvas scroll-canvas conflict

### DIFF
--- a/packages/site/docs/manual/behavior/ZoomCanvas.en.md
+++ b/packages/site/docs/manual/behavior/ZoomCanvas.en.md
@@ -223,11 +223,11 @@ const graph = new Graph({
 
 ### 3. Conflicts when using two-finger touchpad input and scroll-canvas simultaneously
 
-The default action for zoom-canvas is a pinch or expand with two fingers; the default action for scroll-canvas is a swipe with two fingers.
+On a touchpad, both two-finger swipe (for scrolling) and pinch (for zooming) gestures are often interpreted as `wheel` events.
 
-However, when zoom-canvas and scroll-canvas are enabled simultaneously, a swipe with two fingers will trigger both canvas zooming and canvas movement at the same time.
+Because both `zoom-canvas` and `scroll-canvas` respond to `wheel` events by default, using them together can cause conflicts, such as a single gesture triggering both scrolling and zooming.
 
-The specific behavior can be determined by checking `event.ctrlKey`; `true` indicates a **pinch or spread operation**, and `false` indicates a **swipe operation**.
+You can resolve this by checking the `event.ctrlKey` property. On most platforms, a pinch gesture sets `event.ctrlKey` to `true`, while a swipe does not. This allows you to conditionally enable `zoom-canvas` only for pinch gestures.
 
 ```js | ob { inject: true }
 import { Graph } from '@antv/g6';

--- a/packages/site/docs/manual/behavior/ZoomCanvas.en.md
+++ b/packages/site/docs/manual/behavior/ZoomCanvas.en.md
@@ -221,6 +221,38 @@ const graph = new Graph({
 });
 ```
 
+### 3. Conflicts when using two-finger touchpad input and scroll-canvas simultaneously
+
+The default action for zoom-canvas is a pinch or expand with two fingers; the default action for scroll-canvas is a swipe with two fingers.
+
+However, when zoom-canvas and scroll-canvas are enabled simultaneously, a swipe with two fingers will trigger both canvas zooming and canvas movement at the same time.
+
+The specific behavior can be determined by checking `event.ctrlKey`; `true` indicates a **pinch or spread operation**, and `false` indicates a **swipe operation**.
+
+```js | ob { inject: true }
+import { Graph } from '@antv/g6';
+const graph = new Graph({
+  container: 'container',
+  layout: {
+    type: 'grid',
+  },
+  data: {
+    nodes: [{ id: 'node1' }, { id: 'node2' }, { id: 'node3' }],
+  },
+  behaviors: [
+    'scroll-canvas',
+    {
+      key: 'custom-zoom-canvas',
+      type: 'zoom-canvas',
+      enable: (event) => {
+        return event.ctrlKey; // When ctrlKey is true, it performs a two-finger pinch or spread operation; when false, it performs a two-finger swipe operation.
+      },
+    },
+  ],
+});
+graph.render();
+```
+
 ## Practical Example
 
 ```js | ob { inject: true }

--- a/packages/site/docs/manual/behavior/ZoomCanvas.zh.md
+++ b/packages/site/docs/manual/behavior/ZoomCanvas.zh.md
@@ -221,6 +221,38 @@ const graph = new Graph({
 });
 ```
 
+### 3. 触控板双指操作下，与 scroll-canvas 同时使用时的冲突
+
+zoom-canvas 的默认操作为 双指捏合或扩张; scroll-canvas 的默认操作为 双指滑动
+
+但当同时启用了 zoom-canvas scroll-canvas 时; 双指滑动操作会同时触发画布缩放和画布移动
+
+可以通过判断 `event.ctrlKey` 来确定具体行为; 为 `true` 时**双指捏合或扩张操作**，`false` 时**双指滑动操作**
+
+```js | ob { inject: true }
+import { Graph } from '@antv/g6';
+const graph = new Graph({
+  container: 'container',
+  layout: {
+    type: 'grid',
+  },
+  data: {
+    nodes: [{ id: 'node1' }, { id: 'node2' }, { id: 'node3' }],
+  },
+  behaviors: [
+    'scroll-canvas',
+    {
+      key: 'custom-zoom-canvas',
+      type: 'zoom-canvas',
+      enable: (event) => {
+        return event.ctrlKey; // ctrlKey 为 true 时，是双指捏合或扩张操作，false 时是双指滑动操作
+      },
+    },
+  ],
+});
+graph.render();
+```
+
 ## 实际案例
 
 ```js | ob { inject: true }

--- a/packages/site/docs/manual/behavior/ZoomCanvas.zh.md
+++ b/packages/site/docs/manual/behavior/ZoomCanvas.zh.md
@@ -223,11 +223,11 @@ const graph = new Graph({
 
 ### 3. 触控板双指操作下，与 scroll-canvas 同时使用时的冲突
 
-zoom-canvas 的默认操作为 双指捏合或扩张; scroll-canvas 的默认操作为 双指滑动
+在触控板上，双指滑动（用于滚动）和双指捏合（用于缩放）手势通常都会被解析为 `wheel` 事件。
 
-但当同时启用了 zoom-canvas scroll-canvas 时; 双指滑动操作会同时触发画布缩放和画布移动
+由于 `zoom-canvas` 和 `scroll-canvas` 默认都会响应 `wheel` 事件，当它们同时使用时会产生冲突，例如一个手势会同时触发滚动和缩放。
 
-可以通过判断 `event.ctrlKey` 来确定具体行为; 为 `true` 时**双指捏合或扩张操作**，`false` 时**双指滑动操作**
+你可以通过检查 `event.ctrlKey` 属性来解决这个问题。在多数平台上，捏合手势会使 `event.ctrlKey` 为 `true`，而滑动则不会。这允许你有条件地仅为捏合手势启用 `zoom-canvas`。
 
 ```js | ob { inject: true }
 import { Graph } from '@antv/g6';

--- a/packages/site/examples/behavior/canvas/demo/meta.json
+++ b/packages/site/examples/behavior/canvas/demo/meta.json
@@ -43,6 +43,14 @@
         "en": "Hide Elements When Dragging and Zooming"
       },
       "screenshot": "https://mdn.alipayobjects.com/huamei_qa8qxu/afts/img/A*AZ4IRJkIZr8AAAAAAAAAAAAADmJ7AQ/original"
+    },
+    {
+      "filename": "scroll-and-zoom.js",
+      "title": {
+        "zh": "滚动和缩放画布",
+        "en": "Scroll Canvas and Zoom Canvas"
+      },
+      "screenshot": "https://mdn.alipayobjects.com/huamei_qa8qxu/afts/img/A*VoBZR7Z62KEAAAAAAAAAAAAADmJ7AQ/original"
     }
   ]
 }

--- a/packages/site/examples/behavior/canvas/demo/scroll-and-zoom.js
+++ b/packages/site/examples/behavior/canvas/demo/scroll-and-zoom.js
@@ -1,0 +1,31 @@
+import { Graph } from '@antv/g6';
+
+const graph = new Graph({
+  container: 'container',
+  layout: {
+    type: 'grid',
+  },
+  data: {
+    nodes: [{ id: 'node1' }, { id: 'node2' }, { id: 'node3' }, { id: 'node4' }, { id: 'node5' }],
+    edges: [
+      { source: 'node1', target: 'node2' },
+      { source: 'node1', target: 'node3' },
+      { source: 'node1', target: 'node4' },
+      { source: 'node2', target: 'node3' },
+      { source: 'node3', target: 'node4' },
+      { source: 'node4', target: 'node5' },
+    ],
+  },
+  behaviors: [
+    'scroll-canvas',
+    {
+      key: 'custom-zoom-canvas',
+      type: 'zoom-canvas',
+      enable: (event) => {
+        return event.ctrlKey; // ctrlKey 为 true 时，是双指捏合或扩张操作，false 时是双指滑动操作
+      },
+    },
+  ],
+});
+
+graph.render();


### PR DESCRIPTION
Fixes #7117 , #7416

为什么不直接修改g6？
考虑到有可能有用户使用了zoom-canvas，且是通过双指滑动触发的，直接修改不行

<img width="1089" height="1053" alt="image" src="https://github.com/user-attachments/assets/28398092-9451-47aa-a784-ee943ae34ea8" />
