### PR TITLE
fix: 修复几个TreeLayout相关BUG

### DIFF
--- a/packages/g6/__tests__/snapshots/runtime/graph/add-children-data/add-children-data.svg
+++ b/packages/g6/__tests__/snapshots/runtime/graph/add-children-data/add-children-data.svg
@@ -1,200 +1,200 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" color-interpolation-filters="sRGB" style="background: transparent; outline: none;" tabindex="1">
-  <g transform="matrix(.47801 0 0 .47801 52.524 130.4971)">
+  <g transform="matrix(.47801 0 0 .47801 91.5105 130.4971)">
     <g fill="none">
       <g fill="none" class="elements">
         <g fill="none">
           <g>
-            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="M-.44 289c100 0 100-364 200-364" class="key"/>
+            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="M-82 289c100 0 100-364 200-364" class="key"/>
             <path fill="none" stroke="transparent" stroke-width="3" d="M-82 289c100 0 100-364 200-364" class="key"/>
           </g>
         </g>
         <g fill="none">
           <g>
-            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="M-.44 289c100 0 100 39 200 39" class="key"/>
+            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="M-82 289c100 0 100 39 200 39" class="key"/>
             <path fill="none" stroke="transparent" stroke-width="3" d="M-82 289c100 0 100 39 200 39" class="key"/>
           </g>
         </g>
         <g fill="none">
           <g>
-            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="M-.44 289c100 0 100 364 200 364" class="key"/>
+            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="M-82 289c100 0 100 364 200 364" class="key"/>
             <path fill="none" stroke="transparent" stroke-width="3" d="M-82 289c100 0 100 364 200 364" class="key"/>
           </g>
         </g>
         <g fill="none">
           <g>
-            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="M231.56-75c100 0 100-182 200-182" class="key"/>
+            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="M150-75c100 0 100-182 200-182" class="key"/>
             <path fill="none" stroke="transparent" stroke-width="3" d="M150-75c100 0 100-182 200-182" class="key"/>
           </g>
         </g>
         <g fill="none">
           <g>
-            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="M231.56-75c100 0 100-130 200-130" class="key"/>
+            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="M150-75c100 0 100-130 200-130" class="key"/>
             <path fill="none" stroke="transparent" stroke-width="3" d="M150-75c100 0 100-130 200-130" class="key"/>
           </g>
         </g>
         <g fill="none">
           <g>
-            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="M231.56-75c100 0 100-78 200-78" class="key"/>
+            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="M150-75c100 0 100-78 200-78" class="key"/>
             <path fill="none" stroke="transparent" stroke-width="3" d="M150-75c100 0 100-78 200-78" class="key"/>
           </g>
         </g>
         <g fill="none">
           <g>
-            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="M231.56-75c100 0 100-26 200-26" class="key"/>
+            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="M150-75c100 0 100-26 200-26" class="key"/>
             <path fill="none" stroke="transparent" stroke-width="3" d="M150-75c100 0 100-26 200-26" class="key"/>
           </g>
         </g>
         <g fill="none">
           <g>
-            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="M231.56-75c100 0 100 26 200 26" class="key"/>
+            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="M150-75c100 0 100 26 200 26" class="key"/>
             <path fill="none" stroke="transparent" stroke-width="3" d="M150-75c100 0 100 26 200 26" class="key"/>
           </g>
         </g>
         <g fill="none">
           <g>
-            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="M231.56-75c100 0 100 78 200 78" class="key"/>
+            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="M150-75c100 0 100 78 200 78" class="key"/>
             <path fill="none" stroke="transparent" stroke-width="3" d="M150-75c100 0 100 78 200 78" class="key"/>
           </g>
         </g>
         <g fill="none">
           <g>
-            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="M231.56-75c100 0 100 130 200 130" class="key"/>
+            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="M150-75c100 0 100 130 200 130" class="key"/>
             <path fill="none" stroke="transparent" stroke-width="3" d="M150-75c100 0 100 130 200 130" class="key"/>
           </g>
         </g>
         <g fill="none">
           <g>
-            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="M231.56-75c100 0 100 182 200 182" class="key"/>
+            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="M150-75c100 0 100 182 200 182" class="key"/>
             <path fill="none" stroke="transparent" stroke-width="3" d="M150-75c100 0 100 182 200 182" class="key"/>
           </g>
         </g>
         <g fill="none">
           <g>
