### PR TITLE
Fix brush-select modifier key not working until canvas is focused

### DIFF
--- a/packages/g6/src/utils/shortcut.ts
+++ b/packages/g6/src/utils/shortcut.ts
@@ -58,8 +58,8 @@ export class Shortcut {
   private bindEvents() {
     const { emitter } = this;
 
-    emitter.on(CommonEvent.KEY_DOWN, this.onKeyDown);
-    emitter.on(CommonEvent.KEY_UP, this.onKeyUp);
+    window.addEventListener(CommonEvent.KEY_DOWN, this.onKeyDown);
+    window.addEventListener(CommonEvent.KEY_UP, this.onKeyUp);
     emitter.on(CommonEvent.WHEEL, this.onWheel);
     emitter.on(CommonEvent.DRAG, this.onDrag);
 
@@ -125,8 +125,8 @@ export class Shortcut {
 
   public destroy() {
     this.unbindAll();
-    this.emitter.off(CommonEvent.KEY_DOWN, this.onKeyDown);
-    this.emitter.off(CommonEvent.KEY_UP, this.onKeyUp);
+    window.removeEventListener(CommonEvent.KEY_DOWN, this.onKeyDown);
+    window.removeEventListener(CommonEvent.KEY_UP, this.onKeyUp);
     this.emitter.off(CommonEvent.WHEEL, this.onWheel);
     this.emitter.off(CommonEvent.DRAG, this.onDrag);
     this.pinchHandler?.off('pinchmove', this.boundHandlePinch);


### PR DESCRIPTION
I understand that this was an issue that was decided to be intentional and not worth fixing for G6 maintainers (https://github.com/antvis/G6/issues/7302), but my contention is that it feels unintuitive.

I'm not sure what the reasoning for closing the issue was, but I decided to open a draft PR to demonstrate what the fix might look like. I don't think it is too unreasonable to have window listeners just to track whether a modifier key is down, as these listeners do not inherently actually do anything by themselves. You still need to actually click on the canvas once the key is held down to activate the brush-select behavior.

@yvonneyx If you think this fix is inacceptable I would love to at least hear what the reasoning behind rejecting this method would be, or alternatively if you need me to do anything extra I'd be happy to keep working on this, but I figure that trying to reach out first would be better since this feels to me to be more intuitive behavior.