### PR TITLE
fix: contextmenu cant be scrolled

### DIFF
--- a/packages/g6/src/plugins/contextmenu/index.ts
+++ b/packages/g6/src/plugins/contextmenu/index.ts
@@ -108,9 +108,6 @@ export class Contextmenu extends BasePlugin<ContextmenuOptions> {
     const { className } = this.options;
     if (className) this.$element.classList.add(className);
 
-    // 阻止滚轮事件冒泡，防止触发画布的 zoom-canvas 拦截逻辑
-    this.$element.addEventListener('wheel', this.wheelHandler);
-
     const $container = this.context.canvas.getContainer();
     $container!.appendChild(this.$element);
 
@@ -220,6 +217,8 @@ export class Contextmenu extends BasePlugin<ContextmenuOptions> {
     graph.on(`combo:${trigger}`, this.onTriggerEvent);
 
     document.addEventListener('click', this.onMenuItemClick);
+    // 阻止滚轮事件冒泡，防止触发画布的 zoom-canvas 拦截逻辑
+    this.$element.addEventListener('wheel', this.wheelHandler);
   }
 
   private unbindEvents() {


### PR DESCRIPTION
修复Contextmenu无法滚动的问题

Graph 初始化时，Contextmenu 的这三个函数触发顺序是这样的 `initElement()` -> `unbindEvents()` -> `bindEvents()`，导致 `wheelHandler` 添加后接着被移除

将 `addEventListener` 从 `initElement` 中移动到 `bindEvents` 即可解决