### PR TITLE
fix: 修复 create-edge 连线位置偏移问题

### DIFF
--- a/packages/g6/src/behaviors/create-edge.ts
+++ b/packages/g6/src/behaviors/create-edge.ts
@@ -162,8 +162,10 @@ export class CreateEdge extends BaseBehavior<CreateEdgeOptions> {
 
   private updateAssistEdge = async (event: IPointerEvent) => {
     if (!this.source) return;
-    const { model, element } = this.context;
-    model.translateNodeTo(ASSIST_NODE_ID, [event.client.x, event.client.y]);
+    const { graph, model, element } = this.context;
+    // 将客户端坐标转换为画布坐标，避免容器偏移导致的连线位置错误
+    const [x, y] = graph.getCanvasByClient([event.client.x, event.client.y]);
+    model.translateNodeTo(ASSIST_NODE_ID, [x, y]);
     await element!.draw({ animation: false, silence: true })?.finished;
   };
 


### PR DESCRIPTION
## 修复 Issue #7618

### 问题描述
create-edge 时连接线发生偏移，不跟随鼠标，但连接节点后连接线正常。

### 修复方案
将客户端坐标转换为画布坐标，避免容器偏移导致的连线位置错误。

### 修改内容
- 修改 `packages/g6/src/behaviors/create-edge.ts` 中的 `updateAssistEdge` 方法
- 使用 `graph.getCanvasByClient()` 将浏览器客户端坐标转换为画布坐标

### 测试
该修复已针对 issue #7618 中描述的场景进行测试，当容器有 margin/padding 或非全屏时，连线能正确跟随鼠标。

Closes #7618