-            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="M231.56 328c100 0 100-169 200-169" class="key"/>
+            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="M150 328c100 0 100-169 200-169" class="key"/>
             <path fill="none" stroke="transparent" stroke-width="3" d="M150 328c100 0 100-169 200-169" class="key"/>
           </g>
         </g>
         <g fill="none">
           <g>
-            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="M231.56 328c100 0 100 39 200 39" class="key"/>
+            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="M150 328c100 0 100 39 200 39" class="key"/>
             <path fill="none" stroke="transparent" stroke-width="3" d="M150 328c100 0 100 39 200 39" class="key"/>
           </g>
         </g>
         <g fill="none">
           <g>
-            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="M231.56 328c100 0 100 169 200 169" class="key"/>
+            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="M150 328c100 0 100 169 200 169" class="key"/>
             <path fill="none" stroke="transparent" stroke-width="3" d="M150 328c100 0 100 169 200 169" class="key"/>
           </g>
         </g>
         <g fill="none">
           <g>
-            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="M463.56 159c100 0 100-130 200-130" class="key"/>
+            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="M382 159c100 0 100-130 200-130" class="key"/>
             <path fill="none" stroke="transparent" stroke-width="3" d="M382 159c100 0 100-130 200-130" class="key"/>
           </g>
         </g>
         <g fill="none">
           <g>
-            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="M463.56 159c100 0 100-78 200-78" class="key"/>
+            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="M382 159c100 0 100-78 200-78" class="key"/>
             <path fill="none" stroke="transparent" stroke-width="3" d="M382 159c100 0 100-78 200-78" class="key"/>
           </g>
         </g>
         <g fill="none">
           <g>
-            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="M463.56 159c100 0 100-26 200-26" class="key"/>
+            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="M382 159c100 0 100-26 200-26" class="key"/>
             <path fill="none" stroke="transparent" stroke-width="3" d="M382 159c100 0 100-26 200-26" class="key"/>
           </g>
         </g>
         <g fill="none">
           <g>
-            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="M463.56 159c100 0 100 26 200 26" class="key"/>
+            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="M382 159c100 0 100 26 200 26" class="key"/>
             <path fill="none" stroke="transparent" stroke-width="3" d="M382 159c100 0 100 26 200 26" class="key"/>
           </g>
         </g>
         <g fill="none">
           <g>
-            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="M463.56 159c100 0 100 78 200 78" class="key"/>
+            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="M382 159c100 0 100 78 200 78" class="key"/>
             <path fill="none" stroke="transparent" stroke-width="3" d="M382 159c100 0 100 78 200 78" class="key"/>
           </g>
         </g>
         <g fill="none">
           <g>
-            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="M463.56 159c100 0 100 130 200 130" class="key"/>
+            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="M382 159c100 0 100 130 200 130" class="key"/>
             <path fill="none" stroke="transparent" stroke-width="3" d="M382 159c100 0 100 130 200 130" class="key"/>
           </g>
         </g>
         <g fill="none">
           <g>
-            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="M463.56 367c100 0 100-26 200-26" class="key"/>
+            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="M382 367c100 0 100-26 200-26" class="key"/>
             <path fill="none" stroke="transparent" stroke-width="3" d="M382 367c100 0 100-26 200-26" class="key"/>
           </g>
         </g>
         <g fill="none">
           <g>
-            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="M463.56 367c100 0 100 26 200 26" class="key"/>
+            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="M382 367c100 0 100 26 200 26" class="key"/>
             <path fill="none" stroke="transparent" stroke-width="3" d="M382 367c100 0 100 26 200 26" class="key"/>
           </g>
         </g>
         <g fill="none">
           <g>
-            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="M463.56 497c100 0 100-52 200-52" class="key"/>
+            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="M382 497c100 0 100-52 200-52" class="key"/>
             <path fill="none" stroke="transparent" stroke-width="3" d="M382 497c100 0 100-52 200-52" class="key"/>
           </g>
         </g>
         <g fill="none">
           <g>
