### PR TITLE
fix(behavior): restore node zIndex after drag-element ends

### DIFF
--- a/packages/g6/__tests__/unit/behaviors/drag-element.spec.ts
+++ b/packages/g6/__tests__/unit/behaviors/drag-element.spec.ts
@@ -41,6 +41,17 @@ describe('behavior drag element', () => {
     await expect(graph).toMatchSnapshot(__filename, 'after-drag');
   });
 
+  it('restores zIndex after drag end', () => {
+    graph.setBehaviors(['drag-element']);
+    const originalZIndex = graph.getElementZIndex('node-4');
+
+    graph.emit(NodeEvent.DRAG_START, { target: { id: 'node-4' }, targetType: 'node' });
+    graph.emit(NodeEvent.DRAG, { dx: 10, dy: 10 });
+    graph.emit(NodeEvent.DRAG_END);
+
+    expect(graph.getElementZIndex('node-4')).toBe(originalZIndex);
+  });
+
   it('hide edges', async () => {
     graph.setBehaviors([{ type: 'drag-element', hideEdge: 'both' }]);
     graph.emit(NodeEvent.DRAG_START, { target: { id: 'node-4' }, targetType: 'node' });

--- a/packages/g6/src/behaviors/drag-element.ts
+++ b/packages/g6/src/behaviors/drag-element.ts
@@ -164,6 +164,8 @@ export class DragElement extends BaseBehavior<DragElementOptions> {
 
   private hiddenEdges: ID[] = [];
 
+  private originalZIndices: Record<ID, number> = {};
+
   private isDragging: boolean = false;
 
   private shortcut: Shortcut;
@@ -270,6 +272,7 @@ export class DragElement extends BaseBehavior<DragElementOptions> {
     else this.target = [id];
 
     this.hideEdge();
+    this.storeOriginalZIndices(this.target);
     this.context.graph.frontElement(this.target);
     if (this.options.shadow) this.createShadow(this.target);
   }
@@ -306,6 +309,7 @@ export class DragElement extends BaseBehavior<DragElementOptions> {
       this.moveElement(this.target, [dx, dy]);
     }
     this.showEdges();
+    this.restoreOriginalZIndices();
     this.options.onFinish?.(this.target);
     const { batch, canvas } = this.context;
     batch!.endBatch();
@@ -385,6 +389,22 @@ export class DragElement extends BaseBehavior<DragElementOptions> {
   protected clampByRotation([dx, dy]: Point): Vector2 {
     const rotation = this.context.graph.getRotation();
     return rotate([dx, dy], rotation);
+  }
+
+  private storeOriginalZIndices(ids: ID[]) {
+    const { graph } = this.context;
+    this.originalZIndices = {};
+    ids.forEach((id) => {
+      this.originalZIndices[id] = graph.getElementZIndex(id);
+    });
+  }
+
+  private restoreOriginalZIndices() {
+    const { graph } = this.context;
+    if (Object.keys(this.originalZIndices).length > 0) {
+      graph.setElementZIndex(this.originalZIndices);
+      this.originalZIndices = {};
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary

`drag-element.onDragStart` calls `graph.frontElement(target)`, which sets the dragged node's `zIndex` to `max(all_elements) + 1`. This elevated zIndex **persists after drag ends** - there is no reset.

When `hover-activate` later fires on the same node, `computeZIndex` recalculates edge zIndex as `Math.max(source.zIndex, target.zIndex) - 1`. Because the dragged node's zIndex is now elevated, its edges get a zIndex higher than non-neighbor nodes (still at 0), causing edges to render on top of unrelated nodes.

The problem compounds: each subsequent drag of any node further escalates the global max zIndex.

### Fix

- Store original zIndex values before `frontElement()` in `onDragStart`
- Restore them via `setElementZIndex()` in `onDragEnd`
- `frontElement()` is still called during drag so the dragged node renders above others while dragging

### Reproduction

**JSFiddle:** https://jsfiddle.net/z03jrefa/5/

1. Hover "Hub" — edges render behind bystander nodes ✅
2. Drag "Hub", release
3. Hover "Hub" again — edges now render on top of bystander nodes ❌

### Snapshot tests

Some snapshot tests will need regeneration — they previously captured the buggy elevated zIndex state after drag-end. The new snapshots reflect the corrected behavior.

## Test plan

- [x] Added unit test verifying `getElementZIndex()` returns original value after drag cycle
- [ ] Regenerate affected snapshot baselines (`drag-element`, `z-index`, `bubble-sets`, `hull`, `click-select-drag-node`, `element-combo-drag`, `drag-element-combo`)
