### PR TITLE
fix: One edge will not have parallel edges(transforms/process-parallel-edges)

### DIFF
--- a/packages/g6/src/transforms/process-parallel-edges.ts
+++ b/packages/g6/src/transforms/process-parallel-edges.ts
@@ -178,7 +178,7 @@ export class ProcessParallelEdges extends BaseTransform<ProcessParallelEdgesOpti
           style.loopPlacement = CUBIC_LOOP_PLACEMENTS[i % len];
           style.loopDist = Math.floor(i / len) * distance + 50;
         } else if (length === 1) {
-          style.curveOffset = 0;
+          return;
         } else {
           const sign = (i % 2 === 0 ? 1 : -1) * (reverses[`${edge.source}|${edge.target}|${i}`] ? -1 : 1);
           style.curveOffset =


### PR DESCRIPTION
当两个节点之间只有一条边时，不应该进入平行边的transform处理。#7477