-            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="M463.56 497c100 0 100 0 200 0" class="key"/>
+            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="M382 497c100 0 100 0 200 0" class="key"/>
             <path fill="none" stroke="transparent" stroke-width="3" d="M382 497c100 0 100 0 200 0" class="key"/>
           </g>
         </g>
         <g fill="none">
           <g>
-            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="M463.56 497c100 0 100 52 200 52" class="key"/>
+            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="M382 497c100 0 100 52 200 52" class="key"/>
             <path fill="none" stroke="transparent" stroke-width="3" d="M382 497c100 0 100 52 200 52" class="key"/>
           </g>
         </g>
         <g fill="none">
           <g>
-            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="M231.56 653c100 0 100-104 200-104" class="key"/>
+            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="M150 653c100 0 100-104 200-104" class="key"/>
             <path fill="none" stroke="transparent" stroke-width="3" d="M150 653c100 0 100-104 200-104" class="key"/>
           </g>
         </g>
         <g fill="none">
           <g>
-            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="M231.56 653c100 0 100-52 200-52" class="key"/>
+            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="M150 653c100 0 100-52 200-52" class="key"/>
             <path fill="none" stroke="transparent" stroke-width="3" d="M150 653c100 0 100-52 200-52" class="key"/>
           </g>
         </g>
         <g fill="none">
           <g>
-            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="M231.56 653c100 0 100 0 200 0" class="key"/>
+            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="M150 653c100 0 100 0 200 0" class="key"/>
             <path fill="none" stroke="transparent" stroke-width="3" d="M150 653c100 0 100 0 200 0" class="key"/>
           </g>
         </g>
         <g fill="none">
           <g>
-            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="M231.56 653c100 0 100 52 200 52" class="key"/>
+            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="M150 653c100 0 100 52 200 52" class="key"/>
             <path fill="none" stroke="transparent" stroke-width="3" d="M150 653c100 0 100 52 200 52" class="key"/>
           </g>
         </g>
         <g fill="none">
           <g>
-            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="M231.56 653c100 0 100 104 200 104" class="key"/>
+            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="M150 653c100 0 100 104 200 104" class="key"/>
             <path fill="none" stroke="transparent" stroke-width="3" d="M150 653c100 0 100 104 200 104" class="key"/>
           </g>
         </g>
         <g fill="none">
           <g>
-            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="M463.56-153c100 0 100-26 200-26" class="key"/>
-            <path fill="none" stroke="transparent" stroke-width="3" d="M350-153c-167 0-167 153-334 153" class="key"/>
+            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="M382-153c100 0 100-26 200-26" class="key"/>
+            <path fill="none" stroke="transparent" stroke-width="3" d="M382-153c0 0 0 0 0 0" class="key"/>
           </g>
         </g>
         <g fill="none">
           <g>
-            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="M463.56-153c100 0 100 26 200 26" class="key"/>
-            <path fill="none" stroke="transparent" stroke-width="3" d="M350-153c-167 0-167 153-334 153" class="key"/>
+            <path fill="none" stroke="rgba(153,173,209,1)" stroke-width="1" d="M382-153c100 0 100 26 200 26" class="key"/>
+            <path fill="none" stroke="transparent" stroke-width="3" d="M382-153c0 0 0 0 0 0" class="key"/>
           </g>
         </g>
-        <g fill="none" transform="matrix(1 0 0 1 -16.44 289)">
+        <g fill="none" transform="matrix(1 0 0 1 -98 289)">
           <g>
             <circle r="16" fill="rgba(23,131,255,1)" stroke="rgba(0,0,0,1)" stroke-width="0" class="key"/>
           </g>
@@ -204,7 +204,7 @@
             </g>
           </g>
         </g>
-        <g fill="none" transform="matrix(1 0 0 1 215.56 -75)">
+        <g fill="none" transform="matrix(1 0 0 1 134 -75)">
           <g>
             <circle r="16" fill="rgba(23,131,255,1)" stroke="rgba(0,0,0,1)" stroke-width="0" class="key"/>
           </g>
@@ -214,7 +214,7 @@
             </g>
           </g>
         </g>
-        <g fill="none" transform="matrix(1 0 0 1 447.56 -257)">
+        <g fill="none" transform="matrix(1 0 0 1 366 -257)">
           <g>
             <circle r="16" fill="rgba(23,131,255,1)" stroke="rgba(0,0,0,1)" stroke-width="0" class="key"/>
           </g>
@@ -224,7 +224,7 @@
             </g>
           </g>
         </g>
-        <g fill="none" transform="matrix(1 0 0 1 447.56 -205)">
+        <g fill="none" transform="matrix(1 0 0 1 366 -205)">
           <g>
             <circle r="16" fill="rgba(23,131,255,1)" stroke="rgba(0,0,0,1)" stroke-width="0" class="key"/>
           </g>
@@ -234,7 +234,7 @@
             </g>
           </g>
         </g>
-        <g fill="none" transform="matrix(1 0 0 1 447.56 -153)">
+        <g fill="none" transform="matrix(1 0 0 1 366 -153)">
           <g>
             <circle r="16" fill="rgba(23,131,255,1)" stroke="rgba(0,0,0,1)" stroke-width="0" class="key"/>
           </g>
@@ -244,7 +244,7 @@
             </g>
           </g>
         </g>
-        <g fill="none" transform="matrix(1 0 0 1 447.56 -101)">
+        <g fill="none" transform="matrix(1 0 0 1 366 -101)">
           <g>
             <circle r="16" fill="rgba(23,131,255,1)" stroke="rgba(0,0,0,1)" stroke-width="0" class="key"/>
           </g>
@@ -254,7 +254,7 @@
             </g>
           </g>
         </g>
-        <g fill="none" transform="matrix(1 0 0 1 447.56 -49)">
+        <g fill="none" transform="matrix(1 0 0 1 366 -49)">
           <g>
             <circle r="16" fill="rgba(23,131,255,1)" stroke="rgba(0,0,0,1)" stroke-width="0" class="key"/>
           </g>
@@ -264,7 +264,7 @@
             </g>
           </g>
         </g>
-        <g fill="none" transform="matrix(1 0 0 1 447.56 3)">
+        <g fill="none" transform="matrix(1 0 0 1 366 3)">
           <g>
             <circle r="16" fill="rgba(23,131,255,1)" stroke="rgba(0,0,0,1)" stroke-width="0" class="key"/>
           </g>
@@ -274,7 +274,7 @@
             </g>
           </g>
         </g>
-        <g fill="none" transform="matrix(1 0 0 1 447.56 55)">
+        <g fill="none" transform="matrix(1 0 0 1 366 55)">
           <g>
             <circle r="16" fill="rgba(23,131,255,1)" stroke="rgba(0,0,0,1)" stroke-width="0" class="key"/>
           </g>
@@ -284,7 +284,7 @@
             </g>
           </g>
         </g>
-        <g fill="none" transform="matrix(1 0 0 1 447.56 107)">
+        <g fill="none" transform="matrix(1 0 0 1 366 107)">
           <g>
             <circle r="16" fill="rgba(23,131,255,1)" stroke="rgba(0,0,0,1)" stroke-width="0" class="key"/>
           </g>
@@ -294,7 +294,7 @@
             </g>
           </g>
         </g>
-        <g fill="none" transform="matrix(1 0 0 1 215.56 328)">
+        <g fill="none" transform="matrix(1 0 0 1 134 328)">
           <g>
             <circle r="16" fill="rgba(23,131,255,1)" stroke="rgba(0,0,0,1)" stroke-width="0" class="key"/>
           </g>
@@ -304,7 +304,7 @@
             </g>
           </g>
         </g>
-        <g fill="none" transform="matrix(1 0 0 1 447.56 159)">
+        <g fill="none" transform="matrix(1 0 0 1 366 159)">
           <g>
             <circle r="16" fill="rgba(23,131,255,1)" stroke="rgba(0,0,0,1)" stroke-width="0" class="key"/>
           </g>
@@ -314,7 +314,7 @@
             </g>
           </g>
         </g>
-        <g fill="none" transform="matrix(1 0 0 1 679.56 29)">
+        <g fill="none" transform="matrix(1 0 0 1 598 29)">
           <g>
             <circle r="16" fill="rgba(23,131,255,1)" stroke="rgba(0,0,0,1)" stroke-width="0" class="key"/>
           </g>
@@ -324,7 +324,7 @@
             </g>
           </g>
         </g>
-        <g fill="none" transform="matrix(1 0 0 1 679.56 81)">
+        <g fill="none" transform="matrix(1 0 0 1 598 81)">
           <g>
             <circle r="16" fill="rgba(23,131,255,1)" stroke="rgba(0,0,0,1)" stroke-width="0" class="key"/>
           </g>
@@ -334,7 +334,7 @@
             </g>
           </g>
         </g>
-        <g fill="none" transform="matrix(1 0 0 1 679.56 133)">
+        <g fill="none" transform="matrix(1 0 0 1 598 133)">
           <g>
             <circle r="16" fill="rgba(23,131,255,1)" stroke="rgba(0,0,0,1)" stroke-width="0" class="key"/>
           </g>
@@ -344,7 +344,7 @@
             </g>
           </g>
         </g>
-        <g fill="none" transform="matrix(1 0 0 1 679.56 185)">
+        <g fill="none" transform="matrix(1 0 0 1 598 185)">
           <g>
             <circle r="16" fill="rgba(23,131,255,1)" stroke="rgba(0,0,0,1)" stroke-width="0" class="key"/>
           </g>
@@ -354,7 +354,7 @@
             </g>
           </g>
         </g>
-        <g fill="none" transform="matrix(1 0 0 1 679.56 237)">
+        <g fill="none" transform="matrix(1 0 0 1 598 237)">
           <g>
             <circle r="16" fill="rgba(23,131,255,1)" stroke="rgba(0,0,0,1)" stroke-width="0" class="key"/>
           </g>
@@ -364,7 +364,7 @@
             </g>
           </g>
         </g>
-        <g fill="none" transform="matrix(1 0 0 1 679.56 289)">
+        <g fill="none" transform="matrix(1 0 0 1 598 289)">
           <g>
             <circle r="16" fill="rgba(23,131,255,1)" stroke="rgba(0,0,0,1)" stroke-width="0" class="key"/>
           </g>
@@ -374,7 +374,7 @@
             </g>
           </g>
         </g>
-        <g fill="none" transform="matrix(1 0 0 1 447.56 367)">
+        <g fill="none" transform="matrix(1 0 0 1 366 367)">
           <g>
             <circle r="16" fill="rgba(23,131,255,1)" stroke="rgba(0,0,0,1)" stroke-width="0" class="key"/>
           </g>
@@ -384,7 +384,7 @@
             </g>
           </g>
         </g>
-        <g fill="none" transform="matrix(1 0 0 1 679.56 341)">
+        <g fill="none" transform="matrix(1 0 0 1 598 341)">
           <g>
             <circle r="16" fill="rgba(23,131,255,1)" stroke="rgba(0,0,0,1)" stroke-width="0" class="key"/>
           </g>
@@ -394,7 +394,7 @@
             </g>
           </g>
         </g>
-        <g fill="none" transform="matrix(1 0 0 1 679.56 393)">
+        <g fill="none" transform="matrix(1 0 0 1 598 393)">
           <g>
             <circle r="16" fill="rgba(23,131,255,1)" stroke="rgba(0,0,0,1)" stroke-width="0" class="key"/>
           </g>
@@ -404,7 +404,7 @@
             </g>
           </g>
         </g>
-        <g fill="none" transform="matrix(1 0 0 1 447.56 497)">
+        <g fill="none" transform="matrix(1 0 0 1 366 497)">
           <g>
             <circle r="16" fill="rgba(23,131,255,1)" stroke="rgba(0,0,0,1)" stroke-width="0" class="key"/>
           </g>
@@ -414,7 +414,7 @@
             </g>
           </g>
         </g>
-        <g fill="none" transform="matrix(1 0 0 1 679.56 445)">
+        <g fill="none" transform="matrix(1 0 0 1 598 445)">
           <g>
             <circle r="16" fill="rgba(23,131,255,1)" stroke="rgba(0,0,0,1)" stroke-width="0" class="key"/>
           </g>
@@ -424,7 +424,7 @@
             </g>
           </g>
         </g>
-        <g fill="none" transform="matrix(1 0 0 1 679.56 497)">
+        <g fill="none" transform="matrix(1 0 0 1 598 497)">
           <g>
             <circle r="16" fill="rgba(23,131,255,1)" stroke="rgba(0,0,0,1)" stroke-width="0" class="key"/>
           </g>
@@ -434,7 +434,7 @@
             </g>
           </g>
         </g>
-        <g fill="none" transform="matrix(1 0 0 1 679.56 549)">
+        <g fill="none" transform="matrix(1 0 0 1 598 549)">
           <g>
             <circle r="16" fill="rgba(23,131,255,1)" stroke="rgba(0,0,0,1)" stroke-width="0" class="key"/>
           </g>
@@ -444,7 +444,7 @@
             </g>
           </g>
         </g>
-        <g fill="none" transform="matrix(1 0 0 1 215.56 653)">
+        <g fill="none" transform="matrix(1 0 0 1 134 653)">
           <g>
             <circle r="16" fill="rgba(23,131,255,1)" stroke="rgba(0,0,0,1)" stroke-width="0" class="key"/>
           </g>
@@ -454,7 +454,7 @@
             </g>
           </g>
         </g>
-        <g fill="none" transform="matrix(1 0 0 1 447.56 549)">
+        <g fill="none" transform="matrix(1 0 0 1 366 549)">
           <g>
             <circle r="16" fill="rgba(23,131,255,1)" stroke="rgba(0,0,0,1)" stroke-width="0" class="key"/>
           </g>
@@ -464,7 +464,7 @@
             </g>
           </g>
         </g>
-        <g fill="none" transform="matrix(1 0 0 1 447.56 601)">
+        <g fill="none" transform="matrix(1 0 0 1 366 601)">
           <g>
             <circle r="16" fill="rgba(23,131,255,1)" stroke="rgba(0,0,0,1)" stroke-width="0" class="key"/>
           </g>
@@ -474,7 +474,7 @@
             </g>
           </g>
         </g>
-        <g fill="none" transform="matrix(1 0 0 1 447.56 653)">
+        <g fill="none" transform="matrix(1 0 0 1 366 653)">
           <g>
             <circle r="16" fill="rgba(23,131,255,1)" stroke="rgba(0,0,0,1)" stroke-width="0" class="key"/>
           </g>
@@ -484,7 +484,7 @@
             </g>
           </g>
         </g>
-        <g fill="none" transform="matrix(1 0 0 1 447.56 705)">
+        <g fill="none" transform="matrix(1 0 0 1 366 705)">
           <g>
             <circle r="16" fill="rgba(23,131,255,1)" stroke="rgba(0,0,0,1)" stroke-width="0" class="key"/>
           </g>
@@ -494,7 +494,7 @@
             </g>
           </g>
         </g>
-        <g fill="none" transform="matrix(1 0 0 1 447.56 757)">
+        <g fill="none" transform="matrix(1 0 0 1 366 757)">
           <g>
             <circle r="16" fill="rgba(23,131,255,1)" stroke="rgba(0,0,0,1)" stroke-width="0" class="key"/>
           </g>
@@ -504,7 +504,7 @@
             </g>
           </g>
         </g>
-        <g fill="none" transform="matrix(1 0 0 1 679.56 -179)">
+        <g fill="none" transform="matrix(1 0 0 1 598 -179)">
           <g>
             <circle r="16" fill="rgba(23,131,255,1)" stroke="rgba(0,0,0,1)" stroke-width="0" class="key"/>
           </g>
@@ -514,7 +514,7 @@
             </g>
           </g>
         </g>
-        <g fill="none" transform="matrix(1 0 0 1 679.56 -127)">
+        <g fill="none" transform="matrix(1 0 0 1 598 -127)">
           <g>
             <circle r="16" fill="rgba(23,131,255,1)" stroke="rgba(0,0,0,1)" stroke-width="0" class="key"/>
           </g>

--- a/packages/g6/src/runtime/data.ts
+++ b/packages/g6/src/runtime/data.ts
@@ -385,7 +385,16 @@ export class DataController {
   public addChildrenData(parentId: ID, childrenData: NodeData[]) {
     const parentData = this.getNodeLikeDatum(parentId) as NodeData;
     const childrenId = childrenData.map(idOf);
-    this.addNodeData(childrenData);
+    // 新子节点未设坐标时使用父节点位置，draw 时画在父节点下，layout 时再从父节点过渡到最终位置
+    const [parentX, parentY] = positionOf(parentData);
+    const nodesToAdd = childrenData.map((child) => {
+      const style = child.style ?? {};
+      if (style.x == null && style.y == null) {
+        return { ...child, style: { ...style, x: parentX, y: parentY } };
+      }
+      return child;
+    });
+    this.addNodeData(nodesToAdd);
     this.updateNodeData([{ id: parentId, children: [...(parentData.children || []), ...childrenId] }]);
     this.addEdgeData(childrenId.map((childId) => ({ source: parentId, target: childId })));
   }

--- a/packages/g6/src/runtime/data.ts
+++ b/packages/g6/src/runtime/data.ts
@@ -25,7 +25,7 @@ import { cloneElementData, isElementDataEqual, mergeElementsData } from '../util
 import { arrayDiff } from '../utils/diff';
 import { toG6Data, toGraphlibData } from '../utils/graphlib';
 import { idOf, parentIdOf } from '../utils/id';
-import { positionOf } from '../utils/position';
+import { hasPosition, positionOf } from '../utils/position';
 import { format, print } from '../utils/print';
 import { dfs } from '../utils/traverse';
 import { add } from '../utils/vector';
@@ -389,7 +389,7 @@ export class DataController {
     const [parentX, parentY] = positionOf(parentData);
     const nodesToAdd = childrenData.map((child) => {
       const style = child.style ?? {};
-      if (style.x == null && style.y == null) {
+      if (!hasPosition(child)) {
         return { ...child, style: { ...style, x: parentX, y: parentY } };
       }
       return child;

--- a/packages/g6/src/runtime/layout.ts
+++ b/packages/g6/src/runtime/layout.ts
@@ -232,14 +232,13 @@ export class LayoutController {
         'TB',
       );
 
-      // 根节点已在画布上时，以其当前坐标为锚点计算偏移，避免布局后画布跳动（类 fitCenter 效果）；
-      // 首次布局时根节点尚未渲染，回退到视口居中逻辑。
-      // When the root is already on canvas, anchor offset to its current position to prevent
-      // the layout from causing a fitCenter-like jump; fall back to viewport centering on first layout.
-      const rootElement = this.context.element?.getElement(root.id);
+      // 重新布局时以根节点当前坐标为锚点计算偏移，避免布局后画布跳动；
+      // 首次布局（Graph.rendered === false）回退到视口居中逻辑。
+      // On re-layout, anchor offset to root's current position to prevent canvas jump;
+      // fall back to viewport centering on first layout (Graph.rendered === false).
       let offset: [number, number];
 
-      if (rootElement) {
+      if (this.context.graph.rendered) {
         const rootNodeData = nodes.find((n) => idOf(n) === root.id);
         const currentX = Number(rootNodeData?.style?.x ?? 0);
         const currentY = Number(rootNodeData?.style?.y ?? 0);

--- a/packages/g6/src/runtime/layout.ts
+++ b/packages/g6/src/runtime/layout.ts
@@ -17,6 +17,7 @@ import { emit, GraphLifeCycleEvent } from '../utils/event';
 import { createTreeStructure } from '../utils/graphlib';
 import { idOf } from '../utils/id';
 import { isLegacyAntVLayout, isTreeLayout, layoutAdapter, legacyLayoutAdapter } from '../utils/layout';
+import { hasPosition, positionOf } from '../utils/position';
 import { print } from '../utils/print';
 import { dfs } from '../utils/traverse';
 import type { RuntimeContext } from './types';
@@ -232,17 +233,15 @@ export class LayoutController {
         'TB',
       );
 
-      // 重新布局时以根节点当前坐标为锚点计算偏移，避免布局后画布跳动；
-      // 首次布局（Graph.rendered === false）回退到视口居中逻辑。
-      // On re-layout, anchor offset to root's current position to prevent canvas jump;
-      // fall back to viewport centering on first layout (Graph.rendered === false).
+      // 布局时以根节点当前坐标为锚点计算偏移，避免布局后画布跳动；
+      // 根节点未设置位置（首次布局）时回退到视口居中逻辑。
+      // On layout, anchor offset to root's current position to prevent canvas jump;
+      // if root node has no position (first layout), fall back to viewport centering.
       let offset: [number, number];
-
-      if (this.context.graph.rendered) {
-        const rootNodeData = nodes.find((n) => idOf(n) === root.id);
-        const currentX = Number(rootNodeData?.style?.x ?? 0);
-        const currentY = Number(rootNodeData?.style?.y ?? 0);
-        offset = [currentX - rx, currentY - ry];
+      const rootNodeData = nodes.find((n) => idOf(n) === root.id);
+      if (rootNodeData && hasPosition(rootNodeData)) {
+        const [rootX, rootY] = positionOf(rootNodeData);
+        offset = [rootX - rx, rootY - ry];
       } else {
         offset = this.inferTreeLayoutOffset({
           nodes: subtreeNodes.map(({ id, x, y, z }) => ({ id, style: { x, y, z } })),

--- a/packages/g6/src/runtime/layout.ts
+++ b/packages/g6/src/runtime/layout.ts
@@ -259,8 +259,10 @@ export class LayoutController {
 
     if (animation) {
       // 先将所有节点移动到根节点位置 / Move all nodes to the root node position first
-      this.updateElementPosition(layoutPreset, false);
-
+      // this.updateElementPosition(layoutPreset, false);
+      // 直接从当前位置过渡到布局结果，跳过「先将所有节点移动到根节点位置」避免每次 layout 都从根节点位置重播展开动画
+      // Animate from current positions to layout result; skip "Move all nodes to the root node position first"
+      // to avoid re-expand
       const animationResult = this.updateElementPosition(layoutResult, animation);
       await animationResult?.finished;
     }

--- a/packages/g6/src/runtime/layout.ts
+++ b/packages/g6/src/runtime/layout.ts
@@ -219,25 +219,46 @@ export class LayoutController {
 
       const result = layout(root, options);
       const { x: rx, y: ry, z: rz = 0 } = result;
+
       // 将布局结果转化为 LayoutMapping 格式 / Convert the layout result to LayoutMapping format
+      const subtreeNodes: Array<{ id: ID; x: number; y: number; z: number }> = [];
       dfs(
         result,
         (node) => {
           const { id, x, y, z = 0 } = node;
-          layoutPreset.nodes!.push({ id, style: { x: rx, y: ry, z: rz } });
-          layoutResult.nodes!.push({ id, style: { x, y, z } });
+          subtreeNodes.push({ id, x, y, z });
         },
         (node) => node.children,
         'TB',
       );
-    });
 
-    const offset = this.inferTreeLayoutOffset(layoutResult);
-    applyTreeLayoutOffset(layoutResult, offset);
+      // 根节点已在画布上时，以其当前坐标为锚点计算偏移，避免布局后画布跳动（类 fitCenter 效果）；
+      // 首次布局时根节点尚未渲染，回退到视口居中逻辑。
+      // When the root is already on canvas, anchor offset to its current position to prevent
+      // the layout from causing a fitCenter-like jump; fall back to viewport centering on first layout.
+      const rootElement = this.context.element?.getElement(root.id);
+      let offset: [number, number];
+
+      if (rootElement) {
+        const rootNodeData = nodes.find((n) => idOf(n) === root.id);
+        const currentX = Number(rootNodeData?.style?.x ?? 0);
+        const currentY = Number(rootNodeData?.style?.y ?? 0);
+        offset = [currentX - rx, currentY - ry];
+      } else {
+        offset = this.inferTreeLayoutOffset({
+          nodes: subtreeNodes.map(({ id, x, y, z }) => ({ id, style: { x, y, z } })),
+        });
+      }
+
+      const [ox, oy] = offset;
+      subtreeNodes.forEach(({ id, x, y, z }) => {
+        layoutPreset.nodes!.push({ id, style: { x: rx + ox, y: ry + oy, z: rz } });
+        layoutResult.nodes!.push({ id, style: { x: x + ox, y: y + oy, z } });
+      });
+    });
 
     if (animation) {
       // 先将所有节点移动到根节点位置 / Move all nodes to the root node position first
-      applyTreeLayoutOffset(layoutPreset, offset);
       this.updateElementPosition(layoutPreset, false);
 
       const animationResult = this.updateElementPosition(layoutResult, animation);


### PR DESCRIPTION
## TreeLayout 相关BUG
1. 修复每次调用 layout 后自动居中的问题
2. 修复新增 child node 时, 初始位置总是在root node，导致过度动画错误的问题 #6302
3. 修复调用 render/layout 方法后整棵树都会重新展开 #6222 #7166